### PR TITLE
feat(cat): the user's public GitHub repositories in Cat's context

### DIFF
--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -73,6 +73,9 @@ export const DATABASE_TABLES = {
   // Stakeholder graph (typed edges between projects: customer, collaborator, ...)
   STAKEHOLDER_RELATIONSHIPS: 'stakeholder_relationships',
 
+  // Cache of a user's public GitHub repos (for Cat context)
+  GITHUB_REPO_CACHE: 'github_repo_cache',
+
   // Documents
   USER_DOCUMENTS: 'user_documents',
 

--- a/src/services/ai/context-string-builder.ts
+++ b/src/services/ai/context-string-builder.ts
@@ -284,6 +284,29 @@ export function buildFullContextString(context: FullUserContext): string {
     );
   }
 
+  // GitHub repos — the user's public GitHub work (from their profile handle).
+  if (context.githubRepos && context.githubRepos.length > 0) {
+    const lines = context.githubRepos.map(r => {
+      const meta: string[] = [];
+      if (r.language) {
+        meta.push(r.language);
+      }
+      if (r.stars > 0) {
+        meta.push(`★${r.stars}`);
+      }
+      if (r.archived) {
+        meta.push('archived');
+      }
+      const metaStr = meta.length ? ` (${meta.join(', ')})` : '';
+      const desc = r.description ? ` — ${r.description.slice(0, 120)}` : '';
+      const when = r.pushedAt ? ` [pushed ${r.pushedAt.slice(0, 10)}]` : '';
+      return `- **${r.name}**${metaStr}${desc}${when}`;
+    });
+    sections.push(
+      `## GitHub Repositories\nThe user's public GitHub projects (most recently pushed first):\n${lines.join('\n')}`
+    );
+  }
+
   // Tasks section
   if (context.tasks.length > 0) {
     const now = new Date();

--- a/src/services/ai/document-context-types.ts
+++ b/src/services/ai/document-context-types.ts
@@ -133,6 +133,18 @@ export interface StakeholderSummary {
   status: string | null;
 }
 
+/** One of the user's public GitHub repositories (cached). */
+export interface GitHubRepoSummary {
+  name: string;
+  description: string | null;
+  language: string | null;
+  stars: number;
+  url: string;
+  pushedAt: string;
+  fork: boolean;
+  archived: boolean;
+}
+
 /** The user's follow graph — counts plus a few people they follow, for context. */
 export interface SocialGraphSummary {
   followers: number;
@@ -198,6 +210,7 @@ export interface FullUserContext {
   socialGraph: SocialGraphSummary;
   projectActivity: ProjectActivityEvent[];
   stakeholders: StakeholderSummary[];
+  githubRepos: GitHubRepoSummary[];
   paymentCapabilities: PaymentCapabilities;
   /** Runtime session context — what's true RIGHT NOW. See RuntimeContext for fields. */
   runtime: RuntimeContext;

--- a/src/services/ai/document-context.ts
+++ b/src/services/ai/document-context.ts
@@ -34,6 +34,7 @@ import {
   fetchSocialGraphForCat,
 } from './social-context-fetcher';
 import { fetchProjectActivityForCat, fetchStakeholdersForCat } from './project-activity-fetcher';
+import { fetchGitHubReposForCat } from './github-repos-fetcher';
 
 // Re-export types so existing callers stay unchanged
 export type {
@@ -51,6 +52,7 @@ export type {
   SocialGraphSummary,
   ProjectActivityEvent,
   StakeholderSummary,
+  GitHubRepoSummary,
   FullUserContext,
   RuntimeContext,
 } from './document-context-types';
@@ -71,6 +73,9 @@ export {
 
 // Re-export project-activity / stakeholder fetchers
 export { fetchProjectActivityForCat, fetchStakeholdersForCat } from './project-activity-fetcher';
+
+// Re-export GitHub repos fetcher
+export { fetchGitHubReposForCat } from './github-repos-fetcher';
 
 async function fetchDocumentsForCat(
   supabase: AnySupabaseClient,
@@ -344,6 +349,7 @@ export async function fetchFullContextForCat(
     socialGraph,
     projectActivity,
     stakeholders,
+    githubRepos,
   ] = await Promise.all([
     fetchProfileForCat(supabase, userId),
     fetchDocumentsForCat(supabase, userId),
@@ -356,6 +362,7 @@ export async function fetchFullContextForCat(
     fetchSocialGraphForCat(supabase, userId),
     fetchProjectActivityForCat(supabase, userId),
     fetchStakeholdersForCat(supabase, userId),
+    fetchGitHubReposForCat(supabase, userId),
   ]);
 
   const runtime = await fetchRuntimeContextForCat(supabase, userId, runtimeHints, profile);
@@ -381,6 +388,7 @@ export async function fetchFullContextForCat(
     socialGraph,
     projectActivity,
     stakeholders,
+    githubRepos,
     paymentCapabilities,
     runtime,
     stats: {

--- a/src/services/ai/github-repos-fetcher.ts
+++ b/src/services/ai/github-repos-fetcher.ts
@@ -1,0 +1,160 @@
+/**
+ * GitHub repos context for Cat.
+ *
+ * Gives Cat awareness of the user's PUBLIC GitHub work, keyed off the GitHub
+ * handle they've added to their profile social links. Public data only — no
+ * OAuth scope, no stored credential.
+ *
+ * To keep the Cat hot path fast and within GitHub's unauthenticated rate limit,
+ * results are cached per user (github_repo_cache) and refreshed lazily on a TTL.
+ * On any failure we fall back to the cached rows (even if stale) or an empty
+ * list — GitHub being slow or down never blocks a Cat reply.
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { logger } from '@/utils/logger';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import type { GitHubRepoSummary } from './document-context-types';
+
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6h
+const FETCH_TIMEOUT_MS = 3500;
+const MAX_REPOS = 15;
+
+interface SocialLink {
+  value?: string;
+  platform?: string;
+}
+
+/** Pull a bare GitHub username out of a handle, @handle, or profile URL. */
+function parseGitHubHandle(raw: string | undefined): string | null {
+  if (!raw) {
+    return null;
+  }
+  const trimmed = raw.trim().replace(/^@/, '');
+  const urlMatch = trimmed.match(/github\.com\/([\w-]+)/i);
+  const handle = urlMatch ? urlMatch[1] : trimmed;
+  return /^[\w-]+$/.test(handle) ? handle : null;
+}
+
+async function getHandle(supabase: AnySupabaseClient, userId: string): Promise<string | null> {
+  const { data } = await supabase
+    .from(DATABASE_TABLES.PROFILES)
+    .select('social_links')
+    .eq('id', userId)
+    .maybeSingle();
+
+  const links = (data?.social_links as { links?: SocialLink[] } | null)?.links;
+  if (!Array.isArray(links)) {
+    return null;
+  }
+  const gh = links.find(l => l.platform === 'github');
+  return parseGitHubHandle(gh?.value);
+}
+
+interface GitHubApiRepo {
+  name: string;
+  description: string | null;
+  language: string | null;
+  stargazers_count: number;
+  html_url: string;
+  pushed_at: string;
+  fork: boolean;
+  archived: boolean;
+}
+
+async function fetchFromGitHub(handle: string): Promise<GitHubRepoSummary[] | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'OrangeCat',
+    };
+    // Optional: a server token raises the shared rate limit. Public data only.
+    if (process.env.GITHUB_TOKEN) {
+      headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+    const res = await fetch(
+      `https://api.github.com/users/${encodeURIComponent(handle)}/repos?sort=pushed&per_page=30&type=owner`,
+      { headers, signal: controller.signal }
+    );
+    if (!res.ok) {
+      logger.warn('GitHub repos fetch non-OK', { handle, status: res.status }, 'GitHubRepos');
+      return null;
+    }
+    const repos = (await res.json()) as GitHubApiRepo[];
+    return repos
+      .filter(r => !r.fork)
+      .slice(0, MAX_REPOS)
+      .map(r => ({
+        name: r.name,
+        description: r.description,
+        language: r.language,
+        stars: r.stargazers_count ?? 0,
+        url: r.html_url,
+        pushedAt: r.pushed_at,
+        fork: r.fork,
+        archived: r.archived,
+      }));
+  } catch (error) {
+    logger.warn('GitHub repos fetch failed', { handle, error: String(error) }, 'GitHubRepos');
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * The user's public GitHub repos for Cat context. Reads cache first; refreshes
+ * from GitHub only when the cache is missing/stale, and always degrades to
+ * cached/empty on failure.
+ */
+export async function fetchGitHubReposForCat(
+  supabase: AnySupabaseClient,
+  userId: string,
+  nowMs: number = Date.now()
+): Promise<GitHubRepoSummary[]> {
+  try {
+    const handle = await getHandle(supabase, userId);
+    if (!handle) {
+      return [];
+    }
+
+    const { data: cache } = await supabase
+      .from(DATABASE_TABLES.GITHUB_REPO_CACHE)
+      .select('handle, repos, fetched_at')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    const cachedRepos = (cache?.repos as GitHubRepoSummary[] | undefined) ?? [];
+    const fresh =
+      cache &&
+      cache.handle === handle &&
+      nowMs - new Date(cache.fetched_at as string).getTime() < CACHE_TTL_MS;
+
+    if (fresh) {
+      return cachedRepos;
+    }
+
+    const fetched = await fetchFromGitHub(handle);
+    if (!fetched) {
+      // GitHub failed — keep serving whatever we had.
+      return cachedRepos;
+    }
+
+    await supabase.from(DATABASE_TABLES.GITHUB_REPO_CACHE).upsert(
+      {
+        user_id: userId,
+        handle,
+        repos: fetched,
+        fetched_at: new Date(nowMs).toISOString(),
+      },
+      { onConflict: 'user_id' }
+    );
+
+    return fetched;
+  } catch (error) {
+    logger.error('Exception fetching github repos for cat', error, 'GitHubRepos');
+    return [];
+  }
+}

--- a/supabase/migrations/20260625000001_github_repo_cache.sql
+++ b/supabase/migrations/20260625000001_github_repo_cache.sql
@@ -1,0 +1,24 @@
+-- Cache of a user's PUBLIC GitHub repositories, so Cat can know "the user's
+-- GitHub projects" without hitting the GitHub API on every chat message.
+--
+-- Public data only (fetched by GitHub handle from profiles.social_links). The
+-- fetcher refreshes lazily on a TTL; this table is the read source on the Cat
+-- hot path. One row per user.
+
+CREATE TABLE IF NOT EXISTS public.github_repo_cache (
+  user_id    uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  handle     text NOT NULL,
+  repos      jsonb NOT NULL DEFAULT '[]'::jsonb,
+  fetched_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.github_repo_cache ENABLE ROW LEVEL SECURITY;
+
+-- Owner-scoped: a user reads/writes only their own cache row (the Cat context
+-- builder runs as the authenticated user).
+DROP POLICY IF EXISTS github_repo_cache_owner ON public.github_repo_cache;
+CREATE POLICY github_repo_cache_owner ON public.github_repo_cache
+  FOR ALL
+  TO authenticated
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));


### PR DESCRIPTION
Third in the series — gives Cat awareness of the user's **public GitHub repos**, so it can reason about their code projects. Public-only, lightweight (no entities), per the chosen scope.

## What changed
- Keyed off the GitHub handle already in the user's profile **social links** (parses `handle` / `@handle` / `github.com/<handle>`).
- Server-side fetch of public repos (newest-pushed first, forks filtered, top 15).
- **Cached** per user in a new `github_repo_cache` table (owner-RLS), refreshed lazily on a **6h TTL** — so the Cat hot path reads cache (≈1 external call per user per TTL). 3.5s timeout; **degrades to cached/empty on any failure** so GitHub never blocks a reply. Optional `GITHUB_TOKEN` raises the shared rate limit but isn't required.
- New "GitHub Repositories" context section (name, language, ★stars, description, last push).

## Scope
- **Public repos only** — no OAuth scope, no stored credential. Private repos are intentionally out (would need a stored repo-scoped token); offered as a future opt-in.
- Migration `20260625000001_github_repo_cache.sql` already applied to the self-hosted DB; committed here as SSOT.

## Verification
- `eslint` clean, `tsc --noEmit` (non-incremental) 0 errors, `test:unit` 554/554

🤖 Generated with [Claude Code](https://claude.com/claude-code)