### PR TITLE
fix(ui): error + empty states for async flows

### DIFF
--- a/src/components/groups/events/EventsList.tsx
+++ b/src/components/groups/events/EventsList.tsx
@@ -41,6 +41,7 @@ export function EventsList({ groupId, groupSlug, canCreateEvent = false }: Event
   const { user: _user } = useAuth();
   const [events, setEvents] = useState<GroupEvent[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [statusFilter, setStatusFilter] = useState<EventStatusFilter>('upcoming');
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const loadIdRef = useRef(0);
@@ -49,6 +50,7 @@ export function EventsList({ groupId, groupSlug, canCreateEvent = false }: Event
     const myLoadId = ++loadIdRef.current;
     try {
       setLoading(true);
+      setError(false);
       const params = new URLSearchParams();
       if (statusFilter !== 'all') {
         params.append('status', statusFilter);
@@ -77,6 +79,7 @@ export function EventsList({ groupId, groupSlug, canCreateEvent = false }: Event
         return;
       }
       logger.error('Failed to load events:', error);
+      setError(true);
       toast.error('Failed to load events');
     } finally {
       if (myLoadId === loadIdRef.current) {
@@ -105,6 +108,19 @@ export function EventsList({ groupId, groupSlug, canCreateEvent = false }: Event
       <Card>
         <CardContent className="flex items-center justify-center py-12">
           <Loader2 className="h-8 w-8 animate-spin text-fg-tertiary" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+          <p className="text-sm text-fg-secondary">Couldn’t load events.</p>
+          <Button variant="outline" size="sm" onClick={() => loadEvents()}>
+            Try again
+          </Button>
         </CardContent>
       </Card>
     );

--- a/src/components/groups/proposals/ProposalsList.tsx
+++ b/src/components/groups/proposals/ProposalsList.tsx
@@ -48,6 +48,7 @@ export function ProposalsList({
   const { user } = useAuth();
   const [proposals, setProposals] = useState<ProposalWithSlug[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [statusFilter, setStatusFilter] = useState<ProposalStatusFilter>('all');
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   // Monotonic load id — only the most recent load writes state.
@@ -57,6 +58,7 @@ export function ProposalsList({
     const myLoadId = ++loadIdRef.current;
     try {
       setLoading(true);
+      setError(false);
       const params = new URLSearchParams();
       if (statusFilter !== 'all') {
         params.append('status', statusFilter);
@@ -94,6 +96,7 @@ export function ProposalsList({
         return;
       }
       logger.error('Failed to load proposals:', error);
+      setError(true);
       toast.error('Failed to load proposals');
     } finally {
       if (myLoadId === loadIdRef.current) {
@@ -123,6 +126,19 @@ export function ProposalsList({
           <div className="flex items-center justify-center">
             <Loader2 className="h-6 w-6 animate-spin text-fg-tertiary" />
           </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+          <p className="text-sm text-fg-secondary">Couldn’t load proposals.</p>
+          <Button variant="outline" size="sm" onClick={() => loadProposals()}>
+            Try again
+          </Button>
         </CardContent>
       </Card>
     );

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -40,14 +40,13 @@ export default function ConversationList({
   onStartNew,
 }: ConversationListProps) {
   const { user } = useAuth();
-  const [error, setError] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [isPointerSelecting, setIsPointerSelecting] = useState(false);
   const [dragAction, setDragAction] = useState<'select' | 'deselect' | null>(null);
   const pressTimerRef = React.useRef<number | null>(null);
   const currentUserId = user?.id;
 
-  const { conversations, loading, refresh, removeLocal } = useConversations(
+  const { conversations, loading, error, refresh, removeLocal } = useConversations(
     searchQuery,
     selectedConversationId
   );
@@ -176,10 +175,7 @@ export default function ConversationList({
         <MessageSquare className="mx-auto mb-2 h-8 w-8 text-status-negative" />
         <p className="mb-3 text-sm text-status-negative">{error}</p>
         <button
-          onClick={() => {
-            setError(null);
-            refresh();
-          }}
+          onClick={() => refresh()}
           className="inline-flex items-center gap-2 text-sm text-fg-primary hover:text-fg-secondary"
         >
           <RefreshCw className="w-4 h-4" />

--- a/src/components/messaging/MessageView/MessageList.tsx
+++ b/src/components/messaging/MessageView/MessageList.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { useRef, useCallback, useEffect, useState } from 'react';
-import { ChevronUp, Loader2 } from 'lucide-react';
+import { ChevronUp, Loader2, MessageSquare } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import MessageItem, { shouldShowDateDivider, getDateDividerText } from './MessageItem';
 import type { Message } from '@/features/messaging/types';
@@ -101,6 +101,15 @@ export default function MessageList({
             )}
             {isLoadingMore ? 'Loading...' : 'Load older messages'}
           </Button>
+        </div>
+      )}
+
+      {/* Empty state — new/empty conversation (no blank screen) */}
+      {messages.length === 0 && !hasMore && (
+        <div className="flex flex-1 flex-col items-center justify-center py-16 text-center">
+          <MessageSquare className="mb-3 h-10 w-10 text-fg-tertiary" />
+          <p className="text-sm font-medium text-fg-primary">No messages yet</p>
+          <p className="text-sm text-fg-secondary">Say hello to start the conversation.</p>
         </div>
       )}
 

--- a/src/components/profile/ProfilePeopleTab.tsx
+++ b/src/components/profile/ProfilePeopleTab.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Users } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
 import type { ScalableProfile } from '@/services/profile/types';
 import DefaultAvatar from '@/components/ui/DefaultAvatar';
 import supabase from '@/lib/supabase/browser';
@@ -46,6 +47,8 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
   const [following, setFollowing] = useState<Connection[]>([]);
   const [followers, setFollowers] = useState<Connection[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
   const [activeView, setActiveView] = useState<'following' | 'followers'>('followers');
 
   useEffect(() => {
@@ -57,6 +60,7 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
     const fetchConnections = async () => {
       try {
         setLoading(true);
+        setError(false);
 
         // Check if this is the user's own profile (use prop or check user)
         const isCurrentUserProfile = isOwnProfile || user?.id === profile.id;
@@ -160,6 +164,7 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
       } catch (error) {
         if (!cancelled) {
           logger.error('Failed to fetch connections:', error);
+          setError(true);
         }
       } finally {
         if (!cancelled) {
@@ -172,10 +177,23 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
     return () => {
       cancelled = true;
     };
-  }, [profile.id, isOwnProfile, user?.id]);
+  }, [profile.id, isOwnProfile, user?.id, reloadKey]);
 
   if (loading) {
     return <div className="text-fg-secondary text-sm py-8 text-center">Loading connections...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <Users className="w-12 h-12 mx-auto mb-4 text-fg-tertiary" />
+        <h3 className="text-lg font-semibold text-fg-primary mb-2">Couldn’t load connections</h3>
+        <p className="text-fg-secondary mb-6">Something went wrong fetching followers.</p>
+        <Button variant="outline" onClick={() => setReloadKey(k => k + 1)}>
+          Try again
+        </Button>
+      </div>
+    );
   }
 
   const currentList = activeView === 'following' ? following : followers;

--- a/src/components/profile/ProfileProjectsTab.tsx
+++ b/src/components/profile/ProfileProjectsTab.tsx
@@ -46,6 +46,8 @@ interface ProfileProjectsTabProps {
 export default function ProfileProjectsTab({ profile, isOwnProfile }: ProfileProjectsTabProps) {
   const [projects, setProjects] = useState<ProfileProjectItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     if (!profile.id) {
@@ -55,11 +57,15 @@ export default function ProfileProjectsTab({ profile, isOwnProfile }: ProfilePro
     const fetchProjects = async () => {
       try {
         setLoading(true);
+        setError(false);
         const response = await fetch(API_ROUTES.PROFILES.PROJECTS(profile.id), {
           signal: controller.signal,
         });
         if (controller.signal.aborted) {
           return;
+        }
+        if (!response.ok) {
+          throw new Error(`Failed to load projects (${response.status})`);
         }
         const result = await response.json();
         if (controller.signal.aborted) {
@@ -74,6 +80,7 @@ export default function ProfileProjectsTab({ profile, isOwnProfile }: ProfilePro
           return;
         }
         logger.error('Failed to fetch projects:', error);
+        setError(true);
       } finally {
         if (!controller.signal.aborted) {
           setLoading(false);
@@ -83,10 +90,23 @@ export default function ProfileProjectsTab({ profile, isOwnProfile }: ProfilePro
 
     fetchProjects();
     return () => controller.abort();
-  }, [profile.id]);
+  }, [profile.id, reloadKey]);
 
   if (loading) {
     return <div className="text-fg-secondary text-sm py-8 text-center">Loading projects...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <Target className="w-12 h-12 mx-auto mb-4 text-fg-tertiary" />
+        <h3 className="text-lg font-semibold text-fg-primary mb-2">Couldn’t load projects</h3>
+        <p className="text-fg-secondary mb-6">Something went wrong fetching projects.</p>
+        <Button variant="outline" onClick={() => setReloadKey(k => k + 1)}>
+          Try again
+        </Button>
+      </div>
+    );
   }
 
   // Filter out drafts for public display


### PR DESCRIPTION
Deep-dive audit found high-traffic async views that fail silently. Added the missing states (per the CLAUDE.md Loading/Empty/Error/Success standard).

- **MessageList**: empty state for a new conversation (was a blank message area).
- **ProfileProjectsTab**, **ProfilePeopleTab**: inline error + "Try again" (a failed fetch previously rendered "No projects/connections" — indistinguishable from genuinely empty).
- **ConversationList**: `useConversations` returned an `error` that was never surfaced (dead local error state) — wired it to the existing error UI + retry.
- **EventsList**, **ProposalsList**: inline error card + "Try again" (previously only a fleeting toast → empty list).

## Verification
- `eslint` clean, `tsc --noEmit` (non-incremental) 0 errors, `test:unit` 554/554

🤖 Generated with [Claude Code](https://claude.com/claude-code)