### PR TITLE
fix(notifications): stop double-fetch on mount and filter change

### DIFF
--- a/__tests__/unit/hooks/useNotifications.test.ts
+++ b/__tests__/unit/hooks/useNotifications.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression test for the notifications double-fetch.
+ *
+ * Bug: `offset` was state AND a dependency of `fetchNotifications`, which is
+ * itself a dependency of the load effect. The first reset-fetch called
+ * `setOffset(limit)`, changing `fetchNotifications`'s reference, which re-ran
+ * the effect and fetched page 1 a second time on every mount / filter change.
+ *
+ * Fix: `offset` became a ref, removing it from the callback deps. These tests
+ * lock in "exactly one list fetch on mount" and "filter change refetches once".
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useNotifications } from '@/hooks/useNotifications';
+import { API_ROUTES } from '@/config/api-routes';
+
+// Stable references — real useAuth returns a stable user across renders, so the
+// mock must too (a fresh object each render would itself retrigger the effect).
+const mockStableAuth = { user: { id: 'user-1' } };
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockStableAuth,
+}));
+jest.mock('@/hooks/useNotificationsRealtime', () => ({
+  useNotificationsRealtime: jest.fn(),
+}));
+jest.mock('@/hooks/useNotificationsMutations', () => ({
+  useNotificationsMutations: () => ({
+    markAsRead: jest.fn(),
+    deleteNotification: jest.fn(),
+    clearRead: jest.fn(),
+  }),
+}));
+
+const listUrl = (url: string) => url.startsWith(API_ROUTES.NOTIFICATIONS.BASE + '?');
+
+function mockFetch() {
+  return jest.fn((url: string) => {
+    if (url === API_ROUTES.NOTIFICATIONS.UNREAD) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ success: true, data: { count: 0 } }),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ success: true, data: { notifications: [], total: 0 } }),
+    });
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useNotifications — no double-fetch', () => {
+  it('fetches the notifications list exactly once on mount', async () => {
+    const fetchMock = mockFetch();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    renderHook(() => useNotifications());
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([url]) => listUrl(url as string)).length).toBeGreaterThan(
+        0
+      );
+    });
+    // Give any erroneous re-fetch effect a chance to fire before asserting.
+    await new Promise(r => setTimeout(r, 50));
+
+    const listCalls = fetchMock.mock.calls.filter(([url]) => listUrl(url as string));
+    expect(listCalls).toHaveLength(1);
+  });
+
+  it('refetches the list once when the filter changes', async () => {
+    const fetchMock = mockFetch();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { rerender } = renderHook(({ filter }) => useNotifications({ filter }), {
+      initialProps: { filter: 'all' },
+    });
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.filter(([url]) => listUrl(url as string)).length).toBe(1)
+    );
+
+    rerender({ filter: 'unread' });
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.filter(([url]) => listUrl(url as string)).length).toBe(2)
+    );
+    await new Promise(r => setTimeout(r, 50));
+    expect(fetchMock.mock.calls.filter(([url]) => listUrl(url as string))).toHaveLength(2);
+  });
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { logger } from '@/utils/logger';
 import { API_ROUTES } from '@/config/api-routes';
@@ -53,7 +53,11 @@ export function useNotifications(options: UseNotificationsOptions = {}) {
   const [unreadCount, setUnreadCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
-  const [offset, setOffset] = useState(0);
+  // Pagination cursor. A ref, not state: it is only read inside fetchNotifications
+  // and must NOT be a dependency of it — otherwise advancing the cursor recreates
+  // fetchNotifications, which is an effect dependency, re-running the load effect
+  // and double-fetching page 1 on every mount / filter change.
+  const offsetRef = useRef(0);
   const [total, setTotal] = useState(0);
 
   const fetchNotifications = useCallback(
@@ -66,7 +70,7 @@ export function useNotifications(options: UseNotificationsOptions = {}) {
         setIsLoading(true);
         setError(null);
 
-        const currentOffset = reset ? 0 : offset;
+        const currentOffset = reset ? 0 : offsetRef.current;
         const params = new URLSearchParams({
           limit: limit.toString(),
           offset: currentOffset.toString(),
@@ -86,10 +90,10 @@ export function useNotifications(options: UseNotificationsOptions = {}) {
 
         if (reset) {
           setNotifications(data.data.notifications);
-          setOffset(limit);
+          offsetRef.current = limit;
         } else {
           setNotifications(prev => [...prev, ...data.data.notifications]);
-          setOffset(prev => prev + limit);
+          offsetRef.current = currentOffset + limit;
         }
         setTotal(data.data.total);
       } catch (err) {
@@ -98,7 +102,7 @@ export function useNotifications(options: UseNotificationsOptions = {}) {
         setIsLoading(false);
       }
     },
-    [user, offset, limit, filter]
+    [user, limit, filter]
   );
 
   const fetchUnreadCount = useCallback(async () => {


### PR DESCRIPTION
## Bug
The notification panel fetched **page 1 twice** on every mount and every filter change.

`offset` was state *and* a dependency of `fetchNotifications`, which is itself a dependency of the load effect. The first reset-fetch ran `setOffset(limit)`, changing `fetchNotifications`'s reference → effect re-ran → page 1 fetched again. (It stabilized after one extra fetch, so wasteful rather than infinite.)

## Fix
`offset` is only read inside `fetchNotifications` and never returned, so it becomes a `useRef`. The callback no longer depends on it, so advancing the cursor no longer recreates the callback or re-runs the effect. `loadMore`/reset semantics unchanged.

## Test
`renderHook` regression test: exactly one list fetch on mount, one refetch per filter change. Fails on the old offset-as-state code.

## Verify (local — CI billing-blocked)
type-check ✓ · lint ✓ · build ✓ · jest 2/2 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)