### PR TITLE
test(payments): cover checkPaymentStatus access control + lifecycle

### DIFF
--- a/__tests__/unit/domain/payments/checkPaymentStatus.test.ts
+++ b/__tests__/unit/domain/payments/checkPaymentStatus.test.ts
@@ -1,0 +1,93 @@
+/**
+ * checkPaymentStatus — access control + lifecycle short-circuits.
+ *
+ * Security-relevant: only the buyer or seller of an intent may read its status.
+ * Lifecycle: terminal states return immediately, and an expired invoice flips
+ * to EXPIRED. Payment methods that require active relay/mempool checks are not
+ * exercised here (covered by their own services); these tests use a method that
+ * returns the current status without an external call.
+ */
+
+import { checkPaymentStatus } from '@/domain/payments/paymentFlowService';
+import { STATUS } from '@/config/database-constants';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/lib/email/send-seller-notification', () => ({
+  sendSellerPaymentNotification: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/services/notifications/dispatcher', () => ({
+  NotificationDispatcher: { dispatch: jest.fn().mockResolvedValue(undefined) },
+}));
+
+const PI_ID = 'pi-1';
+const BUYER = 'buyer-1';
+const SELLER = 'seller-1';
+
+function makeSupabase(intent: Record<string, unknown> | null) {
+  const update = jest.fn();
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'update', 'eq', 'in']) {
+    builder[m] = jest.fn((...args: unknown[]) => {
+      if (m === 'update') update(...args);
+      return builder;
+    });
+  }
+  builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
+  // Awaited update chains resolve cleanly.
+  builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve({ error: null }).then(resolve, reject);
+  return { client: { from: jest.fn(() => builder) } as never, update };
+}
+
+const baseIntent = {
+  id: PI_ID,
+  buyer_id: BUYER,
+  seller_id: SELLER,
+  status: STATUS.PAYMENT_INTENTS.INVOICE_READY,
+  payment_method: 'lightning_address', // no auto relay/mempool check
+  paid_at: null,
+  expires_at: null as string | null,
+};
+
+describe('checkPaymentStatus', () => {
+  it('throws when the intent does not exist', async () => {
+    const { client } = makeSupabase(null);
+    await expect(checkPaymentStatus(client, PI_ID, BUYER)).rejects.toThrow('Payment not found');
+  });
+
+  it('denies access to a third party', async () => {
+    const { client } = makeSupabase(baseIntent);
+    await expect(checkPaymentStatus(client, PI_ID, 'intruder')).rejects.toThrow('Access denied');
+  });
+
+  it('allows the seller to read status', async () => {
+    const { client } = makeSupabase(baseIntent);
+    const res = await checkPaymentStatus(client, PI_ID, SELLER);
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.INVOICE_READY);
+  });
+
+  it('returns terminal status immediately without writing', async () => {
+    const { client, update } = makeSupabase({
+      ...baseIntent,
+      status: STATUS.PAYMENT_INTENTS.PAID,
+      paid_at: 'ts',
+    });
+    const res = await checkPaymentStatus(client, PI_ID, BUYER);
+    expect(res).toEqual({ status: STATUS.PAYMENT_INTENTS.PAID, paid_at: 'ts' });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('flips an expired invoice to EXPIRED', async () => {
+    const { client, update } = makeSupabase({
+      ...baseIntent,
+      expires_at: '2000-01-01T00:00:00.000Z',
+    });
+    const res = await checkPaymentStatus(client, PI_ID, BUYER);
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.EXPIRED);
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: STATUS.PAYMENT_INTENTS.EXPIRED })
+    );
+  });
+});


### PR DESCRIPTION
## Why
`checkPaymentStatus` enforces that only the **buyer or seller** of an intent may read its status, and short-circuits terminal/expired states — all previously untested.

## Coverage
- intent not found → throws
- third party → `Access denied`
- seller may read status
- terminal status (PAID) returned immediately **without** a write
- expired invoice → flips to EXPIRED

Active relay/mempool paths are out of scope (own services); tests use `lightning_address` which returns current status without an external call.

## Verify (local — CI billing-blocked)
type-check ✓ · lint ✓ · full unit suite 538/538 ✓ (test-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)