### PR TITLE
feat(groups): leave group, member admin actions, group search

### DIFF
--- a/src/components/groups/GroupMembers.tsx
+++ b/src/components/groups/GroupMembers.tsx
@@ -14,7 +14,24 @@ import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/badge';
-import { Users, UserPlus, Crown, Shield, User } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import {
+  Users,
+  UserPlus,
+  Crown,
+  Shield,
+  ShieldOff,
+  User,
+  LogOut,
+  MoreVertical,
+  UserMinus,
+} from 'lucide-react';
 import { STATUS } from '@/config/database-constants';
 import type { GroupMember, GroupRole } from '@/types/group';
 import { getInitial } from '@/utils/string';
@@ -39,6 +56,9 @@ interface GroupMembersProps {
 export function GroupMembers({ groupId, members, onUpdate }: GroupMembersProps) {
   const { user } = useAuth();
   const [joining, setJoining] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+  const [confirmLeave, setConfirmLeave] = useState(false);
+  const [busyMemberId, setBusyMemberId] = useState<string | null>(null);
 
   const handleJoin = async () => {
     try {
@@ -58,7 +78,73 @@ export function GroupMembers({ groupId, members, onUpdate }: GroupMembersProps) 
     }
   };
 
-  const isMember = members.some(m => m.user_id === user?.id);
+  const handleLeave = async () => {
+    try {
+      setLeaving(true);
+      const result = await groupsService.leaveGroup(groupId);
+      if (result.success) {
+        toast.success('You left the group');
+        setConfirmLeave(false);
+        onUpdate?.();
+      } else {
+        toast.error(result.error || 'Failed to leave group');
+      }
+    } catch (error) {
+      logger.error('Failed to leave group:', error);
+      toast.error('Failed to leave group');
+    } finally {
+      setLeaving(false);
+    }
+  };
+
+  const currentMember = members.find(m => m.user_id === user?.id);
+  const isMember = !!currentMember;
+  // Founders cannot leave (must transfer ownership or delete) — the service
+  // rejects it, so we don't even offer the affordance.
+  const canLeave = isMember && currentMember?.role !== STATUS.GROUP_MEMBERS.FOUNDER;
+  // Founders/admins manage members. The service re-checks permissions, so this
+  // only gates the affordance — the server is the source of truth.
+  const canManage =
+    currentMember?.role === STATUS.GROUP_MEMBERS.FOUNDER ||
+    currentMember?.role === STATUS.GROUP_MEMBERS.ADMIN;
+
+  const handleRoleChange = async (memberUserId: string, role: GroupRole) => {
+    try {
+      setBusyMemberId(memberUserId);
+      const result = await groupsService.updateMember(groupId, memberUserId, { role });
+      if (result.success) {
+        toast.success(
+          role === STATUS.GROUP_MEMBERS.ADMIN ? 'Member promoted to admin' : 'Admin set to member'
+        );
+        onUpdate?.();
+      } else {
+        toast.error(result.error || 'Failed to update member');
+      }
+    } catch (error) {
+      logger.error('Failed to update member role:', error);
+      toast.error('Failed to update member');
+    } finally {
+      setBusyMemberId(null);
+    }
+  };
+
+  const handleRemove = async (memberUserId: string) => {
+    try {
+      setBusyMemberId(memberUserId);
+      const result = await groupsService.removeMember(groupId, memberUserId);
+      if (result.success) {
+        toast.success('Member removed');
+        onUpdate?.();
+      } else {
+        toast.error(result.error || 'Failed to remove member');
+      }
+    } catch (error) {
+      logger.error('Failed to remove member:', error);
+      toast.error('Failed to remove member');
+    } finally {
+      setBusyMemberId(null);
+    }
+  };
 
   const getRoleIcon = (role: GroupRole) => {
     switch (role) {
@@ -131,13 +217,93 @@ export function GroupMembers({ groupId, members, onUpdate }: GroupMembersProps) 
                       </p>
                     </div>
                   </div>
-                  <div className="flex items-center gap-2">{getRoleBadge(member.role)}</div>
+                  <div className="flex items-center gap-2">
+                    {getRoleBadge(member.role)}
+                    {canManage &&
+                      member.user_id !== user?.id &&
+                      member.role !== STATUS.GROUP_MEMBERS.FOUNDER && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0"
+                              disabled={busyMemberId === member.user_id}
+                              aria-label="Manage member"
+                            >
+                              <MoreVertical className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            {member.role === STATUS.GROUP_MEMBERS.ADMIN ? (
+                              <DropdownMenuItem
+                                onClick={() =>
+                                  handleRoleChange(member.user_id, STATUS.GROUP_MEMBERS.MEMBER)
+                                }
+                              >
+                                <ShieldOff className="h-4 w-4 mr-2" />
+                                Make member
+                              </DropdownMenuItem>
+                            ) : (
+                              <DropdownMenuItem
+                                onClick={() =>
+                                  handleRoleChange(member.user_id, STATUS.GROUP_MEMBERS.ADMIN)
+                                }
+                              >
+                                <Shield className="h-4 w-4 mr-2" />
+                                Make admin
+                              </DropdownMenuItem>
+                            )}
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onClick={() => handleRemove(member.user_id)}
+                              className="text-status-negative focus:text-status-negative"
+                            >
+                              <UserMinus className="h-4 w-4 mr-2" />
+                              Remove from group
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                  </div>
                 </div>
               ))}
             </div>
           )}
         </CardContent>
       </Card>
