### PR TITLE
feat(profile): explore-&-fund hub — projects with one-tap Support

### DIFF
--- a/src/app/profiles/[username]/page.tsx
+++ b/src/app/profiles/[username]/page.tsx
@@ -175,6 +175,7 @@ export default async function PublicProfilePage({ params }: PageProps) {
       goal_amount,
       currency,
       raised_amount,
+      cover_image_url,
       created_at,
       updated_at
     `

--- a/src/components/profile/ProfileLayout.tsx
+++ b/src/components/profile/ProfileLayout.tsx
@@ -56,7 +56,7 @@ interface ProfileLayoutProps {
 
 export default function ProfileLayout({
   profile,
-  projects: _projects,
+  projects,
   stats,
   mode: _mode = 'view',
   onSave,
@@ -86,6 +86,7 @@ export default function ProfileLayout({
       content: (
         <ProfileOverviewTab
           profile={profile}
+          projects={projects}
           stats={stats}
           isOwnProfile={isOwnProfile}
           context="public"

--- a/src/components/profile/ProfileOverviewTab.tsx
+++ b/src/components/profile/ProfileOverviewTab.tsx
@@ -1,17 +1,39 @@
 'use client';
 
+import Link from 'next/link';
 import type { ScalableProfile } from '@/services/profile/types';
 import { Card, CardHeader, CardContent } from '@/components/ui/Card';
-import { User, Globe, Calendar, Mail, Phone } from 'lucide-react';
+import { User, Globe, Calendar, Mail, Phone, ArrowRight } from 'lucide-react';
 import { SocialLinksDisplay } from './SocialLinksDisplay';
 import { ProfileSupportSection } from './ProfileSupportSection';
+import ProfileProjectCard from './ProfileProjectCard';
 import { SocialLink } from '@/types/social';
 import { ROUTES } from '@/config/routes';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 
+/** Loose project shape — the page passes server-fetched rows; we read defensively. */
+interface OverviewProject {
+  id: string;
+  title: string;
+  description?: string | null;
+  cover_image_url?: string | null;
+  thumbnail_url?: string | null;
+  goal_amount?: number | null;
+  goal_currency?: string | null;
+  currency?: string | null;
+  raised_amount?: number | null;
+  bitcoin_balance_btc?: number | null;
+  category?: string | null;
+  status?: string | null;
+  bitcoin_address?: string | null;
+  created_at: string;
+}
+
 interface ProfileOverviewTabProps {
   profile: ScalableProfile;
+  /** Owner's projects, surfaced as an explore-and-fund section. */
+  projects?: OverviewProject[];
   stats?: {
     projectCount: number;
     totalRaised: number;
@@ -37,11 +59,16 @@ interface ProfileOverviewTabProps {
  */
 export default function ProfileOverviewTab({
   profile,
+  projects,
   stats,
   isOwnProfile = false,
   context = 'public',
 }: ProfileOverviewTabProps) {
   const isDashboardView = context === 'dashboard';
+  const PROJECTS_PREVIEW = 3;
+  const visibleProjects = (projects ?? []).slice(0, PROJECTS_PREVIEW);
+  const ProjectIcon = ENTITY_REGISTRY.project.icon;
+  const projectsTabHref = `${ROUTES.PROFILES.VIEW(profile.username || profile.id)}?tab=projects`;
   // Public contact email is ONLY the opt-in contact_email field — never the
   // private account login email (profile.email). See profile email-leak fix.
   const publicContactEmail = profile.contact_email;
@@ -77,6 +104,48 @@ export default function ProfileOverviewTab({
           )}
         </CardContent>
       </Card>
+
+      {/* Projects — explore the owner's work and back any of it without leaving. */}
+      {visibleProjects.length > 0 && (
+        <section className="space-y-3 sm:space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="flex items-center gap-2 text-base font-semibold text-fg-primary sm:text-lg">
+              <ProjectIcon className="h-4 w-4 text-fg-secondary sm:h-5 sm:w-5" />
+              {ENTITY_REGISTRY.project.namePlural}
+            </h3>
+            {(projects?.length ?? 0) > PROJECTS_PREVIEW && (
+              <Link
+                href={projectsTabHref}
+                className="inline-flex items-center gap-1 text-sm text-fg-secondary hover:text-fg-primary"
+              >
+                View all {projects?.length}
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            )}
+          </div>
+          <div className="space-y-4">
+            {visibleProjects.map(p => (
+              <ProfileProjectCard
+                key={p.id}
+                project={{
+                  id: p.id,
+                  title: p.title,
+                  description: p.description,
+                  imageUrl: p.cover_image_url ?? p.thumbnail_url ?? null,
+                  goalAmount: p.goal_amount,
+                  raisedAmount: p.raised_amount ?? undefined,
+                  balanceBtc: p.bitcoin_balance_btc ?? undefined,
+                  currency: p.goal_currency ?? p.currency ?? undefined,
+                  category: p.category,
+                  status: p.status,
+                  hasWallet: !!p.bitcoin_address,
+                  createdAt: p.created_at,
+                }}
+              />
+            ))}
+          </div>
+        </section>
+      )}
 
       <ProfileSupportSection profile={profile} />
 

--- a/src/components/profile/ProfileProjectCard.tsx
+++ b/src/components/profile/ProfileProjectCard.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+/**
+ * ProfileProjectCard — one project as an explore-and-fund card.
+ *
+ * Shared by the profile Overview's "Projects" section and the Projects tab so
+ * a shared profile shows the owner's actual work (not just a count) and lets a
+ * visitor jump straight to funding any project. The card body links to the
+ * project; a separate "Support" button deep-links to the project's donate
+ * panel (#pay) so backing something is one tap from the listing.
+ */
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { Target, Bitcoin } from 'lucide-react';
+import Button from '@/components/ui/Button';
+import { ROUTES } from '@/config/routes';
+import { CurrencyDisplay } from '@/components/ui/CurrencyDisplay';
+import { formatBitcoinDisplay } from '@/services/currency/formatting';
+import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
+import { formatRelativeTimeCompact } from '@/utils/dates';
+import { getStatusInfo } from '@/config/status-config';
+import { PROJECT_STATUS } from '@/config/project-statuses';
+
+/** Normalized shape — callers map their own row type (server Project / tab item) to this. */
+export interface ProfileProjectCardData {
+  id: string;
+  title: string;
+  description?: string | null;
+  imageUrl?: string | null;
+  goalAmount?: number | null;
+  /** Legacy fiat "raised" total, used when there's no on-chain balance. */
+  raisedAmount?: number;
+  /** On-chain balance in BTC, preferred when present. */
+  balanceBtc?: number;
+  currency?: string;
+  category?: string | null;
+  status?: string | null;
+  hasWallet?: boolean;
+  createdAt: string;
+}
+
+export default function ProfileProjectCard({ project }: { project: ProfileProjectCardData }) {
+  const currency = project.currency || PLATFORM_DEFAULT_CURRENCY;
+  const balanceBTC = project.balanceBtc || 0;
+  const goalAmount = project.goalAmount || 0;
+  const raisedAmount = project.raisedAmount || 0;
+  const currentAmount = balanceBTC > 0 ? balanceBTC : raisedAmount;
+  const progress = goalAmount > 0 ? Math.min((currentAmount / goalAmount) * 100, 100) : 0;
+  const statusInfo = getStatusInfo(project.status || PROJECT_STATUS.ACTIVE);
+  const showStatusBadge =
+    project.status &&
+    !([PROJECT_STATUS.ACTIVE, PROJECT_STATUS.DRAFT] as string[]).includes(
+      project.status.toLowerCase()
+    );
+  const viewHref = ROUTES.PROJECTS.VIEW(project.id);
+
+  return (
+    <div className="overflow-hidden rounded-lg border-2 border-default bg-surface-base transition-all duration-200 hover:border-strong hover:shadow-sm group">
+      <Link href={viewHref} className="block">
+        <div className="flex flex-col sm:flex-row">
+          {/* Thumbnail */}
+          <div className="relative h-48 w-full flex-shrink-0 bg-surface-raised sm:h-auto sm:w-32">
+            {project.imageUrl ? (
+              <Image
+                src={project.imageUrl}
+                alt={project.title}
+                fill
+                unoptimized
+                className="object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <Target className="h-12 w-12 text-fg-secondary" />
+              </div>
+            )}
+            {project.category && (
+              <div className="absolute left-2 top-2">
+                <span className="rounded-md bg-surface-base/90 px-2 py-1 text-xs font-medium text-fg-primary backdrop-blur-sm">
+                  {project.category}
+                </span>
+              </div>
+            )}
+            {showStatusBadge && (
+              <div className="absolute right-2 top-2">
+                <span
+                  className={`rounded-md px-2 py-1 text-xs font-medium ${statusInfo.className}`}
+                >
+                  {statusInfo.label}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* Content */}
+          <div className="flex flex-1 flex-col p-4 sm:p-5">
+            <div className="flex-1">
+              <h4 className="mb-1.5 line-clamp-1 text-lg font-bold text-fg-primary">
+                {project.title}
+              </h4>
+              {project.description && (
+                <p className="mb-3 line-clamp-2 text-sm text-fg-secondary">{project.description}</p>
+              )}
+            </div>
+
+            {/* Progress / balance */}
+            {goalAmount > 0 ? (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-fg-secondary">Progress</span>
+                  <span className="font-semibold text-fg-primary">{progress.toFixed(1)}%</span>
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-surface-raised">
+                  <div
+                    className="h-2 rounded-full bg-fg-primary transition-all duration-300"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-fg-secondary">
+                    <CurrencyDisplay amount={currentAmount} currency={currency} size="sm" />
+                  </span>
+                  <span className="text-fg-secondary">
+                    of <CurrencyDisplay amount={goalAmount} currency={currency} size="sm" />
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <Bitcoin className="h-4 w-4 text-bitcoinOrange" />
+                <span className="text-sm font-semibold text-fg-primary">
+                  {balanceBTC > 0 ? (
+                    formatBitcoinDisplay(balanceBTC)
+                  ) : raisedAmount > 0 ? (
+                    <CurrencyDisplay amount={raisedAmount} currency={currency} size="sm" />
+                  ) : (
+                    'No funds yet'
+                  )}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      </Link>
+
+      {/* Footer — meta + a one-tap Support that jumps to the donate panel */}
+      <div className="flex items-center justify-between gap-3 border-t border-subtle px-4 py-3 sm:px-5">
+        <div className="flex items-center gap-3 text-xs text-fg-secondary">
+          <span>{formatRelativeTimeCompact(project.createdAt)}</span>
+          {project.hasWallet && (
+            <span className="flex items-center gap-1 text-bitcoinOrange">
+              <Bitcoin className="h-3 w-3" />
+              Wallet
+            </span>
+          )}
+        </div>
+        <Button href={`${viewHref}#pay`} size="sm" className="gap-1.5">
+          <Bitcoin className="h-4 w-4" />
+          Support
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileProjectsTab.tsx
+++ b/src/components/profile/ProfileProjectsTab.tsx
@@ -3,17 +3,12 @@ import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
-import { Target, Bitcoin, ArrowRight } from 'lucide-react';
+import { Target, ArrowRight } from 'lucide-react';
 import type { ScalableProfile } from '@/services/profile/types';
 import Button from '@/components/ui/Button';
+import ProfileProjectCard from '@/components/profile/ProfileProjectCard';
 import { ROUTES } from '@/config/routes';
 import { API_ROUTES } from '@/config/api-routes';
-import { CurrencyDisplay } from '@/components/ui/CurrencyDisplay';
-import { formatBitcoinDisplay } from '@/services/currency/formatting';
-import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
-import { formatRelativeTimeCompact } from '@/utils/dates';
-import { getStatusInfo } from '@/config/status-config';
 import { PROJECT_STATUS } from '@/config/project-statuses';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 
@@ -142,140 +137,25 @@ export default function ProfileProjectsTab({ profile, isOwnProfile }: ProfilePro
 
       {/* Projects Grid */}
       <div className="space-y-4">
-        {publicProjects.map(project => {
-          const statusInfo = getStatusInfo(project.status || PROJECT_STATUS.ACTIVE);
-          const balanceBTC = project.bitcoin_balance_btc || 0;
-          const goalAmount = project.goal_amount || 0;
-          const raisedAmount = project.raised_amount || 0;
-          const currentAmount = balanceBTC > 0 ? balanceBTC : raisedAmount;
-          const progress = goalAmount > 0 ? Math.min((currentAmount / goalAmount) * 100, 100) : 0;
-          const showStatusBadge =
-            project.status &&
-            !([PROJECT_STATUS.ACTIVE, PROJECT_STATUS.DRAFT] as string[]).includes(
-              project.status.toLowerCase()
-            );
-
-          return (
-            <Link
-              key={project.id}
-              href={ROUTES.PROJECTS.VIEW(project.id)}
-              className="block overflow-hidden rounded-lg border-2 border-default hover:border-strong hover:shadow-sm bg-surface-base transition-all duration-200 group"
-            >
-              <div className="flex flex-col sm:flex-row">
-                {/* Thumbnail */}
-                <div className="relative w-full sm:w-32 h-48 sm:h-auto flex-shrink-0 bg-surface-raised">
-                  {project.thumbnail_url ? (
-                    <Image
-                      src={project.thumbnail_url}
-                      alt={project.title}
-                      fill
-                      className="object-cover group-hover:scale-105 transition-transform duration-300"
-                    />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center">
-                      <Target className="w-12 h-12 text-fg-secondary" />
-                    </div>
-                  )}
-                  {project.category && (
-                    <div className="absolute top-2 left-2">
-                      <span className="px-2 py-1 bg-surface-base/90 dark:bg-surface-base/90 backdrop-blur-sm rounded-md text-xs font-medium text-fg-primary">
-                        {project.category}
-                      </span>
-                    </div>
-                  )}
-                  {showStatusBadge && (
-                    <div className="absolute top-2 right-2">
-                      <span
-                        className={`px-2 py-1 rounded-md text-xs font-medium ${statusInfo.className}`}
-                      >
-                        {statusInfo.label}
-                      </span>
-                    </div>
-                  )}
-                </div>
-
-                {/* Content */}
-                <div className="flex-1 p-4 sm:p-5 flex flex-col">
-                  <div className="flex-1">
-                    <h4 className="font-bold text-fg-primary text-lg mb-1.5 line-clamp-1">
-                      {project.title}
-                    </h4>
-                    {project.description && (
-                      <p className="text-sm text-fg-secondary line-clamp-2 mb-3">
-                        {project.description}
-                      </p>
-                    )}
-                  </div>
-
-                  {/* Progress */}
-                  {goalAmount > 0 ? (
-                    <div className="space-y-2 mb-3">
-                      <div className="flex items-center justify-between text-xs">
-                        <span className="text-fg-secondary">Progress</span>
-                        <span className="font-semibold text-fg-primary">
-                          {progress.toFixed(1)}%
-                        </span>
-                      </div>
-                      <div className="w-full bg-surface-raised rounded-full h-2 overflow-hidden">
-                        <div
-                          className="bg-fg-primary h-2 rounded-full transition-all duration-300"
-                          style={{ width: `${progress}%` }}
-                        />
-                      </div>
-                      <div className="flex items-center justify-between text-xs">
-                        <span className="text-fg-secondary">
-                          <CurrencyDisplay
-                            amount={currentAmount}
-                            currency={project.currency || PLATFORM_DEFAULT_CURRENCY}
-                            size="sm"
-                          />
-                        </span>
-                        <span className="text-fg-secondary">
-                          of{' '}
-                          <CurrencyDisplay
-                            amount={goalAmount}
-                            currency={project.currency || PLATFORM_DEFAULT_CURRENCY}
-                            size="sm"
-                          />
-                        </span>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="mb-3">
-                      <div className="flex items-center gap-2">
-                        <Bitcoin className="w-4 h-4 text-bitcoinOrange" />
-                        <span className="text-sm font-semibold text-fg-primary">
-                          {balanceBTC > 0 ? (
-                            formatBitcoinDisplay(balanceBTC)
-                          ) : raisedAmount > 0 ? (
-                            <CurrencyDisplay
-                              amount={raisedAmount}
-                              currency={project.currency || PLATFORM_DEFAULT_CURRENCY}
-                              size="sm"
-                            />
-                          ) : (
-                            'No funds yet'
-                          )}
-                        </span>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Footer */}
-                  <div className="flex items-center justify-between text-xs text-fg-secondary pt-2 border-t border-subtle">
-                    <span>{formatRelativeTimeCompact(project.created_at)}</span>
-                    {project.bitcoin_address && (
-                      <span className="flex items-center gap-1 text-bitcoinOrange">
-                        <Bitcoin className="w-3 h-3" />
-                        Wallet
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </Link>
-          );
-        })}
+        {publicProjects.map(project => (
+          <ProfileProjectCard
+            key={project.id}
+            project={{
+              id: project.id,
+              title: project.title,
+              description: project.description,
+              imageUrl: project.thumbnail_url,
+              goalAmount: project.goal_amount,
+              raisedAmount: project.raised_amount,
+              balanceBtc: project.bitcoin_balance_btc,
+              currency: project.currency,
+              category: project.category,
+              status: project.status,
+              hasWallet: !!project.bitcoin_address,
+              createdAt: project.created_at,
+            }}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/components/project/ProjectPageClient.tsx
+++ b/src/components/project/ProjectPageClient.tsx
@@ -154,21 +154,23 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
             </div>
           </div>
           <div className="space-y-6">
-            <PublicEntityPaymentSection
-              entityType="project"
-              entityId={project.id}
-              entityTitle={project.title}
-              sellerProfileId={project.user_id}
-              sellerUserId={project.user_id}
-              sellerReceive={
-                project.bitcoin_address
-                  ? { method: 'onchain', address: project.bitcoin_address }
-                  : project.lightning_address
-                    ? { method: 'lightning_address', address: project.lightning_address }
-                    : null
-              }
-              signInRedirect={ROUTES.PROJECTS.VIEW(project.id)}
-            />
+            <div id="pay" className="scroll-mt-24">
+              <PublicEntityPaymentSection
+                entityType="project"
+                entityId={project.id}
+                entityTitle={project.title}
+                sellerProfileId={project.user_id}
+                sellerUserId={project.user_id}
+                sellerReceive={
+                  project.bitcoin_address
+                    ? { method: 'onchain', address: project.bitcoin_address }
+                    : project.lightning_address
+                      ? { method: 'lightning_address', address: project.lightning_address }
+                      : null
+                }
+                signInRedirect={ROUTES.PROJECTS.VIEW(project.id)}
+              />
+            </div>
 
             <ProjectSummaryRail
               project={{


### PR DESCRIPTION
Polishes the "share my profile → people explore my work → donate to any project" flow.

## Problem
A shared profile opened on the Overview showing only a bio + stat **counts** ("2 Projects"). To actually see someone's work a visitor had to hunt for a separate tab, and there was no way to back a project from the listing — you had to drill into each detail page first.

## Change
The Overview now surfaces the owner's real projects as cards (cover image + funding progress), each with a **Support** button that deep-links straight to that project's donate panel (`/projects/:id#pay`). A shared link is now immediately *see what I do → explore → fund any project*.

- **New `ProfileProjectCard`** (shared): the card body links to the project; a separate **Support** button jumps to `#pay`. Also reused in the Projects tab — removed the duplicated inline card markup, so there's **one** card source now (DRY).
- Overview shows the top 3 projects + a "View all → Projects tab" link.
- Threaded the already-server-fetched `projects` into the Overview (no new fetch); added `cover_image_url` to the profile project query.
- Added `id="pay"` (with `scroll-mt`) to the project page so the Support deep-link lands on the donate panel.

## Wallets
Unchanged here — per-project vs shared still resolves via the existing entity-wallet → profile-wallet fallback, with **one shared wallet as the default path** (the agreed model). Making that choice more explicit in the create flow is a follow-up.

## Verified (live data, logged-out)
- `/profiles/mao` Overview renders 2 project cards (FleetCrown, OrangeCat) with funding + Support buttons.
- Support → `/projects/:id#pay` lands on the PublicPayPanel (address + QR + "no account needed").
- `tsc` 0 errors · ESLint clean · 0 console errors · pre-push E2E green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)