### PR TITLE
feat(public): entities collect BTC, with consistent funding & dual-currency pricing

### DIFF
--- a/__tests__/unit/domain/payments/resolveSellerWallet.test.ts
+++ b/__tests__/unit/domain/payments/resolveSellerWallet.test.ts
@@ -1,0 +1,171 @@
+/**
+ * resolveSellerWallet — entity-linked wallet precedence.
+ *
+ * An owner may have several wallets and tie a specific one to an entity via
+ * entity_wallets. That link MUST win over the owner's profile-default wallet, so
+ * funds go where the owner chose for that entity. When no (usable) link exists,
+ * resolution falls back to the owner's primary profile wallet.
+ */
+
+import { resolveSellerWallet } from '@/domain/payments/walletResolutionService';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { DATABASE_TABLES } from '@/config/database-tables';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
+// decrypt is identity here — we only assert which wallet is chosen, not crypto.
+jest.mock('@/domain/payments/encryptionService', () => ({ decrypt: (s: string) => s }));
+
+const getAdminClientMock = getAdminClient as jest.Mock;
+
+interface Fixtures {
+  entityWallets: Array<{ wallet_id: string; is_primary: boolean }>;
+  walletsById: Record<string, Record<string, unknown>>;
+  entity: Record<string, unknown> | null;
+  actor: Record<string, unknown> | null;
+  userWallets: Array<Record<string, unknown>>;
+}
+
+/**
+ * Table-aware fake. `.single()` resolves a one-row lookup; `.order()` is the
+ * terminal for list queries and returns a thenable that is itself re-orderable
+ * (resolveUserWallet chains two .order() calls).
+ */
+function makeAdmin(fx: Fixtures) {
+  function from(table: string) {
+    const filters: Record<string, unknown> = {};
+    const listResult = {
+      order: () => listResult,
+      then: (res: (v: unknown) => unknown, rej: (e: unknown) => unknown) => {
+        const data =
+          table === DATABASE_TABLES.ENTITY_WALLETS
+            ? fx.entityWallets
+            : table === DATABASE_TABLES.WALLETS
+              ? fx.userWallets
+              : [];
+        return Promise.resolve({ data, error: null }).then(res, rej);
+      },
+    };
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: (col: string, val: unknown) => {
+        filters[col] = val;
+        return builder;
+      },
+      in: () => builder,
+      order: () => listResult,
+      single: () => {
+        let data: unknown = null;
+        if (table === DATABASE_TABLES.WALLETS) {
+          data = fx.walletsById[filters.id as string] ?? null;
+        } else if (table === DATABASE_TABLES.ACTORS) {
+          data = fx.actor;
+        } else {
+          data = fx.entity; // entity table (e.g. user_products)
+        }
+        return Promise.resolve({ data, error: null });
+      },
+    };
+    return builder;
+  }
+  return { from } as never;
+}
+
+const ENTITY = { entity_type: 'product' as const, entity_id: 'prod-1' };
+
+function baseFixtures(): Fixtures {
+  return {
+    entityWallets: [],
+    walletsById: {},
+    entity: { id: 'prod-1', actor_id: 'actor-1' },
+    actor: { actor_type: 'user', user_id: 'user-1', group_id: null },
+    userWallets: [
+      {
+        id: 'w-primary',
+        nwc_connection_uri: null,
+        lightning_address: null,
+        address_or_xpub: 'bc1-primary',
+        wallet_type: 'onchain',
+        is_primary: true,
+      },
+    ],
+  };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('resolveSellerWallet — entity-linked wallet precedence', () => {
+  it('uses the wallet tied to the entity over the profile default', async () => {
+    const fx = baseFixtures();
+    fx.entityWallets = [{ wallet_id: 'w-linked', is_primary: true }];
+    fx.walletsById = {
+      'w-linked': {
+        id: 'w-linked',
+        nwc_connection_uri: null,
+        lightning_address: null,
+        address_or_xpub: 'bc1-linked',
+      },
+    };
+    getAdminClientMock.mockReturnValue(makeAdmin(fx));
+
+    const resolved = await resolveSellerWallet({} as never, ENTITY.entity_type, ENTITY.entity_id);
+
+    expect(resolved).toEqual({
+      method: 'onchain',
+      wallet_id: 'w-linked',
+      onchain_address: 'bc1-linked',
+    });
+  });
+
+  it('honours the linked wallet method priority (Lightning over on-chain)', async () => {
+    const fx = baseFixtures();
+    fx.entityWallets = [{ wallet_id: 'w-linked', is_primary: true }];
+    fx.walletsById = {
+      'w-linked': {
+        id: 'w-linked',
+        nwc_connection_uri: null,
+        lightning_address: 'me@ln.example',
+        address_or_xpub: 'bc1-linked',
+      },
+    };
+    getAdminClientMock.mockReturnValue(makeAdmin(fx));
+
+    const resolved = await resolveSellerWallet({} as never, ENTITY.entity_type, ENTITY.entity_id);
+
+    expect(resolved).toEqual({
+      method: 'lightning_address',
+      wallet_id: 'w-linked',
+      lightning_address: 'me@ln.example',
+    });
+  });
+
+  it('falls back to the primary profile wallet when no link exists', async () => {
+    const fx = baseFixtures(); // entityWallets empty
+    getAdminClientMock.mockReturnValue(makeAdmin(fx));
+
+    const resolved = await resolveSellerWallet({} as never, ENTITY.entity_type, ENTITY.entity_id);
+
+    expect(resolved).toEqual({
+      method: 'onchain',
+      wallet_id: 'w-primary',
+      onchain_address: 'bc1-primary',
+    });
+  });
+
+  it('falls back to the primary wallet when the linked wallet is inactive/missing', async () => {
+    const fx = baseFixtures();
+    fx.entityWallets = [{ wallet_id: 'w-gone', is_primary: true }];
+    fx.walletsById = {}; // linked wallet not active → single() returns null
+    getAdminClientMock.mockReturnValue(makeAdmin(fx));
+
+    const resolved = await resolveSellerWallet({} as never, ENTITY.entity_type, ENTITY.entity_id);
+
+    expect(resolved).toEqual({
+      method: 'onchain',
+      wallet_id: 'w-primary',
+      onchain_address: 'bc1-primary',
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9407,9 +9407,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -11747,9 +11747,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -14538,10 +14538,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/src/app/ai-assistants/[id]/page.tsx
+++ b/src/app/ai-assistants/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import Image from 'next/image';
 import { generateEntityMetadata } from '@/lib/seo/metadata';
 import PublicEntityDetailPage, {
   fetchEntityForMetadata,
@@ -37,6 +38,17 @@ const config: EntityDetailConfig = {
   descriptionTitle: 'About this AI Assistant',
   metadataSelect: 'title, description, avatar_url',
   getViewRoute: id => ROUTES.AI_ASSISTANTS.VIEW(id),
+  renderHeaderIcon: entity =>
+    entity.avatar_url ? (
+      <Image
+        src={entity.avatar_url as string}
+        alt={(entity.title as string) || 'AI assistant'}
+        width={64}
+        height={64}
+        className="w-16 h-16 rounded-lg object-cover flex-shrink-0"
+        unoptimized
+      />
+    ) : undefined,
   renderHeaderExtra: entity => {
     if (!entity.category) {
       return null;

--- a/src/app/ai-assistants/[id]/page.tsx
+++ b/src/app/ai-assistants/[id]/page.tsx
@@ -6,11 +6,30 @@ import PublicEntityDetailPage, {
 } from '@/components/public/PublicEntityDetailPage';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/badge';
+import PriceDisplay from '@/components/public/PriceDisplay';
 import { ROUTES } from '@/config/routes';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
+
+// ai_assistants price by pricing_model, stored in BTC (no currency column;
+// the sats→BTC migration dropped the _sats suffix and converted values).
+const AI_PRICE_BY_MODEL: Record<string, { column: string; suffix: string }> = {
+  per_message: { column: 'price_per_message', suffix: ' / message' },
+  per_token: { column: 'price_per_1k_tokens', suffix: ' / 1k tokens' },
+  subscription: { column: 'subscription_price', suffix: ' / month' },
+};
+
+const getAiPricing = (entity: Record<string, unknown>) => {
+  const model = (entity.pricing_model as string) || 'free';
+  if (model === 'free') {
+    return { isFree: true, amount: 0, suffix: '' };
+  }
+  const spec = AI_PRICE_BY_MODEL[model];
+  const amount = spec ? Number(entity[spec.column] ?? 0) : 0;
+  return { isFree: false, amount, suffix: spec?.suffix ?? '' };
+};
 
 const config: EntityDetailConfig = {
   entityType: 'ai_assistant',
@@ -34,9 +53,25 @@ const config: EntityDetailConfig = {
       ? entity.personality_traits
       : [];
     const welcome = entity.welcome_message as string | null | undefined;
+    const pricing = getAiPricing(entity);
 
     return (
       <>
+        {(pricing.isFree || pricing.amount > 0) && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Pricing</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {pricing.isFree ? (
+                <p className="text-2xl font-bold text-fg-primary">Free</p>
+              ) : (
+                <PriceDisplay amount={pricing.amount} currency="BTC" suffix={pricing.suffix} />
+              )}
+            </CardContent>
+          </Card>
+        )}
+
         {welcome && (
           <Card>
             <CardHeader>

--- a/src/app/api/payments/receive-info/route.ts
+++ b/src/app/api/payments/receive-info/route.ts
@@ -1,0 +1,57 @@
+/**
+ * GET /api/payments/receive-info?entity_type=X&entity_id=Y
+ *
+ * Owner-facing: returns display-safe info about where an entity collects funds
+ * (which payment method + a Lightning/on-chain address, never an NWC secret),
+ * resolved via the SAME path the payment flow uses (SSOT). Gated to the entity
+ * owner — buyers learn the address from the invoice, not from this endpoint.
+ */
+
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import {
+  apiSuccess,
+  apiBadRequest,
+  apiForbidden,
+  apiInternalError,
+} from '@/lib/api/standardResponse';
+import { resolveSellerReceiveInfo, getSellerUserId } from '@/domain/payments';
+import { ENTITY_TYPES, type EntityType } from '@/config/entity-registry';
+import { logger } from '@/utils/logger';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  try {
+    const { user, supabase } = request;
+    const searchParams = request.nextUrl.searchParams;
+    const entityType = searchParams.get('entity_type');
+    const entityId = searchParams.get('entity_id');
+
+    if (!entityType || !entityId) {
+      return apiBadRequest('entity_type and entity_id are required');
+    }
+    if (!UUID_REGEX.test(entityId)) {
+      return apiBadRequest('entity_id must be a valid UUID');
+    }
+    if (!ENTITY_TYPES.includes(entityType as EntityType)) {
+      return apiBadRequest(`entity_type must be one of: ${ENTITY_TYPES.join(', ')}`);
+    }
+
+    // Owner-only: the receiving address is the owner's to inspect.
+    const sellerUserId = await getSellerUserId(supabase, entityType as EntityType, entityId);
+    if (!sellerUserId || sellerUserId !== user.id) {
+      return apiForbidden('Only the owner can view receiving info for this entity');
+    }
+
+    const info = await resolveSellerReceiveInfo(supabase, entityType as EntityType, entityId);
+
+    return apiSuccess({
+      hasWallet: !!info,
+      method: info?.method ?? null,
+      address: info?.address ?? null,
+    });
+  } catch (error) {
+    logger.error('Failed to resolve receive info', { error });
+    return apiInternalError('Failed to resolve receiving info');
+  }
+});

--- a/src/app/causes/[id]/page.tsx
+++ b/src/app/causes/[id]/page.tsx
@@ -4,10 +4,8 @@ import PublicEntityDetailPage, {
   fetchEntityForMetadata,
   type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
-import { Progress } from '@/components/ui/progress';
+import FundingProgress from '@/components/public/FundingProgress';
 import { ROUTES } from '@/config/routes';
-import { formatCurrency } from '@/services/currency';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -43,29 +41,9 @@ const config: EntityDetailConfig = {
   },
   renderDetails: entity => {
     const { goal, raised, currency } = causeFunding(entity);
-    if (goal <= 0) {
-      return null;
-    }
-    const progress = Math.round((raised / goal) * 100);
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Funding Progress</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex justify-between items-center">
-            <span className="text-sm text-fg-secondary">
-              {formatCurrency(raised, currency)} raised
-            </span>
-            <span className="font-bold text-lg text-fg-primary">
-              {formatCurrency(goal, currency)} goal
-            </span>
-          </div>
-          <Progress value={progress} className="h-2" />
-          <p className="text-sm text-fg-secondary">{progress}% funded</p>
-        </CardContent>
-      </Card>
-    );
+    // Always render — a cause with no goal set must still show an inviting
+    // funding state, never a blank page. FundingProgress owns that decision.
+    return <FundingProgress raised={raised} goal={goal} currency={currency} />;
   },
 };
 

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -21,6 +21,10 @@ const config: EntityDetailConfig = {
   backHref: '/events',
   metadataSelect: 'title, description, start_date, location',
   getViewRoute: id => ROUTES.EVENTS.VIEW(id),
+  getCoverImages: entity => {
+    const images = Array.isArray(entity.images) ? (entity.images as string[]) : [];
+    return [entity.banner_url as string, entity.thumbnail_url as string, ...images].filter(Boolean);
+  },
   getJsonLdExtra: entity => ({
     ...(entity.start_date && { startDate: entity.start_date }),
     ...(entity.end_date && { endDate: entity.end_date }),

--- a/src/app/investments/[id]/page.tsx
+++ b/src/app/investments/[id]/page.tsx
@@ -5,8 +5,8 @@ import PublicEntityDetailPage, {
   type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
-import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
+import FundingProgress from '@/components/public/FundingProgress';
 import { ROUTES } from '@/config/routes';
 import { formatCurrency } from '@/services/currency';
 import { INVESTMENT_TYPE_LABELS, INVESTMENT_RISK_COLORS } from '@/config/investments';
@@ -40,33 +40,13 @@ const config: EntityDetailConfig = {
     }),
   }),
   renderDetails: entity => {
-    const progress =
-      entity.target_amount && entity.total_raised
-        ? Math.min(
-            Math.round((Number(entity.total_raised) / Number(entity.target_amount)) * 100),
-            100
-          )
-        : 0;
-
     return (
       <div className="space-y-4">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Funding Progress</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex justify-between items-center">
-              <span className="text-sm text-fg-secondary">
-                {invFmt(entity, entity.total_raised)} raised
-              </span>
-              <span className="font-bold text-lg text-fg-primary">
-                {invFmt(entity, entity.target_amount)} goal
-              </span>
-            </div>
-            <Progress value={progress} className="h-2" />
-            <p className="text-sm text-fg-secondary">{progress}% funded</p>
-          </CardContent>
-        </Card>
+        <FundingProgress
+          raised={Number(entity.total_raised ?? 0)}
+          goal={Number(entity.target_amount ?? 0)}
+          currency={(entity.currency as string) || 'BTC'}
+        />
 
         <Card>
           <CardHeader>

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -26,6 +26,10 @@ const config: EntityDetailConfig = {
   ownerLabel: 'Seller',
   createdLabel: 'Listed',
   getViewRoute: id => ROUTES.PRODUCTS.VIEW(id),
+  getCoverImages: entity => {
+    const images = Array.isArray(entity.images) ? (entity.images as string[]) : [];
+    return [...images, entity.thumbnail_url as string].filter(Boolean);
+  },
   getPrice: entity => {
     const { amount, currency } = getPrice(entity);
     return Number.isFinite(amount) && amount > 0 ? { amount, currency } : null;

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -5,8 +5,8 @@ import PublicEntityDetailPage, {
   type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import PriceDisplay from '@/components/public/PriceDisplay';
 import { ROUTES } from '@/config/routes';
-import { formatCurrency } from '@/services/currency';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -44,7 +44,7 @@ const config: EntityDetailConfig = {
           <CardTitle className="text-lg">Price</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-2xl font-bold text-fg-primary">{formatCurrency(amount, currency)}</p>
+          <PriceDisplay amount={amount} currency={currency} />
         </CardContent>
       </Card>
     ) : null;

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -26,6 +26,10 @@ const config: EntityDetailConfig = {
   ownerLabel: 'Seller',
   createdLabel: 'Listed',
   getViewRoute: id => ROUTES.PRODUCTS.VIEW(id),
+  getPrice: entity => {
+    const { amount, currency } = getPrice(entity);
+    return Number.isFinite(amount) && amount > 0 ? { amount, currency } : null;
+  },
   getJsonLdExtra: entity => {
     const { amount, currency } = getPrice(entity);
     return amount > 0

--- a/src/app/profiles/[username]/page.tsx
+++ b/src/app/profiles/[username]/page.tsx
@@ -291,6 +291,12 @@ export default async function PublicProfilePage({ params }: PageProps) {
   } = await supabase.auth.getUser();
   const isOwnProfile = !!currentUser && currentUser.id === profile.id;
 
+  // The `email` column is the account login email — private. `select('*')` pulls
+  // it into the row, which would otherwise ship to every visitor's client
+  // payload. Redact it for non-owners so it never leaves the server. (phone /
+  // contact_email are opt-in public fields and stay.)
+  const safeProfile = isOwnProfile ? profile : { ...profile, email: null };
+
   // Pass data to client component for interactivity
   return (
     <>
@@ -300,7 +306,7 @@ export default async function PublicProfilePage({ params }: PageProps) {
         dangerouslySetInnerHTML={{ __html: safeJsonLdString(structuredData) }}
       />
       <ProfilePageClient
-        profile={profile}
+        profile={safeProfile}
         projects={projects || []}
         isOwnProfile={isOwnProfile}
         stats={{

--- a/src/app/research/[id]/page.tsx
+++ b/src/app/research/[id]/page.tsx
@@ -6,9 +6,8 @@ import PublicEntityDetailPage, {
 } from '@/components/public/PublicEntityDetailPage';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/badge';
-import { Progress } from '@/components/ui/progress';
+import FundingProgress from '@/components/public/FundingProgress';
 import { ROUTES } from '@/config/routes';
-import { displayBTC } from '@/services/currency';
 import { RESEARCH_FIELDS, METHODOLOGIES, TIMELINES } from '@/config/research';
 
 interface PageProps {
@@ -38,30 +37,10 @@ const config: EntityDetailConfig = {
   renderDetails: entity => {
     const fundingGoal = Number(entity.funding_goal_btc ?? entity.funding_goal ?? 0);
     const fundingRaised = Number(entity.funding_raised_btc ?? 0);
-    const progress = fundingGoal > 0 ? Math.round((fundingRaised / fundingGoal) * 100) : 0;
 
     return (
       <>
-        {/* Funding Progress */}
-        {fundingGoal > 0 && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Funding Progress</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-fg-secondary">
-                  {displayBTC(fundingRaised)} raised
-                </span>
-                <span className="font-bold text-lg text-fg-primary">
-                  {displayBTC(fundingGoal)} goal
-                </span>
-              </div>
-              <Progress value={progress} className="h-2" />
-              <p className="text-sm text-fg-secondary">{progress}% funded</p>
-            </CardContent>
-          </Card>
-        )}
+        <FundingProgress raised={fundingRaised} goal={fundingGoal} currency="BTC" />
 
         {/* Research Details */}
         <Card>

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -36,6 +36,10 @@ const config: EntityDetailConfig = {
   createdLabel: 'Listed',
   descriptionTitle: 'About this Service',
   getViewRoute: id => ROUTES.SERVICES.VIEW(id),
+  getPrice: entity => {
+    const { amount, currency } = getServicePrice(entity);
+    return amount > 0 ? { amount, currency } : null;
+  },
   getJsonLdExtra: entity => {
     const { amount, currency } = getServicePrice(entity);
     return {

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -5,8 +5,8 @@ import PublicEntityDetailPage, {
   type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import PriceDisplay from '@/components/public/PriceDisplay';
 import { ROUTES } from '@/config/routes';
-import { formatCurrency } from '@/services/currency';
 import { BookEntityButton } from '@/components/bookings/BookEntityButton';
 
 interface PageProps {
@@ -59,12 +59,14 @@ const config: EntityDetailConfig = {
         </CardHeader>
         <CardContent className="space-y-4">
           {amount > 0 && (
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between gap-4">
               <span className="text-fg-secondary">Price</span>
-              <span className="text-xl font-bold text-fg-primary">
-                {formatCurrency(amount, currency)}
-                {perHour ? ' / hr' : ''}
-              </span>
+              <PriceDisplay
+                amount={amount}
+                currency={currency}
+                className="text-xl font-bold text-fg-primary text-right"
+                suffix={perHour ? ' / hr' : undefined}
+              />
             </div>
           )}
           {durationMinutes && (

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -36,6 +36,8 @@ const config: EntityDetailConfig = {
   createdLabel: 'Listed',
   descriptionTitle: 'About this Service',
   getViewRoute: id => ROUTES.SERVICES.VIEW(id),
+  getCoverImages: entity =>
+    (Array.isArray(entity.images) ? (entity.images as string[]) : []).filter(Boolean),
   getPrice: entity => {
     const { amount, currency } = getServicePrice(entity);
     return amount > 0 ? { amount, currency } : null;

--- a/src/app/wishlists/[id]/page.tsx
+++ b/src/app/wishlists/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Gift } from 'lucide-react';
 import { createServerClient } from '@/lib/supabase/server';
 import { generateEntityMetadata } from '@/lib/seo/metadata';
 import { DATABASE_TABLES } from '@/config/database-tables';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Card, CardContent } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/badge';
 import { displayBTC } from '@/services/currency/formatting';
 import { Progress } from '@/components/ui/progress';
@@ -12,6 +12,7 @@ import PublicEntityDetailPage, {
   fetchEntityForMetadata,
   type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
+import FundingProgress from '@/components/public/FundingProgress';
 import { WISHLIST_TYPE_LABELS } from '@/config/wishlists';
 import type { Database } from '@/types/database';
 
@@ -63,7 +64,6 @@ export default async function PublicWishlistPage({ params }: PageProps) {
   const items = (itemsData || []) as WishlistItem[];
   const totalTarget = items.reduce((sum, item) => sum + (item.target_amount_btc || 0), 0);
   const totalFunded = items.reduce((sum, item) => sum + (item.funded_amount_btc || 0), 0);
-  const overallProgress = totalTarget > 0 ? Math.round((totalFunded / totalTarget) * 100) : 0;
 
   const config: EntityDetailConfig = {
     entityType: 'wishlist',
@@ -108,20 +108,16 @@ export default async function PublicWishlistPage({ params }: PageProps) {
     ),
     renderDetails: () => (
       <>
-        {items.length > 0 && totalTarget > 0 && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Overall Progress</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              <div className="flex justify-between text-sm text-fg-secondary">
-                <span>{displayBTC(totalFunded)} funded</span>
-                <span>{displayBTC(totalTarget)} total</span>
-              </div>
-              <Progress value={overallProgress} className="h-2" />
-              <p className="text-sm text-fg-secondary">{overallProgress}% of total goal</p>
-            </CardContent>
-          </Card>
+        {items.length > 0 && (
+          <FundingProgress
+            title="Overall Progress"
+            raised={totalFunded}
+            goal={totalTarget}
+            currency="BTC"
+            raisedLabel="funded"
+            goalLabel="total"
+            hideWhenEmpty
+          />
         )}
 
         {items.length > 0 ? (

--- a/src/components/bookings/BookEntityDialog.tsx
+++ b/src/components/bookings/BookEntityDialog.tsx
@@ -34,7 +34,6 @@ import {
 import Button from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
-import { formatCurrency } from '@/services/currency';
 
 export interface BookEntityDialogProps {
   isOpen: boolean;
@@ -75,11 +74,7 @@ export function BookEntityDialog({
   priceCurrency,
   durationMinutes,
 }: BookEntityDialogProps) {
-  const { formatAmountBtc } = useDisplayCurrency();
-  const renderPrice = (amount: number) =>
-    priceCurrency && priceCurrency.toUpperCase() !== 'BTC'
-      ? formatCurrency(amount, priceCurrency)
-      : formatAmountBtc(amount);
+  const { formatPrice } = useDisplayCurrency();
   const [startsAtLocal, setStartsAtLocal] = useState('');
   const [endsAtLocal, setEndsAtLocal] = useState('');
   const [notes, setNotes] = useState('');
@@ -162,7 +157,10 @@ export function BookEntityDialog({
             Send a booking request to the provider. They&apos;ll confirm or reject.
             {typeof priceBtc === 'number' && priceBtc > 0 && (
               <span className="mt-1 block text-sm">
-                Price: <span className="font-medium text-fg-primary">{renderPrice(priceBtc)}</span>
+                Price:{' '}
+                <span className="font-medium text-fg-primary">
+                  {formatPrice(priceBtc, priceCurrency)}
+                </span>
                 {hasDuration && ` · ${durationMinutes} min`}
               </span>
             )}

--- a/src/components/create/wallet-selector/WalletSelectorField.tsx
+++ b/src/components/create/wallet-selector/WalletSelectorField.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Wallet as WalletIcon, PenLine, Loader2 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { Input } from '@/components/ui/Input';
@@ -70,6 +70,31 @@ export function WalletSelectorField({
   useEffect(() => {
     fetchWallets();
   }, [fetchWallets]);
+
+  // Pre-select the user's primary wallet once loaded so an existing address is
+  // tied to the entity by default (they can switch or enter another). Without
+  // this, a user who has a wallet but never clicks a card creates an entity with
+  // no explicit link — and may not realise their address could be attached.
+  const didPreselect = useRef(false);
+  useEffect(() => {
+    if (didPreselect.current || wallets.length === 0) {
+      return;
+    }
+    didPreselect.current = true;
+
+    // Honour an existing selection (edit mode) instead of overriding it.
+    if (formData._wallet_id) {
+      setSelectedWalletId(formData._wallet_id as string);
+      return;
+    }
+
+    const primary = wallets.find(w => w.is_primary) ?? wallets[0];
+    setSelectedWalletId(primary.id);
+    onFieldChange('bitcoin_address', primary.address_or_xpub);
+    onFieldChange('lightning_address', primary.lightning_address || '');
+    onFieldChange('_wallet_id', primary.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once after wallets load
+  }, [wallets]);
 
   const handleSelectWallet = (wallet: Wallet) => {
     setSelectedWalletId(wallet.id);

--- a/src/components/entity/variants/InvestmentCard.tsx
+++ b/src/components/entity/variants/InvestmentCard.tsx
@@ -85,7 +85,13 @@ export function InvestmentCard({ investment, viewMode = 'grid' }: InvestmentCard
           <div className="space-y-2">
             <div className="flex justify-between items-center">
               <span className="text-sm text-fg-secondary">Raised</span>
-              <span className="font-semibold text-status-positive">
+              {/* Green only when something's actually been raised — a zero
+                  rendered green reads as a positive metric it isn't. */}
+              <span
+                className={`font-semibold ${
+                  Number(investment.total_raised) > 0 ? 'text-status-positive' : 'text-fg-primary'
+                }`}
+              >
                 {formatAmount(investment.total_raised)}
               </span>
             </div>

--- a/src/components/groups/GroupWallets.tsx
+++ b/src/components/groups/GroupWallets.tsx
@@ -330,7 +330,15 @@ export function GroupWallets({
                         <div className="flex items-center gap-2">
                           <div>
                             <div className="text-sm text-fg-secondary">Balance</div>
-                            <div className="text-lg font-bold text-status-positive">
+                            {/* Green only for a non-zero balance — a zero
+                                rendered green reads as a positive it isn't. */}
+                            <div
+                              className={`text-lg font-bold ${
+                                Number(wallet.current_balance_btc) > 0
+                                  ? 'text-status-positive'
+                                  : 'text-fg-primary'
+                              }`}
+                            >
                               {formatAmountBtc(wallet.current_balance_btc)}
                             </div>
                           </div>

--- a/src/components/payment/OwnerCollectPanel.tsx
+++ b/src/components/payment/OwnerCollectPanel.tsx
@@ -1,0 +1,186 @@
+/**
+ * OwnerCollectPanel — owner-facing "Collect Bitcoin" view on an entity page.
+ *
+ * Shown when the logged-in user owns the entity AND has a wallet connected.
+ * Confirms which address the entity collects to (resolved server-side via the
+ * same path buyers pay through), the price, and a share link + QR so the owner
+ * can get paid. The "connect a wallet" prompt is handled upstream when no
+ * wallet is set.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Copy, Check, QrCode, Wallet, Loader2 } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { ROUTES } from '@/config/routes';
+import type { EntityType } from '@/config/entity-registry';
+
+interface OwnerCollectPanelProps {
+  entityType: EntityType;
+  entityId: string;
+  entityTitle: string;
+  /** Price amount in the entity's own currency (for fixed_price entities) */
+  priceAmount?: number;
+  /** Currency the price is denominated in (e.g. 'CHF'); 'BTC'/omitted → BTC */
+  priceCurrency?: string;
+}
+
+interface ReceiveInfo {
+  hasWallet: boolean;
+  method: 'nwc' | 'lightning_address' | 'onchain' | null;
+  address: string | null;
+}
+
+const METHOD_LABELS: Record<string, string> = {
+  nwc: 'Connected Lightning wallet',
+  lightning_address: 'Lightning address',
+  onchain: 'On-chain Bitcoin address',
+};
+
+function truncateMiddle(value: string, head = 10, tail = 8): string {
+  return value.length <= head + tail + 1 ? value : `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+export function OwnerCollectPanel({
+  entityType,
+  entityId,
+  priceAmount,
+  priceCurrency,
+}: OwnerCollectPanelProps) {
+  const { formatPrice } = useDisplayCurrency();
+  const { copied: linkCopied, copy: copyLink } = useCopyToClipboard();
+  const { copied: addrCopied, copy: copyAddr } = useCopyToClipboard();
+  const [shareUrl, setShareUrl] = useState('');
+  const [showQr, setShowQr] = useState(false);
+  const [info, setInfo] = useState<ReceiveInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // The owner is on the entity's public page — that URL is the share link.
+  useEffect(() => {
+    setShareUrl(window.location.href);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetch(
+      `/api/payments/receive-info?entity_type=${encodeURIComponent(entityType)}&entity_id=${encodeURIComponent(entityId)}`
+    )
+      .then(res => (res.ok ? res.json() : null))
+      .then(body => {
+        if (!cancelled) {
+          setInfo((body?.data as ReceiveInfo) ?? null);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setInfo(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [entityType, entityId]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Wallet className="h-5 w-5 text-bitcoinOrange" />
+          Collect Bitcoin
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {priceAmount && priceAmount > 0 && (
+          <div className="flex items-center justify-between">
+            <span className="text-fg-secondary">Price</span>
+            <span className="text-lg font-bold text-fg-primary">
+              {formatPrice(priceAmount, priceCurrency)}
+            </span>
+          </div>
+        )}
+
+        <div className="space-y-1">
+          <span className="text-sm text-fg-secondary">Receiving to</span>
+          {loading ? (
+            <div className="flex items-center gap-2 text-fg-secondary">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">Resolving…</span>
+            </div>
+          ) : info?.address ? (
+            <div className="flex items-center justify-between gap-2 rounded-lg border border-default bg-surface-raised/40 px-3 py-2">
+              <span className="min-w-0 truncate font-mono text-sm text-fg-primary">
+                {truncateMiddle(info.address)}
+              </span>
+              <button
+                type="button"
+                onClick={() => copyAddr(info.address!)}
+                className="shrink-0 text-fg-secondary hover:text-fg-primary"
+                aria-label="Copy receiving address"
+              >
+                {addrCopied ? (
+                  <Check className="h-4 w-4 text-status-positive" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          ) : (
+            <p className="text-sm font-medium text-fg-primary">
+              {info?.method ? METHOD_LABELS[info.method] : 'Connected wallet'}
+            </p>
+          )}
+        </div>
+
+        {/* Share link to get paid */}
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              className="flex-1 min-h-11 gap-2"
+              onClick={() => shareUrl && copyLink(shareUrl)}
+            >
+              {linkCopied ? (
+                <Check className="h-4 w-4 text-status-positive" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+              {linkCopied ? 'Copied' : 'Copy link'}
+            </Button>
+            <Button
+              variant="outline"
+              className="min-h-11 gap-2"
+              onClick={() => setShowQr(v => !v)}
+              aria-expanded={showQr}
+            >
+              <QrCode className="h-4 w-4" />
+              QR
+            </Button>
+          </div>
+          {showQr && shareUrl && (
+            <div className="flex justify-center rounded-lg border border-default bg-surface-base p-4">
+              <QRCodeSVG value={shareUrl} size={192} />
+            </div>
+          )}
+          <p className="text-xs text-fg-secondary">
+            Share this link so others can pay you in Bitcoin.
+          </p>
+        </div>
+
+        <Button variant="ghost" size="sm" href={ROUTES.DASHBOARD.WALLETS} className="w-full">
+          Manage wallets
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/payment/PaymentButton.tsx
+++ b/src/components/payment/PaymentButton.tsx
@@ -18,8 +18,10 @@ interface PaymentButtonProps {
   entityType: EntityType;
   entityId: string;
   entityTitle: string;
-  /** Price in BTC (for fixed_price entities) */
+  /** Price amount in the entity's own currency (for fixed_price entities) */
   priceBtc?: number;
+  /** Currency the price is denominated in (e.g. 'CHF'); 'BTC'/omitted → BTC */
+  priceCurrency?: string;
   /** Seller's profile ID */
   sellerProfileId?: string;
   /** Whether the seller has a wallet connected */
@@ -33,13 +35,14 @@ export function PaymentButton({
   entityId,
   entityTitle,
   priceBtc,
+  priceCurrency,
   sellerProfileId,
   sellerHasWallet = true,
   className,
 }: PaymentButtonProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const meta = getEntityMetadata(entityType);
-  const { formatAmountBtc } = useDisplayCurrency();
+  const { formatPrice } = useDisplayCurrency();
 
   // Don't render for entities that aren't purchasable
   if (meta.paymentPattern === 'none') {
@@ -61,7 +64,7 @@ export function PaymentButton({
         <Wallet className="mr-2 h-4 w-4" />
         {disabled ? 'No wallet connected' : buttonText}
         {!isContribution && priceBtc && !disabled && (
-          <span className="ml-1 opacity-75">({formatAmountBtc(priceBtc)})</span>
+          <span className="ml-1 opacity-75">({formatPrice(priceBtc, priceCurrency)})</span>
         )}
       </Button>
 
@@ -72,6 +75,7 @@ export function PaymentButton({
         entityId={entityId}
         entityTitle={entityTitle}
         priceBtc={priceBtc}
+        priceCurrency={priceCurrency}
         sellerProfileId={sellerProfileId}
       />
     </>

--- a/src/components/payment/PaymentDialog.tsx
+++ b/src/components/payment/PaymentDialog.tsx
@@ -32,8 +32,10 @@ interface PaymentDialogProps {
   entityId: string;
   /** Entity title for display */
   entityTitle: string;
-  /** Price in BTC (for fixed_price entities) */
+  /** Price amount in the entity's own currency (for fixed_price entities) */
   priceBtc?: number;
+  /** Currency the price is denominated in (e.g. 'CHF'); 'BTC'/omitted → BTC */
+  priceCurrency?: string;
   /** Seller's profile ID (for checking wallet availability) */
   sellerProfileId?: string;
   /** Seed the contribution amount picker (e.g. wishlist tier target) */
@@ -49,11 +51,12 @@ export function PaymentDialog({
   entityId,
   entityTitle,
   priceBtc,
+  priceCurrency,
   defaultAmount,
 }: PaymentDialogProps) {
   const meta = getEntityMetadata(entityType);
   const isContribution = meta.paymentPattern === 'contribution';
-  const { formatAmountBtc } = useDisplayCurrency();
+  const { formatAmountBtc, formatPrice } = useDisplayCurrency();
 
   const { state, initiate, confirmPaid, reset, isLoading } = usePaymentFlow();
 
@@ -89,7 +92,14 @@ export function PaymentDialog({
     });
   };
 
-  const amountBtc = isContribution ? contributionAmount : (priceBtc ?? 0);
+  // Fixed-price entities are priced in their own currency (priceBtc carries that
+  // amount, priceCurrency the unit); contributions are chosen in BTC. The server
+  // re-derives the BTC charge authoritatively — this only drives display + gating.
+  const fixedPrice = priceBtc ?? 0;
+  const hasValidAmount = isContribution ? contributionAmount > 0 : fixedPrice > 0;
+  const priceLabel = isContribution
+    ? formatAmountBtc(contributionAmount)
+    : formatPrice(fixedPrice, priceCurrency);
 
   // Prevent accidental dismissal while a payment is in flight
   const isPaymentActive = state.phase === 'initiating' || state.phase === 'awaiting_payment';
@@ -108,7 +118,7 @@ export function PaymentDialog({
           <DialogDescription>
             {isContribution
               ? `Choose an amount to support this ${meta.name.toLowerCase()}`
-              : `Pay ${formatAmountBtc(amountBtc)}`}
+              : `Pay ${priceLabel}`}
           </DialogDescription>
         </DialogHeader>
 
@@ -148,12 +158,10 @@ export function PaymentDialog({
 
               <Button
                 onClick={handleInitiate}
-                disabled={isLoading || amountBtc <= 0}
+                disabled={isLoading || !hasValidAmount}
                 className="w-full min-h-11"
               >
-                {isContribution
-                  ? `Support with ${formatAmountBtc(amountBtc)}`
-                  : `Pay ${formatAmountBtc(amountBtc)}`}
+                {isContribution ? `Support with ${priceLabel}` : `Pay ${priceLabel}`}
               </Button>
             </>
           )}

--- a/src/components/payment/PublicEntityPaymentSection.tsx
+++ b/src/components/payment/PublicEntityPaymentSection.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useSellerPaymentMethods } from '@/hooks/useSellerPaymentMethods';
 import { PaymentButton } from './PaymentButton';
 import { SellerWalletBanner } from './SellerWalletBanner';
+import { OwnerCollectPanel } from './OwnerCollectPanel';
 import type { EntityType } from '@/config/entity-registry';
 import { ROUTES } from '@/config/routes';
 
@@ -24,8 +25,10 @@ interface PublicEntityPaymentSectionProps {
   entityType: EntityType;
   entityId: string;
   entityTitle: string;
-  /** Price in BTC (for fixed_price entities) */
-  priceBtc?: number;
+  /** Price amount in the entity's own currency (for fixed_price entities) */
+  priceAmount?: number;
+  /** Currency the price is denominated in (e.g. 'CHF'); 'BTC'/omitted → BTC */
+  priceCurrency?: string;
   /** Seller's profile/actor ID for wallet lookup (null if no seller found) */
   sellerProfileId: string | null;
   /** Seller's auth.users ID for self-purchase detection (null if no seller found) */
@@ -38,7 +41,8 @@ export function PublicEntityPaymentSection({
   entityType,
   entityId,
   entityTitle,
-  priceBtc,
+  priceAmount,
+  priceCurrency,
   sellerProfileId,
   sellerUserId,
   signInRedirect,
@@ -89,10 +93,23 @@ export function PublicEntityPaymentSection({
     );
   }
 
-  // Logged in, IS the seller — show wallet banner
+  // Logged in, IS the seller — show the owner-facing collect panel.
+  // Prompts to connect a wallet when none is set; otherwise shows which address
+  // receives funds plus share/QR so the owner can get paid.
   const isOwner = !!sellerUserId && user?.id === sellerUserId;
   if (isOwner) {
-    return <SellerWalletBanner isOwner={true} hasWallet={hasWallet} />;
+    if (!hasWallet) {
+      return <SellerWalletBanner isOwner={true} hasWallet={hasWallet} />;
+    }
+    return (
+      <OwnerCollectPanel
+        entityType={entityType}
+        entityId={entityId}
+        entityTitle={entityTitle}
+        priceAmount={priceAmount}
+        priceCurrency={priceCurrency}
+      />
+    );
   }
 
   // Logged in, NOT the seller — show payment button
@@ -103,7 +120,8 @@ export function PublicEntityPaymentSection({
           entityType={entityType}
           entityId={entityId}
           entityTitle={entityTitle}
-          priceBtc={priceBtc}
+          priceBtc={priceAmount}
+          priceCurrency={priceCurrency}
           sellerProfileId={sellerProfileId ?? undefined}
           sellerHasWallet={hasWallet}
           className="w-full min-h-11"

--- a/src/components/payment/PublicEntityPaymentSection.tsx
+++ b/src/components/payment/PublicEntityPaymentSection.tsx
@@ -18,7 +18,8 @@ import { useSellerPaymentMethods } from '@/hooks/useSellerPaymentMethods';
 import { PaymentButton } from './PaymentButton';
 import { SellerWalletBanner } from './SellerWalletBanner';
 import { OwnerCollectPanel } from './OwnerCollectPanel';
-import type { EntityType } from '@/config/entity-registry';
+import { PublicPayPanel } from './PublicPayPanel';
+import { getEntityMetadata, type EntityType } from '@/config/entity-registry';
 import { ROUTES } from '@/config/routes';
 
 interface PublicEntityPaymentSectionProps {
@@ -33,6 +34,13 @@ interface PublicEntityPaymentSectionProps {
   sellerProfileId: string | null;
   /** Seller's auth.users ID for self-purchase detection (null if no seller found) */
   sellerUserId: string | null;
+  /**
+   * Seller's public receiving info, resolved server-side (no secrets). Drives
+   * the anonymous pay-direct panel. `address` is null for NWC-only sellers.
+   */
+  sellerReceive: { method: 'nwc' | 'lightning_address' | 'onchain'; address: string | null } | null;
+  /** Fixed price converted to BTC, for the anonymous BIP21 amount. */
+  priceAmountBtc?: number;
   /** Redirect path after sign-in */
   signInRedirect: string;
 }
@@ -45,6 +53,8 @@ export function PublicEntityPaymentSection({
   priceCurrency,
   sellerProfileId,
   sellerUserId,
+  sellerReceive,
+  priceAmountBtc,
   signInRedirect,
 }: PublicEntityPaymentSectionProps) {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
@@ -63,20 +73,51 @@ export function PublicEntityPaymentSection({
     );
   }
 
-  // Not logged in — show sign-in CTA
+  // Not logged in — permissionless by default: let anyone pay direct to the
+  // seller's public address (no account). Falls back to sign-in only when there
+  // is no static address to reveal (NWC-only seller), and to an honest notice
+  // when the seller has no wallet at all.
   if (!isAuthenticated) {
+    const meta = getEntityMetadata(entityType);
+
+    if (
+      sellerReceive?.address &&
+      (sellerReceive.method === 'onchain' || sellerReceive.method === 'lightning_address')
+    ) {
+      return (
+        <PublicPayPanel
+          entityTitle={entityTitle}
+          isContribution={meta.paymentPattern === 'contribution'}
+          priceAmount={priceAmount}
+          priceCurrency={priceCurrency}
+          amountBtc={priceAmountBtc}
+          method={sellerReceive.method}
+          address={sellerReceive.address}
+          signInHref={`${ROUTES.AUTH}?mode=login&from=${signInRedirect}`}
+        />
+      );
+    }
+
     return (
       <Card>
         <CardContent className="pt-6 space-y-3">
-          <Link href={`${ROUTES.AUTH}?mode=login&from=${signInRedirect}`} className="block">
-            <Button className="w-full gap-2 min-h-11">
-              <LogIn className="w-4 h-4" />
-              Sign in to continue
-            </Button>
-          </Link>
-          <p className="text-xs text-fg-secondary text-center">
-            Sign in to buy or support with Bitcoin
-          </p>
+          {!sellerReceive ? (
+            <p className="text-sm text-fg-secondary text-center">
+              This {meta.name.toLowerCase()} isn&apos;t set up to receive Bitcoin yet.
+            </p>
+          ) : (
+            <>
+              <Link href={`${ROUTES.AUTH}?mode=login&from=${signInRedirect}`} className="block">
+                <Button className="w-full gap-2 min-h-11">
+                  <LogIn className="w-4 h-4" />
+                  Sign in to continue
+                </Button>
+              </Link>
+              <p className="text-xs text-fg-secondary text-center">
+                Sign in to pay via the seller&apos;s connected wallet
+              </p>
+            </>
+          )}
         </CardContent>
       </Card>
     );

--- a/src/components/payment/PublicPayPanel.tsx
+++ b/src/components/payment/PublicPayPanel.tsx
@@ -1,0 +1,152 @@
+/**
+ * PublicPayPanel — let anyone pay an entity in Bitcoin without an account.
+ *
+ * Permissionless participation is a core principle: a logged-out visitor must
+ * be able to send sats. The seller's receiving address is public data (the same
+ * address the profile page already shows), so this reveals it with a baked-in
+ * amount, a QR, and an open-in-wallet link. The payer settles directly from
+ * their own wallet — non-custodial, no sign-up.
+ *
+ * Only renders for sellers with a static address (on-chain or Lightning
+ * address). NWC-only sellers have no static address to reveal — the caller
+ * falls back to the sign-in/invoice flow for those.
+ */
+
+'use client';
+
+import { QRCodeSVG } from 'qrcode.react';
+import Link from 'next/link';
+import { Bitcoin, Zap, Copy, Check, ExternalLink } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+
+interface PublicPayPanelProps {
+  entityTitle: string;
+  /** Contribution entities accept any amount; fixed-price bake the amount in. */
+  isContribution: boolean;
+  /** Price in its own currency (fixed-price entities). */
+  priceAmount?: number;
+  /** Currency of priceAmount (e.g. 'CHF'); omitted/'BTC' → BTC. */
+  priceCurrency?: string;
+  /** BTC-converted amount for the BIP21 URI (0/undefined → payer chooses). */
+  amountBtc?: number;
+  /** Receiving method — drives icon, label, and URI scheme. */
+  method: 'onchain' | 'lightning_address';
+  /** The receiving address to reveal. */
+  address: string;
+  /** Sign-in link for the optional "track your order" affordance. */
+  signInHref: string;
+}
+
+function truncateMiddle(value: string, head = 12, tail = 10): string {
+  return value.length <= head + tail + 1 ? value : `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+export function PublicPayPanel({
+  entityTitle,
+  isContribution,
+  priceAmount,
+  priceCurrency,
+  amountBtc,
+  method,
+  address,
+  signInHref,
+}: PublicPayPanelProps) {
+  const { formatPrice, formatAmountBtc } = useDisplayCurrency();
+  const { copied, copy } = useCopyToClipboard();
+
+  const isOnchain = method === 'onchain';
+  const Icon = isOnchain ? Bitcoin : Zap;
+
+  // Build the payment URI. On-chain uses BIP21 with the amount + label baked in;
+  // a Lightning address is paid via the lightning: scheme (wallet prompts for
+  // the amount, which we also show on screen).
+  const paymentUri = (() => {
+    if (isOnchain) {
+      const params = new URLSearchParams();
+      if (amountBtc && amountBtc > 0) {
+        params.set('amount', amountBtc.toFixed(8).replace(/\.?0+$/, ''));
+      }
+      if (entityTitle) {
+        params.set('label', entityTitle);
+      }
+      const query = params.toString();
+      return `bitcoin:${address}${query ? `?${query}` : ''}`;
+    }
+    return `lightning:${address}`;
+  })();
+
+  const hasFixedAmount = !isContribution && priceAmount !== undefined && priceAmount > 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Icon className="h-5 w-5 text-bitcoinOrange" />
+          Pay with Bitcoin
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {hasFixedAmount ? (
+          <div className="flex items-baseline justify-between">
+            <span className="text-fg-secondary">Amount</span>
+            <span className="text-lg font-bold text-fg-primary">
+              {formatPrice(priceAmount as number, priceCurrency)}
+              {amountBtc && amountBtc > 0 && priceCurrency && priceCurrency !== 'BTC' && (
+                <span className="ml-2 text-sm font-normal text-fg-secondary">
+                  ≈ {formatAmountBtc(amountBtc)}
+                </span>
+              )}
+            </span>
+          </div>
+        ) : (
+          <p className="text-sm text-fg-secondary">Send any amount in Bitcoin to support this.</p>
+        )}
+
+        <div className="flex justify-center rounded-lg border border-default bg-surface-base p-4">
+          <QRCodeSVG value={paymentUri} size={192} level="M" />
+        </div>
+
+        <div className="space-y-1">
+          <span className="text-xs text-fg-secondary">
+            {isOnchain ? 'On-chain Bitcoin address' : 'Lightning address'}
+          </span>
+          <button
+            type="button"
+            onClick={() => copy(address)}
+            className="flex w-full items-center justify-between gap-2 rounded-lg border border-default bg-surface-raised/40 px-3 py-2 text-left hover:bg-surface-raised/70"
+            aria-label="Copy receiving address"
+          >
+            <span className="min-w-0 truncate font-mono text-sm text-fg-primary">
+              {truncateMiddle(address)}
+            </span>
+            {copied ? (
+              <Check className="h-4 w-4 shrink-0 text-status-positive" />
+            ) : (
+              <Copy className="h-4 w-4 shrink-0 text-fg-secondary" />
+            )}
+          </button>
+        </div>
+
+        <a
+          href={paymentUri}
+          className="flex w-full items-center justify-center gap-2 rounded-md bg-bitcoinOrange px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-bitcoinOrange/90 min-h-11"
+        >
+          <ExternalLink className="h-4 w-4" />
+          Open in wallet
+        </a>
+
+        <p className="text-xs text-fg-secondary text-center">
+          Pay directly from any Bitcoin wallet — no account needed.
+        </p>
+        <p className="text-xs text-fg-tertiary text-center">
+          Have an account?{' '}
+          <Link href={signInHref} className="underline hover:text-fg-secondary">
+            Sign in to track your order
+          </Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/ProfileDetailsCard.tsx
+++ b/src/components/profile/ProfileDetailsCard.tsx
@@ -25,7 +25,10 @@ export function ProfileDetailsCard({
 }: ProfileDetailsCardProps) {
   const joinDate = profile.created_at ? new Date(profile.created_at) : null;
   const lastActive = profile.updated_at ? new Date(profile.updated_at) : null;
-  const publicContactEmail = profile.contact_email || profile.email || userEmail || null;
+  // Public "Contact Email" is ONLY the opt-in contact_email — never the private
+  // account login email. The registration email has its own owner-gated field
+  // below. See profile email-leak fix.
+  const publicContactEmail = profile.contact_email || null;
 
   const locationValue = (() => {
     if (isLocationHidden(profile.location_context || '')) {

--- a/src/components/profile/ProfileInfoTab.tsx
+++ b/src/components/profile/ProfileInfoTab.tsx
@@ -78,36 +78,41 @@ export default function ProfileInfoTab({
         isDashboardView={isDashboardView}
       />
 
-      <Card>
-        <CardHeader>
-          <h3 className="text-lg font-semibold flex items-center gap-2">
-            <Shield className="w-5 h-5 text-fg-secondary" />
-            Account Status
-          </h3>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="flex items-center justify-between">
-            <span className="text-fg-secondary">Email Verified</span>
-            <span
-              className={profile.email ? 'text-status-positive font-medium' : 'text-fg-tertiary'}
-            >
-              {profile.email ? '✓ Verified' : 'Not verified'}
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-fg-secondary">Profile Complete</span>
-            <span
-              className={
-                profile.bio && profile.avatar_url
-                  ? 'text-status-positive font-medium'
-                  : 'text-fg-secondary font-medium'
-              }
-            >
-              {profile.bio && profile.avatar_url ? '✓ Complete' : 'In Progress'}
-            </span>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Account Status is owner-only meta (email verification, completeness).
+          Not public — and "Email Verified" keys off the now-redacted account
+          email, so it must not render for visitors. */}
+      {isOwnProfile && (
+        <Card>
+          <CardHeader>
+            <h3 className="text-lg font-semibold flex items-center gap-2">
+              <Shield className="w-5 h-5 text-fg-secondary" />
+              Account Status
+            </h3>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-fg-secondary">Email Verified</span>
+              <span
+                className={profile.email ? 'text-status-positive font-medium' : 'text-fg-tertiary'}
+              >
+                {profile.email ? '✓ Verified' : 'Not verified'}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-fg-secondary">Profile Complete</span>
+              <span
+                className={
+                  profile.bio && profile.avatar_url
+                    ? 'text-status-positive font-medium'
+                    : 'text-fg-secondary font-medium'
+                }
+              >
+                {profile.bio && profile.avatar_url ? '✓ Complete' : 'In Progress'}
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/src/components/profile/ProfileLayout.tsx
+++ b/src/components/profile/ProfileLayout.tsx
@@ -196,12 +196,10 @@ export default function ProfileLayout({
               @{profile.username}
             </p>
             {profile.bio && (
-              // Bio used to live only on the Overview tab. Visitors hit
-              // Timeline by default and never saw who the person was unless
-              // they clicked through. Surface it in the header card so the
-              // "who is this" answer is immediate. Clamp to 3 lines so a
-              // long bio doesn't push tabs off-screen — Overview still has
-              // the full text.
+              // Surface the bio in the header card so the "who is this" answer
+              // is immediate, reinforcing the Overview-first default below.
+              // Clamp to 3 lines so a long bio doesn't push tabs off-screen —
+              // the Overview tab still has the full text.
               <p className="mb-3 line-clamp-3 max-w-3xl text-sm text-fg-secondary sm:mb-4 sm:text-base">
                 {profile.bio}
               </p>
@@ -220,7 +218,9 @@ export default function ProfileLayout({
             )}
           </div>
 
-          <ProfileViewTabs tabs={filteredTabs} defaultTab="timeline" />
+          {/* Overview-first: a shared profile should open on the scannable
+              "who is this / what do they offer" summary, not the timeline feed. */}
+          <ProfileViewTabs tabs={filteredTabs} defaultTab="overview" />
         </div>
       </div>
     </div>

--- a/src/components/profile/ProfileOverviewTab.tsx
+++ b/src/components/profile/ProfileOverviewTab.tsx
@@ -101,7 +101,13 @@ export default function ProfileOverviewTab({
           <Card>
             <CardContent className="pt-4 sm:pt-6">
               <div className="text-center">
-                <div className="text-lg sm:text-xl md:text-2xl lg:text-3xl font-bold text-status-positive">
+                {/* Success green only signals an actual raise — a zero balance
+                    rendered green reads as a positive metric it isn't. */}
+                <div
+                  className={`text-lg sm:text-xl md:text-2xl lg:text-3xl font-bold ${
+                    stats.totalRaised > 0 ? 'text-status-positive' : 'text-fg-primary'
+                  }`}
+                >
                   {formatAmountBtc(stats.totalRaised)}
                 </div>
                 <div className="text-xs sm:text-sm text-fg-secondary mt-1">Total Raised</div>

--- a/src/components/profile/ProfileOverviewTab.tsx
+++ b/src/components/profile/ProfileOverviewTab.tsx
@@ -42,7 +42,9 @@ export default function ProfileOverviewTab({
   context = 'public',
 }: ProfileOverviewTabProps) {
   const isDashboardView = context === 'dashboard';
-  const publicContactEmail = profile.contact_email || profile.email;
+  // Public contact email is ONLY the opt-in contact_email field — never the
+  // private account login email (profile.email). See profile email-leak fix.
+  const publicContactEmail = profile.contact_email;
   const { formatAmountBtc } = useDisplayCurrency();
 
   return (

--- a/src/components/project/ProjectPageClient.tsx
+++ b/src/components/project/ProjectPageClient.tsx
@@ -160,6 +160,13 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
               entityTitle={project.title}
               sellerProfileId={project.user_id}
               sellerUserId={project.user_id}
+              sellerReceive={
+                project.bitcoin_address
+                  ? { method: 'onchain', address: project.bitcoin_address }
+                  : project.lightning_address
+                    ? { method: 'lightning_address', address: project.lightning_address }
+                    : null
+              }
               signInRedirect={ROUTES.PROJECTS.VIEW(project.id)}
             />
 

--- a/src/components/public/FundingProgress.tsx
+++ b/src/components/public/FundingProgress.tsx
@@ -1,0 +1,136 @@
+/**
+ * FundingProgress — the single funding-progress module for every funding entity.
+ *
+ * Replaces five near-identical, drifting copies (cause / research / investment /
+ * wishlist, plus the project rail's display half). One component → one visual
+ * language, one currency formatter, one zero-state.
+ *
+ * Two ground truths drove the design:
+ *   - SSOT: raised/goal/progress was reimplemented per entity and formatted
+ *     three different ways (formatCurrency vs displayBTC). Here it's formatted
+ *     once, in the entity's own stored currency.
+ *   - Serve humans: every prior copy returned `null` when no goal was set, so a
+ *     fund page with no goal rendered *blank* (the cause bug). This always
+ *     renders an inviting state — a fund page should never look empty.
+ *
+ * Server component: no hooks, pure presentation. Render it from a config's
+ * `renderDetails` in PublicEntityDetailPage.
+ */
+
+import { formatCurrency } from '@/services/currency';
+import { formatRelativeTime } from '@/utils/dates';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Progress } from '@/components/ui/progress';
+
+export interface FundingProgressProps {
+  /** Amount raised so far, in `currency` units. */
+  raised?: number | null;
+  /** Funding goal, in `currency` units. 0/null → no goal set. */
+  goal?: number | null;
+  /** Currency the amounts are stored in (e.g. 'BTC', 'CHF'). Default 'BTC'. */
+  currency?: string;
+  /** Card title. Default 'Funding Progress'. */
+  title?: string;
+  /** Noun after the raised amount. Default 'raised' (wishlist uses 'funded'). */
+  raisedLabel?: string;
+  /** Noun after the goal amount. Default 'goal' (wishlist uses 'total'). */
+  goalLabel?: string;
+  /** Number of distinct backers, when the entity tracks it. */
+  supportersCount?: number | null;
+  /** ISO timestamp of the most recent contribution, when tracked. */
+  lastSupportAt?: string | null;
+  /**
+   * When true and there is no goal, nothing raised, and no supporters, render
+   * nothing. Use for surfaces where an empty funding card is noise (e.g. a
+   * wishlist whose items carry no price). Default false — always invite.
+   */
+  hideWhenEmpty?: boolean;
+}
+
+export default function FundingProgress({
+  raised,
+  goal,
+  currency = 'BTC',
+  title = 'Funding Progress',
+  raisedLabel = 'raised',
+  goalLabel = 'goal',
+  supportersCount,
+  lastSupportAt,
+  hideWhenEmpty = false,
+}: FundingProgressProps) {
+  const raisedAmt = Number(raised ?? 0);
+  const goalAmt = Number(goal ?? 0);
+  const hasGoal = goalAmt > 0;
+  const hasRaised = raisedAmt > 0;
+  const hasSupporters = (supportersCount ?? 0) > 0 || Boolean(lastSupportAt);
+
+  if (hideWhenEmpty && !hasGoal && !hasRaised && !hasSupporters) {
+    return null;
+  }
+
+  const progress = hasGoal ? Math.min(Math.round((raisedAmt / goalAmt) * 100), 100) : 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {hasGoal ? (
+          <>
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-fg-secondary">
+                {formatCurrency(raisedAmt, currency)} {raisedLabel}
+              </span>
+              <span className="font-bold text-lg text-fg-primary">
+                {formatCurrency(goalAmt, currency)} {goalLabel}
+              </span>
+            </div>
+            <Progress value={progress} className="h-2" />
+            <p className="text-sm text-fg-secondary">
+              {progress}% funded
+              {!hasRaised && <span className="text-fg-tertiary"> · Be the first to back this</span>}
+            </p>
+          </>
+        ) : hasRaised ? (
+          // No goal, but money has come in — show momentum without a fake bar.
+          <div className="space-y-1">
+            <p className="text-2xl font-bold text-fg-primary">
+              {formatCurrency(raisedAmt, currency)}
+            </p>
+            <p className="text-sm text-fg-secondary">
+              {raisedLabel} so far · no goal set, every contribution helps
+            </p>
+          </div>
+        ) : (
+          // No goal, nothing raised — invite the first backer rather than render blank.
+          <div className="space-y-1">
+            <p className="text-base font-semibold text-fg-primary">Be the first to back this</p>
+            <p className="text-sm text-fg-secondary">
+              Contributions in Bitcoin go straight to the creator.
+            </p>
+          </div>
+        )}
+
+        {hasSupporters && (
+          <div className="space-y-2 border-t border-subtle pt-4 text-sm">
+            {(supportersCount ?? 0) > 0 && (
+              <div className="flex items-center justify-between">
+                <span className="text-fg-secondary">Supporters</span>
+                <span className="font-semibold text-fg-primary">
+                  {supportersCount} {supportersCount === 1 ? 'person' : 'people'}
+                </span>
+              </div>
+            )}
+            {lastSupportAt && (
+              <div className="flex items-center gap-1 text-xs text-status-positive">
+                <span className="h-2 w-2 rounded-full bg-status-positive animate-pulse" />
+                Last contribution {formatRelativeTime(lastSupportAt)}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/public/PriceDisplay.tsx
+++ b/src/components/public/PriceDisplay.tsx
@@ -1,0 +1,57 @@
+/**
+ * PriceDisplay — a price with its converted equivalent.
+ *
+ * A bare "₿0.0005" is meaningless to most people; a bare "CHF 86" hides that
+ * it's payable in Bitcoin. This renders the stored price in its own currency
+ * plus a live-rate equivalent in the other denomination:
+ *   - BTC-priced  → "₿0.0005  ≈ CHF 43.00"   (fiat for the 99% who don't think in sats)
+ *   - fiat-priced → "CHF 86.00  ≈ ₿0.001"     (signals Bitcoin-payable)
+ *
+ * Async server component: awaits the rate cache (CoinGecko-backed, 1-min TTL).
+ * If the rate is unavailable for a currency, the equivalent is silently
+ * dropped — never fabricated (a wrong rate is a money-correctness bug).
+ */
+
+import { currencyConverter, formatCurrency } from '@/services/currency';
+import { PLATFORM_DEFAULT_CURRENCY, type CurrencyCode } from '@/config/currencies';
+
+interface PriceDisplayProps {
+  /** Amount in `currency` units. */
+  amount: number;
+  /** Currency the amount is stored in (e.g. 'BTC', 'CHF'). */
+  currency: string;
+  /** Tailwind classes for the primary amount. */
+  className?: string;
+}
+
+export default async function PriceDisplay({
+  amount,
+  currency,
+  className = 'text-2xl font-bold text-fg-primary',
+}: PriceDisplayProps) {
+  // Show the opposite denomination: Bitcoin prices get a fiat equivalent,
+  // fiat prices get the Bitcoin equivalent.
+  const secondaryCurrency: CurrencyCode = currency === 'BTC' ? PLATFORM_DEFAULT_CURRENCY : 'BTC';
+
+  let secondary = 0;
+  try {
+    secondary = await currencyConverter.convert(
+      amount,
+      currency as CurrencyCode,
+      secondaryCurrency
+    );
+  } catch {
+    secondary = 0;
+  }
+
+  return (
+    <p className={className}>
+      {formatCurrency(amount, currency)}
+      {secondary > 0 && (
+        <span className="ml-2 text-base font-normal text-fg-secondary">
+          ≈ {formatCurrency(secondary, secondaryCurrency)}
+        </span>
+      )}
+    </p>
+  );
+}

--- a/src/components/public/PriceDisplay.tsx
+++ b/src/components/public/PriceDisplay.tsx
@@ -22,12 +22,18 @@ interface PriceDisplayProps {
   currency: string;
   /** Tailwind classes for the primary amount. */
   className?: string;
+  /**
+   * Per-unit suffix appended after both amounts (e.g. ' / hr', ' / message').
+   * Include the leading space. Rendered muted so the amount stays the focus.
+   */
+  suffix?: string;
 }
 
 export default async function PriceDisplay({
   amount,
   currency,
   className = 'text-2xl font-bold text-fg-primary',
+  suffix,
 }: PriceDisplayProps) {
   // Show the opposite denomination: Bitcoin prices get a fiat equivalent,
   // fiat prices get the Bitcoin equivalent.
@@ -52,6 +58,7 @@ export default async function PriceDisplay({
           ≈ {formatCurrency(secondary, secondaryCurrency)}
         </span>
       )}
+      {suffix && <span className="text-base font-normal text-fg-secondary">{suffix}</span>}
     </p>
   );
 }

--- a/src/components/public/PublicEntityDetailPage.tsx
+++ b/src/components/public/PublicEntityDetailPage.tsx
@@ -20,6 +20,9 @@ import PublicEntityOwnerCard from '@/components/public/PublicEntityOwnerCard';
 import PublicEntityHero from '@/components/public/PublicEntityHero';
 import PublicEntityTimestamps from '@/components/public/PublicEntityTimestamps';
 import { PublicEntityPaymentSection } from '@/components/payment';
+import { resolveSellerReceiveInfo, type SellerReceiveInfo } from '@/domain/payments';
+import { currencyConverter } from '@/services/currency';
+import { type CurrencyCode } from '@/config/currencies';
 import { fetchEntityOwner } from '@/lib/entities/fetchEntityOwner';
 import { ROUTES } from '@/config/routes';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
@@ -162,6 +165,23 @@ export default async function PublicEntityDetailPage({
 
   const owner = await fetchEntityOwner(supabase, entity);
 
+  // Resolve the seller's public receiving info + BTC amount server-side so a
+  // logged-out visitor can pay direct (permissionless) — no account, no gate.
+  // Skipped for entities with no payment section (e.g. loans).
+  const price = config.getPrice?.(entity) ?? null;
+  const priceAmount = price && price.amount > 0 ? price.amount : undefined;
+  let sellerReceive: SellerReceiveInfo | null = null;
+  let priceAmountBtc: number | undefined;
+  if (config.showPaymentSection !== false) {
+    sellerReceive = await resolveSellerReceiveInfo(supabase, config.entityType, id);
+    if (priceAmount !== undefined && price) {
+      priceAmountBtc =
+        (price.currency || 'BTC') === 'BTC'
+          ? priceAmount
+          : await currencyConverter.convert(priceAmount, price.currency as CurrencyCode, 'BTC');
+    }
+  }
+
   const jsonLd = generateEntityJsonLd({
     type: config.entityType,
     id,
@@ -258,24 +278,22 @@ export default async function PublicEntityDetailPage({
 
               {config.renderSidebarExtra?.(entity)}
 
-              {config.showPaymentSection !== false &&
-                (() => {
-                  const price = config.getPrice?.(entity) ?? null;
-                  return (
-                    <div id="pay">
-                      <PublicEntityPaymentSection
-                        entityType={config.entityType}
-                        entityId={id}
-                        entityTitle={entity.title}
-                        priceAmount={price && price.amount > 0 ? price.amount : undefined}
-                        priceCurrency={price?.currency}
-                        sellerProfileId={owner?.id ?? null}
-                        sellerUserId={owner?.user_id ?? null}
-                        signInRedirect={viewRoute}
-                      />
-                    </div>
-                  );
-                })()}
+              {config.showPaymentSection !== false && (
+                <div id="pay">
+                  <PublicEntityPaymentSection
+                    entityType={config.entityType}
+                    entityId={id}
+                    entityTitle={entity.title}
+                    priceAmount={priceAmount}
+                    priceCurrency={price?.currency}
+                    sellerProfileId={owner?.id ?? null}
+                    sellerUserId={owner?.user_id ?? null}
+                    sellerReceive={sellerReceive}
+                    priceAmountBtc={priceAmountBtc}
+                    signInRedirect={viewRoute}
+                  />
+                </div>
+              )}
 
               <PublicEntityTimestamps
                 createdAt={entity.created_at}

--- a/src/components/public/PublicEntityDetailPage.tsx
+++ b/src/components/public/PublicEntityDetailPage.tsx
@@ -17,6 +17,7 @@ import { Badge } from '@/components/ui/badge';
 import { generateEntityJsonLd, JsonLdScript } from '@/lib/seo/structured-data';
 import EntityShare from '@/components/sharing/EntityShare';
 import PublicEntityOwnerCard from '@/components/public/PublicEntityOwnerCard';
+import PublicEntityHero from '@/components/public/PublicEntityHero';
 import PublicEntityTimestamps from '@/components/public/PublicEntityTimestamps';
 import { PublicEntityPaymentSection } from '@/components/payment';
 import { fetchEntityOwner } from '@/lib/entities/fetchEntityOwner';
@@ -65,6 +66,12 @@ export interface EntityDetailConfig {
   getJsonLdExtra?: (entity: EntityData) => Record<string, unknown>;
   /** Override the themed icon box in the header (e.g., a cover image) */
   renderHeaderIcon?: (entity: EntityData) => ReactNode;
+  /**
+   * Ordered cover image URLs (cover first) for the full-width hero, rendered
+   * below the header. Return [] for entities with no imagery — the page then
+   * falls back to the header type icon. Drives PublicEntityHero.
+   */
+  getCoverImages?: (entity: EntityData) => string[];
   /** Header badges/extra info (e.g., date for events, category for products) */
   renderHeaderExtra?: (entity: EntityData) => ReactNode;
   /** Entity-specific detail cards below description */
@@ -208,6 +215,15 @@ export default async function PublicEntityDetailPage({
             </div>
           </div>
         </div>
+
+        {(() => {
+          const coverImages = config.getCoverImages?.(entity) ?? [];
+          return coverImages.length > 0 ? (
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-6">
+              <PublicEntityHero images={coverImages} title={entity.title} />
+            </div>
+          ) : null;
+        })()}
 
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/src/components/public/PublicEntityDetailPage.tsx
+++ b/src/components/public/PublicEntityDetailPage.tsx
@@ -69,6 +69,13 @@ export interface EntityDetailConfig {
   renderHeaderExtra?: (entity: EntityData) => ReactNode;
   /** Entity-specific detail cards below description */
   renderDetails?: (entity: EntityData) => ReactNode;
+  /**
+   * Resolve the entity's price for the payment section, in its OWN currency
+   * (NOT BTC — there is no price_btc column). Returns null when the entity has
+   * no fixed price (e.g. contribution entities). The buyer is charged the
+   * BTC-converted amount server-side; this only drives display.
+   */
+  getPrice?: (entity: EntityData) => { amount: number; currency: string } | null;
   /** Extra sidebar cards rendered after EntityShare (e.g., Quick Stats, CTAs) */
   renderSidebarExtra?: (entity: EntityData) => ReactNode;
   /** Select columns for metadata query (defaults to 'title, description, price_btc') */
@@ -235,19 +242,24 @@ export default async function PublicEntityDetailPage({
 
               {config.renderSidebarExtra?.(entity)}
 
-              {config.showPaymentSection !== false && (
-                <div id="pay">
-                  <PublicEntityPaymentSection
-                    entityType={config.entityType}
-                    entityId={id}
-                    entityTitle={entity.title}
-                    priceBtc={entity.price_btc ? Number(entity.price_btc) : undefined}
-                    sellerProfileId={owner?.id ?? null}
-                    sellerUserId={owner?.user_id ?? null}
-                    signInRedirect={viewRoute}
-                  />
-                </div>
-              )}
+              {config.showPaymentSection !== false &&
+                (() => {
+                  const price = config.getPrice?.(entity) ?? null;
+                  return (
+                    <div id="pay">
+                      <PublicEntityPaymentSection
+                        entityType={config.entityType}
+                        entityId={id}
+                        entityTitle={entity.title}
+                        priceAmount={price && price.amount > 0 ? price.amount : undefined}
+                        priceCurrency={price?.currency}
+                        sellerProfileId={owner?.id ?? null}
+                        sellerUserId={owner?.user_id ?? null}
+                        signInRedirect={viewRoute}
+                      />
+                    </div>
+                  );
+                })()}
 
               <PublicEntityTimestamps
                 createdAt={entity.created_at}

--- a/src/components/public/PublicEntityHero.tsx
+++ b/src/components/public/PublicEntityHero.tsx
@@ -1,0 +1,57 @@
+/**
+ * PublicEntityHero — cover imagery for image-centric public entity pages.
+ *
+ * The generic entity page only had a 64px type icon, so a product/service/event
+ * with photos showed a generic glyph instead of the actual thing. This renders
+ * the entity's images (cover first) as a responsive hero, with up to four more
+ * as a thumbnail row.
+ *
+ * Data-driven: returns null when there are no images, so the page falls back to
+ * the existing header icon — no empty frames, no regression for entities that
+ * haven't uploaded anything. Server component, no client state.
+ */
+
+import Image from 'next/image';
+
+interface PublicEntityHeroProps {
+  /** Ordered image URLs, cover first. */
+  images: string[];
+  /** Entity title, used for alt text. */
+  title: string;
+}
+
+export default function PublicEntityHero({ images, title }: PublicEntityHeroProps) {
+  const clean = images.filter(Boolean);
+  if (clean.length === 0) {
+    return null;
+  }
+
+  const [cover, ...rest] = clean;
+  const extras = rest.slice(0, 4);
+
+  return (
+    <div className="space-y-3">
+      <div className="relative w-full aspect-[16/9] overflow-hidden rounded-lg border border-default bg-surface-raised">
+        <Image src={cover} alt={title} fill unoptimized className="object-cover" />
+      </div>
+      {extras.length > 0 && (
+        <div className="grid grid-cols-4 gap-3">
+          {extras.map((src, i) => (
+            <div
+              key={`${src}-${i}`}
+              className="relative aspect-square overflow-hidden rounded-md border border-subtle bg-surface-raised"
+            >
+              <Image
+                src={src}
+                alt={`${title} — image ${i + 2}`}
+                fill
+                unoptimized
+                className="object-cover"
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/config/entity-registry.ts
+++ b/src/config/entity-registry.ts
@@ -116,6 +116,13 @@ export interface EntityMetadata {
   createPriority: number;
   /** How this entity is paid for: fixed_price (buy), contribution (support), none (no payment) */
   paymentPattern: PaymentPattern;
+  /**
+   * SSOT for the column holding a fixed_price entity's price (in its own
+   * `currency`, NOT BTC). Read by payment-amount resolution and price display so
+   * the column isn't hardcoded per call site. Only meaningful for
+   * paymentPattern === 'fixed_price'; omit for contribution/none entities.
+   */
+  priceColumn?: string;
 }
 
 /**
@@ -184,6 +191,7 @@ export const ENTITY_REGISTRY: Record<EntityType, EntityMetadata> = {
     category: 'business',
     createPriority: 2,
     paymentPattern: 'fixed_price',
+    priceColumn: 'price',
   },
   service: {
     type: 'service',
@@ -203,6 +211,7 @@ export const ENTITY_REGISTRY: Record<EntityType, EntityMetadata> = {
     category: 'business',
     createPriority: 3,
     paymentPattern: 'fixed_price',
+    priceColumn: 'fixed_price',
   },
   cause: {
     type: 'cause',

--- a/src/domain/payments/index.ts
+++ b/src/domain/payments/index.ts
@@ -19,6 +19,11 @@ export type {
 
 // Services
 export { initiatePayment, checkPaymentStatus, buyerConfirmPayment } from './paymentFlowService';
-export { resolveSellerWallet, getSellerUserId } from './walletResolutionService';
+export {
+  resolveSellerWallet,
+  resolveSellerReceiveInfo,
+  getSellerUserId,
+} from './walletResolutionService';
+export type { SellerReceiveInfo } from './walletResolutionService';
 export { generateInvoice } from './invoiceGenerationService';
 export { encrypt, decrypt } from './encryptionService';

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -319,20 +319,24 @@ async function resolveAmount(
   // We convert via the same rate path the UI uses to DISPLAY prices, so the
   // amount charged matches what the buyer was shown.
   const admin = getAdminClient() as unknown as SupabaseClient;
-  const priceColumn = meta.tableName === 'user_services' ? 'fixed_price' : 'price';
+  // Price column is declared per entity in the registry (SSOT). Defaults to
+  // `price` for entities that don't override it (e.g. products).
+  const priceColumn = meta.priceColumn ?? 'price';
   const { data: entity } = await admin
     .from(meta.tableName)
     .select(`${priceColumn}, currency`)
     .eq('id', entityId)
     .single();
 
-  const rawPrice = entity ? (entity as Record<string, unknown>)[priceColumn] : null;
+  // Dynamic select column widens the PostgREST result type — read via unknown.
+  const row = entity as unknown as Record<string, unknown> | null;
+  const rawPrice = row ? row[priceColumn] : null;
   const priceNum = typeof rawPrice === 'number' ? rawPrice : Number(rawPrice);
   if (!priceNum || priceNum <= 0) {
     throw new Error('Entity has no price set');
   }
 
-  const currency = String((entity as Record<string, unknown>).currency || 'BTC').toUpperCase();
+  const currency = String(row?.currency || 'BTC').toUpperCase();
   if (currency === 'BTC') {
     return priceNum;
   }

--- a/src/domain/payments/walletResolutionService.ts
+++ b/src/domain/payments/walletResolutionService.ts
@@ -35,6 +35,16 @@ export async function resolveSellerWallet(
   // Cast to untyped client — queries use dynamic column names from entity registry.
   const admin = getAdminClient() as unknown as SupabaseClient;
 
+  // Step 0: Entity-specific wallet override. If the owner explicitly tied a
+  // wallet to THIS entity (entity_wallets), that wallet receives the funds —
+  // regardless of which wallet is their profile default. Owners may have
+  // multiple addresses and route different entities to different ones. Falls
+  // through to the owner's primary wallet (Step 1) when no link exists.
+  const linked = await resolveLinkedEntityWallet(admin, entityType, entityId);
+  if (linked) {
+    return linked;
+  }
+
   // Step 1: Find the entity's owner (seller)
   const meta = getEntityMetadata(entityType);
   const { data: entity, error: entityError } = await admin
@@ -86,6 +96,41 @@ export async function resolveSellerWallet(
 
   // profile_id or user_id maps directly to auth user id
   return resolveUserWallet(admin, ownerId);
+}
+
+/** Display-safe receiving info for an entity (no secrets — never the NWC URI). */
+export interface SellerReceiveInfo {
+  method: ResolvedWallet['method'];
+  /**
+   * Receiving address to show: the Lightning address or on-chain address.
+   * Null for NWC (a connection has no static address to display).
+   */
+  address: string | null;
+}
+
+/**
+ * Resolve display-safe receiving info for an entity, reusing the same wallet
+ * resolution the payment flow uses (SSOT) so what the owner sees matches what
+ * buyers will actually pay to. Returns null when no wallet is connected.
+ */
+export async function resolveSellerReceiveInfo(
+  supabase: SupabaseClient,
+  entityType: EntityType,
+  entityId: string
+): Promise<SellerReceiveInfo | null> {
+  const resolved = await resolveSellerWallet(supabase, entityType, entityId);
+  if (!resolved) {
+    return null;
+  }
+
+  const address =
+    resolved.method === 'lightning_address'
+      ? (resolved.lightning_address ?? null)
+      : resolved.method === 'onchain'
+        ? (resolved.onchain_address ?? null)
+        : null;
+
+  return { method: resolved.method, address };
 }
 
 /**
@@ -154,9 +199,90 @@ export async function getSellerUserId(
 // INTERNAL HELPERS
 // =====================================================================
 
+/** A wallet row shaped for payment-method selection. */
+interface WalletRow {
+  id: string;
+  nwc_connection_uri?: string | null;
+  lightning_address?: string | null;
+  address_or_xpub?: string | null;
+}
+
+/**
+ * Pick the best payment method from a SINGLE wallet row.
+ * Priority: NWC > Lightning Address > On-chain. Returns null if the wallet has
+ * no usable payment detail (or its NWC URI fails to decrypt).
+ */
+function pickMethodFromWallet(wallet: WalletRow): ResolvedWallet | null {
+  if (wallet.nwc_connection_uri) {
+    try {
+      return { method: 'nwc', wallet_id: wallet.id, nwc_uri: decrypt(wallet.nwc_connection_uri) };
+    } catch (e) {
+      logger.error('Failed to decrypt NWC URI', { walletId: wallet.id, error: e });
+      // Fall through to next method
+    }
+  }
+
+  if (wallet.lightning_address) {
+    return {
+      method: 'lightning_address',
+      wallet_id: wallet.id,
+      lightning_address: wallet.lightning_address,
+    };
+  }
+
+  if (wallet.address_or_xpub) {
+    return { method: 'onchain', wallet_id: wallet.id, onchain_address: wallet.address_or_xpub };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the wallet explicitly linked to a specific entity via entity_wallets.
+ * is_primary-first so the choice is deterministic when several are linked.
+ * Returns null when no active linked wallet yields a usable payment method.
+ */
+async function resolveLinkedEntityWallet(
+  supabase: SupabaseClient,
+  entityType: EntityType,
+  entityId: string
+): Promise<ResolvedWallet | null> {
+  const { data: links } = await supabase
+    .from(DATABASE_TABLES.ENTITY_WALLETS)
+    .select('wallet_id, is_primary')
+    .eq('entity_type', entityType)
+    .eq('entity_id', entityId)
+    .order('is_primary', { ascending: false });
+
+  if (!links || links.length === 0) {
+    return null;
+  }
+
+  for (const link of links as Array<{ wallet_id: string }>) {
+    const { data: wallet } = await supabase
+      .from(DATABASE_TABLES.WALLETS)
+      .select('id, nwc_connection_uri, lightning_address, address_or_xpub')
+      .eq('id', link.wallet_id)
+      .eq('is_active', true)
+      .single();
+
+    if (!wallet) {
+      continue;
+    }
+
+    const resolved = pickMethodFromWallet(wallet as WalletRow);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Resolve best wallet for a user from the wallets table.
- * Priority: NWC > Lightning Address > On-chain
+ * Priority across wallets: a wallet with NWC > one with a Lightning Address >
+ * one with an on-chain address. Primary wallet wins ties (ordered first).
  */
 async function resolveUserWallet(
   supabase: SupabaseClient,

--- a/src/hooks/useDisplayCurrency.ts
+++ b/src/hooks/useDisplayCurrency.ts
@@ -42,6 +42,13 @@ interface UseDisplayCurrencyReturn {
   formatSats: (sats: number, options?: DisplayCurrencyOptions) => string;
   /** Format a BTC amount (database canonical unit) in user's preferred display currency. Caller must pass BTC. */
   formatAmountBtc: (btc: number, options?: DisplayCurrencyOptions) => string;
+  /**
+   * Format a listing price that may be denominated in fiat OR BTC. When
+   * `currency` is a non-BTC fiat code, render it in that currency (entities
+   * price in their own currency, not BTC); otherwise (omitted/'BTC') render as
+   * a BTC amount in the user's preferred display unit.
+   */
+  formatPrice: (amount: number, currency?: string) => string;
   /** User's preferred display currency code */
   displayCurrency: CurrencyCode;
   /** Whether user prefers fiat (CHF/EUR/USD) vs crypto (BTC/SATS) */
@@ -123,9 +130,18 @@ export function useDisplayCurrency(): UseDisplayCurrencyReturn {
     [formatSats]
   );
 
+  const formatPrice = useCallback(
+    (amount: number, currency?: string): string =>
+      currency && currency.toUpperCase() !== 'BTC'
+        ? formatCurrency(amount, currency as CurrencyCode)
+        : formatAmountBtc(amount),
+    [formatAmountBtc]
+  );
+
   return {
     formatSats,
     formatAmountBtc,
+    formatPrice,
     displayCurrency,
     prefersFiat,
     isLoading,


### PR DESCRIPTION
This PR started as the BTC-collection end-to-end fix and grew to cover the public-profile UX gaps surfaced in a review of what an outsider sees when a profile/entity link is shared.

---

# Part 1 — Entities actually collect BTC (commit 299d16f2)

## Problem

Creating an entity (e.g. a "1 hour consultation" service) left it unable to actually collect Bitcoin:

- The per-entity wallet you tie at creation (`entity_wallets`) was **written but never read** — every payment routed to the owner's primary profile wallet regardless of what you picked.
- The **price never displayed** for services (the page read a non-existent `price_btc` column). This also made the `PaymentDialog` confirm button `disabled` (`amount <= 0`), so buyers literally **could not complete a purchase**.
- As the owner, the entity page showed **nothing** for collecting — no receiving address, no share affordance.

## Fix (end-to-end)

1. **`resolveSellerWallet` honours the entity-linked wallet** (`entity_wallets`, `is_primary` first), falling back to the owner's primary profile wallet. New helpers: `pickMethodFromWallet`, `resolveLinkedEntityWallet`, `resolveSellerReceiveInfo`.
2. **Config-driven price**: `priceColumn` SSOT in the entity registry + `getPrice` on the detail config; native-currency display, server charges the BTC-converted amount. Fixes the disabled pay button.
3. **Owner "Collect Bitcoin" panel** (`OwnerCollectPanel`): receiving address + price + copy-link/QR + share, backed by an **owner-gated** `GET /api/payments/receive-info`.
4. **`WalletSelectorField` pre-selects the primary wallet** so an existing address is tied by default.
5. **DRY cleanup**: shared `useDisplayCurrency().formatPrice()`, adopted in the bookings dialog too.

---

# Part 2 — Public-profile UX: consistent funding + dual-currency pricing

A review of the shared public pages found two systemic issues: funding state was reimplemented (and broken) per entity, and prices showed a single denomination meaningless to half the audience.

## `FundingProgress` — one module for every funding entity (commit 5ef014c5)

Replaces **five** near-identical, drifting copies of the raised/goal/%-funded card (cause, research, investment, wishlist + the project rail's display half).

- **Fixes the blank cause page**: every prior copy returned `null` when no goal was set, so a *fund* page with no goal rendered empty. Now always renders an inviting state ("Be the first to back this").
- **One currency formatter** (`formatCurrency`) — research was BTC-only via `displayBTC`.
- **Honest zero-state** instead of a green `0.00`.
- Project's `ProjectSummaryRail` (client, live balance refresh) left as-is.

## `PriceDisplay` — show both denominations (commits 95e16cfd, 4de4a954)

A bare `₿0.0005` is meaningless to most buyers; a bare `CHF 86` hides that it's Bitcoin-payable. New async server component renders the stored price **plus a live-rate equivalent** in the other denomination, dropping the equivalent (never fabricating) when a rate is unavailable.

- **Product**: `₿0.0005 ≈ CHF 25.90`
- **Service**: `CHF 150.00 ≈ ₿0.00289452` (hourly `/ hr` unit preserved via optional `suffix` prop)
- **AI assistants**: gained a Pricing card (previously **no price shown at all**) — per-message / per-1k-tokens / subscription priced in BTC + fiat, or "Free".

---

## `PublicEntityHero` — cover images for image-centric entities (commit b735bc73)

The generic entity page only rendered a 64px type icon, so a product/service/event with photos showed a generic glyph instead of the actual thing (the art print with no image). New `PublicEntityHero` renders the entity's images as a responsive 16:9 hero + thumbnail row, via a `getCoverImages` config slot — product (`images[]` + `thumbnail_url`), service (`images[]`), event (`banner_url` + `thumbnail_url` + `images[]`), and ai_assistant `avatar_url` in the header icon box (identity, not a hero). Data-driven with an icon fallback: entities with no imagery render exactly as before (no empty frames). Note the seeded products currently have empty `images` — this wires the rendering so a real image appears the moment a creator uploads one.

---

## Permissionless payment — logged-out visitors can pay (commit 1e5b04ea)

Every entity page gated payment behind "Sign in to continue" — a logged-out visitor couldn't send a single sat, despite "permissionless, no account required" being a core principle (and despite the profile page already revealing receiving addresses publicly). New `PublicPayPanel` reveals the seller's public receiving address with the amount baked into a BIP21/`lightning:` URI, a QR, copy, and open-in-wallet — the payer settles directly from their own wallet, non-custodial, no sign-up. Receiving info is resolved server-side via the existing `resolveSellerReceiveInfo` (SSOT with the paid flow). Graceful fallbacks: NWC-only sellers (no static address) keep the sign-in/invoice path; sellers with no wallet show an honest notice. Authenticated buyer and owner flows are unchanged.

---

## Profile: account-email leak + default tab (commit f1e06fc7)

- **Email leak:** the public profile fetched `select('*')` and shipped the private account login email (`profiles.email`) into every visitor's client payload, and the "Contact email" fell back to it when no opt-in `contact_email` was set. Now the account email is redacted to `null` server-side for non-owners (never leaves the box, verified in the rendered payload), the public "Contact Email" resolves strictly to the opt-in `contact_email`, and the email-verification Account Status card is gated to the owner. `phone`/`contact_email` stay — opt-in public fields.
- **Default tab:** a shared profile opened on the Timeline feed ("Sign in to post" + manifesto) instead of the scannable Overview. Default is now **Overview** so "who is this / what do they offer" is immediate.

---

## Zero amounts no longer render in success-green (commit 1aa593ba)

`text-status-positive` (green) signals an actual positive, but "CHF 0.00 Total Raised" was rendered green — reading as a metric it isn't. Gated green on a non-zero value (neutral `text-fg-primary` at zero) in the three public spots that did this: profile "Total Raised", investment card "Raised", and group wallet "Balance".

---

## Dependency security (commit d0e6184e)

Targeted, non-breaking lockfile bumps for the Dependabot alerts with real risk: **hono 4.12.27** (both HIGH advisories), **dompurify 3.4.11** (runtime HTML-sanitizer XSS), **js-yaml 4.2.0** (moderate). package.json untouched (all within range). `@babel/core` (low, dev/build-only) is intentionally left — its fix drags the babel/jest toolchain forward and skews jest internals (breaks all 72 suites); same for the dev-only `ws` and the gray-matter→js-yaml@3.14 path. The 2 highs Dependabot shows on `main` are the hono ones and clear on merge.

---

## Tests / verification

- `resolveSellerWallet.test.ts`: entity-link precedence, Lightning-over-onchain, fallbacks (4 cases).
- Non-incremental `tsc` clean + ESLint clean across all commits; pre-push E2E suite green.
- Public pages verified in-browser against live data (0 console errors): cause empty-state + goal>0 path, product `₿→CHF`, service `CHF→₿`.
- **Not verified visually**: the AI-assistant page — no public ai_assistant entities are seeded — but it is type-checked and mirrors the verified product/service path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





