### PR TITLE
fix(bookings): let the customer pay a confirmed booking (G1)

### DIFF
--- a/src/app/(authenticated)/dashboard/bookings/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/bookings/[id]/page.tsx
@@ -15,7 +15,14 @@ import { STATUS } from '@/config/database-constants';
 import { formatDate, formatTime } from '@/utils/dates';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { logger } from '@/utils/logger';
+import { PublicPayPanel } from '@/components/payment/PublicPayPanel';
 import type { Booking } from '@/services/bookings';
+
+interface ReceiveInfo {
+  hasWallet: boolean;
+  method: 'nwc' | 'lightning_address' | 'onchain' | null;
+  address: string | null;
+}
 
 type BookingWithCustomer = Booking & {
   customer?: {
@@ -43,6 +50,8 @@ export default function BookingDetailPage() {
   const [booking, setBooking] = useState<BookingWithCustomer | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isActing, setIsActing] = useState(false);
+  // undefined = not fetched yet, null = no payable wallet, object = resolved
+  const [receive, setReceive] = useState<ReceiveInfo | null | undefined>(undefined);
 
   const id = params.id as string;
 
@@ -72,6 +81,40 @@ export default function BookingDetailPage() {
   useEffect(() => {
     void loadBooking();
   }, [loadBooking]);
+
+  // For the customer on a confirmed-but-unpaid booking, fetch where to pay
+  // (the provider's public receiving address) so we can show a pay panel.
+  useEffect(() => {
+    if (!booking) {
+      return;
+    }
+    const payable =
+      booking.role === 'customer' &&
+      (booking.status === STATUS.BOOKINGS.CONFIRMED ||
+        booking.status === STATUS.BOOKINGS.IN_PROGRESS) &&
+      booking.price_btc > 0 &&
+      (booking.total_paid_btc ?? 0) < booking.price_btc;
+    if (!payable) {
+      setReceive(null);
+      return;
+    }
+    let cancelled = false;
+    fetch(API_ROUTES.BOOKINGS.RECEIVE_INFO(id))
+      .then(res => (res.ok ? res.json() : null))
+      .then(body => {
+        if (!cancelled) {
+          setReceive((body?.data as ReceiveInfo) ?? null);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setReceive(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [booking, id]);
 
   const handleAction = async (action: 'confirm' | 'reject' | 'complete' | 'cancel') => {
     setIsActing(true);
@@ -216,6 +259,38 @@ export default function BookingDetailPage() {
         </CardContent>
       </Card>
 
+      {/* Customer pay step — the booking dead-ended here before: confirmed,
+          but no way to pay. Reveal the provider's address + exact amount. */}
+      {!isProvider &&
+        (booking.status === STATUS.BOOKINGS.CONFIRMED ||
+          booking.status === STATUS.BOOKINGS.IN_PROGRESS) &&
+        booking.price_btc > 0 &&
+        (booking.total_paid_btc ?? 0) < booking.price_btc &&
+        (receive === undefined ? (
+          <Card>
+            <CardContent className="pt-6 flex items-center gap-2 text-sm text-fg-secondary">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading payment details…
+            </CardContent>
+          </Card>
+        ) : receive?.address &&
+          (receive.method === 'onchain' || receive.method === 'lightning_address') ? (
+          <PublicPayPanel
+            entityTitle={serviceTitle}
+            isContribution={false}
+            priceAmount={booking.price_btc}
+            priceCurrency="BTC"
+            amountBtc={booking.price_btc}
+            method={receive.method}
+            address={receive.address}
+          />
+        ) : (
+          <Card>
+            <CardContent className="pt-6 text-sm text-fg-secondary">
+              The provider hasn&apos;t set up a payable Bitcoin address for this booking yet.
+            </CardContent>
+          </Card>
+        ))}
+
       {(booking.customer_notes || booking.provider_notes || booking.cancellation_reason) && (
         <Card>
           <CardHeader>
@@ -278,6 +353,23 @@ export default function BookingDetailPage() {
           )}
         </div>
       )}
+
+      {/* Customer can cancel a pending or confirmed booking (had no actions before). */}
+      {!isProvider &&
+        (booking.status === STATUS.BOOKINGS.PENDING ||
+          booking.status === STATUS.BOOKINGS.CONFIRMED) && (
+          <div className="flex gap-3 flex-wrap">
+            <Button
+              variant="outline"
+              onClick={() => handleAction('cancel')}
+              disabled={isActing}
+              className="gap-2"
+            >
+              {isActing && <Loader2 className="h-4 w-4 animate-spin" />}
+              Cancel booking
+            </Button>
+          </div>
+        )}
     </div>
   );
 }

--- a/src/app/api/bookings/[id]/receive-info/route.ts
+++ b/src/app/api/bookings/[id]/receive-info/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET /api/bookings/[id]/receive-info
+ *
+ * Display-safe receiving info (method + Lightning/on-chain address, never an
+ * NWC secret) for the provider of a booking, so the CUSTOMER can pay a
+ * confirmed booking directly. Authorized to the booking's two parties only.
+ * Resolved via the same path the rest of payments use (SSOT).
+ */
+
+import { createBookingService } from '@/services/bookings';
+import { resolveSellerReceiveInfo } from '@/domain/payments';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import type { EntityType } from '@/config/entity-registry';
+import {
+  apiSuccess,
+  apiNotFound,
+  apiForbidden,
+  apiInternalError,
+} from '@/lib/api/standardResponse';
+import { validateUUID, getValidationError } from '@/lib/api/validation';
+import { logger } from '@/utils/logger';
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+async function getActorIds(supabase: AnySupabaseClient, userId: string): Promise<string[]> {
+  const { data: actors } = await supabase
+    .from(DATABASE_TABLES.ACTORS)
+    .select('id')
+    .eq('user_id', userId);
+  return actors?.map((a: { id: string }) => a.id) || [];
+}
+
+export const GET = withAuth(async (request: AuthenticatedRequest, context: RouteContext) => {
+  const { id } = await context.params;
+  const idValidation = getValidationError(validateUUID(id, 'booking ID'));
+  if (idValidation) {
+    return idValidation;
+  }
+  try {
+    const { user, supabase } = request;
+    const booking = await createBookingService(supabase).getBooking(id);
+    if (!booking) {
+      return apiNotFound('Booking not found');
+    }
+
+    // Parties only — the address belongs to this booking's provider/customer.
+    const actorIds = await getActorIds(supabase, user.id);
+    const isCustomer = booking.customer_user_id === user.id;
+    const isProvider = actorIds.includes(booking.provider_actor_id);
+    if (!isCustomer && !isProvider) {
+      return apiForbidden('Access denied');
+    }
+
+    const info = await resolveSellerReceiveInfo(
+      supabase,
+      booking.bookable_type as EntityType,
+      booking.bookable_id
+    );
+
+    return apiSuccess({
+      hasWallet: !!info,
+      method: info?.method ?? null,
+      address: info?.address ?? null,
+    });
+  } catch (error) {
+    logger.error('Booking receive-info error', error, 'BookingsAPI');
+    return apiInternalError();
+  }
+});

--- a/src/components/payment/PublicPayPanel.tsx
+++ b/src/components/payment/PublicPayPanel.tsx
@@ -35,8 +35,11 @@ interface PublicPayPanelProps {
   method: 'onchain' | 'lightning_address';
   /** The receiving address to reveal. */
   address: string;
-  /** Sign-in link for the optional "track your order" affordance. */
-  signInHref: string;
+  /**
+   * Sign-in link for the optional "track your order" affordance (anonymous
+   * visitors). Omit for already-authed contexts (e.g. a booking customer).
+   */
+  signInHref?: string;
 }
 
 function truncateMiddle(value: string, head = 12, tail = 10): string {
@@ -140,12 +143,14 @@ export function PublicPayPanel({
         <p className="text-xs text-fg-secondary text-center">
           Pay directly from any Bitcoin wallet — no account needed.
         </p>
-        <p className="text-xs text-fg-tertiary text-center">
-          Have an account?{' '}
-          <Link href={signInHref} className="underline hover:text-fg-secondary">
-            Sign in to track your order
-          </Link>
-        </p>
+        {signInHref && (
+          <p className="text-xs text-fg-tertiary text-center">
+            Have an account?{' '}
+            <Link href={signInHref} className="underline hover:text-fg-secondary">
+              Sign in to track your order
+            </Link>
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -149,6 +149,7 @@ export const API_ROUTES = {
   BOOKINGS: {
     BASE: '/api/bookings',
     BY_ID: (id: string) => `/api/bookings/${id}`,
+    RECEIVE_INFO: (id: string) => `/api/bookings/${id}/receive-info`,
   },
   PRESENCE: {
     OFFLINE: '/api/presence/offline',


### PR DESCRIPTION
Audit gap **G1** — booking dead-ended: a customer could request a service booking and the provider could confirm it, but the customer had **zero actions** — no way to pay. Service commerce never completed.

## Fix
- New `GET /api/bookings/[id]/receive-info` — provider's public receiving address (on-chain/Lightning, never an NWC secret), authorized to the booking's two parties, via the same `resolveSellerReceiveInfo` path as the rest of payments.
- Booking detail page: on a confirmed/in-progress unpaid booking, the customer gets a **Pay panel** (reuses `PublicPayPanel`) with the **exact booking amount** in a BIP21/Lightning URI + QR + open-in-wallet. Graceful notice if the provider is NWC-only.
- Customer can now also **Cancel** a pending/confirmed booking (had no actions before).
- `PublicPayPanel.signInHref` made optional (hide the anonymous footer for the authed customer).

tsc 0 · ESLint clean · unit 554 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)