### PR TITLE
feat(services): weekly availability — editor + shown up front before booking

### DIFF
--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import PriceDisplay from '@/components/public/PriceDisplay';
 import { ROUTES } from '@/config/routes';
 import { BookEntityButton } from '@/components/bookings/BookEntityButton';
+import { hasAvailability, formatAvailabilityLines } from '@/lib/availability';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -75,6 +76,18 @@ const config: EntityDetailConfig = {
             <div className="flex items-center justify-between">
               <span className="text-fg-secondary">Duration</span>
               <span className="font-medium">{durationMinutes} minutes</span>
+            </div>
+          )}
+          {hasAvailability(entity.availability_schedule) && (
+            <div className="flex items-start justify-between gap-4">
+              <span className="text-fg-secondary">Availability</span>
+              <div className="text-right">
+                {formatAvailabilityLines(entity.availability_schedule).map(line => (
+                  <div key={line} className="font-medium text-fg-primary">
+                    {line}
+                  </div>
+                ))}
+              </div>
             </div>
           )}
           <BookEntityButton

--- a/src/components/create/FormField.tsx
+++ b/src/components/create/FormField.tsx
@@ -18,6 +18,7 @@ import { useUserCurrency } from '@/hooks/useUserCurrency';
 import type { FormFieldProps } from './types';
 import type { Currency } from '@/types/settings';
 import { DictationButton } from '@/components/ui/DictationButton';
+import { AvailabilityEditor } from './fields/AvailabilityEditor';
 
 // ==================== COMPONENT ====================
 
