### PR TITLE
feat(cat): budget + prioritize context (overflow-safe)

### DIFF
--- a/src/services/ai/context-string-builder.ts
+++ b/src/services/ai/context-string-builder.ts
@@ -555,9 +555,34 @@ export function buildFullContextString(context: FullUserContext): string {
     return '';
   }
 
+  // Budget the context so it can't overflow the model window or drown a small
+  // free model on large accounts. Sections are pushed in priority order
+  // (session → profile → documents → entities → … → activity summary), so we
+  // greedily keep the highest-priority ones that fit and note any omission.
+  // ~28k chars ≈ ~7k tokens — leaves ample room for the system prompt + history.
+  const CONTEXT_CHAR_BUDGET = 28000;
+  const SEP = '\n\n';
+  const budgetedSections: string[] = [];
+  let used = 0;
+  let omitted = 0;
+  for (const section of sections) {
+    const cost = section.length + SEP.length;
+    if (used + cost <= CONTEXT_CHAR_BUDGET || budgetedSections.length === 0) {
+      budgetedSections.push(section);
+      used += cost;
+    } else {
+      omitted++;
+    }
+  }
+  if (omitted > 0) {
+    budgetedSections.push(
+      `_(${omitted} lower-priority context section(s) omitted to stay within limits. Ask about a specific area for more detail.)_`
+    );
+  }
+
   return `# User Context for Personalized Advice
 
-${sections.join('\n\n')}
+${budgetedSections.join(SEP)}
 
 ---
 **Instructions for using this context**:


### PR DESCRIPTION
Cat dumped the user's full context every turn with no total size cap — overflow risk / drowns small free models on large accounts. Now greedily keeps the highest-priority sections within a ~28k-char (~7k-token) budget (sections are already pushed in priority order) and notes any omissions.

Verification: eslint clean, tsc 0 errors, test:unit 554/554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)