### PR TITLE
fix(routes): repair two dead-end edit links (404 / malformed)

### DIFF
--- a/src/app/(authenticated)/dashboard/documents/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/documents/[id]/page.tsx
@@ -145,7 +145,7 @@ export default async function DocumentDetailPage({ params }: PageProps) {
         </div>
 
         <div className="flex items-center gap-2">
-          <Link href={`/dashboard/cat?tab=context/create?edit=${id}`}>
+          <Link href={`${ROUTES.DASHBOARD.DOCUMENTS_CREATE}?edit=${id}`}>
             <Button variant="outline" size="sm">
               <Edit className="h-4 w-4 mr-2" />
               Edit

--- a/src/components/ai-chat/ModernChatPanel/index.tsx
+++ b/src/components/ai-chat/ModernChatPanel/index.tsx
@@ -151,8 +151,11 @@ export function ModernChatPanel({
         }
       } else if (action.type === 'update_entity' || action.type === 'publish_entity') {
         const entityMeta = ENTITY_REGISTRY[action.entityType];
-        if (entityMeta?.basePath) {
-          router.push(`${entityMeta.basePath}/${action.entityId}/edit`);
+        // Entities are edited via their create page in edit mode (?edit=<id>) —
+        // EntityCreateEditPage reads it. There is no /{basePath}/{id}/edit route
+        // for most types, so the old path 404'd for everything but causes/tasks.
+        if (entityMeta?.createPath) {
+          router.push(`${entityMeta.createPath}?edit=${action.entityId}`);
         }
       } else if (action.type === 'suggest_wallet') {
         const walletMeta = ENTITY_REGISTRY.wallet;


### PR DESCRIPTION
Found via a dead-route audit (same bug class as the group Settings 404).

## 1. Cat "edit entity" 404'd for most types
`ModernChatPanel`'s `update_entity` / `publish_entity` action pushed to `${basePath}/${id}/edit`, but **no such route exists** except for causes/tasks. So when Cat offered to edit a product / service / project / etc., the user hit a 404. Entities are edited via their **create page in edit mode** (`?edit=<id>`, read by `EntityCreateEditPage`). Now pushes `${createPath}?edit=${id}` — works for every registry entity.

## 2. Document "Edit" link was malformed
`/dashboard/cat?tab=context/create?edit=${id}` — two query strings, and `/dashboard/cat` doesn't read `create`/`edit` anyway. Now points at the document's edit page: `${ROUTES.DASHBOARD.DOCUMENTS_CREATE}?edit=${id}`.

## Verification
- `eslint` clean, `tsc --noEmit` (non-incremental) 0 errors, `test:unit` 554/554
- Edit routes confirmed: only causes/tasks have `[id]/edit`; all entity create pages read `?edit` via `EntityCreateEditPage` / `useDocumentCreate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)