@@ -222,6 +223,9 @@ export function FormField({
             className={baseInputClass}
           />
         );
+
+      case 'availability':
+        return <AvailabilityEditor value={value} onChange={onChange} />;
 
       case 'text':
       default:

--- a/src/components/create/fields/AvailabilityEditor.tsx
+++ b/src/components/create/fields/AvailabilityEditor.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+/**
+ * Weekly availability editor — pick the days you're available + the hours.
+ * Used as the 'availability' field type in the entity form (services).
+ * Emits the shared AvailabilitySchedule ({ days, hours }); people see it on the
+ * public page before booking. v1 uses a single hours range applied to all days.
+ */
+
+import { WEEKDAYS, parseAvailability, type AvailabilitySchedule } from '@/lib/availability';
+
+interface AvailabilityEditorProps {
+  value: unknown;
+  onChange: (value: AvailabilitySchedule) => void;
+}
+
+const DEFAULT_START = '09:00';
+const DEFAULT_END = '17:00';
+
+export function AvailabilityEditor({ value, onChange }: AvailabilityEditorProps) {
+  const current = parseAvailability(value);
+  const selectedDays = new Set(current.days ?? []);
+  const range = current.hours?.[0] ?? { start: DEFAULT_START, end: DEFAULT_END };
+
+  const emit = (next: AvailabilitySchedule) => {
+    // Only keep hours when at least one day is selected, so an empty schedule
+    // round-trips to "no availability set".
+    const days = next.days ?? [];
+    onChange(days.length ? { days, hours: next.hours ?? [range] } : {});
+  };
+
+  const toggleDay = (day: (typeof WEEKDAYS)[number]['key'], on: boolean) => {
+    const days = new Set(selectedDays);
+    if (on) {
+      days.add(day);
+    } else {
+      days.delete(day);
+    }
+    emit({ days: Array.from(days), hours: [range] });
+  };
+
+  const setTime = (field: 'start' | 'end', time: string) => {
+    emit({ days: Array.from(selectedDays), hours: [{ ...range, [field]: time }] });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {WEEKDAYS.map(({ key, short }) => {
+          const on = selectedDays.has(key);
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => toggleDay(key, !on)}
+              aria-pressed={on}
+              className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
+                on
+                  ? 'border-interactive/60 bg-surface-raised/60 text-fg-primary'
+                  : 'border-subtle text-fg-secondary hover:bg-surface-raised/30'
+              }`}
+            >
+              {short}
+            </button>
+          );
+        })}
+      </div>
+
+      {selectedDays.size > 0 && (
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-fg-secondary">Hours</span>
+          <input
+            type="time"
+            value={range.start}
+            onChange={e => setTime('start', e.target.value)}
+            className="rounded-md border border-subtle bg-surface-base px-2 py-1 text-sm text-fg-primary"
+            aria-label="Available from"
+          />
+          <span className="text-fg-tertiary">–</span>
+          <input
+            type="time"
+            value={range.end}
+            onChange={e => setTime('end', e.target.value)}
+            className="rounded-md border border-subtle bg-surface-base px-2 py-1 text-sm text-fg-primary"
+            aria-label="Available until"
+          />
+          {range.start >= range.end && (
+            <span className="text-xs text-status-negative">End must be after start</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/create/types.ts
+++ b/src/components/create/types.ts
@@ -37,7 +37,8 @@ export type FieldInputType =
   | 'phone'
   | 'currency'
   | 'bitcoin_address'
-  | 'tags';
+  | 'tags'
+  | 'availability';
 
 export interface SelectOption {
   value: string;

--- a/src/config/entity-configs/service-config.ts
+++ b/src/config/entity-configs/service-config.ts
@@ -134,6 +134,13 @@ const fieldGroups: FieldGroup[] = [
         },
         colSpan: 2,
       },
+      {
+        name: 'availability_schedule',
+        label: 'Weekly availability',
+        type: 'availability',
+        hint: 'When are you available? Shown to people before they book.',
+        colSpan: 2,
+      },
     ],
   },
   {

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -1,0 +1,104 @@
+/**
+ * Weekly availability for bookable entities (services).
+ *
+ * Mirrors the existing `availability_schedule` jsonb shape — the
+ * AvailabilitySchedule interface in domain/commerce/service.ts and the Zod in
+ * lib/validation/commerce.ts: a set of available `days` + one or more `hours`
+ * ranges that apply to those days. This module is the shared client-side type +
+ * display/parse helpers so the editor and public display agree on the shape.
+ */
+
+import { DAYS_OF_WEEK, type DayOfWeek } from '@/config/schedule';
+
+export interface AvailabilityHours {
+  start: string; // "HH:MM" 24h
+  end: string; // "HH:MM" 24h
+}
+
+export interface AvailabilitySchedule {
+  days?: DayOfWeek[];
+  hours?: AvailabilityHours[];
+  timezone?: string;
+}
+
+/** Day metadata in week order, with short labels for compact display. */
+export const WEEKDAYS: Array<{ key: DayOfWeek; label: string; short: string }> = [
+  { key: 'monday', label: 'Monday', short: 'Mon' },
+  { key: 'tuesday', label: 'Tuesday', short: 'Tue' },
+  { key: 'wednesday', label: 'Wednesday', short: 'Wed' },
+  { key: 'thursday', label: 'Thursday', short: 'Thu' },
+  { key: 'friday', label: 'Friday', short: 'Fri' },
+  { key: 'saturday', label: 'Saturday', short: 'Sat' },
+  { key: 'sunday', label: 'Sunday', short: 'Sun' },
+];
+
+const DAY_ORDER: Record<DayOfWeek, number> = WEEKDAYS.reduce(
+  (acc, d, i) => {
+    acc[d.key] = i;
+    return acc;
+  },
+  {} as Record<DayOfWeek, number>
+);
+
+/** Narrow unknown jsonb into a clean AvailabilitySchedule (defensive). */
+export function parseAvailability(value: unknown): AvailabilitySchedule {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+  const v = value as { days?: unknown; hours?: unknown; timezone?: unknown };
+  const days = Array.isArray(v.days)
+    ? (v.days.filter(d => (DAYS_OF_WEEK as readonly string[]).includes(d as string)) as DayOfWeek[])
+    : undefined;
+  const hours = Array.isArray(v.hours)
+    ? (v.hours.filter(
+        (h): h is AvailabilityHours =>
+          !!h &&
+          typeof h === 'object' &&
+          typeof (h as AvailabilityHours).start === 'string' &&
+          typeof (h as AvailabilityHours).end === 'string'
+      ) as AvailabilityHours[])
+    : undefined;
+  return {
+    ...(days && days.length ? { days } : {}),
+    ...(hours && hours.length ? { hours } : {}),
+    ...(typeof v.timezone === 'string' ? { timezone: v.timezone } : {}),
+  };
+}
+
+/** True when there's at least one day AND one hour range to show. */
+export function hasAvailability(value: unknown): boolean {
+  const a = parseAvailability(value);
+  return !!a.days?.length && !!a.hours?.length;
+}
+
+const shortOf = (d: DayOfWeek) => WEEKDAYS.find(w => w.key === d)?.short ?? d;
+
+/**
+ * Compact human-readable summary, e.g.:
+ *   { days: ['monday','tuesday','wednesday','thursday','friday'], hours:[{09:00–17:00}] }
+ *   → ["Mon–Fri", "09:00–17:00"]
+ * Consecutive days collapse into a range; otherwise they're comma-joined.
+ */
+export function formatAvailabilityLines(value: unknown): string[] {
+  const { days, hours } = parseAvailability(value);
+  if (!days?.length || !hours?.length) {
+    return [];
+  }
+  const sorted = [...days].sort((a, b) => DAY_ORDER[a] - DAY_ORDER[b]);
+
+  // Collapse consecutive days into ranges.
+  const groups: string[] = [];
+  let i = 0;
+  while (i < sorted.length) {
+    let j = i;
+    while (j + 1 < sorted.length && DAY_ORDER[sorted[j + 1]] === DAY_ORDER[sorted[j]] + 1) {
+      j++;
+    }
+    groups.push(i === j ? shortOf(sorted[i]) : `${shortOf(sorted[i])}–${shortOf(sorted[j])}`);
+    i = j + 1;
+  }
+
+  const daysLine = groups.join(', ');
+  const hoursLine = hours.map(h => `${h.start}–${h.end}`).join(', ');
+  return [daysLine, hoursLine];
+}


### PR DESCRIPTION
Booking showed no availability to the buyer. Now providers set their weekly availability and it appears on the public service page **right above the Book CTA** — so recipients see when you're free before committing.

## What changed
- New **'availability' form field type** backed by an `AvailabilityEditor` (pick days + an hours range), added to the service form's "Location & Availability" group.
- **Public display**: an "Availability" row on the service detail page (e.g. "Mon–Fri · 09:00–17:00"), above the Book button.
- Uses the **existing** `availability_schedule` shape (`{ days, hours, timezone }`) — the domain (`CreateServiceInput`) and the service PATCH route already persist it; new shared `lib/availability.ts` type + parse/format helpers agree on that one shape (no competing model).

## Scope (v1)
A single hours range applied to the selected days. The column supports more (multiple ranges / per-day hours) and booking-time enforcement — both can follow.

## Verification
- `eslint` clean, `tsc --noEmit` (non-incremental) 0 errors, `test:unit` 554/554
- I'll verify live after deploy: set availability on a service → see it on the public page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)