### PR TITLE
feat(cat): run Cat on ANY model (custom model id for BYOK)

### DIFF
--- a/src/components/ai-chat/ModernChatPanel/components/ModelSelector.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/ModelSelector.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { getFreeModels, getModelMetadata } from '@/config/ai-models';
-import { Sparkles, ChevronDown, Check } from 'lucide-react';
+import { Sparkles, ChevronDown, Check, ArrowRight } from 'lucide-react';
 
 interface ModelSelectorProps {
   selectedModel: string;
@@ -26,10 +26,21 @@ export function ModelSelector({
   subtle,
 }: ModelSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [customModel, setCustomModel] = useState('');
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const freeModels = getFreeModels();
   const selectedMeta = getModelMetadata(selectedModel);
+
+  const applyCustom = () => {
+    const id = customModel.trim();
+    if (!id) {
+      return;
+    }
+    onSelect(id);
+    setCustomModel('');
+    setIsOpen(false);
+  };
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -125,6 +136,44 @@ export function ModelSelector({
               </div>
             </button>
           ))}
+
+          <div className="h-px bg-border-subtle my-1" />
+
+          {/* Custom model — run Cat on ANY model id (requires your own API key in
+              Settings → AI; OpenRouter unlocks 200+ models with one key). */}
+          <div className="px-3 py-1.5 text-xs font-medium text-fg-secondary uppercase">
+            Custom model
+          </div>
+          <div className="px-3 pb-2">
+            <div className="flex items-center gap-1.5">
+              <input
+                type="text"
+                value={customModel}
+                onChange={e => setCustomModel(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    applyCustom();
+                  }
+                }}
+                placeholder="e.g. anthropic/claude-3.5-sonnet"
+                className="min-w-0 flex-1 rounded-md border border-subtle bg-surface-base px-2 py-1.5 text-sm text-fg-primary placeholder:text-fg-tertiary"
+                aria-label="Custom model id"
+              />
+              <button
+                type="button"
+                onClick={applyCustom}
+                disabled={!customModel.trim()}
+                aria-label="Use custom model"
+                className="flex h-8 w-8 items-center justify-center rounded-md border border-subtle text-fg-secondary hover:bg-surface-raised disabled:opacity-40"
+              >
+                <ArrowRight className="h-4 w-4" />
+              </button>
+            </div>
+            <p className="mt-1 text-xs text-fg-tertiary">
+              Any model id from a provider you’ve added a key for (Settings → AI).
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/ai-chat/ModernChatPanel/index.tsx
+++ b/src/components/ai-chat/ModernChatPanel/index.tsx
@@ -52,8 +52,27 @@ export function ModernChatPanel({
   const router = useRouter();
   const [input, setInput] = useState('');
   const [internalModel, setInternalModel] = useState('auto');
+  // Remember the user's model choice (incl. custom ids) across reloads.
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('cat:model');
+      if (saved) {
+        setInternalModel(saved);
+      }
+    } catch {
+      // localStorage unavailable — fall back to the in-memory default.
+    }
+  }, []);
+  const persistModel = useCallback((m: string) => {
+    setInternalModel(m);
+    try {
+      localStorage.setItem('cat:model', m);
+    } catch {
+      // ignore persistence failures
+    }
+  }, []);
   const selectedModel = selectedModelProp ?? internalModel;
-  const setSelectedModel = onModelSelect ?? setInternalModel;
+  const setSelectedModel = onModelSelect ?? persistModel;
   const lastUserMessageRef = useRef<string>('');
   const initialMessageSentRef = useRef(false);
   const refreshPendingActionsRef = useRef<(() => Promise<void>) | undefined>(undefined);

--- a/src/services/cat/provider-resolver.ts
+++ b/src/services/cat/provider-resolver.ts
@@ -125,15 +125,19 @@ export async function resolveProvider(
       };
     }
     if (prov === 'openrouter') {
-      let model =
-        requestedModel && requestedModel !== 'auto' && requestedModel !== 'any'
-          ? requestedModel
-          : DEFAULT_FREE_MODEL_ID;
-      if (requestedModel === 'auto' || requestedModel === 'any') {
+      const explicit = requestedModel && requestedModel !== 'auto' && requestedModel !== 'any';
+      let model: string;
+      if (explicit) {
+        // BYOK: the user pays for their own OpenRouter key, so trust whatever
+        // model id they chose — including any of OpenRouter's 200+ models that
+        // aren't in our curated registry. (Platform/non-BYOK usage goes through
+        // buildPlatformProviders, which stays registry-constrained.)
+        model = requestedModel;
+      } else {
         model = createAutoRouter().selectModel({ message, conversationHistory: [] }).model;
-      }
-      if (!getModelMetadata(model)) {
-        model = DEFAULT_FREE_MODEL_ID;
+        if (!getModelMetadata(model)) {
+          model = DEFAULT_FREE_MODEL_ID;
+        }
       }
       return {
         provider: 'openrouter',


### PR DESCRIPTION
"Use whatever model you want to power Cat."

- **Model picker**: new **Custom model** input — type any model id (e.g. \`anthropic/claude-3.5-sonnet\`). The choice (incl. custom ids) now **persists across reloads** via localStorage (was resetting to Auto every refresh).
- **Resolver**: a BYOK OpenRouter key now passes an explicitly-chosen model id through as-is instead of rejecting non-registry ids — so OpenRouter's **200+ models** all work. Platform/non-BYOK usage stays registry-constrained; OpenAI-compatible BYOK providers already honored the requested model.

This is the v1 of "any model": via an OpenRouter BYOK key it's literally any model. A dedicated **Custom (OpenAI-compatible) endpoint** provider (arbitrary base URL) is a sensible follow-up but has SSRF/security considerations worth its own design.

Verification: eslint clean, tsc 0 errors, test:unit 554/554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)