### PR TITLE
feat(cat): persistent semantic memory (Tier 3)

### DIFF
--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -21,6 +21,7 @@ import { useRequireAuth } from '@/hooks/useAuth';
 import { useAISettings } from '@/hooks/useAISettings';
 import Loading from '@/components/Loading';
 import { AIKeyManager } from '@/components/ai/AIKeyManager';
+import { CatMemoryManager } from '@/components/ai/CatMemoryManager';
 import { getProvidersByCategory } from '@/data/aiProviders';
 
 export default function AISettingsPage() {
@@ -128,6 +129,9 @@ export default function AISettingsPage() {
             isLoading={settingsLoading}
           />
         </section>
+
+        {/* ── Memory ────────────────────────────────────────────────────── */}
+        <CatMemoryManager />
 
         {/* ── Local ─────────────────────────────────────────────────────── */}
         <section className="rounded-lg border border-default bg-surface-base p-6">

--- a/src/app/api/cat/chat/route.ts
+++ b/src/app/api/cat/chat/route.ts
@@ -27,6 +27,7 @@ import {
   saveMessages,
 } from '@/services/cat/conversation-history';
 import { resolveProvider, type FallbackProvider } from '@/services/cat/provider-resolver';
+import { recallMemories, extractAndStoreMemories } from '@/services/cat/memory';
 import {
   maybeEnrichWithSearchResults,
   type ToolAugmentedMessage,
@@ -205,6 +206,10 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       locale,
       lastVisitedPath,
     });
+    // Recall durable facts Cat has learned about this user, ranked by relevance
+    // to THIS message, and fold them into the context (rendered near the top so
+    // the budget always keeps them). Best-effort: [] if memory is unavailable.
+    userContext.memories = await recallMemories(supabase, user.id, message);
     const contextString = buildFullContextString(userContext);
     // Examples are appended as labeled text (not injected as fake conversation
     // turns) so weaker models can't mistake the example people for the real user.
@@ -372,6 +377,17 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
               ]).catch((err: unknown) => {
                 logger.error('Failed to persist streaming messages', { err }, 'cat/chat');
               });
+              // Learn durable facts from this exchange for future turns. Fully
+              // best-effort and detached — never blocks or fails the response.
+              void extractAndStoreMemories(
+                supabase,
+                user.id,
+                conversationId,
+                message,
+                fullContent,
+                activeService,
+                activeModel
+              );
             }
             if (!hasByok && usage?.totalTokens) {
               await keyService.incrementPlatformUsage(user.id, 1, usage.totalTokens);
@@ -513,6 +529,16 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       ]).catch((err: unknown) => {
         logger.error('Failed to persist messages', { err }, 'cat/chat');
       });
