### PR TITLE
feat(cat): project activity (FleetCrown-ready) + stakeholder edges

### DIFF
--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -70,6 +70,9 @@ export const DATABASE_TABLES = {
   COMMUNITY_TIMELINE: 'community_timeline_no_duplicates',
   TIMELINE_POSTS: 'timeline_posts',
 
+  // Stakeholder graph (typed edges between projects: customer, collaborator, ...)
+  STAKEHOLDER_RELATIONSHIPS: 'stakeholder_relationships',
+
   // Documents
   USER_DOCUMENTS: 'user_documents',
 

--- a/src/services/ai/context-string-builder.ts
+++ b/src/services/ai/context-string-builder.ts
@@ -254,6 +254,36 @@ export function buildFullContextString(context: FullUserContext): string {
     }
   }
 
+  // Project activity — recent timeline updates about the user's projects,
+  // including FleetCrown-published build updates (source: fleetcrown).
+  if (context.projectActivity && context.projectActivity.length > 0) {
+    const lines = context.projectActivity.map(e => {
+      const tag = e.source === 'fleetcrown' ? ' [via FleetCrown]' : '';
+      const when = e.at ? ` (${e.at.slice(0, 10)})` : '';
+      const desc = e.description ? ` — ${e.description.slice(0, 140)}` : '';
+      return `- **${e.title}**${tag}${when}${desc}`;
+    });
+    sections.push(
+      `## Recent Project Activity\nUpdates on the user's projects (FleetCrown build updates are tagged):\n${lines.join('\n')}`
+    );
+  }
+
+  // Stakeholder edges — who the user's projects are connected to (customers, ...).
+  if (context.stakeholders && context.stakeholders.length > 0) {
+    const byKind = new Map<string, string[]>();
+    for (const s of context.stakeholders) {
+      const list = byKind.get(s.kind) ?? [];
+      list.push(s.counterparty);
+      byKind.set(s.kind, list);
+    }
+    const lines = Array.from(byKind.entries()).map(
+      ([kind, parties]) => `- ${kind}: ${parties.join(', ')}`
+    );
+    sections.push(
+      `## Stakeholders\nTyped relationships on the user's projects (e.g. customers):\n${lines.join('\n')}`
+    );
+  }
+
   // Tasks section
   if (context.tasks.length > 0) {
     const now = new Date();

--- a/src/services/ai/document-context-types.ts
+++ b/src/services/ai/document-context-types.ts
@@ -109,6 +109,30 @@ export interface GroupMembershipSummary {
   visibility: 'public' | 'members_only' | 'private';
 }
 
+/**
+ * A recent activity event about one of the user's projects. Sourced from the
+ * timeline_events bus — `source: 'fleetcrown'` rows are build updates published
+ * by FleetCrown; `'orangecat'` rows are native platform activity.
+ */
+export interface ProjectActivityEvent {
+  projectId: string;
+  title: string;
+  description: string | null;
+  eventType: string;
+  source: 'fleetcrown' | 'orangecat';
+  at: string;
+}
+
+/**
+ * A typed relationship the user's project has with another party — most
+ * importantly "customer" (e.g. FleetCrown built X for this customer).
+ */
+export interface StakeholderSummary {
+  kind: string;
+  counterparty: string;
+  status: string | null;
+}
+
 /** The user's follow graph — counts plus a few people they follow, for context. */
 export interface SocialGraphSummary {
   followers: number;
@@ -172,6 +196,8 @@ export interface FullUserContext {
   inboundActivity: InboundActivity;
   memberGroups: GroupMembershipSummary[];
   socialGraph: SocialGraphSummary;
+  projectActivity: ProjectActivityEvent[];
+  stakeholders: StakeholderSummary[];
   paymentCapabilities: PaymentCapabilities;
   /** Runtime session context — what's true RIGHT NOW. See RuntimeContext for fields. */
   runtime: RuntimeContext;

--- a/src/services/ai/document-context.ts
+++ b/src/services/ai/document-context.ts
@@ -33,6 +33,7 @@ import {
   fetchGroupMembershipsForCat,
   fetchSocialGraphForCat,
 } from './social-context-fetcher';
+import { fetchProjectActivityForCat, fetchStakeholdersForCat } from './project-activity-fetcher';
 
 // Re-export types so existing callers stay unchanged
 export type {
@@ -47,6 +48,9 @@ export type {
   GroupMembershipSummary,
   BookingRecord,
   InboundActivity,
+  SocialGraphSummary,
+  ProjectActivityEvent,
+  StakeholderSummary,
   FullUserContext,
   RuntimeContext,
 } from './document-context-types';
@@ -64,6 +68,9 @@ export {
   fetchGroupMembershipsForCat,
   fetchSocialGraphForCat,
 } from './social-context-fetcher';
+
+// Re-export project-activity / stakeholder fetchers
+export { fetchProjectActivityForCat, fetchStakeholdersForCat } from './project-activity-fetcher';
 
 async function fetchDocumentsForCat(
   supabase: AnySupabaseClient,
@@ -335,6 +342,8 @@ export async function fetchFullContextForCat(
     inboundActivity,
     memberGroups,
     socialGraph,
+    projectActivity,
+    stakeholders,
   ] = await Promise.all([
     fetchProfileForCat(supabase, userId),
     fetchDocumentsForCat(supabase, userId),
@@ -345,6 +354,8 @@ export async function fetchFullContextForCat(
     fetchInboundActivityForCat(supabase, userId),
     fetchGroupMembershipsForCat(supabase, userId),
     fetchSocialGraphForCat(supabase, userId),
+    fetchProjectActivityForCat(supabase, userId),
+    fetchStakeholdersForCat(supabase, userId),
   ]);
 
   const runtime = await fetchRuntimeContextForCat(supabase, userId, runtimeHints, profile);
@@ -368,6 +379,8 @@ export async function fetchFullContextForCat(
     inboundActivity,
     memberGroups,
     socialGraph,
+    projectActivity,
+    stakeholders,
     paymentCapabilities,
     runtime,
     stats: {

--- a/src/services/ai/project-activity-fetcher.ts
+++ b/src/services/ai/project-activity-fetcher.ts
@@ -1,0 +1,145 @@
+/**
+ * Project-activity + stakeholder context for Cat.
+ *
+ * Lets Cat answer "what's happening with my projects?" and "who are my
+ * customers?". Project activity is read from the timeline_events publish bus —
+ * including build updates published by FleetCrown (metadata.source ===
+ * 'fleetcrown'), so once FleetCrown publishes to a project's wall, Cat sees it
+ * here with no further wiring. Stakeholder edges expose the typed "customer"
+ * relationship (and collaborator/investor/...).
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { logger } from '@/utils/logger';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { ENTITY_REGISTRY } from '@/config/entity-registry';
+import type { ProjectActivityEvent, StakeholderSummary } from './document-context-types';
+
+const PROJECTS_TABLE = ENTITY_REGISTRY['project'].tableName;
+
+/** Resolve the user's actor id (user-type actor). Returns null if none. */
+async function resolveActorId(supabase: AnySupabaseClient, userId: string): Promise<string | null> {
+  const { data } = await supabase
+    .from(DATABASE_TABLES.ACTORS)
+    .select('id')
+    .eq('actor_type', 'user')
+    .eq('user_id', userId)
+    .maybeSingle();
+  return (data?.id as string | undefined) ?? null;
+}
+
+/**
+ * Recent timeline events about the user's own projects (newest first).
+ * FleetCrown-published build updates surface here automatically.
+ */
+export async function fetchProjectActivityForCat(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<ProjectActivityEvent[]> {
+  try {
+    // The user's project ids — ownership is by actor, falling back to user_id.
+    const actorId = await resolveActorId(supabase, userId);
+    const projectQuery = supabase.from(PROJECTS_TABLE).select('id').limit(50);
+    const { data: projects } = actorId
+      ? await projectQuery.eq('actor_id', actorId)
+      : await projectQuery.eq('user_id', userId);
+
+    const projectIds = (projects || []).map((p: { id: string }) => p.id);
+    if (projectIds.length === 0) {
+      return [];
+    }
+
+    const { data: events, error } = await supabase
+      .from(DATABASE_TABLES.TIMELINE_EVENTS)
+      .select('subject_id, title, description, event_type, metadata, event_timestamp')
+      .eq('subject_type', 'project')
+      .in('subject_id', projectIds)
+      .order('event_timestamp', { ascending: false })
+      .limit(15);
+
+    if (error) {
+      logger.warn(
+        'Failed to fetch project activity for cat',
+        { error: error.message },
+        'DocumentContext'
+      );
+      return [];
+    }
+
+    return (
+      (events as {
+        subject_id: string;
+        title: string;
+        description: string | null;
+        event_type: string;
+        metadata: { source?: string } | null;
+        event_timestamp: string;
+      }[]) || []
+    ).map(e => ({
+      projectId: e.subject_id,
+      title: e.title,
+      description: e.description,
+      eventType: e.event_type,
+      source: e.metadata?.source === 'fleetcrown' ? 'fleetcrown' : 'orangecat',
+      at: e.event_timestamp,
+    }));
+  } catch (error) {
+    logger.error('Exception fetching project activity for cat', error, 'DocumentContext');
+    return [];
+  }
+}
+
+/**
+ * Typed stakeholder edges the user owns (customer, collaborator, investor, ...).
+ * The counterparty may be another OC actor/project or an external name/URL.
+ */
+export async function fetchStakeholdersForCat(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<StakeholderSummary[]> {
+  try {
+    const actorId = await resolveActorId(supabase, userId);
+    if (!actorId) {
+      return [];
+    }
+
+    const { data, error } = await supabase
+      .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
+      .select('kind, status, to_external_name, to_actor_id, to_project_id')
+      .eq('owner_actor_id', actorId)
+      .order('updated_at', { ascending: false })
+      .limit(25);
+
+    if (error) {
+      logger.warn(
+        'Failed to fetch stakeholders for cat',
+        { error: error.message },
+        'DocumentContext'
+      );
+      return [];
+    }
+
+    return (
+      (data as {
+        kind: string;
+        status: string | null;
+        to_external_name: string | null;
+        to_actor_id: string | null;
+        to_project_id: string | null;
+      }[]) || []
+    ).map(r => ({
+      kind: r.kind,
+      counterparty:
+        r.to_external_name ||
+        (r.to_actor_id
+          ? 'an OrangeCat actor'
+          : r.to_project_id
+            ? 'an OrangeCat project'
+            : 'unknown'),
+      status: r.status,
+    }));
+  } catch (error) {
+    logger.error('Exception fetching stakeholders for cat', error, 'DocumentContext');
+    return [];
+  }
+}


### PR DESCRIPTION
Second in the "make Cat know your projects" series. Makes Cat aware of **what's happening with your projects** and **who they're connected to**.

## What changed
- **Recent project activity** — Cat now reads `timeline_events` about the user's own projects (newest first). FleetCrown-published build updates (`metadata.source === 'fleetcrown'`) surface automatically, tagged **[via FleetCrown]**, so "what's the status of my project?" becomes answerable. Native OrangeCat project updates show today.
- **Stakeholder edges** — Cat reads the typed `stakeholder_relationships` the user owns, grouped by kind, so it knows the project's **customers** / collaborators / investors.

## How
- New `project-activity-fetcher.ts` (`fetchProjectActivityForCat`, `fetchStakeholdersForCat`), added to the existing parallel context sweep (2 extra queries). Projects resolved by `actor_id` (falls back to `user_id`); table via `ENTITY_REGISTRY['project']`.
- New `ProjectActivityEvent` / `StakeholderSummary` types on `FullUserContext`; rendered as "Recent Project Activity" + "Stakeholders" context sections.
- Added `STAKEHOLDER_RELATIONSHIPS` to `DATABASE_TABLES` (SSOT).

## Honest status of the data
This is the **OrangeCat consumption side**. Today there are **0** `source='fleetcrown'` timeline rows (FleetCrown isn't publishing to the bus yet) and **1** stakeholder row — so the FleetCrown/customer payoff is **latent until that data flows** (FleetCrown-side work). Native project timeline updates light up immediately. No schema change; read-only context.

## Verification
- `eslint` clean, `tsc --noEmit` (non-incremental) 0 errors, `test:unit` 554/554

🤖 Generated with [Claude Code](https://claude.com/claude-code)