### PR TITLE
fix(currency): fail safe to 0 for unpriced currencies + conversion tests

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"184f858f-1b23-4068-b3bf-4eed84748912","pid":1533236,"procStart":"1090295","acquiredAt":1778957983433}
+{"sessionId":"4b93e302-9d53-48a5-abd5-35ab7801f3d6","pid":1187686,"procStart":"15086894","acquiredAt":1781841532016}

--- a/__tests__/unit/services/currency/conversion.test.ts
+++ b/__tests__/unit/services/currency/conversion.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for the synchronous currency conversion module.
+ *
+ * Covers BTC<->SATS arithmetic, BTC<->fiat conversion against the seeded rate
+ * cache, the round-trip identity, and — critically — the safe-failure behavior
+ * when a currency has no known rate (must return 0, never fabricate a value).
+ */
+
+import {
+  satsToBitcoin,
+  bitcoinToSats,
+  convertBtcTo,
+  convertToBtc,
+  convert,
+} from '@/services/currency/conversion';
+import { cache } from '@/services/currency/rates';
+
+// Silence the warn that the missing-rate path emits.
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const SATS_PER_BTC = 100_000_000;
+
+describe('BTC <-> SATS', () => {
+  it('satsToBitcoin divides by 100M', () => {
+    expect(satsToBitcoin(SATS_PER_BTC)).toBe(1);
+    expect(satsToBitcoin(50_000_000)).toBe(0.5);
+    expect(satsToBitcoin(0)).toBe(0);
+  });
+
+  it('bitcoinToSats multiplies by 100M and rounds', () => {
+    expect(bitcoinToSats(1)).toBe(SATS_PER_BTC);
+    expect(bitcoinToSats(0.5)).toBe(50_000_000);
+    // Floating point: 0.1 BTC -> exactly 10,000,000 sats (rounded, not 9999999.9)
+    expect(bitcoinToSats(0.1)).toBe(10_000_000);
+  });
+
+  it('round-trips sats -> btc -> sats', () => {
+    expect(bitcoinToSats(satsToBitcoin(123_456_789))).toBe(123_456_789);
+  });
+});
+
+describe('convertBtcTo', () => {
+  it('returns the amount unchanged for BTC', () => {
+    expect(convertBtcTo(0.5, 'BTC')).toBe(0.5);
+  });
+
+  it('converts BTC to SATS (rounded integer)', () => {
+    expect(convertBtcTo(0.001, 'SATS')).toBe(100_000);
+  });
+
+  it('converts BTC to a seeded fiat using the cached rate', () => {
+    const rate = cache.rates['BTC_CHF'];
+    expect(convertBtcTo(2, 'CHF')).toBe(2 * rate);
+  });
+
+  it('returns 0 for an unsupported currency (never fabricates)', () => {
+    expect(convertBtcTo(1, 'JPY')).toBe(0);
+  });
+});
+
+describe('convertToBtc', () => {
+  it('returns the amount unchanged for BTC', () => {
+    expect(convertToBtc(0.5, 'BTC')).toBe(0.5);
+  });
+
+  it('converts SATS to BTC', () => {
+    expect(convertToBtc(100_000, 'SATS')).toBe(0.001);
+  });
+
+  it('converts a seeded fiat to BTC using the cached rate', () => {
+    const rate = cache.rates['BTC_USD'];
+    expect(convertToBtc(rate, 'USD')).toBe(1);
+  });
+
+  it('returns 0 for an unsupported currency — must NOT treat fiat as BTC', () => {
+    // The bug this guards against: `amount / 1` rendering "100 JPY" as "100 BTC".
+    expect(convertToBtc(100, 'JPY')).toBe(0);
+  });
+});
+
+describe('convert (fiat <-> fiat via BTC)', () => {
+  it('returns the amount unchanged when currencies match', () => {
+    expect(convert(42, 'CHF', 'CHF')).toBe(42);
+  });
+
+  it('round-trips CHF -> BTC -> CHF without drift', () => {
+    const out = convert(convert(100, 'CHF', 'BTC'), 'BTC', 'CHF');
+    expect(out).toBeCloseTo(100, 6);
+  });
+
+  it('converts between two seeded fiats consistently with the rates', () => {
+    const usd = 100;
+    const expectedChf = (usd / cache.rates['BTC_USD']) * cache.rates['BTC_CHF'];
+    expect(convert(usd, 'USD', 'CHF')).toBeCloseTo(expectedChf, 8);
+  });
+
+  it('yields 0 when either leg has no rate', () => {
+    expect(convert(100, 'JPY', 'CHF')).toBe(0);
+    expect(convert(100, 'CHF', 'JPY')).toBe(0);
+  });
+});

--- a/src/services/currency/conversion.ts
+++ b/src/services/currency/conversion.ts
@@ -2,8 +2,15 @@
  * Currency Conversion Functions
  *
  * Synchronous conversion between BTC, sats, and fiat currencies.
+ *
+ * These read the in-memory `cache.rates`, which is seeded with sane defaults for
+ * every supported fiat (USD/EUR/CHF/GBP) and refreshed from the API. A missing
+ * rate therefore means an *unsupported* currency code — we must NOT fabricate a
+ * value. Fabricating is a money-correctness bug: `amount / 1` would render e.g.
+ * "100 CHF" as "100 BTC". For an unknown rate we fail safe to 0 and warn.
  */
 
+import { logger } from '@/utils/logger';
 import { cache } from './rates';
 
 const SATS_PER_BTC = 100_000_000;
@@ -27,7 +34,11 @@ export function convertBtcTo(amount: number, targetCurrency: string): number {
   if (targetCurrency === 'SATS') {
     return Math.round(amount * SATS_PER_BTC);
   }
-  const rate = cache.rates[`BTC_${targetCurrency}`] || 0;
+  const rate = cache.rates[`BTC_${targetCurrency}`];
+  if (!rate) {
+    logger.warn('No BTC rate for currency; cannot convert', { targetCurrency }, 'Currency');
+    return 0;
+  }
   return amount * rate;
 }
 
@@ -38,7 +49,12 @@ export function convertToBtc(amount: number, fromCurrency: string): number {
   if (fromCurrency === 'SATS') {
     return amount / SATS_PER_BTC;
   }
-  const rate = cache.rates[`BTC_${fromCurrency}`] || 1;
+  const rate = cache.rates[`BTC_${fromCurrency}`];
+  if (!rate) {
+    // Fail safe to 0 — never treat an unpriced fiat amount as if it were BTC.
+    logger.warn('No BTC rate for currency; cannot convert', { fromCurrency }, 'Currency');
+    return 0;
+  }
   return amount / rate;
 }
 


### PR DESCRIPTION
## What
`convertToBtc` previously fell back to `rate || 1`, silently treating an unpriced fiat amount as if it were BTC (e.g. rendering "100 CHF" as "100 BTC") — a money-correctness bug. `convertBtcTo`'s `|| 0` was the inconsistent mirror.

## Fix
Both functions detect a missing rate, `logger.warn`, and return `0` instead of fabricating a value. The rate cache is always seeded for every supported fiat (USD/EUR/CHF/GBP), so a missing rate can only mean an unsupported currency code.

## Tests
First unit coverage for the sync conversion module: BTC<->SATS, BTC<->fiat against the seeded cache, round-trip identity, missing-rate safe-failure. 15 tests, all green.

## Verify (local — CI billing-blocked)
type-check ✓ · lint ✓ · jest 15/15 ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)