+      // Learn durable facts from this exchange (best-effort, detached).
+      void extractAndStoreMemories(
+        supabase,
+        user.id,
+        conversationId,
+        message,
+        cleanedMessage,
+        fellBackTo?.aiService ?? aiService,
+        fellBackTo?.modelToUse ?? modelToUse
+      );
     }
 
     return applyRateLimitHeaders(

--- a/src/app/api/cat/memories/route.ts
+++ b/src/app/api/cat/memories/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Cat Memory API
+ *
+ * GET    /api/cat/memories          - List what Cat remembers about you
+ * DELETE /api/cat/memories?id=<id>  - Forget one memory
+ * DELETE /api/cat/memories?all=true - Forget everything
+ *
+ * Memory is private and RLS-scoped; these endpoints let users see and control
+ * exactly what Cat has learned (privacy-first, ChatGPT-style memory controls).
+ */
+
+import { listMemories, deleteMemory, deleteAllMemories } from '@/services/cat/memory';
+import { apiSuccess, apiError, apiRateLimited, handleApiError } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+  try {
+    const memories = await listMemories(supabase, user.id);
+    return apiSuccess({ memories });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const DELETE = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+  const all = searchParams.get('all') === 'true';
+
+  try {
+    if (all) {
+      const ok = await deleteAllMemories(supabase, user.id);
+      return ok
+        ? apiSuccess({ success: true })
+        : apiError('Failed to clear memories', 'INTERNAL_ERROR', 500);
+    }
+    if (id) {
+      const ok = await deleteMemory(supabase, user.id, id);
+      return ok
+        ? apiSuccess({ success: true })
+        : apiError('Failed to delete memory', 'INTERNAL_ERROR', 500);
+    }
+    return apiError('Provide ?id=<id> or ?all=true', 'BAD_REQUEST', 400);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/src/components/ai/CatMemoryManager.tsx
+++ b/src/components/ai/CatMemoryManager.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+/**
+ * CatMemoryManager — view and control what Cat remembers about you.
+ *
+ * Lists the durable facts Cat has learned (from chat), with per-item delete and
+ * a guarded "Forget everything". Privacy-first: memory is only useful if the
+ * user can see and erase it, ChatGPT-style. Talks to /api/cat/memories.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Brain, Trash2, Loader2, AlertCircle } from 'lucide-react';
+import { toast } from 'sonner';
+import Button from '@/components/ui/Button';
+import { logger } from '@/utils/logger';
+
+interface Memory {
+  id: string;
+  content: string;
+  created_at: string;
+}
+
+export function CatMemoryManager() {
+  const [memories, setMemories] = useState<Memory[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/cat/memories');
+      if (!res.ok) {
+        throw new Error('Failed to load memories');
+      }
+      const json = await res.json();
+      setMemories((json?.data?.memories ?? []) as Memory[]);
+    } catch (err) {
+      logger.error('Failed to load cat memories', err, 'CatMemory');
+      setError('Could not load memories. Try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    setDeletingId(id);
+    try {
+      const res = await fetch(`/api/cat/memories?id=${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        throw new Error('delete failed');
+      }
+      setMemories(prev => prev.filter(m => m.id !== id));
+      toast.success('Memory forgotten');
+    } catch (err) {
+      logger.error('Failed to delete memory', err, 'CatMemory');
+      toast.error('Could not delete that memory');
+    } finally {
+      setDeletingId(null);
+    }
+  }, []);
+
+  const handleClearAll = useCallback(async () => {
+    setIsClearing(true);
+    try {
+      const res = await fetch('/api/cat/memories?all=true', { method: 'DELETE' });
+      if (!res.ok) {
+        throw new Error('clear failed');
+      }
+      setMemories([]);
+      setConfirmClear(false);
+      toast.success('Cleared everything Cat remembered');
+    } catch (err) {
+      logger.error('Failed to clear memories', err, 'CatMemory');
+      toast.error('Could not clear memories');
+    } finally {
+      setIsClearing(false);
+    }
+  }, []);
+
+  return (
+    <section className="rounded-lg border border-default bg-surface-base p-6">
+      <div className="mb-4 flex items-start gap-3">
+        <div className="rounded-md bg-surface-raised p-2">
+          <Brain className="h-5 w-5 text-fg-primary" />
+        </div>
+        <div className="flex-1">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-fg-primary">What Cat remembers</h2>
+            {memories.length > 0 && !confirmClear && (
+              <button
+                type="button"
+                onClick={() => setConfirmClear(true)}
+                className="text-sm text-fg-secondary underline hover:text-status-negative"
+              >
+                Forget everything
+              </button>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-fg-secondary">
+            Durable facts Cat has learned about you from your conversations, so it carries context
+            across sessions. You control all of it — delete anything, anytime.
+          </p>
+        </div>
+      </div>
+
+      {confirmClear && (
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-status-negative/30 bg-status-negative-subtle p-3">
+          <span className="text-sm text-fg-primary">
+            Forget everything Cat remembers? This can&apos;t be undone.
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setConfirmClear(false)}
+              disabled={isClearing}
+              className="h-8 px-3 text-sm"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleClearAll}
+              disabled={isClearing}
+              className="h-8 gap-2 bg-status-negative px-3 text-sm text-fg-inverted hover:bg-status-negative/90"
+            >
+              {isClearing && <Loader2 className="h-4 w-4 animate-spin" />}
+              Forget everything
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 py-6 text-sm text-fg-secondary">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading memories…
+        </div>
+      ) : error ? (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-subtle bg-surface-raised/30 p-4">
+          <span className="flex items-center gap-2 text-sm text-status-negative">
+            <AlertCircle className="h-4 w-4" /> {error}
+          </span>
+          <Button variant="outline" onClick={load} className="h-8 px-3 text-sm">
+            Retry
+          </Button>
+        </div>
+      ) : memories.length === 0 ? (
+        <div className="rounded-md border border-subtle bg-surface-raised/30 p-6 text-center">
+          <p className="text-sm text-fg-secondary">
+            Cat hasn&apos;t saved any memories yet. As you chat and share preferences, goals, or
+            details about your projects, it&apos;ll remember the durable ones here.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {memories.map(m => (
+            <li
+              key={m.id}
+              className="flex items-start justify-between gap-3 rounded-md border border-subtle bg-surface-raised/30 p-3"
+            >
+              <span className="text-sm text-fg-primary">{m.content}</span>
+              <button
+                type="button"
+                onClick={() => handleDelete(m.id)}
+                disabled={deletingId === m.id}
+                aria-label="Forget this memory"
+                className="shrink-0 rounded-md p-1 text-fg-tertiary hover:bg-surface-raised hover:text-status-negative disabled:opacity-40"
+              >
+                {deletingId === m.id ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Trash2 className="h-4 w-4" />
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default CatMemoryManager;

--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -144,6 +144,7 @@ export const DATABASE_TABLES = {
   CAT_PERMISSIONS: 'cat_permissions',
   CAT_ACTION_LOG: 'cat_action_log',
   CAT_PENDING_ACTIONS: 'cat_pending_actions',
+  CAT_MEMORIES: 'cat_memories',
 
   // Messaging Views
   MESSAGE_DETAILS: 'message_details',

--- a/src/services/ai/context-string-builder.ts
+++ b/src/services/ai/context-string-builder.ts
@@ -96,6 +96,17 @@ export function buildFullContextString(context: FullUserContext): string {
     }
   }
 
+  // Persistent memory — durable facts Cat has learned about this user, recalled
+  // semantically for THIS message. Placed near the top (right after the session)
+  // so it's effectively always kept by the budget and Cat treats it as known
+  // truth about the person, not a transient detail.
+  if (context.memories && context.memories.length > 0) {
+    const memoryLines = context.memories.map(m => `- ${m.content}`);
+    sections.push(
+      `## What you remember about this user\nThese are durable facts you've learned about them across past conversations. Treat them as known and use them naturally — don't re-ask what you already know.\n${memoryLines.join('\n')}`
+    );
+  }
+
   // Current date/time — injected so Cat can reason temporally about reminders,
   // deadlines, overdue tasks, and upcoming events. Formatted in the user's locale.
   {

--- a/src/services/ai/document-context-types.ts
+++ b/src/services/ai/document-context-types.ts
@@ -200,6 +200,12 @@ export interface RuntimeContext {
 
 export interface FullUserContext {
   profile: ProfileContext | null;
+  /**
+   * Durable facts Cat remembers about this user, recalled semantically for the
+   * CURRENT message (see cat/memory.ts). Optional: only the chat path populates
+   * it; other context consumers leave it undefined.
+   */
+  memories?: Array<{ content: string }>;
   documents: DocumentContext[];
   entities: EntitySummary[];
   tasks: TaskSummary[];

--- a/src/services/cat/memory.ts
+++ b/src/services/cat/memory.ts
@@ -1,0 +1,327 @@
+/**
+ * Cat Memory Service
+ *
+ * Persistent, semantic memory for My Cat. Durable facts about a user
+ * ("Prefers Lightning over on-chain", "Building FleetCrown") are extracted
+ * from chat, embedded, and recalled by MEANING on later turns — so Cat keeps
+ * context across sessions instead of re-deriving everything each time.
+ *
+ * Two paths, both best-effort and non-blocking (Cat never breaks if memory is
+ * unavailable — missing table, no embeddings provider, or a failed LLM call all
+ * degrade to "no memory this turn"):
+ *   - recallMemories():       embed the current message → nearest stored facts
+ *   - extractAndStoreMemories(): after a turn, distil new durable facts → store
+ *
+ * Reuses the platform's 1536-dim pgvector setup (see content_embeddings) via the
+ * match_cat_memories RPC. Privacy: cat_memories is RLS-scoped to the owner, and
+ * users can view/delete everything Cat remembers (Settings → AI).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { embeddingsEnabled, embedText, embedTexts } from '@/services/ai/embeddings';
+import { logger } from '@/utils/logger';
+
+export interface CatMemory {
+  id: string;
+  content: string;
+  /** Cosine similarity to the recall query (0–1), present only on recall. */
+  similarity?: number;
+  created_at: string;
+}
+
+/** How many memories to recall and inject per turn. */
+const RECALL_COUNT = 6;
+/** Relevance floor for recall — below this a memory isn't worth injecting. */
+const RECALL_MIN_SIMILARITY = 0.3;
+/** A candidate fact this close to an existing one is treated as already known. */
+const DEDUP_SIMILARITY = 0.88;
+/** Cap facts distilled from a single exchange — keeps extraction cheap + focused. */
+const MAX_FACTS_PER_TURN = 3;
+/** Soft cap per user; oldest beyond this are pruned on write. */
+const MAX_MEMORIES_PER_USER = 300;
+/** Trim any single fact to this length before storing. */
+const MAX_FACT_CHARS = 240;
+
+/** Minimal Ai service shape used for extraction (matches the chat provider). */
+export interface MemoryAiService {
+  chatCompletion(opts: {
+    model: string;
+    messages: Array<{ role: string; content: string }>;
+    temperature: number;
+  }): Promise<{ content: string }>;
+}
+
+// ─── Recall ───────────────────────────────────────────────────────────────────
+
+/**
+ * Recall the memories most relevant to the current message. Returns [] (never
+ * throws) when embeddings are disabled, the query is empty, or anything fails.
+ */
+export async function recallMemories(
+  supabase: AnySupabaseClient,
+  userId: string,
+  queryText: string
+): Promise<CatMemory[]> {
+  if (!embeddingsEnabled() || !queryText?.trim()) {
+    return [];
+  }
+  try {
+    const vec = await embedText(queryText);
+    if (!vec) {
+      return [];
+    }
+    const { data, error } = await supabase.rpc('match_cat_memories', {
+      p_user_id: userId,
+      // pgvector accepts its text format ("[0.1,0.2,…]") for the vector param.
+      query_embedding: JSON.stringify(vec),
+      match_count: RECALL_COUNT,
+      min_similarity: RECALL_MIN_SIMILARITY,
+    });
+    if (error) {
+      logger.warn('match_cat_memories RPC failed', { error }, 'CatMemory');
+      return [];
+    }
+    return (data ?? []) as CatMemory[];
+  } catch (err) {
+    logger.warn('recallMemories threw', { err }, 'CatMemory');
+    return [];
+  }
+}
+
+// ─── Extraction ─────────────────────────────────────────────────────────────
+
+/**
+ * Cheap gate: only spend an LLM call on extraction when the user's message
+ * plausibly discloses something durable about them (preference, identity, goal,
+ * relationship). Mirrors the tool-use keyword pre-filter — most utility queries
+ * ("convert 0.1 BTC", "what's my balance") skip extraction entirely.
+ */
+function looksLikeSelfDisclosure(message: string): boolean {
+  const m = message.toLowerCase();
+  if (m.trim().length < 12) {
+    return false;
+  }
+  return SELF_DISCLOSURE_SIGNALS.some(s => m.includes(s));
+}
+
+const SELF_DISCLOSURE_SIGNALS = [
+  'i ',
+  "i'm",
+  'i am',
+  'i prefer',
+  'i like',
+  'i love',
+  'i hate',
+  'i use',
+  'i have',
+  'i live',
+  'i work',
+  'i build',
+  'i run',
+  'my ',
+  'me ',
+  'we ',
+  'our ',
+  "we're",
+  'remember',
+  'prefer',
+  'always',
+  'never',
+  'usually',
+  'call me',
+  'working on',
+  'focused on',
+];
+
+const EXTRACTION_SYSTEM = `You extract durable, user-specific facts worth remembering long-term about a person, from one chat exchange.
+
+Return ONLY a JSON array of short factual statements written in the third person, e.g.:
+["Prefers Lightning over on-chain payments", "Building FleetCrown, a life-OS for builders", "Based in Zürich"]
+
+Include ONLY stable facts: preferences, identity, goals, skills, relationships, or constraints that will still be true next week.
+EXCLUDE: one-off requests, questions, the assistant's suggestions, transient state, and anything trivial or already obvious.
+If there is nothing durable worth remembering, return exactly [].
+Return at most ${MAX_FACTS_PER_TURN} facts. No prose, no markdown — just the JSON array.`;
+
+/** Parse the model's reply into a clean list of fact strings (defensive). */
+function parseFacts(raw: string): string[] {
+  if (!raw) {
+    return [];
+  }
+  // Strip code fences and grab the first JSON array if the model wrapped it.
+  const cleaned = raw.replace(/```(?:json)?/gi, '').trim();
+  const match = cleaned.match(/\[[\s\S]*\]/);
+  if (!match) {
+    return [];
+  }
+  try {
+    const arr = JSON.parse(match[0]);
+    if (!Array.isArray(arr)) {
+      return [];
+    }
+    return arr
+      .filter((x): x is string => typeof x === 'string')
+      .map(s => s.trim().slice(0, MAX_FACT_CHARS))
+      .filter(s => s.length >= 3)
+      .slice(0, MAX_FACTS_PER_TURN);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Distil durable facts from one exchange and store the new ones. Best-effort
+ * and non-blocking — call without awaiting on the response path. Skips silently
+ * when embeddings are off, the message isn't self-disclosure, or the LLM/DB
+ * fails. Dedupes against existing memories by vector similarity.
+ */
+export async function extractAndStoreMemories(
+  supabase: AnySupabaseClient,
+  userId: string,
+  conversationId: string | null,
+  userMessage: string,
+  assistantMessage: string,
+  aiService: MemoryAiService,
+  model: string
+): Promise<void> {
+  if (!embeddingsEnabled() || !looksLikeSelfDisclosure(userMessage)) {
+    return;
+  }
+  try {
+    const { content } = await aiService.chatCompletion({
+      model,
+      temperature: 0,
+      messages: [
+        { role: 'system', content: EXTRACTION_SYSTEM },
+        {
+          role: 'user',
+          content: `User said: "${userMessage}"\n\nAssistant replied: "${assistantMessage.slice(0, 800)}"\n\nExtract durable facts about the user as a JSON array.`,
+        },
+      ],
+    });
+
+    const facts = parseFacts(content);
+    if (facts.length === 0) {
+      return;
+    }
+
+    // Embed all candidates in one batch, then dedupe each against what we know.
+    const vectors = await embedTexts(facts);
+    const toInsert: Array<{ content: string; embedding: string }> = [];
+    for (let i = 0; i < facts.length; i++) {
+      const vec = vectors[i];
+      if (!vec) {
+        continue;
+      }
+      const { data: near } = await supabase.rpc('match_cat_memories', {
+        p_user_id: userId,
+        query_embedding: JSON.stringify(vec),
+        match_count: 1,
+        min_similarity: DEDUP_SIMILARITY,
+      });
+      if (Array.isArray(near) && near.length > 0) {
+        continue; // already remember something equivalent
+      }
+      toInsert.push({ content: facts[i], embedding: JSON.stringify(vec) });
+    }
+
+    if (toInsert.length === 0) {
+      return;
+    }
+
+    const { error } = await supabase.from(DATABASE_TABLES.CAT_MEMORIES).insert(
+      toInsert.map(m => ({
+        user_id: userId,
+        content: m.content,
+        embedding: m.embedding,
+        source: 'chat',
+        source_conversation_id: conversationId,
+      }))
+    );
+    if (error) {
+      logger.warn('Failed to insert cat memories', { error }, 'CatMemory');
+      return;
+    }
+
+    await pruneIfNeeded(supabase, userId);
+  } catch (err) {
+    logger.warn('extractAndStoreMemories threw', { err }, 'CatMemory');
+  }
+}
+
+/** Keep the corpus bounded: delete the oldest memories beyond the per-user cap. */
+async function pruneIfNeeded(supabase: AnySupabaseClient, userId: string): Promise<void> {
+  const { count } = await supabase
+    .from(DATABASE_TABLES.CAT_MEMORIES)
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId);
+  if (!count || count <= MAX_MEMORIES_PER_USER) {
+    return;
+  }
+  const { data: oldest } = await supabase
+    .from(DATABASE_TABLES.CAT_MEMORIES)
+    .select('id')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true })
+    .limit(count - MAX_MEMORIES_PER_USER);
+  const ids = (oldest as Array<{ id: string }> | null)?.map(r => r.id) ?? [];
+  if (ids.length > 0) {
+    await supabase.from(DATABASE_TABLES.CAT_MEMORIES).delete().in('id', ids);
+  }
+}
+
+// ─── Management (list / delete) ───────────────────────────────────────────────
+
+/** List a user's memories, newest first (for the Settings → AI manager). */
+export async function listMemories(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<CatMemory[]> {
+  const { data, error } = await supabase
+    .from(DATABASE_TABLES.CAT_MEMORIES)
+    .select('id, content, created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(MAX_MEMORIES_PER_USER);
+  if (error) {
+    logger.warn('listMemories failed', { error }, 'CatMemory');
+    return [];
+  }
+  return (data ?? []) as CatMemory[];
+}
+
+/** Delete one memory the user owns. RLS guarantees cross-user safety. */
+export async function deleteMemory(
+  supabase: AnySupabaseClient,
+  userId: string,
+  id: string
+): Promise<boolean> {
+  const { error } = await supabase
+    .from(DATABASE_TABLES.CAT_MEMORIES)
+    .delete()
+    .eq('id', id)
+    .eq('user_id', userId);
+  if (error) {
+    logger.warn('deleteMemory failed', { error }, 'CatMemory');
+    return false;
+  }
+  return true;
+}
+
+/** Forget everything Cat remembers about the user. */
+export async function deleteAllMemories(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<boolean> {
+  const { error } = await supabase
+    .from(DATABASE_TABLES.CAT_MEMORIES)
+    .delete()
+    .eq('user_id', userId);
+  if (error) {
+    logger.warn('deleteAllMemories failed', { error }, 'CatMemory');
+    return false;
+  }
+  return true;
+}

--- a/supabase/migrations/20260625000000_cat_memories.sql
+++ b/supabase/migrations/20260625000000_cat_memories.sql
@@ -1,0 +1,89 @@
+-- ============================================================================
+-- Cat persistent memory: cat_memories + match_cat_memories RPC (pgvector)
+-- ============================================================================
+-- One row per durable fact the Cat has learned about a user ("Prefers
+-- Lightning over on-chain", "Building FleetCrown, a life-OS for builders").
+-- Facts are extracted from chat (and explicit "remember that…" asks),
+-- embedded, and recalled by MEANING on later turns — so Cat carries context
+-- across sessions instead of re-deriving everything from a budget-capped pack.
+--
+-- Unlike public.content_embeddings (public, search-facing), this is PRIVATE
+-- per-user data → row-level security, scoped to the owner.
+--
+-- Schema note: pgvector lives in the `printcraft` schema on this self-host box
+-- (see 20260616000001_content_embeddings.sql), so we schema-qualify
+-- `printcraft.vector`. Dimension 1536 = OpenAI text-embedding-3-small (default
+-- embeddings provider; swappable via env — a model with a different dimension
+-- needs a new migration recreating the column + index).
+-- ============================================================================
+
+create table if not exists public.cat_memories (
+  id                     uuid primary key default uuid_generate_v4(),
+  user_id                uuid not null references auth.users(id) on delete cascade,
+  content                text not null,                          -- the fact, third person
+  embedding              printcraft.vector(1536),                -- meaning vector (null if embeddings disabled)
+  source                 text not null default 'chat',           -- 'chat' | 'explicit'
+  source_conversation_id uuid references public.cat_conversations(id) on delete set null,
+  created_at             timestamptz not null default now(),
+  updated_at             timestamptz not null default now()
+);
+
+-- HNSW cosine index for fast nearest-neighbour recall (scales with the corpus).
+create index if not exists cat_memories_hnsw
+  on public.cat_memories using hnsw (embedding printcraft.vector_cosine_ops);
+
+-- Listing / pruning by recency, per user.
+create index if not exists cat_memories_user_created
+  on public.cat_memories (user_id, created_at desc);
+
+-- Row-level security: a user can only ever see or touch their own memories.
+alter table public.cat_memories enable row level security;
+
+drop policy if exists cat_memories_select_own on public.cat_memories;
+create policy cat_memories_select_own on public.cat_memories
+  for select using (user_id = auth.uid());
+
+drop policy if exists cat_memories_insert_own on public.cat_memories;
+create policy cat_memories_insert_own on public.cat_memories
+  for insert with check (user_id = auth.uid());
+
+drop policy if exists cat_memories_update_own on public.cat_memories;
+create policy cat_memories_update_own on public.cat_memories
+  for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+drop policy if exists cat_memories_delete_own on public.cat_memories;
+create policy cat_memories_delete_own on public.cat_memories
+  for delete using (user_id = auth.uid());
+
+-- Nearest memories for one user by cosine similarity, gated on a relevance floor.
+-- SECURITY INVOKER (default) so the caller's RLS still applies — the explicit
+-- user_id filter is belt-and-suspenders and lets a service client scope too.
+-- search_path includes printcraft so the `<=>` distance operator resolves.
+create or replace function public.match_cat_memories(
+  p_user_id uuid,
+  query_embedding printcraft.vector(1536),
+  match_count int default 6,
+  min_similarity float default 0.3
+)
+returns table (
+  id uuid,
+  content text,
+  similarity float,
+  created_at timestamptz
+)
+language sql
+stable
+set search_path = public, printcraft
+as $$
+  select
+    cm.id,
+    cm.content,
+    1 - (cm.embedding <=> query_embedding) as similarity,
+    cm.created_at
+  from public.cat_memories cm
+  where cm.user_id = p_user_id
+    and cm.embedding is not null
+    and 1 - (cm.embedding <=> query_embedding) >= min_similarity
+  order by cm.embedding <=> query_embedding
+  limit match_count;
+$$;


### PR DESCRIPTION
## What

Cat now **remembers durable facts about you across sessions** — preferences, identity, goals, relationships — instead of re-deriving everything each turn from a budget-capped context pack. This is the "retrieval + memory" tier.

## How it works

- **Schema**: new `cat_memories` table (content + 1536-d embedding + RLS), reusing the existing pgvector setup (`printcraft.vector`, same as `content_embeddings`) + a user-scoped `match_cat_memories` RPC. Migration already applied to the self-host box.
- **Recall**: each turn embeds the user's message → folds top matches into context as a high-priority *"What you remember about this user"* section (placed right after the session block so the budget always keeps it).
- **Extraction**: after each exchange, a cheap, heuristic-gated, **detached** LLM pass distils durable facts, dedupes by vector similarity, and stores new ones. Mirrors the non-blocking `saveMessages` pattern.
- **Management**: `GET`/`DELETE /api/cat/memories` + a *"What Cat remembers"* panel in Settings → AI (view / delete one / forget everything). Privacy-first.

## Safety / graceful degradation

No embeddings provider, missing table, or a failed LLM/DB call all just mean "no memory this turn" — Cat keeps working. Every memory path is wrapped best-effort.

## Verification

- tsc clean (non-incremental), eslint clean, 554/554 unit tests.
- Migration applied + verified on box (table, HNSW index, RLS enabled, RPC present).
- Will verify live after deploy: chat a durable fact → confirm it's stored (Settings → AI) and recalled in a later turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)