### PR TITLE
test(wallets): guard executeWalletTransfer + money-path coverage

### DIFF
--- a/__tests__/unit/domain/wallets/transferService.test.ts
+++ b/__tests__/unit/domain/wallets/transferService.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit coverage for executeWalletTransfer — the money-movement guard rails.
+ *
+ * The happy path and each failure code are exercised against a chainable
+ * supabase stub. The guard tests matter most: a non-positive amount or a
+ * same-wallet transfer must short-circuit BEFORE any balance-move RPC runs.
+ */
+
+import { executeWalletTransfer } from '@/domain/wallets/transferService';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/lib/api/auditLog', () => ({
+  auditSuccess: jest.fn().mockResolvedValue(undefined),
+  AUDIT_ACTIONS: { WALLET_BALANCE_REFRESHED: 'wallet.balance_refreshed' },
+}));
+
+const USER = 'user-1';
+const FROM = 'wallet-from';
+const TO = 'wallet-to';
+
+/**
+ * Chainable supabase stub. Each awaited builder chain and each single()/rpc()
+ * call shifts the next queued response, in consumption order.
+ */
+function makeSupabase(responses: Array<{ data?: unknown; error?: unknown }>) {
+  const queue = [...responses];
+  const next = () => (queue.length ? queue.shift()! : { data: null, error: null });
+
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'in', 'eq', 'insert', 'update']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  builder.single = jest.fn(() => Promise.resolve(next()));
+  // Make the builder thenable so `await from().select().in().eq()` resolves.
+  builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(next()).then(resolve, reject);
+
+  const rpc = jest.fn(() => Promise.resolve(next()));
+  return { client: { from: jest.fn(() => builder), rpc }, rpc };
+}
+
+const twoWallets = () => [
+  { id: FROM, user_id: USER, label: 'From', balance_btc: 1, profile_id: 'p1', project_id: null },
+  { id: TO, user_id: USER, label: 'To', balance_btc: 0, profile_id: 'p2', project_id: null },
+];
+
+describe('executeWalletTransfer — guards (no DB touched)', () => {
+  it('rejects a non-positive amount before any query', async () => {
+    const { client } = makeSupabase([]);
+    const res = await executeWalletTransfer(client, USER, FROM, TO, 0);
+    expect(res).toMatchObject({ ok: false, code: 'INVALID_AMOUNT' });
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('rejects a negative amount (would otherwise flow funds backwards)', async () => {
+    const { client } = makeSupabase([]);
+    const res = await executeWalletTransfer(client, USER, FROM, TO, -0.5);
+    expect(res).toMatchObject({ ok: false, code: 'INVALID_AMOUNT' });
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('rejects a same-wallet transfer', async () => {
+    const { client } = makeSupabase([]);
+    const res = await executeWalletTransfer(client, USER, FROM, FROM, 0.1);
+    expect(res).toMatchObject({ ok: false, code: 'SAME_WALLET' });
+    expect(client.from).not.toHaveBeenCalled();
+  });
+});
+
+describe('executeWalletTransfer — validated paths', () => {
+  it('returns NOT_FOUND when both wallets are not returned', async () => {
+    const { client } = makeSupabase([{ data: [{ id: FROM }], error: null }]);
+    const res = await executeWalletTransfer(client, USER, FROM, TO, 0.1);
+    expect(res).toMatchObject({ ok: false, code: 'NOT_FOUND' });
+  });
+
+  it('returns FORBIDDEN when a wallet belongs to another user', async () => {
+    const wallets = twoWallets();
+    wallets[1].user_id = 'someone-else';
+    const { client } = makeSupabase([{ data: wallets, error: null }]);
+    const res = await executeWalletTransfer(client, USER, FROM, TO, 0.1);
+    expect(res).toMatchObject({ ok: false, code: 'FORBIDDEN' });
+  });
+
+  it('returns INSUFFICIENT_BALANCE when amount exceeds balance', async () => {
+    const { client } = makeSupabase([{ data: twoWallets(), error: null }]);
+    const res = await executeWalletTransfer(client, USER, FROM, TO, 5);
+    expect(res).toMatchObject({ ok: false, code: 'INSUFFICIENT_BALANCE' });
+  });
+
+  it('completes the transfer and calls the balance-move RPC', async () => {
+    const { client, rpc } = makeSupabase([
+      { data: twoWallets(), error: null }, // wallets fetch
+      { data: { id: 'tx-1' }, error: null }, // transaction insert
+      { error: null }, // rpc
+      { data: twoWallets(), error: null }, // updated wallets fetch
+    ]);
+    const res = await executeWalletTransfer(client, USER, FROM, TO, 0.5, 'rent');
+    expect(res.ok).toBe(true);
+    expect(rpc).toHaveBeenCalledWith(
+      'transfer_between_wallets',
+      expect.objectContaining({
+        p_from_wallet_id: FROM,
+        p_to_wallet_id: TO,
+        p_amount_btc: 0.5,
+        p_transaction_id: 'tx-1',
+      })
+    );
+  });
+
+  it('returns UPDATE_ERROR and does not report success when the RPC fails', async () => {
+    const { client } = makeSupabase([
+      { data: twoWallets(), error: null },
+      { data: { id: 'tx-1' }, error: null },
+      { error: { message: 'rpc boom' } }, // rpc fails
+    ]);
+    const res = await executeWalletTransfer(client, USER, FROM, TO, 0.5);
+    expect(res).toMatchObject({ ok: false, code: 'UPDATE_ERROR' });
+  });
+});

--- a/src/app/api/wallets/transfer/route.ts
+++ b/src/app/api/wallets/transfer/route.ts
@@ -45,6 +45,9 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
 
     if (!result.ok) {
       switch (result.code) {
+        case 'INVALID_AMOUNT':
+        case 'SAME_WALLET':
+          return apiBadRequest(result.message);
         case 'NOT_FOUND':
           return apiNotFound(result.message);
         case 'FORBIDDEN':

--- a/src/domain/wallets/transferService.ts
+++ b/src/domain/wallets/transferService.ts
@@ -17,7 +17,14 @@ type TransferResult =
   | { ok: true; transaction: Record<string, unknown>; wallets: Wallet[] | null; message: string }
   | {
       ok: false;
-      code: 'NOT_FOUND' | 'FORBIDDEN' | 'INSUFFICIENT_BALANCE' | 'TX_ERROR' | 'UPDATE_ERROR';
+      code:
+        | 'INVALID_AMOUNT'
+        | 'SAME_WALLET'
+        | 'NOT_FOUND'
+        | 'FORBIDDEN'
+        | 'INSUFFICIENT_BALANCE'
+        | 'TX_ERROR'
+        | 'UPDATE_ERROR';
       message: string;
     };
 
@@ -29,6 +36,17 @@ export async function executeWalletTransfer(
   amountBtc: number,
   note?: string
 ): Promise<TransferResult> {
+  // Defense-in-depth: the API boundary validates these, but this service is also
+  // callable from CLI/jobs. A non-positive amount or a same-wallet transfer must
+  // never reach the balance-move RPC — a negative amount would flow funds the
+  // wrong direction (it passes the `balance < amount` check).
+  if (!Number.isFinite(amountBtc) || amountBtc <= 0) {
+    return { ok: false, code: 'INVALID_AMOUNT', message: 'Transfer amount must be positive' };
+  }
+  if (fromWalletId === toWalletId) {
+    return { ok: false, code: 'SAME_WALLET', message: 'Cannot transfer to the same wallet' };
+  }
+
   // Fetch both wallets and verify they exist
   const { data: walletsData, error: walletsError } = await (
     supabase.from(DATABASE_TABLES.WALLETS) as AnyClient


### PR DESCRIPTION
## Why
`executeWalletTransfer` is a domain service (reusable from CLI/jobs), but had **zero** unit coverage on money-movement logic. The API boundary validates amount/distinct-wallets, but the service itself trusted its inputs — a negative amount passes the `balance < amount` check and would flow funds *backwards* through the `transfer_between_wallets` RPC.

## Changes
- **Defense-in-depth guards** in the service: reject non-positive amount (`INVALID_AMOUNT`) and same-wallet transfer (`SAME_WALLET`) before any DB access. New codes mapped to 400 in the route (switch stays exhaustive).
- **First unit coverage**: guards (asserting no DB is touched), NOT_FOUND / FORBIDDEN / INSUFFICIENT_BALANCE, happy path (verifying RPC args), RPC-failure → UPDATE_ERROR. 8 tests green.

## Verify (local — CI billing-blocked)
type-check ✓ · lint ✓ · build ✓ · jest 8/8 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)