### PR TITLE
feat(ux): notification auto-save + shorter default donate flow

### DIFF
--- a/src/app/(authenticated)/settings/notifications/page.tsx
+++ b/src/app/(authenticated)/settings/notifications/page.tsx
@@ -18,9 +18,9 @@
  * Created: 2026-06-04
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Bell, LogIn, Save } from 'lucide-react';
+import { ArrowLeft, Bell, Check, Loader2, LogIn } from 'lucide-react';
 import { useRequireAuth } from '@/hooks/useAuth';
 import { ROUTES } from '@/config/routes';
 import Loading from '@/components/Loading';
@@ -108,49 +108,58 @@ export default function NotificationSettingsPage() {
     };
   }, [user]);
 
+  // Auto-save on every change — optimistic, reverting if the server rejects.
+  // No "Save" button to forget (the old flow silently lost unsaved toggles).
+  const persist = useCallback(
+    async (next: NotificationPreferences, prev: NotificationPreferences) => {
+      setPrefs(next); // optimistic
+      setSaving(true);
+      setError(null);
+      setSavedAt(null);
+      try {
+        const body = {
+          economic_emails: next.economic_emails,
+          social_emails: next.social_emails,
+          group_emails: next.group_emails,
+          progress_emails: next.progress_emails,
+          reengagement_emails: next.reengagement_emails,
+          digest_frequency: next.digest_frequency,
+        };
+        const res = await fetch('/api/notifications/preferences', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const errBody = (await res.json().catch(() => null)) as { error?: string } | null;
+          throw new Error(errBody?.error || `Failed to save (${res.status})`);
+        }
+        const json = (await res.json()) as { data: NotificationPreferences };
+        setPrefs(json.data);
+        setSavedAt(new Date().toLocaleTimeString());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to save');
+        setPrefs(prev); // revert so the UI never lies about what's saved
+      } finally {
+        setSaving(false);
+      }
+    },
+    []
+  );
+
   function setToggle(key: (typeof CATEGORIES)[number]['key'], value: boolean) {
-    setPrefs(prev => (prev ? { ...prev, [key]: value } : prev));
-    setSavedAt(null);
-  }
-
-  function setDigest(value: DigestFrequency) {
-    setPrefs(prev => (prev ? { ...prev, digest_frequency: value } : prev));
-    setSavedAt(null);
-  }
-
-  async function handleSave() {
     if (!prefs) {
       return;
     }
-    setSaving(true);
-    setError(null);
-    try {
-      const body = {
-        economic_emails: prefs.economic_emails,
-        social_emails: prefs.social_emails,
-        group_emails: prefs.group_emails,
-        progress_emails: prefs.progress_emails,
-        reengagement_emails: prefs.reengagement_emails,
-        digest_frequency: prefs.digest_frequency,
-      };
-      const res = await fetch('/api/notifications/preferences', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const errBody = (await res.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(errBody?.error || `Failed to save (${res.status})`);
-      }
-      const json = (await res.json()) as { data: NotificationPreferences };
-      setPrefs(json.data);
-      setSavedAt(new Date().toLocaleTimeString());
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save');
-    } finally {
-      setSaving(false);
+    void persist({ ...prefs, [key]: value }, prefs);
+  }
+
+  function setDigest(value: DigestFrequency) {
+    if (!prefs) {
+      return;
     }
+    void persist({ ...prefs, digest_frequency: value }, prefs);
   }
 
   if (authLoading) {
@@ -266,12 +275,18 @@ export default function NotificationSettingsPage() {
             </div>
           </section>
 
-          <div className="flex items-center justify-end gap-3">
-            {savedAt && <span className="text-xs text-fg-secondary">Saved at {savedAt}</span>}
-            <Button onClick={handleSave} disabled={saving}>
-              <Save className="mr-1 h-4 w-4" />
-              {saving ? 'Saving…' : 'Save changes'}
-            </Button>
+          <div className="flex items-center justify-end gap-2 text-xs text-fg-secondary">
+            {saving ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" /> Saving…
+              </>
+            ) : savedAt ? (
+              <>
+                <Check className="h-3.5 w-3.5 text-status-positive" /> Saved {savedAt}
+              </>
+            ) : (
+              <span>Changes save automatically</span>
+            )}
           </div>
         </>
       )}

--- a/src/components/payment/PaymentDialog.tsx
+++ b/src/components/payment/PaymentDialog.tsx
@@ -74,10 +74,15 @@ export function PaymentDialog({
   }, [defaultAmount]);
   const [message, setMessage] = useState('');
   const [isAnonymous, setIsAnonymous] = useState(false);
+  // Message + anonymous are optional — keep them one tap away so the default
+  // path is just amount → pay (fewer decisions, shortest path to support).
+  const [showMore, setShowMore] = useState(false);
 
   const handleClose = () => {
     reset();
     setMessage('');
+    setIsAnonymous(false);
+    setShowMore(false);
     setContributionAmount(defaultAmount ?? DEFAULT_CONTRIBUTION_BTC);
     onOpenChange(false);
   };
@@ -132,27 +137,39 @@ export function PaymentDialog({
                     value={contributionAmount}
                     onChange={setContributionAmount}
                   />
-                  <div>
-                    <label className="text-sm font-medium text-fg-primary">
-                      Message (optional)
-                    </label>
-                    <Textarea
-                      value={message}
-                      onChange={e => setMessage(e.target.value)}
-                      placeholder="Leave a message of support..."
-                      rows={2}
-                      className="mt-1"
-                    />
-                  </div>
-                  <label className="flex items-center gap-2 text-sm">
-                    <input
-                      type="checkbox"
-                      checked={isAnonymous}
-                      onChange={e => setIsAnonymous(e.target.checked)}
-                      className="rounded border-strong"
-                    />
-                    Contribute anonymously
-                  </label>
+                  {showMore ? (
+                    <div className="space-y-4">
+                      <div>
+                        <label className="text-sm font-medium text-fg-primary">
+                          Message (optional)
+                        </label>
+                        <Textarea
+                          value={message}
+                          onChange={e => setMessage(e.target.value)}
+                          placeholder="Leave a message of support..."
+                          rows={2}
+                          className="mt-1"
+                        />
+                      </div>
+                      <label className="flex items-center gap-2 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={isAnonymous}
+                          onChange={e => setIsAnonymous(e.target.checked)}
+                          className="rounded border-strong"
+                        />
+                        Contribute anonymously
+                      </label>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setShowMore(true)}
+                      className="text-sm text-fg-secondary underline-offset-4 hover:text-fg-primary hover:underline"
+                    >
+                      Add a message or give anonymously
+                    </button>
+                  )}
                 </div>
               )}
 


### PR DESCRIPTION
Two friction fixes from the user-actions audit (`docs/audits/USER_ACTIONS_AUDIT.md`).

## What changed

**F4 — Notification settings auto-save** (`settings/notifications`)
- Replaced the easy-to-forget **Save** button with optimistic auto-save that reverts on server error.
- Added an auto-save status indicator (Saving… / Saved <time> / "Changes save automatically").
- The old flow silently lost unsaved toggles when the user navigated away.

**F3 — Shorter default donate/support flow** (`PaymentDialog`)
- Collapsed the optional **message** + **anonymous** controls behind a one-tap "Add a message or give anonymously" disclosure.
- Default support path is now just **amount → pay** — fewer decisions, shortest path to support.

**F5 — AI model "Auto" default**
- Assessed: already satisfied. `ModernChatPanel` defaults to `'auto'` ("Auto (Best Free)", first in the list) and sends no model so the server picks the best free one. No code change needed.

## Why
Reduce clicks, page loads, and reading time on the two highest-traffic interactions (managing notifications, supporting an entity), per the "shortest path / least cognitive load" goal.

## Verification
- `eslint` clean on both changed files
- `npm run type-check` (non-incremental) — 0 errors
- `npm run test:unit` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)