### PR TITLE
a11y(nav): make header dropdown an accessible disclosure

### DIFF
--- a/__tests__/unit/components/layout/HeaderNavigation.a11y.test.tsx
+++ b/__tests__/unit/components/layout/HeaderNavigation.a11y.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Accessibility behavior for the header navigation dropdown (disclosure pattern).
+ *
+ * The trigger must advertise its expanded state and control relationship so
+ * screen-reader users know a button opens a menu, and Escape must close it.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { HeaderNavigation, type NavigationItem } from '@/components/layout/HeaderNavigation';
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: React.PropsWithChildren<React.AnchorHTMLAttributes<HTMLAnchorElement>>) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+const items: NavigationItem[] = [
+  {
+    name: 'Explore',
+    children: [
+      { name: 'Projects', href: '/projects', description: 'Fundraising' },
+      { name: 'Causes', href: '/causes' },
+    ],
+  },
+];
+
+describe('HeaderNavigation dropdown — a11y', () => {
+  it('trigger exposes haspopup and collapsed state initially', () => {
+    render(<HeaderNavigation items={items} isActive={() => false} />);
+    const trigger = screen.getByRole('button', { name: /explore/i });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'true');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveAttribute('aria-controls');
+  });
+
+  it('toggles aria-expanded and reveals the linked panel on click', () => {
+    render(<HeaderNavigation items={items} isActive={() => false} />);
+    const trigger = screen.getByRole('button', { name: /explore/i });
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // The panel referenced by aria-controls is now present and labelled.
+    const panelId = trigger.getAttribute('aria-controls')!;
+    const panel = document.getElementById(panelId);
+    expect(panel).toBeInTheDocument();
+    expect(panel).toHaveAttribute('aria-label', 'Explore');
+    expect(screen.getByText('Projects')).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    render(<HeaderNavigation items={items} isActive={() => false} />);
+    const trigger = screen.getByRole('button', { name: /explore/i });
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/src/components/layout/HeaderNavigation.tsx
+++ b/src/components/layout/HeaderNavigation.tsx
@@ -11,7 +11,7 @@
 
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useId } from 'react';
 import Link from 'next/link';
 import { ChevronDown, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -171,6 +171,9 @@ interface HeaderNavDropdownProps {
 function HeaderNavDropdown({ item, isActive }: HeaderNavDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  // Stable id linking the trigger (aria-controls) to the panel — disclosure pattern.
+  const panelId = useId();
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -180,12 +183,22 @@ function HeaderNavDropdown({ item, isActive }: HeaderNavDropdownProps) {
       }
     };
 
+    // Escape closes the panel and returns focus to the trigger (keyboard a11y).
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+
     if (isOpen) {
       document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleKeyDown);
     }
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isOpen]);
 
@@ -195,7 +208,11 @@ function HeaderNavDropdown({ item, isActive }: HeaderNavDropdownProps) {
   return (
     <div className="relative" ref={dropdownRef}>
       <button
+        ref={buttonRef}
         onClick={() => setIsOpen(!isOpen)}
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
         className={cn(
           'px-4 py-2.5 min-h-11 text-sm font-medium rounded-md transition-colors duration-150 relative flex items-center gap-1',
           hasActiveChild
@@ -204,12 +221,19 @@ function HeaderNavDropdown({ item, isActive }: HeaderNavDropdownProps) {
         )}
       >
         {item.name}
-        <ChevronDown className={cn('w-4 h-4 transition-transform', isOpen && 'rotate-180')} />
+        <ChevronDown
+          aria-hidden="true"
+          className={cn('w-4 h-4 transition-transform', isOpen && 'rotate-180')}
+        />
         {hasActiveChild && <div className="absolute inset-x-3 bottom-0 h-px bg-fg-primary" />}
       </button>
 
       {isOpen && (
-        <div className="absolute top-full left-0 mt-2 w-56 bg-surface-base rounded-lg shadow-sm border border-default py-2 z-50">
+        <div
+          id={panelId}
+          aria-label={item.name}
+          className="absolute top-full left-0 mt-2 w-56 bg-surface-base rounded-lg shadow-sm border border-default py-2 z-50"
+        >
           {item.children?.map((child, _index) => {
             // Skip children without href
             if (!child.href) {


### PR DESCRIPTION
## Problem
The header navigation dropdown trigger gave screen-reader users no signal that it opens a menu (no `aria-haspopup`/`aria-expanded`), and there was no keyboard way to dismiss it (Escape did nothing). This is on every page.

## Fix — WAI-ARIA disclosure pattern
Links navigate to pages, so the disclosure pattern fits (not the menu/actions pattern):
- `aria-haspopup`, `aria-expanded` reflecting open state, `aria-controls` linking the trigger to a labelled panel (`useId`)
- decorative chevron marked `aria-hidden`
- Escape closes the panel and returns focus to the trigger

## Tests
`__tests__/unit/components/layout/HeaderNavigation.a11y.test.tsx` — trigger ARIA attributes, expanded-state toggle, panel linkage, Escape dismissal. 3 tests green.

## Verify (local — CI billing-blocked)
type-check ✓ · lint ✓ · build ✓ · jest 3/3 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)