### PR TITLE
fix(groups): allow members to leave (RLS) + show member avatars

### DIFF
--- a/src/components/groups/GroupMembers.tsx
+++ b/src/components/groups/GroupMembers.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/badge';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -202,9 +203,15 @@ export function GroupMembers({ groupId, members, onUpdate }: GroupMembersProps) 
                   className="flex items-center justify-between p-3 rounded-lg border hover:bg-surface-raised/40 dark:hover:bg-gray-800 transition-colors"
                 >
                   <div className="flex items-center gap-3 flex-1 min-w-0">
-                    <div className="h-10 w-10 rounded-full flex items-center justify-center bg-surface-raised text-fg-secondary border-2 border-strong">
-                      {getInitial(member.display_name || member.username)}
-                    </div>
+                    <Avatar className="h-10 w-10 border-2 border-strong">
+                      <AvatarImage
+                        src={member.avatar_url || undefined}
+                        alt={member.display_name || member.username || 'Member'}
+                      />
+                      <AvatarFallback className="bg-surface-raised text-fg-secondary">
+                        {getInitial(member.display_name || member.username)}
+                      </AvatarFallback>
+                    </Avatar>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
                         <p className="font-medium truncate">

--- a/supabase/migrations/20260625000000_group_members_self_leave_policy.sql
+++ b/supabase/migrations/20260625000000_group_members_self_leave_policy.sql
@@ -1,0 +1,29 @@
+-- Allow a member to leave a group (delete their OWN membership row).
+--
+-- The previous DELETE policy (group_members_delete_auth) only permitted
+-- founders/admins to delete rows — it was written for the admin "remove
+-- member" case and never accounted for self-leave. As a result, a regular
+-- member calling leaveGroup() had their DELETE silently filtered by RLS
+-- (0 rows affected, no error) — the UI reported success but the membership
+-- persisted. This surfaced once the "Leave group" button shipped.
+--
+-- New rule:
+--   * Anyone except a founder may delete their OWN membership (leave).
+--   * Founders/admins may delete any membership (remove members).
+-- Founders still cannot leave (must transfer ownership or delete the group);
+-- the app layer (leaveGroup) and the removeMember founder-guard remain in place.
+
+DROP POLICY IF EXISTS group_members_delete_auth ON public.group_members;
+
+CREATE POLICY group_members_delete_auth ON public.group_members
+  FOR DELETE
+  TO authenticated
+  USING (
+    -- Self-leave: members and admins can remove their own row; founders cannot.
+    (
+      user_id = (SELECT auth.uid())
+      AND get_user_group_role(group_id, (SELECT auth.uid())) <> 'founder'
+    )
+    -- Admin/founder removing any member.
+    OR get_user_group_role(group_id, (SELECT auth.uid())) = ANY (ARRAY['founder', 'admin'])
+  );


### PR DESCRIPTION
Two issues found while **verifying the group-UX features (#263) on production**.

## 1. Leaving a group silently failed
The `group_members` DELETE RLS policy only allowed founders/admins to delete rows (it was written for the admin "remove member" case). A regular member's self-delete was filtered out by RLS — **0 rows affected, no error** — so `leaveGroup()` reported success while the membership persisted. The "Leave group" button had no UI before #263, so this gap was latent until it shipped.

**Fix** (`migration 20260625000000`): the DELETE policy now also allows self-removal for non-founders. Founders still cannot leave (transfer ownership / delete instead); admins/founders can still remove others.

Verified on the live DB: before the fix the membership row survived a "leave"; after, the row is gone (0 rows) and the UI shows "Join Group" again.

## 2. Member list never showed avatars
`GroupMembers` always rendered the initial, even though the query already returns `avatar_url`. Now uses `Avatar` + `AvatarImage` with the initial as fallback. (Spotted by @maonakamoto when their avatar didn't appear after joining.)

## Notes
- The migration is **already applied** to the self-hosted DB; committed here as SSOT.
- `ProjectHeader`, `ProofOfPurchaseCard`, `ProfileCard` were checked — they already render avatars correctly; `GroupMembers` was the only offender.

## Verification
- `eslint` clean, `npm run type-check` (non-incremental) 0 errors, `npm run test:unit` 554/554
- Leave + avatar behaviors confirmed live on orangecat.ch

🤖 Generated with [Claude Code](https://claude.com/claude-code)