### PR TITLE
feat(auth): anonymous-first onboarding — lead with "Start instantly"

### DIFF
--- a/src/app/auth/AuthSocialLogin.tsx
+++ b/src/app/auth/AuthSocialLogin.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Loader2 } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import { OAUTH_PROVIDERS } from './OAuthIcons';
 import { useEnabledOAuthProviders } from './oauthProviders';
@@ -11,16 +10,9 @@ interface AuthSocialLoginProps {
   setMode: (mode: AuthMode) => void;
   loading: boolean;
   onOAuthSignIn: (provider: OAuthProvider) => void;
-  onAnonymousSignIn: () => void;
 }
 
-export function AuthSocialLogin({
-  mode,
-  setMode,
-  loading,
-  onOAuthSignIn,
-  onAnonymousSignIn,
-}: AuthSocialLoginProps) {
+export function AuthSocialLogin({ mode, setMode, loading, onOAuthSignIn }: AuthSocialLoginProps) {
   // Only show providers the server actually has enabled — never a button that fails.
   const { enabled } = useEnabledOAuthProviders();
   const providers = OAUTH_PROVIDERS.filter(p => enabled.has(p.id));
@@ -42,10 +34,9 @@ export function AuthSocialLogin({
 
   return (
     <>
-      {/* Single divider — was two stacked dividers ("or continue with" then
-          "or") which looked broken. One divider, OAuth grid below, an
-          anonymous-sign-in TEXT LINK below that (no second full-width
-          button competing for attention with the OAuth options). */}
+      {/* OAuth providers only. Anonymous sign-in is now the lead CTA above the
+          email form (anonymous-first onboarding), so there's no secondary
+          anonymous link here. */}
       <div className="mt-6">
         {/* Social providers — only rendered for providers the server has
             enabled (see useEnabledOAuthProviders). When none are enabled the
@@ -88,30 +79,6 @@ export function AuthSocialLogin({
             </div>
           </>
         )}
-
-        {/* Anonymous sign-in — secondary text link, not a heavyweight button.
-            Privacy-conscious users will find it; default users won't be
-            distracted by it. */}
-        <div className="mt-5 text-center">
-          <button
-            type="button"
-            disabled={loading}
-            onClick={onAnonymousSignIn}
-            className="inline-flex items-center gap-1 text-sm text-fg-secondary hover:text-fg-primary disabled:opacity-60"
-          >
-            {loading ? (
-              <>
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                <span>Continuing…</span>
-              </>
-            ) : (
-              <>
-                Try it anonymously
-                <span className="text-fg-tertiary">— upgrade anytime</span>
-              </>
-            )}
-          </button>
-        </div>
       </div>
 
       <div className="mt-6 text-center">

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { AlertCircle, ArrowLeft, CheckCircle2, RefreshCw } from 'lucide-react';
+import { AlertCircle, ArrowLeft, CheckCircle2, Loader2, RefreshCw, Sparkles } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
 import Button from '@/components/ui/Button';
 import Loading from '@/components/Loading';
@@ -135,6 +135,43 @@ export default function AuthPage() {
             </div>
           )}
 
+          {/* Anonymous-first: the fastest way in is the lead CTA. Pseudonymous
+              by default is a core principle — let people start with zero friction
+              and add an email later. Email/social remain right below. */}
+          {mode !== 'forgot' && (
+            <div className="mb-6">
+              <Button
+                type="button"
+                variant="accent"
+                disabled={loading}
+                onClick={handleAnonymousSignIn}
+                className="w-full h-12 font-semibold"
+              >
+                {loading ? (
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                ) : (
+                  <span className="flex items-center justify-center gap-2">
+                    <Sparkles className="w-5 h-5" />
+                    Start instantly — no email
+                  </span>
+                )}
+              </Button>
+              <p className="mt-2 text-center text-xs text-fg-tertiary">
+                Explore pseudonymously. Add an email anytime to secure your account.
+              </p>
+              <div className="relative mt-5">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t border-default" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase tracking-wider">
+                  <span className="bg-surface-raised/40 dark:bg-surface-page px-3 text-fg-tertiary">
+                    or {mode === 'login' ? 'sign in' : 'sign up'} with email
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+
           <AuthFormBody
             mode={mode}
             setMode={setMode}
@@ -163,7 +200,6 @@ export default function AuthPage() {
             setMode={setMode}
             loading={loading}
             onOAuthSignIn={handleOAuthSignIn}
-            onAnonymousSignIn={handleAnonymousSignIn}
           />
         </div>
       </div>


### PR DESCRIPTION
Pseudonymous-by-default is a core OrangeCat principle, but anonymous sign-in was buried as a small secondary text link. This makes it the **lead CTA**.

## What changed
- A prominent **"Start instantly — no email"** accent button above the email form, with a one-line reassurance ("Explore pseudonymously. Add an email anytime to secure your account.") and a divider ("or sign in/up with email").
- Removed the now-redundant secondary "Try it anonymously" link (and its `onAnonymousSignIn` prop) from `AuthSocialLogin`.
- Email + social sign-in remain right below, unchanged. Hidden in "forgot password" mode.

Uses the existing `signInAnonymously` path — no new auth logic.

## Verification
- `eslint` clean, `tsc --noEmit` (non-incremental) 0 errors, `test:unit` 554/554
- I'll confirm the auth screen live after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)