### PR TITLE
feat(cat): wallet balances + social graph in Cat's context

### DIFF
--- a/src/services/ai/context-string-builder.ts
+++ b/src/services/ai/context-string-builder.ts
@@ -239,6 +239,21 @@ export function buildFullContextString(context: FullUserContext): string {
     );
   }
 
+  // Social graph — follower/following counts + a few accounts they follow.
+  {
+    const sg = context.socialGraph;
+    if (sg && (sg.followers > 0 || sg.following > 0)) {
+      const lines = [`- ${sg.followers} follower(s), following ${sg.following} account(s)`];
+      if (sg.recentFollowing.length > 0) {
+        const handles = sg.recentFollowing
+          .map(p => (p.username ? `@${p.username}` : p.name || 'unknown'))
+          .join(', ');
+        lines.push(`- Recently followed: ${handles}`);
+      }
+      sections.push(`## Social Graph\n${lines.join('\n')}`);
+    }
+  }
+
   // Tasks section
   if (context.tasks.length > 0) {
     const now = new Date();
@@ -302,6 +317,15 @@ export function buildFullContextString(context: FullUserContext): string {
     const walletLines = context.wallets.map(w => {
       const parts = [`- **${w.label}**`];
       parts.push(`(${w.category}`);
+      // Last-synced on-chain balance. Cached (refreshed from the chain), not
+      // real-time — so Cat can answer "how much do I have?" but should caveat
+      // that it's the last synced figure rather than a live wallet balance.
+      if (typeof w.balance_btc === 'number') {
+        parts.push(`, balance: ${w.balance_btc} BTC`);
+        if (w.balance_updated_at) {
+          parts.push(` (synced ${w.balance_updated_at.slice(0, 10)})`);
+        }
+      }
       if (w.behavior_type === 'one_time_goal' && w.goal_amount) {
         parts.push(`, goal: ${w.goal_amount} ${w.goal_currency || 'BTC'}`);
         if (w.goal_deadline) {
@@ -321,7 +345,13 @@ export function buildFullContextString(context: FullUserContext): string {
       return parts.join('');
     });
 
-    sections.push(`## User's Wallets\n${walletLines.join('\n')}`);
+    const totalBtc = context.wallets.reduce((sum, w) => sum + (w.balance_btc ?? 0), 0);
+    const totalLine =
+      totalBtc > 0
+        ? `\n_Total last-synced balance across wallets: ${Number(totalBtc.toFixed(8))} BTC (cached on-chain figures, not real-time)._`
+        : '';
+
+    sections.push(`## User's Wallets\n${walletLines.join('\n')}${totalLine}`);
   }
 
   // Conversations section — gives Cat visibility into recent messages so it can help reply

--- a/src/services/ai/document-context-types.ts
+++ b/src/services/ai/document-context-types.ts
@@ -56,6 +56,10 @@ export interface WalletSummary {
   budget_amount: number | null;
   budget_period: string | null;
   is_primary: boolean;
+  /** Last-synced on-chain balance in BTC (cached; refreshed from chain, not real-time). */
+  balance_btc: number | null;
+  /** When balance_btc was last refreshed from the chain. */
+  balance_updated_at: string | null;
   /** Whether this wallet has a Nostr Wallet Connect URI configured (can auto-send payments) */
   has_nwc: boolean;
   /** Lightning address for receiving payments, if configured */
@@ -103,6 +107,14 @@ export interface GroupMembershipSummary {
   label: string;
   role: 'founder' | 'admin' | 'member';
   visibility: 'public' | 'members_only' | 'private';
+}
+
+/** The user's follow graph — counts plus a few people they follow, for context. */
+export interface SocialGraphSummary {
+  followers: number;
+  following: number;
+  /** A handful of accounts the user follows (most recent first), for grounding. */
+  recentFollowing: Array<{ username: string | null; name: string | null }>;
 }
 
 /** An upcoming booking where the user is the service/asset provider */
@@ -159,6 +171,7 @@ export interface FullUserContext {
   conversations: ConversationSummary[];
   inboundActivity: InboundActivity;
   memberGroups: GroupMembershipSummary[];
+  socialGraph: SocialGraphSummary;
   paymentCapabilities: PaymentCapabilities;
   /** Runtime session context — what's true RIGHT NOW. See RuntimeContext for fields. */
   runtime: RuntimeContext;

--- a/src/services/ai/document-context.ts
+++ b/src/services/ai/document-context.ts
@@ -31,6 +31,7 @@ import {
   fetchConversationsForCat,
   fetchInboundActivityForCat,
   fetchGroupMembershipsForCat,
+  fetchSocialGraphForCat,
 } from './social-context-fetcher';
 
 // Re-export types so existing callers stay unchanged
@@ -61,6 +62,7 @@ export {
   fetchConversationsForCat,
   fetchInboundActivityForCat,
   fetchGroupMembershipsForCat,
+  fetchSocialGraphForCat,
 } from './social-context-fetcher';
 
 async function fetchDocumentsForCat(
@@ -147,7 +149,7 @@ async function fetchWalletsForCat(
     const { data: wallets, error } = await supabase
       .from(DATABASE_TABLES.WALLETS)
       .select(
-        'label, description, category, behavior_type, goal_amount, goal_currency, goal_deadline, budget_amount, budget_period, is_primary, nwc_connection_uri, lightning_address'
+        'label, description, category, behavior_type, goal_amount, goal_currency, goal_deadline, budget_amount, budget_period, is_primary, balance_btc, balance_updated_at, nwc_connection_uri, lightning_address'
       )
       .eq('profile_id', profile.id)
       .eq('is_active', true)
@@ -169,6 +171,8 @@ async function fetchWalletsForCat(
       budget_amount: w.budget_amount,
       budget_period: w.budget_period,
       is_primary: w.is_primary,
+      balance_btc: w.balance_btc ?? null,
+      balance_updated_at: w.balance_updated_at ?? null,
       has_nwc: !!w.nwc_connection_uri,
       lightning_address: w.lightning_address ?? null,
     })) as WalletSummary[];
@@ -330,6 +334,7 @@ export async function fetchFullContextForCat(
     conversations,
     inboundActivity,
     memberGroups,
+    socialGraph,
   ] = await Promise.all([
     fetchProfileForCat(supabase, userId),
     fetchDocumentsForCat(supabase, userId),
@@ -339,6 +344,7 @@ export async function fetchFullContextForCat(
     fetchConversationsForCat(supabase, userId),
     fetchInboundActivityForCat(supabase, userId),
     fetchGroupMembershipsForCat(supabase, userId),
+    fetchSocialGraphForCat(supabase, userId),
   ]);
 
   const runtime = await fetchRuntimeContextForCat(supabase, userId, runtimeHints, profile);
@@ -361,6 +367,7 @@ export async function fetchFullContextForCat(
     conversations,
     inboundActivity,
     memberGroups,
+    socialGraph,
     paymentCapabilities,
     runtime,
     stats: {

--- a/src/services/ai/social-context-fetcher.ts
+++ b/src/services/ai/social-context-fetcher.ts
@@ -8,6 +8,7 @@ import type {
   BookingRecord,
   InboundActivity,
   GroupMembershipSummary,
+  SocialGraphSummary,
 } from './document-context-types';
 
 export async function fetchConversationsForCat(
@@ -218,6 +219,56 @@ export async function fetchInboundActivityForCat(
   } catch (error) {
     logger.error('Exception fetching inbound activity for cat', error, 'DocumentContext');
     return { recentSales: [], upcomingBookings: [] };
+  }
+}
+
+/**
+ * The user's follow graph: follower/following counts + a few accounts they
+ * follow. Gives Cat a sense of the user's network so it can reason about who
+ * they're connected to (e.g. "message someone you follow").
+ */
+export async function fetchSocialGraphForCat(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<SocialGraphSummary> {
+  const empty: SocialGraphSummary = { followers: 0, following: 0, recentFollowing: [] };
+  try {
+    const [followersRes, followingRes, recentRes] = await Promise.all([
+      supabase
+        .from(DATABASE_TABLES.FOLLOWS)
+        .select('id', { count: 'exact', head: true })
+        .eq('following_id', userId),
+      supabase
+        .from(DATABASE_TABLES.FOLLOWS)
+        .select('id', { count: 'exact', head: true })
+        .eq('follower_id', userId),
+      supabase
+        .from(DATABASE_TABLES.FOLLOWS)
+        .select('following:profiles!follows_following_id_fkey(username, name)')
+        .eq('follower_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(5),
+    ]);
+
+    // PostgREST types the to-one FK embed as an array; at runtime it's a single
+    // object (or null). Cast through unknown per the project's PostgREST gotcha.
+    const recentFollowing = (
+      (recentRes.data as unknown as {
+        following: { username: string | null; name: string | null } | null;
+      }[]) || []
+    )
+      .map(r => r.following)
+      .filter((p): p is { username: string | null; name: string | null } => !!p)
+      .map(p => ({ username: p.username, name: p.name }));
+
+    return {
+      followers: followersRes.count ?? 0,
+      following: followingRes.count ?? 0,
+      recentFollowing,
+    };
+  } catch (error) {
+    logger.error('Exception fetching social graph for cat', error, 'DocumentContext');
+    return empty;
   }
 }
 


### PR DESCRIPTION
First of the "make Cat actually know you" series. Closes two context gaps found while auditing what Cat loads about the user.

## What changed
- **Wallet balances** — Cat's wallet context only had metadata (goals, budgets, NWC status), so it couldn't answer "how much BTC do I have / what's my runway?". Now each wallet carries its last-synced on-chain `balance_btc` (+ sync date) and a **total**, explicitly flagged as *cached on-chain figures, not real-time* so Cat caveats correctly (these are address balances refreshed from the chain, not a custodial ledger).
- **Social graph** — Cat had zero awareness of the user's network. Added follower/following counts + a few recently-followed accounts, so Cat can reason about who the user is connected to.

## How
- `fetchWalletsForCat` now selects `balance_btc, balance_updated_at`; rendered per-wallet + as a total in the context string.
- New `fetchSocialGraphForCat` (counts via `head:true` + 5 recent follows) added to the existing parallel context sweep — no new round-trips on the critical path beyond one column + 3 light follow queries.
- New `SocialGraphSummary` type; `socialGraph` added to `FullUserContext`.

## Notes
- Read-only context enrichment — no new Cat actions, no schema changes.
- PostgREST to-one embed cast through `unknown` per the project gotcha.

## Verification
- `eslint` clean, `tsc --noEmit` (non-incremental) 0 errors, `test:unit` 554/554

🤖 Generated with [Claude Code](https://claude.com/claude-code)