### PR TITLE
fix(ui): honest success/error feedback on mutations

### DIFF
--- a/src/components/ai/AIKeyManager.tsx
+++ b/src/components/ai/AIKeyManager.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, type DragEvent } from 'react';
+import { toast } from 'sonner';
 import { Plus, ChevronUp, ChevronDown, GripVertical, Bot } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import {
@@ -74,6 +75,7 @@ export function AIKeyManager({
     try {
       await onDelete(keyToDelete.id);
       setKeyToDelete(null);
+      toast.success('API key deleted');
     } catch (err) {
       setDeleteError(err instanceof Error ? err.message : 'Failed to delete key');
     }

--- a/src/components/assets/CreateAssetDialogForm.tsx
+++ b/src/components/assets/CreateAssetDialogForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { logger } from '@/utils/logger';
+import { toast } from 'sonner';
 
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -91,11 +92,11 @@ export function CreateAssetDialog({
         throw new Error(errorData.error || 'Failed to create asset');
       }
 
+      toast.success('Asset created');
       onAssetCreated();
     } catch (error) {
       logger.error('Failed to create asset:', error);
-      // For now, just show success since the API might be failing due to migration
-      onAssetCreated();
+      toast.error(error instanceof Error ? error.message : 'Failed to create asset');
     } finally {
       setLoading(false);
     }

--- a/src/components/dashboard/CatNudges.tsx
+++ b/src/components/dashboard/CatNudges.tsx
@@ -42,12 +42,23 @@ export function CatNudges() {
   }, []);
 
   const dismiss = (id: string) => {
+    // Optimistically remove, but restore on failure so the nudge doesn't silently
+    // reappear on next load (the dismissal wasn't persisted).
+    const prev = nudges;
     setNudges(n => n?.filter(x => x.id !== id) ?? null);
     fetch('/api/cat/nudges', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'dismiss', id }),
-    }).catch(() => {});
+    })
+      .then(res => {
+        if (!res.ok) {
+          throw new Error(`Failed to dismiss (${res.status})`);
+        }
+      })
+      .catch(() => {
+        setNudges(prev);
+      });
   };
 
   if (!nudges || nudges.length === 0) {

--- a/src/components/settings/IntegrationKeysCard.tsx
+++ b/src/components/settings/IntegrationKeysCard.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
 import IntegrationKeyMintForm from '@/components/settings/IntegrationKeyMintForm';
 import IntegrationKeyRow from '@/components/settings/IntegrationKeyRow';
@@ -174,6 +175,7 @@ export default function IntegrationKeysCard({ actors, defaultActorId }: Props) {
       setKeys(prev =>
         prev.map(k => (k.id === key.id ? { ...k, revoked_at: new Date().toISOString() } : k))
       );
+      toast.success('Integration key revoked');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to revoke key');
     }

--- a/src/components/settings/WebhookEndpointsCard.tsx
+++ b/src/components/settings/WebhookEndpointsCard.tsx
@@ -18,6 +18,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
 import WebhookEndpointMintForm from '@/components/settings/WebhookEndpointMintForm';
 import WebhookEndpointRow, { type WebhookEndpoint } from '@/components/settings/WebhookEndpointRow';
@@ -156,6 +157,7 @@ export default function WebhookEndpointsCard({ actors, defaultActorId }: Props) 
       setEndpoints(prev =>
         prev.map(e => (e.id === endpoint.id ? { ...e, revoked_at: new Date().toISOString() } : e))
       );
+      toast.success('Webhook endpoint revoked');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to revoke endpoint');
     }

--- a/src/components/wishlist/WishlistProofSection.tsx
+++ b/src/components/wishlist/WishlistProofSection.tsx
@@ -12,6 +12,7 @@
 
 import React, { useState } from 'react';
 import { Plus, Receipt, ChevronDown, ChevronUp } from 'lucide-react';
+import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
 import { API_ROUTES } from '@/config/api-routes';
 import { Button } from '@/components/ui/Button';
@@ -40,40 +41,36 @@ export function WishlistProofSection({
     onProofAdded?.(proof);
   };
 
-  const handleLike = async (proofId: string) => {
+  const submitFeedback = async (
+    proofId: string,
+    feedbackType: 'like' | 'dislike',
+    comment?: string
+  ) => {
     try {
-      await fetch(API_ROUTES.WISHLISTS.FEEDBACK, {
+      const res = await fetch(API_ROUTES.WISHLISTS.FEEDBACK, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           wishlist_item_id: wishlistItemId,
           fulfillment_proof_id: proofId,
-          feedback_type: 'like',
+          feedback_type: feedbackType,
+          ...(comment ? { comment } : {}),
         }),
       });
+      if (!res.ok) {
+        throw new Error(`Failed (${res.status})`);
+      }
       onFeedbackChanged?.();
     } catch (error) {
-      logger.error('Error submitting like', error, 'Wishlist');
+      logger.error(`Error submitting ${feedbackType}`, error, 'Wishlist');
+      toast.error('Could not submit your feedback. Please try again.');
     }
   };
 
-  const handleDislike = async (proofId: string, comment: string) => {
-    try {
-      await fetch(API_ROUTES.WISHLISTS.FEEDBACK, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          wishlist_item_id: wishlistItemId,
-          fulfillment_proof_id: proofId,
-          feedback_type: 'dislike',
-          comment,
-        }),
-      });
-      onFeedbackChanged?.();
-    } catch (error) {
-      logger.error('Error submitting dislike', error, 'Wishlist');
-    }
-  };
+  const handleLike = (proofId: string) => submitFeedback(proofId, 'like');
+
+  const handleDislike = (proofId: string, comment: string) =>
+    submitFeedback(proofId, 'dislike', comment);
 
   const handleDelete = async (proofId: string) => {
     if (!confirm('Are you sure you want to delete this proof?')) {
@@ -81,12 +78,17 @@ export function WishlistProofSection({
     }
 
     try {
-      await fetch(`${API_ROUTES.WISHLISTS.PROOFS}/${proofId}`, {
+      const res = await fetch(`${API_ROUTES.WISHLISTS.PROOFS}/${proofId}`, {
         method: 'DELETE',
       });
+      if (!res.ok) {
+        throw new Error(`Failed (${res.status})`);
+      }
+      toast.success('Proof deleted');
       onProofDeleted?.(proofId);
     } catch (error) {
       logger.error('Error deleting proof', error, 'Wishlist');
+      toast.error('Could not delete the proof. Please try again.');
     }
   };
 


### PR DESCRIPTION
Audit (deep-dive) found mutations that swallowed their result — leaving users unsure if an action worked, or worse, showing **false success**.

- **CreateAssetDialogForm**: the catch block called `onAssetCreated()` (claimed success even on failure — a migration-era workaround). Now shows a real error toast; success only on success.
- **CatNudges** dismiss: optimistic with a swallowed error → a failed dismissal silently reappeared on reload. Now **reverts on failure**.
- **AIKeyManager** delete, **IntegrationKeysCard** / **WebhookEndpointsCard** revoke: security-relevant actions with no success feedback → success toasts.
- **WishlistProofSection** like/dislike/delete: fetches ignored `res.ok` and showed nothing on failure → `res.ok` checks + error toasts (and a success toast on delete).

## Verification
- `eslint` clean, `tsc --noEmit` (non-incremental) 0 errors, `test:unit` 554/554

🤖 Generated with [Claude Code](https://claude.com/claude-code)