### PR TITLE
a11y(header): announce notifications button as a dialog disclosure

### DIFF
--- a/__tests__/unit/components/layout/HeaderActions.a11y.test.tsx
+++ b/__tests__/unit/components/layout/HeaderActions.a11y.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * NotificationsButton — disclosure semantics for the bell that opens the
+ * notification center dialog. Screen-reader users must know the button opens a
+ * dialog and whether it's currently open.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { NotificationsButton } from '@/components/layout/HeaderActions';
+
+let mockUnreadCount = 0;
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('@/stores/messaging', () => ({ useUnreadCount: () => 0 }));
+jest.mock('@/hooks/useUnreadNotifications', () => ({
+  useUnreadNotifications: () => ({ count: mockUnreadCount }),
+}));
+
+beforeEach(() => {
+  mockUnreadCount = 0;
+});
+
+describe('NotificationsButton — a11y', () => {
+  it('advertises a dialog popup and collapsed state by default', () => {
+    render(<NotificationsButton onClick={() => {}} />);
+    const btn = screen.getByRole('button', { name: /notifications/i });
+    expect(btn).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('reflects the open state via aria-expanded', () => {
+    render(<NotificationsButton onClick={() => {}} isOpen />);
+    const btn = screen.getByRole('button', { name: /notifications/i });
+    expect(btn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('exposes the unread count in its accessible name', () => {
+    mockUnreadCount = 3;
+    render(<NotificationsButton onClick={() => {}} />);
+    expect(screen.getByRole('button', { name: /3 unread/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -134,7 +134,10 @@ export function Header({
 
             {/* Notifications - Always visible for authenticated users regardless of route */}
             {authStatus.authenticated && (
-              <NotificationsButton onClick={() => setShowNotifications(!showNotifications)} />
+              <NotificationsButton
+                onClick={() => setShowNotifications(!showNotifications)}
+                isOpen={showNotifications}
+              />
             )}
 
             {/* Theme Toggle */}

--- a/src/components/layout/HeaderActions.tsx
+++ b/src/components/layout/HeaderActions.tsx
@@ -35,7 +35,14 @@ export function MessagesButton() {
 /**
  * Notifications button with unread count
  */
-export function NotificationsButton({ onClick }: { onClick: () => void }) {
+export function NotificationsButton({
+  onClick,
+  isOpen = false,
+}: {
+  onClick: () => void;
+  /** Whether the notification center it controls is currently open. */
+  isOpen?: boolean;
+}) {
   const { count: unreadCount } = useUnreadNotifications();
 
   return (
@@ -44,6 +51,9 @@ export function NotificationsButton({ onClick }: { onClick: () => void }) {
       label={`Notifications ${unreadCount > 0 ? `(${unreadCount} unread)` : ''}`}
       onClick={onClick}
       badgeCount={unreadCount}
+      active={isOpen}
+      aria-haspopup="dialog"
+      aria-expanded={isOpen}
     />
   );
 }


### PR DESCRIPTION
## Gap
The header bell opens the notification center (a `Dialog`) but advertised nothing to assistive tech — no `aria-haspopup`, no open/closed state.

## Fix
`NotificationsButton` now sets `aria-haspopup="dialog"` and `aria-expanded` reflecting the open state (wired from Header's `showNotifications`), plus the pressed visual via the existing `active` prop. Consistent with the nav-dropdown disclosure pattern from #236. No primitive change needed — `HeaderIconButton` already spreads ARIA props.

## Tests
dialog-popup hint, expanded-state reflection, unread count in the accessible name. 3 tests green.

## Verify (local — CI billing-blocked)
type-check ✓ · lint ✓ · build ✓ · jest 3/3 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)