+
+      {/* Leave group (members only; founders must transfer/delete instead) */}
+      {canLeave && (
+        <div className="flex justify-end">
+          {confirmLeave ? (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-fg-secondary">Leave this group?</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirmLeave(false)}
+                disabled={leaving}
+              >
+                Cancel
+              </Button>
+              <Button variant="danger" size="sm" onClick={handleLeave} disabled={leaving}>
+                {leaving ? 'Leaving…' : 'Leave'}
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setConfirmLeave(true)}
+              className="text-fg-secondary hover:text-status-negative"
+            >
+              <LogOut className="h-4 w-4 mr-1.5" />
+              Leave group
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/groups/GroupsDashboard.tsx
+++ b/src/components/groups/GroupsDashboard.tsx
@@ -15,7 +15,8 @@ import { useState, useEffect } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { Plus, Users, Target, TrendingUp, Building2 } from 'lucide-react';
+import { Input } from '@/components/ui/Input';
+import { Plus, Users, Target, TrendingUp, Building2, Search } from 'lucide-react';
 import groupsService from '@/services/groups';
 import type { Group } from '@/types/group';
 import { GROUP_LABELS, type GroupLabel } from '@/config/group-labels';
@@ -34,6 +35,7 @@ export function GroupsDashboard() {
   const [myGroups, setMyGroups] = useState<Group[]>([]);
   const [availableGroups, setAvailableGroups] = useState<Group[]>([]);
   const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState('');
 
   useEffect(() => {
     loadDashboardData();
@@ -85,6 +87,14 @@ export function GroupsDashboard() {
   // Formal groups (everything else)
   const formalCount = myGroups.length - informalCount;
 
+  // Client-side search across name + description (lists are already loaded).
+  const q = query.trim().toLowerCase();
+  const matches = (g: Group) =>
+    !q || g.name.toLowerCase().includes(q) || (g.description || '').toLowerCase().includes(q);
+  const filteredMyGroups = myGroups.filter(matches);
+  const filteredAvailable = availableGroups.filter(matches);
+  const hasAnyGroups = myGroups.length + availableGroups.length > 0;
+
   const headerActions = (
     <Link href={ROUTES.DASHBOARD.GROUPS_CREATE}>
       <Button variant="accent" className="gap-2">
@@ -100,16 +110,31 @@ export function GroupsDashboard() {
       description="Create groups, join communities, and collaborate with like-minded people"
       headerActions={headerActions}
     >
+      {/* Search across both tabs (only when there's something to search) */}
+      {hasAnyGroups && (
+        <div className="relative mb-6">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-fg-secondary" />
+          <Input
+            type="search"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search groups by name or description…"
+            className="pl-9"
+            aria-label="Search groups"
+          />
+        </div>
+      )}
+
       {/* Tabs for My Groups and Discover */}
       <Tabs defaultValue="my-groups" className="space-y-6">
         <TabsList className="grid w-full grid-cols-2">
           <TabsTrigger value="my-groups" className="gap-2 text-xs sm:text-sm">
             <Users className="h-4 w-4" />
-            <span className="truncate">My Groups ({myGroups.length})</span>
+            <span className="truncate">My Groups ({filteredMyGroups.length})</span>
           </TabsTrigger>
           <TabsTrigger value="discover" className="gap-2 text-xs sm:text-sm">
             <Building2 className="h-4 w-4" />
-            <span className="truncate">Discover ({availableGroups.length})</span>
+            <span className="truncate">Discover ({filteredAvailable.length})</span>
           </TabsTrigger>
         </TabsList>
 
@@ -125,9 +150,13 @@ export function GroupsDashboard() {
                 </Button>
               </Link>
             </div>
+          ) : filteredMyGroups.length === 0 ? (
+            <div className="text-center py-12 px-4 bg-surface-base rounded-lg border dark:border-default">
+              <p className="text-fg-secondary">No groups match “{query}”.</p>
+            </div>
           ) : (
             <GroupList
-              groups={myGroups}
+              groups={filteredMyGroups}
               onGroupClick={group =>
                 router.push(`${ENTITY_REGISTRY['group'].basePath}/${group.slug}`)
               }
@@ -147,9 +176,13 @@ export function GroupsDashboard() {
                 </Button>
               </Link>
             </div>
+          ) : filteredAvailable.length === 0 ? (
+            <div className="text-center py-12 px-4 bg-surface-base rounded-lg border dark:border-default">
+              <p className="text-fg-secondary">No groups match “{query}”.</p>
+            </div>
           ) : (
             <GroupList
-              groups={availableGroups}
+              groups={filteredAvailable}
               onGroupClick={group =>
                 router.push(`${ENTITY_REGISTRY['group'].basePath}/${group.slug}`)
               }


### PR DESCRIPTION
Closes three group-UX gaps from the user-actions audit. All three reuse existing services — no new endpoints.

## What changed

**Leave group** (`GroupMembers`)
- Members get a two-tap "Leave group" confirm. Founders are not offered it (the `leaveGroup` service rejects — they must transfer ownership or delete the group).

**Member admin actions** (`GroupMembers`)
- Founders/admins get a per-member kebab menu: **Make admin** / **Make member** / **Remove from group**.
- Permissions are re-checked server-side (`manage_members` / `remove_members` via `updateMember` / `removeMember`); the UI only gates the affordance.
- The founder row and your own row are never actionable.

**Group search** (`GroupsDashboard`)
- A search box filters both **My Groups** and **Discover** by name/description, with live tab counts and a "no matches" state.
- Only rendered when there is at least one group to search.

## Why
Member management (leave / promote / remove) and finding a group among many were dead-ends — actions a real group admin needs daily, with services that already existed but no UI. Reduces clicks and removes "I can't do X here" friction.

## Deliberately NOT included
- **Wallet→wallet transfer UI**: the `/api/wallets/transfer` endpoint moves a cached `balance_btc` number between wallet rows, but OrangeCat wallets are non-custodial external addresses whose balance is refreshed from the chain. A transfer UI would mutate a displayed number without moving real Bitcoin (and the next refresh overwrites it) — misrepresenting reality. Skipped on purpose; the API looks like a custodial-model leftover.

## Verification
- `eslint` clean on both changed files
- `npm run type-check` (non-incremental) — 0 errors
- `npm run test:unit` — 554/554 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)