### PR TITLE
fix(payments): log order-update failure on confirmed-payment path

### DIFF
--- a/__tests__/unit/domain/payments/handlePaymentConfirmed.test.ts
+++ b/__tests__/unit/domain/payments/handlePaymentConfirmed.test.ts
@@ -1,0 +1,90 @@
+/**
+ * handlePaymentConfirmed (via the on-chain confirmed path of checkPaymentStatus).
+ *
+ * On a verified payment we must mark it PAID and advance the order — but a
+ * failed order update must NOT throw (the buyer's payment really succeeded and
+ * the terminal-status short-circuit means a retry won't re-run this). It must,
+ * however, be logged loudly for reconciliation rather than failing silently.
+ */
+
+import { checkPaymentStatus } from '@/domain/payments/paymentFlowService';
+import { STATUS } from '@/config/database-constants';
+import { logger } from '@/utils/logger';
+import { checkOnchainPaymentStatus } from '@/domain/payments/paymentStatusService';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/lib/email/send-seller-notification', () => ({
+  sendSellerPaymentNotification: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/services/notifications/dispatcher', () => ({
+  NotificationDispatcher: { dispatch: jest.fn().mockResolvedValue(undefined) },
+}));
+jest.mock('@/domain/payments/paymentStatusService', () => ({
+  checkNWCPaymentStatus: jest.fn(),
+  checkOnchainPaymentStatus: jest.fn(),
+}));
+
+const errorMock = logger.error as jest.Mock;
+const onchainMock = checkOnchainPaymentStatus as jest.Mock;
+
+const PI_ID = 'pi-1';
+const BUYER = 'buyer-1';
+
+const onchainIntent = {
+  id: PI_ID,
+  buyer_id: BUYER,
+  seller_id: 'seller-1',
+  status: STATUS.PAYMENT_INTENTS.INVOICE_READY,
+  payment_method: 'onchain',
+  onchain_address: 'bc1qxyz',
+  entity_type: 'product', // fixed_price
+  entity_id: 'prod-1',
+  amount_btc: 0.01,
+  description: 'Product: Blue Mug',
+  paid_at: null,
+  expires_at: null,
+};
+
+/**
+ * single() -> the intent. Awaited builder chains resolve from a queue in order:
+ *   [ intent status update, order update ].  rpc() resolves cleanly.
+ */
+function makeSupabase(orderUpdateError: unknown) {
+  const awaitQueue: Array<{ error: unknown }> = [{ error: null }, { error: orderUpdateError }];
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'update', 'eq', 'in']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  builder.single = jest.fn(() => Promise.resolve({ data: onchainIntent, error: null }));
+  builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(awaitQueue.shift() ?? { error: null }).then(resolve, reject);
+  const rpc = jest.fn(() => Promise.resolve({ error: null }));
+  return { from: jest.fn(() => builder), rpc } as never;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  onchainMock.mockResolvedValue('confirmed');
+});
+
+describe('handlePaymentConfirmed via checkPaymentStatus (onchain confirmed)', () => {
+  it('returns PAID on a confirmed on-chain payment', async () => {
+    const supabase = makeSupabase(null);
+    const res = await checkPaymentStatus(supabase, PI_ID, BUYER);
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
+  });
+
+  it('does not throw but logs for reconciliation when the order update fails', async () => {
+    const supabase = makeSupabase({ message: 'db down' });
+    const res = await checkPaymentStatus(supabase, PI_ID, BUYER);
+    // Payment succeeded — must still report PAID to the buyer.
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
+    // ...but the stuck order must be logged loudly.
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.stringContaining('reconciliation'),
+      expect.objectContaining({ paymentIntentId: PI_ID })
+    );
+  });
+});

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -397,11 +397,23 @@ async function handlePaymentConfirmed(
   const meta = getEntityMetadata(entityType);
 
   if (meta.paymentPattern === 'fixed_price') {
-    // Update order status
-    await supabase
+    // Update order status. The payment is already verified+paid, so we must NOT
+    // throw here (that would 500 the buyer's status check after a successful
+    // payment, and the terminal-status short-circuit means a retry wouldn't
+    // re-run this anyway). But a silent failure left the order stuck in
+    // pending_payment with no trace — log it loudly so it can be reconciled.
+    const { error: orderError } = await supabase
       .from(DATABASE_TABLES.ORDERS)
       .update({ status: STATUS.ORDERS.PAID })
       .eq('payment_intent_id', piId);
+    if (orderError) {
+      logger.error('Order status update failed after confirmed payment — needs reconciliation', {
+        paymentIntentId: piId,
+        entityType,
+        entityId,
+        error: orderError,
+      });
+    }
 
     // Decrement inventory (atomic — prevents overselling)
     await supabase


### PR DESCRIPTION
## Bug
`handlePaymentConfirmed` (the **verified** NWC/on-chain path) updated the order status without checking the result — a failed write left the order stuck in `pending_payment` with **no trace** (not even a log). This is the sibling of #239, which fixed the trust-based `buyerConfirmPayment` path but didn't touch this one.

## Why log, not throw
Unlike `buyerConfirmPayment`, the payment here is already verified + marked paid. Throwing would 500 the buyer's status check *after* a successful payment, and the terminal-status short-circuit means a retry wouldn't re-run this anyway. So the order error is logged loudly for reconciliation while the buyer correctly sees PAID. (Inventory decrement was already non-fatal-by-design.)

## Tests
On-chain confirmed path: returns PAID on success; on order-update error still returns PAID **and** logs a reconciliation error. 2 tests green.

## Verify (local — CI billing-blocked)
type-check ✓ · lint ✓ · build ✓ · jest 2/2 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)