### PR TITLE
feat(cat): upgrade nudge at the capability boundary + Cat Credits spec

### DIFF
--- a/docs/architecture/CAT_CREDITS.md
+++ b/docs/architecture/CAT_CREDITS.md
@@ -1,0 +1,130 @@
+# Cat Credits — Bitcoin-paid access to frontier models
+
+**Status:** Spec / proposal (not built). Authored 2026-06-25.
+**Companion to:** the Settings → AI "sovereignty ladder" (Free → BYOK → Local) and the in-chat upgrade nudge (shipped).
+
+---
+
+## 1. Why this exists
+
+OrangeCat is **pseudonymous by default** and **Bitcoin-native**. BYOK (the path we have today) quietly violates both: to get an OpenRouter/Anthropic/OpenAI key you need a funded account = a credit card = fiat + identity. So a pseudonymous Bitcoin user **cannot reach frontier models at all** right now.
+
+Cat Credits closes that gap: the user pays **OrangeCat in Bitcoin/Lightning**, OC meters usage against frontier models, no card, no per-provider accounts. It's the only upgrade path consistent with the platform's two deepest principles — and it makes sats _useful inside the product_.
+
+**It does not replace BYOK or Local.** It's a new rung on the ladder, the one most users will actually take:
+
+| Rung                      | Pays              | Pseudonymous? | OC liability           | For                          |
+| ------------------------- | ----------------- | ------------- | ---------------------- | ---------------------------- |
+| Free (managed, capped)    | nobody            | yes           | inference (capped)     | everyone, baseline           |
+| **OC Credits (this doc)** | **OC, in sats**   | **yes**       | **prepaid float only** | **most upgraders**           |
+| BYOK                      | provider directly | no (card)     | none                   | power users, max sovereignty |
+| Local                     | nobody            | yes           | none                   | run-it-yourself              |
+
+---
+
+## 2. Guiding principles (non-negotiable)
+
+1. **Near cost, transparently.** Credits are priced at or barely above wholesale. OC's margin is **Supporter + platform activity, never inference markup** — the Settings page already promises "OrangeCat earns from platform activity, not your AI bill." Keep that promise. Disclose the rate.
+2. **Denominated in sats, 1:1.** A sat of credit = a sat paid. No funny-money "credits" abstraction. Balance shown in sats (+ fiat equiv via `useDisplayCurrency`). Honest and Bitcoin-native.
+3. **Prepaid, single-purpose, non-withdrawable, non-refundable service credit.** Credits buy Cat inference and nothing else; they can never be cashed out or transferred. This is the key design constraint that keeps it _prepaid service credit_ (like buying API credits) rather than _stored value / a wallet_ — materially lowering custody/money-transmission exposure. **Flag for legal review regardless.**
+4. **Ledger is the source of truth.** Balance is derived from an append-only ledger, never a free-floating mutable number (Ground Truth #2 — no state in two places).
+5. **Graceful, never hard-fail.** Out of credits → fall back to the free model + offer top-up. Never a dead end.
+
+---
+
+## 3. Data model
+
+### `cat_credit_entries` (append-only ledger — SSOT)
+
+```
+id              uuid pk
+user_id         uuid not null → auth.users (RLS: read own)
+kind            text  -- 'topup' | 'usage' | 'grant' | 'refund' | 'adjustment'
+amount_sats     bigint not null  -- signed: + topup/grant/refund, − usage
+balance_after   bigint not null  -- denormalized running balance (set in txn)
+ref             text  -- lightning payment hash (topup) | cat_messages.id (usage)
+metadata        jsonb -- { model, inputTokens, outputTokens, costBtc, rateSats }
+created_at      timestamptz default now()
+
+unique (kind, ref) where ref is not null   -- idempotency: a payment/message credits once
+index (user_id, created_at desc)
+```
+
+- **Balance** = `balance_after` of the latest row (O(1) read), with `SUM(amount_sats)` as the reconciliation check. Optionally a thin `cat_credit_balances` cache row, rebuilt from the ledger — but the ledger is truth.
+- Writes are **server-only** (service role); RLS lets a user read their own entries (for the history view) but never insert.
+- Every debit/credit happens in a transaction that reads current balance, writes the entry with the new `balance_after`, and (for usage) refuses to go negative.
+
+---
+
+## 4. Flows
+
+### Top-up (Lightning)
+
+1. User picks an amount (presets: 5k / 20k / 100k sats, or custom).
+2. OC generates a Lightning invoice for N sats (reuse existing Lightning/BTCPay/NWC infra).
+3. On payment confirmation (webhook/callback), append a `topup` entry `+N`, **idempotent on the payment hash** (`unique(kind, ref)` — webhook retries can't double-credit).
+4. UI reflects the new balance.
+
+### Usage (metered debit)
+
+1. A frontier request runs on **OC's managed OpenRouter key** (see §5).
+2. `chatCompletion` already returns `costBtc` + token counts. Convert `costBtc → sats` at the live rate (`currencyConverter`), apply pricing policy (§2.1), and append a `usage` entry `−cost` referencing `cat_messages.id`.
+3. Done **after** the response, like `saveMessages` — non-blocking, in a balance-guarding transaction.
+
+### Pre-flight gate
+
+Before serving a frontier request on credits: if `balance ≤ estimatedCost` → **don't fail**: serve on the free model and surface "you're low on credits — top up?" (the existing upgrade-nudge funnel, inverted).
+
+---
+
+## 5. Resolver integration
+
+The provider-resolver chain today is: per-request header keys → stored BYOK keys (ordered) → platform free default (positioned). Add a **Credits** step:
+
+- Precedence: **BYOK still leads** when present (user pays the provider directly — cheaper for them, zero OC liability). Credits is for users _without_ BYOK who want frontier.
+- Logic: if no BYOK key for a frontier model **and** `creditBalance > 0` **and** the request targets a frontier model (explicit pick or "auto-frontier") → route via OC's managed OpenRouter key, tag the call `meteredToCredits: true`.
+- The **free platform default (gpt-oss) stays the zero-cost baseline.** Credits are only ever spent on an explicitly-better model — never silently.
+
+Backend = **OpenRouter as wholesale** (one key, 200+ models incl. Claude/GPT/Grok, one bill OC pays). ⚠️ **Confirm OpenRouter TOS permits reselling capacity in a managed offering** before building (Phase 0 blocker).
+
+---
+
+## 6. Supporter integration (the on-thesis monetization)
+
+- Supporter includes a **monthly sat allowance** (a recurring `grant` ledger entry) and/or a better effective rate.
+- This is how paying OC aligns with "earn from platform activity, not your AI bill": **becoming a Supporter is platform activity.** One-off Lightning top-ups stay available for free users.
+- Pricing page already has a "Pro (waitlist)" slot — Credits + allowance is what fills it.
+
+---
+
+## 7. UX surfaces
+
+- **Settings → AI:** new "OC Credits (pay with Bitcoin)" rung between Free and BYOK — balance (sats + fiat), top-up (Lightning invoice/QR), usage history (the ledger), and which frontier model to spend on.
+- **QuotaMeter chip:** shows credit balance when on the Credits path (today it shows free-message quota).
+- **Upgrade nudge (shipped):** already links to Settings → AI; once Credits ships, that's where it funnels.
+- **Cat itself (later):** low-balance prompt mid-task ("you're low on credits — top up?").
+
+---
+
+## 8. Risks & open questions (need founder calls)
+
+| #   | Question                                                          | Recommendation                                                                                                                     |
+| --- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | **OpenRouter resale TOS**                                         | Confirm before any build. Blocker. Fallback: OC-held direct provider keys.                                                         |
+| R2  | **Custody / money-transmission** for holding prepaid sat balances | Keep credits **non-withdrawable, single-purpose, non-refundable** (→ service credit, not stored value). Get legal eyes regardless. |
+| R3  | **Pricing: pass-through vs thin margin**                          | Default near-cost; a small disclosed spread (Lightning fees, float, abuse) is defensible. Never a markup business.                 |
+| R4  | **Sats vs abstract credits**                                      | Sats, 1:1. Honest + Bitcoin-native.                                                                                                |
+| R5  | **Abuse / cost exposure**                                         | Prepaid float caps it; reuse existing per-user rate limits; cap max balance/top-up.                                                |
+
+---
+
+## 9. Phased build plan
+
+- **Phase 0 — decisions (no code):** R1 (OpenRouter TOS), R2 (legal sanity), R3 (pricing), Supporter allowance amount.
+- **Phase 1 — ledger:** `cat_credit_entries` migration + balance read + read-only Settings UI (balance + history). No spending.
+- **Phase 2 — top-up:** Lightning invoice + payment webhook → idempotent `topup` entry.
+- **Phase 3 — metering + routing:** resolver Credits path + post-response usage debit (costBtc→sats) + pre-flight gate + free-model fallback. Credits now buy frontier inference.
+- **Phase 4 — Supporter:** monthly `grant` entries + better rate, tied to Supporter status.
+- **Phase 5 — polish:** low-balance Cat prompts, QuotaMeter credit display, top-up presets.
+
+Each phase is independently shippable and reuses existing infra (Lightning, provider-resolver, `costBtc`, currency converter, QuotaMeter). The genuinely new build is the ledger + top-up webhook + metering debit; everything else is wiring.

--- a/src/app/api/cat/chat/route.ts
+++ b/src/app/api/cat/chat/route.ts
@@ -30,10 +30,12 @@ import { resolveProvider, type FallbackProvider } from '@/services/cat/provider-
 import { recallMemories, extractAndStoreMemories } from '@/services/cat/memory';
 import {
   maybeEnrichWithSearchResults,
+  messageMightNeedTools,
   type ToolAugmentedMessage,
   type ToolCallEvent,
   type PrefillProposal,
 } from '@/services/cat/tool-use';
+import { isAgenticModel } from '@/config/model-capability';
 import { fetchFullContextForCat, buildFullContextString } from '@/services/ai/document-context';
 import { createActionExecutor } from '@/services/cat';
 import { getUserActorId } from '@/domain/actors';
@@ -211,6 +213,12 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
     // the budget always keeps them). Best-effort: [] if memory is unavailable.
     userContext.memories = await recallMemories(supabase, user.id, message);
     const contextString = buildFullContextString(userContext);
+
+    // Does this message want more than chat (discovery, creation, multi-step)?
+    // If so AND the answering model isn't agentic (frontier), we flag the
+    // response so the UI can gently suggest upgrading to a more powerful model.
+    // Uses the same signal that gates tool use — one source of truth.
+    const wantsAgentic = messageMightNeedTools(message);
     // Examples are appended as labeled text (not injected as fake conversation
     // turns) so weaker models can't mistake the example people for the real user.
     // The per-turn reply-language directive goes DEAD LAST: weak free models
@@ -309,7 +317,7 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
                   const execResults = await runExecActions(supabase, user.id, actorId, actions);
                   controller.enqueue(
                     encoder.encode(
-                      `data: ${JSON.stringify({ done: true, usage, model: activeModel, provider: activeProvider, actions: actions.length > 0 ? actions : undefined, execResults: execResults.length > 0 ? execResults : undefined, quickReplies })}\n\n`
+                      `data: ${JSON.stringify({ done: true, usage, model: activeModel, provider: activeProvider, actions: actions.length > 0 ? actions : undefined, execResults: execResults.length > 0 ? execResults : undefined, quickReplies, suggestUpgrade: wantsAgentic && !isAgenticModel(activeModel) })}\n\n`
                     )
                   );
                   break;
@@ -552,6 +560,7 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
           collectedPrefillProposals.length > 0 ? collectedPrefillProposals : undefined,
         modelUsed: result.model,
         provider: activeProvider,
+        suggestUpgrade: wantsAgentic && !isAgenticModel(fellBackTo?.modelToUse ?? modelToUse),
         fallback: fellBackTo
           ? {
               from: provider,

--- a/src/components/ai-chat/ModernChatPanel/components/MessageBubble.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/MessageBubble.tsx
@@ -12,6 +12,7 @@ import { renderChatMarkdown } from '@/utils/markdown';
 import { ActionButton } from './ActionButton';
 import { ToolCallChip } from './ToolCallChip';
 import { PrefilledFormCard } from './PrefilledFormCard';
+import { UpgradeNudge } from './UpgradeNudge';
 import type { Message, CatAction, ExecActionResult } from '../types';
 import { ENTITY_REGISTRY, ENTITY_TYPES } from '@/config/entity-registry';
 
@@ -292,6 +293,10 @@ export function MessageBubble({
             instead.
           </p>
         )}
+
+        {/* Upgrade nudge — only on the latest assistant turn, when this task
+            would have been sharper on a frontier model. Dismissable per session. */}
+        {!isUser && isLast && message.suggestUpgrade && displayContent && <UpgradeNudge />}
       </div>
     </div>
   );

--- a/src/components/ai-chat/ModernChatPanel/components/UpgradeNudge.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/UpgradeNudge.tsx
@@ -1,0 +1,67 @@
+/**
+ * UpgradeNudge — gentle, honest prompt to run Cat on a more powerful model.
+ *
+ * Shown under an assistant reply only when the task wanted agentic capability
+ * (discovery / creation / multi-step) but answered on a non-frontier model.
+ * It's a suggestion at the moment of friction, not a nag: dismiss it and it
+ * stays gone for the session (localStorage). Links straight to Settings → AI,
+ * where the upgrade actually happens.
+ */
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Sparkles, ArrowRight, X } from 'lucide-react';
+import { ROUTES } from '@/config/routes';
+
+const DISMISS_KEY = 'cat:upgradeNudge:dismissed';
+
+function alreadyDismissed(): boolean {
+  try {
+    return localStorage.getItem(DISMISS_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function UpgradeNudge() {
+  const [dismissed, setDismissed] = useState<boolean>(alreadyDismissed);
+
+  if (dismissed) {
+    return null;
+  }
+
+  const dismiss = () => {
+    setDismissed(true);
+    try {
+      localStorage.setItem(DISMISS_KEY, '1');
+    } catch {
+      // ignore — worst case it reappears next session
+    }
+  };
+
+  return (
+    <div className="mt-2 flex items-start gap-2 rounded-md border border-subtle bg-surface-raised/40 px-3 py-2">
+      <Sparkles className="mt-0.5 h-4 w-4 flex-shrink-0 text-accent-warm" />
+      <div className="min-w-0 flex-1 text-xs text-fg-secondary">
+        Tasks like this — discovery, matchmaking, multi-step work — are sharper on a frontier model.{' '}
+        <Link
+          href={ROUTES.SETTINGS_AI}
+          className="inline-flex items-center gap-0.5 font-medium text-fg-primary underline decoration-fg-tertiary/50 underline-offset-2 hover:decoration-fg-primary"
+        >
+          Upgrade Cat
+          <ArrowRight className="h-3 w-3" />
+        </Link>
+      </div>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss upgrade suggestion"
+        className="flex-shrink-0 rounded p-0.5 text-fg-tertiary hover:bg-surface-raised hover:text-fg-primary"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+export default UpgradeNudge;

--- a/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
@@ -158,6 +158,7 @@ export function useChatMessages({
         let actions: CatAction[] | undefined;
         let execResults: ExecActionResult[] | undefined;
         let quickReplies: string[] | undefined;
+        let suggestUpgrade = false;
 
         await readEventStream(res.body, (json: unknown) => {
           const event = json as {
@@ -172,6 +173,7 @@ export function useChatMessages({
             tool_call?: ToolCallEvent;
             prefill_proposal?: PrefillProposal;
             fallback?: { from: string; to: string; model: string; reason: string };
+            suggestUpgrade?: boolean;
             error?: string;
           };
           if (event?.error) {
@@ -236,6 +238,9 @@ export function useChatMessages({
               prev.map(m => (m.id === assistantId ? { ...m, fallback: notice } : m))
             );
           }
+          if (event?.done && event.suggestUpgrade) {
+            suggestUpgrade = true;
+          }
         });
 
         if (abortController.signal.aborted) {
@@ -249,7 +254,15 @@ export function useChatMessages({
         setMessages(prev =>
           prev.map(m =>
             m.id === assistantId
-              ? { ...m, modelUsed, provider: providerUsed, actions, execResults, quickReplies }
+              ? {
+                  ...m,
+                  modelUsed,
+                  provider: providerUsed,
+                  actions,
+                  execResults,
+                  quickReplies,
+                  suggestUpgrade,
+                }
               : m
           )
         );

--- a/src/components/ai-chat/ModernChatPanel/types.ts
+++ b/src/components/ai-chat/ModernChatPanel/types.ts
@@ -98,6 +98,11 @@ export interface Message {
   quickReplies?: string[];
   /** Set when the route fell over from primary to fallback provider. */
   fallback?: FallbackNotice;
+  /**
+   * True when this task would benefit from a frontier model but answered on a
+   * weaker one — the UI shows a gentle "upgrade for sharper results" nudge.
+   */
+  suggestUpgrade?: boolean;
 }
 
 export interface UserStatus {

--- a/src/services/cat/tool-use.ts
+++ b/src/services/cat/tool-use.ts
@@ -147,6 +147,18 @@ const TOOL_TRIGGER_KEYWORDS = [
 ];
 
 /**
+ * Whether a message looks like a discovery / creation / multi-step task — the
+ * kind that benefits from an agentic (frontier) model and triggers the tool
+ * pass. Exported so the chat route can decide whether to nudge a user on a
+ * weaker model toward upgrading, using the SAME signal that gates tool use
+ * (one source of truth for "this wants more than chat").
+ */
+export function messageMightNeedTools(message: string): boolean {
+  const lower = message.toLowerCase();
+  return TOOL_TRIGGER_KEYWORDS.some(kw => lower.includes(kw));
+}
+
+/**
  * Strong "I want to create/list my own thing" signals. When present we
  * PROGRAMMATICALLY suppress search_platform tool calls — the weak free-tier
  * models ignore the routing prompt and search anyway, wasting a round-trip and
@@ -438,9 +450,7 @@ export async function maybeEnrichWithSearchResults(
     return messages;
   }
 
-  const lowerMessage = userMessage.toLowerCase();
-  const mightNeedTool = TOOL_TRIGGER_KEYWORDS.some(kw => lowerMessage.includes(kw));
-  if (!mightNeedTool) {
+  if (!messageMightNeedTools(userMessage)) {
     return messages;
   }
 


### PR DESCRIPTION
Two deliverables from the "how should upgrading to powerful models work?" discussion.

## 1. Upgrade nudge (shipped)

When Cat answers a task that's markedly sharper on a frontier model (discovery, matchmaking, multi-step) but ran on a weaker one, it shows a gentle, **dismissable** nudge under the reply linking to Settings → AI — instead of silently under-delivering.

- **Server decides** (`suggestUpgrade`): the message wants agentic capability **AND** the answering model isn't frontier. Reuses the *same* signal that gates tool use (new exported `messageMightNeedTools`) and the `model-capability` SSOT (`isAgenticModel`) — one source of truth, no new heuristics, **no extra LLM cost**.
- Returned on both response paths (streaming `done` + non-streaming), parsed in `useChatMessages`.
- `UpgradeNudge` renders only on the latest assistant turn; dismiss hides it for the session. Fires at the moment of friction, never nags.

## 2. Cat Credits spec (doc only — docs/architecture/CAT_CREDITS.md)

The upgrade path the nudge funnels to. Thesis: **BYOK breaks pseudonymity** (needs a card), so the on-thesis upgrade is **Bitcoin-paid OC Credits** — sats-denominated, near-cost, prepaid/non-withdrawable service credit, integrated with Supporter. Includes ledger schema, top-up/metering/routing flows, resolver integration, risks (OpenRouter resale TOS, custody), and a 6-phase build plan. No code — for review before any build.

## Verification
tsc clean, eslint clean, 554/554 unit tests. Will verify the nudge live after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)