### PR TITLE
feat(messaging): retry a failed message send from the failure toast

### DIFF
--- a/src/components/messaging/messageComposerSend.ts
+++ b/src/components/messaging/messageComposerSend.ts
@@ -82,6 +82,26 @@ export async function sendMessage({
 
   const tempId = optimisticMessage.id;
 
+  // Re-send the same content — wired into the "Retry" action on failure toasts.
+  // Spawns a fresh optimistic message + attempt; the failed one was already
+  // removed by onMessageFailed, so the user never loses what they wrote.
+  const retry = () =>
+    void sendMessage({
+      content: messageContent,
+      isSending: false,
+      user,
+      profile,
+      conversationId,
+      stopTyping,
+      onMessageSent,
+      onMessageFailed,
+      onMessageConfirmed,
+      selectedActor,
+      setIsSending,
+      setContent,
+      textareaRef,
+    });
+
   if (
     await queueIfOffline(
       { conversationId, content: messageContent, messageType: MESSAGE_TYPES.TEXT, tempId },
@@ -127,6 +147,7 @@ export async function sendMessage({
       const desc = errEnvelope?.details ?? errorData.details ?? '';
       toast.error(errMessage || 'Failed to send message', {
         description: typeof desc === 'string' ? desc : undefined,
+        action: { label: 'Retry', onClick: retry },
       });
       onMessageFailed?.(tempId, errMessage || (typeof desc === 'string' ? desc : ''));
     } else {
@@ -163,7 +184,9 @@ export async function sendMessage({
       setIsSending(false);
       return;
     }
-    toast.error('Network error. Please try again.');
+    toast.error('Network error. Please try again.', {
+      action: { label: 'Retry', onClick: retry },
+    });
     onMessageFailed?.(tempId, 'Network error');
   } finally {
     setIsSending(false);


### PR DESCRIPTION
A failed message send removed the optimistic bubble and showed a toast — with no recovery except retyping. Now the failure toast carries a **Retry** action that re-sends the exact failed content (a fresh attempt), for both the API-error and network-error paths.

## Why this shape
`handleMessageFailed` removes the optimistic message (messages don't persist as "failed" bubbles), so the lowest-risk fix is an **actionable toast** rather than reworking the optimistic-message lifecycle/state. The user never loses what they wrote — the retry closure captures the original content.

## Verification
- `eslint` clean, `tsc --noEmit` (non-incremental) 0 errors, `test:unit` 554/554
- Note: the failure path can't be exercised live without forcing a send error, so this is verified by static checks + reasoning rather than a browser run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)