### PR TITLE
Fix SW caching errors; add /privacy and /terms

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Privacy Policy</h1>
+        <p className="text-gray-600 mb-6">We respect your privacy. This page will be updated with our detailed policy.</p>
+      </div>
+    </div>
+  )
+}
+
+

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Terms of Service</h1>
+        <p className="text-gray-600 mb-6">Our terms of service will be published here.</p>
+      </div>
+    </div>
+  )
+}
+
+


### PR DESCRIPTION
- Service Worker: skip non-GET requests; only cache GET responses to prevent Cache.put errors with POST
- Add minimal /privacy and /terms pages to resolve 404s referenced in footer navigation

After deploy, reload to update SW (or close all tabs); test auth/register and legal links.