### PR TITLE
feat(cat): Cat Credits ledger + balance UI (Phase 1)

### DIFF
--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -21,6 +21,7 @@ import { useRequireAuth } from '@/hooks/useAuth';
 import { useAISettings } from '@/hooks/useAISettings';
 import Loading from '@/components/Loading';
 import { AIKeyManager } from '@/components/ai/AIKeyManager';
+import { CatCreditsPanel } from '@/components/ai/CatCreditsPanel';
 import { CatMemoryManager } from '@/components/ai/CatMemoryManager';
 import { getProvidersByCategory } from '@/data/aiProviders';
 
@@ -97,6 +98,9 @@ export default function AISettingsPage() {
             </div>
           </div>
         </section>
+
+        {/* ── Cat Credits (pay with Bitcoin) ────────────────────────────── */}
+        <CatCreditsPanel />
 
         {/* ── BYOK ──────────────────────────────────────────────────────── */}
         <section className="rounded-lg border border-default bg-surface-base p-6">

--- a/src/app/api/cat/credits/route.ts
+++ b/src/app/api/cat/credits/route.ts
@@ -1,0 +1,26 @@
+/**
+ * Cat Credits API
+ *
+ * GET /api/cat/credits - Your sats credit balance + ledger history
+ *
+ * Read-only. Balance is derived from the cat_credit_entries ledger (SSOT).
+ * Top-up (Lightning) and usage metering post entries server-side via
+ * cat_credit_append; see docs/architecture/CAT_CREDITS.md.
+ */
+
+import { getCreditBalance, listCreditEntries } from '@/services/cat/credits';
+import { apiSuccess, handleApiError } from '@/lib/api/standardResponse';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+  try {
+    const [balanceSats, entries] = await Promise.all([
+      getCreditBalance(supabase, user.id),
+      listCreditEntries(supabase, user.id),
+    ]);
+    return apiSuccess({ balanceSats, entries });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/src/components/ai/CatCreditsPanel.tsx
+++ b/src/components/ai/CatCreditsPanel.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+/**
+ * CatCreditsPanel — your Bitcoin-paid Cat credit balance + ledger history.
+ *
+ * Phase 1: read-only. Shows the sats balance (the canonical unit — Bitcoin
+ * Orange applies) with the user's display-currency equivalent, plus the ledger.
+ * "Top up" is shown but disabled until platform Lightning-receiving infra is
+ * provisioned (Phase 2). See docs/architecture/CAT_CREDITS.md.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Coins, Loader2, AlertCircle, ArrowDownLeft, ArrowUpRight } from 'lucide-react';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { logger } from '@/utils/logger';
+
+interface CreditEntry {
+  id: string;
+  kind: 'topup' | 'usage' | 'grant' | 'refund' | 'adjustment';
+  amount_sats: number;
+  balance_after: number;
+  created_at: string;
+}
+
+const KIND_LABELS: Record<CreditEntry['kind'], string> = {
+  topup: 'Top-up',
+  usage: 'Cat usage',
+  grant: 'Included credit',
+  refund: 'Refund',
+  adjustment: 'Adjustment',
+};
+
+export function CatCreditsPanel() {
+  const { formatSats } = useDisplayCurrency();
+  const [balanceSats, setBalanceSats] = useState(0);
+  const [entries, setEntries] = useState<CreditEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/cat/credits');
+      if (!res.ok) {
+        throw new Error('Failed to load credits');
+      }
+      const json = await res.json();
+      setBalanceSats(json?.data?.balanceSats ?? 0);
+      setEntries((json?.data?.entries ?? []) as CreditEntry[]);
+    } catch (err) {
+      logger.error('Failed to load cat credits', err, 'CatCredits');
+      setError('Could not load your credits. Try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <section className="rounded-lg border border-default bg-surface-base p-6">
+      <div className="mb-4 flex items-start gap-3">
+        <div className="rounded-md bg-surface-raised p-2">
+          <Coins className="h-5 w-5 text-bitcoinOrange" />
+        </div>
+        <div className="flex-1">
+          <h2 className="text-lg font-semibold text-fg-primary">Cat Credits</h2>
+          <p className="mt-1 text-sm text-fg-secondary">
+            Pay with Bitcoin to run Cat on frontier models — no card, no per-provider accounts.
+            Credits are priced near cost; OrangeCat earns from platform activity, not your AI bill.
+          </p>
+        </div>
+      </div>
+
+      {/* Balance */}
+      <div className="mb-4 flex items-center justify-between rounded-md border border-subtle bg-surface-raised/30 p-4">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-fg-tertiary">Balance</p>
+          {isLoading ? (
+            <Loader2 className="mt-1 h-5 w-5 animate-spin text-fg-secondary" />
+          ) : (
+            <p className="mt-0.5 text-2xl font-semibold text-bitcoinOrange">
+              {balanceSats.toLocaleString('en-US')}{' '}
+              <span className="text-base font-normal text-fg-secondary">sats</span>
+            </p>
+          )}
+          {!isLoading && balanceSats > 0 && (
+            <p className="text-xs text-fg-tertiary">≈ {formatSats(balanceSats)}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          disabled
+          title="Lightning top-up is coming soon"
+          className="cursor-not-allowed rounded-md border border-subtle px-4 py-2 text-sm font-medium text-fg-tertiary opacity-60"
+        >
+          Top up (soon)
+        </button>
+      </div>
+
+      {/* History */}
+      {error ? (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-subtle bg-surface-raised/30 p-4">
+          <span className="flex items-center gap-2 text-sm text-status-negative">
+            <AlertCircle className="h-4 w-4" /> {error}
+          </span>
+          <button
+            type="button"
+            onClick={load}
+            className="rounded-md border border-subtle px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-raised"
+          >
+            Retry
+          </button>
+        </div>
+      ) : isLoading ? null : entries.length === 0 ? (
+        <p className="text-sm text-fg-tertiary">
+          No credit activity yet. Once top-up is live, your purchases and Cat usage show here.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border-subtle">
+          {entries.map(e => {
+            const credit = e.amount_sats >= 0;
+            return (
+              <li key={e.id} className="flex items-center justify-between py-2 text-sm">
+                <span className="flex items-center gap-2 text-fg-primary">
+                  {credit ? (
+                    <ArrowDownLeft className="h-4 w-4 text-status-positive" />
+                  ) : (
+                    <ArrowUpRight className="h-4 w-4 text-fg-tertiary" />
+                  )}
+                  {KIND_LABELS[e.kind]}
+                  <span className="text-fg-tertiary">
+                    {new Date(e.created_at).toLocaleDateString()}
+                  </span>
+                </span>
+                <span className={credit ? 'text-status-positive' : 'text-fg-secondary'}>
+                  {credit ? '+' : ''}
+                  {e.amount_sats.toLocaleString('en-US')} sats
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default CatCreditsPanel;

--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -145,6 +145,7 @@ export const DATABASE_TABLES = {
   CAT_ACTION_LOG: 'cat_action_log',
   CAT_PENDING_ACTIONS: 'cat_pending_actions',
   CAT_MEMORIES: 'cat_memories',
+  CAT_CREDIT_ENTRIES: 'cat_credit_entries',
 
   // Messaging Views
   MESSAGE_DETAILS: 'message_details',

--- a/src/services/cat/credits.ts
+++ b/src/services/cat/credits.ts
@@ -1,0 +1,120 @@
+/**
+ * Cat Credits Service
+ *
+ * Bitcoin-paid access to frontier models. Users top up a sats balance over
+ * Lightning; frontier inference is metered against it. See
+ * docs/architecture/CAT_CREDITS.md.
+ *
+ * The cat_credit_entries ledger is the single source of truth — balance is
+ * derived from it, never stored separately. Reads are RLS-scoped to the owner;
+ * writes go through the atomic, server-only cat_credit_append RPC (which
+ * serializes per user and refuses to overdraw).
+ *
+ * Phase 1: balance read + history + the write primitive. Top-up (Lightning) and
+ * usage metering are wired in later phases on top of appendCreditEntry.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { logger } from '@/utils/logger';
+
+export type CreditEntryKind = 'topup' | 'usage' | 'grant' | 'refund' | 'adjustment';
+
+export interface CreditEntry {
+  id: string;
+  kind: CreditEntryKind;
+  amount_sats: number;
+  balance_after: number;
+  ref: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+/** Max ledger rows returned for the history view. */
+const HISTORY_LIMIT = 100;
+
+/**
+ * Current credit balance in sats (0 on any failure — missing table, RLS, etc.).
+ * Never throws; callers treat unavailable as "no credits".
+ */
+export async function getCreditBalance(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<number> {
+  try {
+    const { data, error } = await supabase.rpc('cat_credit_balance', { p_user_id: userId });
+    if (error) {
+      logger.warn('cat_credit_balance RPC failed', { error }, 'CatCredits');
+      return 0;
+    }
+    return typeof data === 'number' ? data : Number(data ?? 0);
+  } catch (err) {
+    logger.warn('getCreditBalance threw', { err }, 'CatCredits');
+    return 0;
+  }
+}
+
+/** A user's ledger history, newest first (RLS guarantees they see only theirs). */
+export async function listCreditEntries(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<CreditEntry[]> {
+  try {
+    const { data, error } = await supabase
+      .from(DATABASE_TABLES.CAT_CREDIT_ENTRIES)
+      .select('id, kind, amount_sats, balance_after, ref, metadata, created_at')
+      .eq('user_id', userId)
+      .order('seq', { ascending: false })
+      .limit(HISTORY_LIMIT);
+    if (error) {
+      logger.warn('listCreditEntries failed', { error }, 'CatCredits');
+      return [];
+    }
+    return (data ?? []) as CreditEntry[];
+  } catch (err) {
+    logger.warn('listCreditEntries threw', { err }, 'CatCredits');
+    return [];
+  }
+}
+
+/**
+ * Append a ledger entry atomically and return the new balance. Wraps the
+ * SECURITY DEFINER cat_credit_append RPC, which serializes per user and rejects
+ * an overdraw with 'insufficient_credits'.
+ *
+ * MUST be called with a service-role client — the RPC is revoked from
+ * anon/authenticated so a normal user client cannot post entries. Used by the
+ * top-up (Lightning settlement) and usage-metering paths.
+ *
+ * @returns the new balance in sats, or null on failure (incl. insufficient credits).
+ */
+export async function appendCreditEntry(
+  serviceSupabase: AnySupabaseClient,
+  userId: string,
+  entry: {
+    kind: CreditEntryKind;
+    amountSats: number;
+    ref?: string | null;
+    metadata?: Record<string, unknown> | null;
+  }
+): Promise<number | null> {
+  try {
+    const { data, error } = await serviceSupabase.rpc('cat_credit_append', {
+      p_user_id: userId,
+      p_kind: entry.kind,
+      p_amount_sats: entry.amountSats,
+      p_ref: entry.ref ?? null,
+      p_metadata: entry.metadata ?? null,
+    });
+    if (error) {
+      // 23514 check_violation = insufficient_credits (expected, not exceptional).
+      logger.warn('cat_credit_append failed', { error, kind: entry.kind }, 'CatCredits');
+      return null;
+    }
+    return typeof data === 'number' ? data : Number(data ?? 0);
+  } catch (err) {
+    logger.warn('appendCreditEntry threw', { err }, 'CatCredits');
+    return null;
+  }
+}

--- a/supabase/migrations/20260625120000_cat_credits.sql
+++ b/supabase/migrations/20260625120000_cat_credits.sql
@@ -1,0 +1,107 @@
+-- ============================================================================
+-- Cat Credits: append-only sats ledger (cat_credit_entries) + atomic append RPC
+-- ============================================================================
+-- Bitcoin-paid access to frontier models. Users top up a sats balance over
+-- Lightning; frontier inference is metered against it. See
+-- docs/architecture/CAT_CREDITS.md.
+--
+-- The LEDGER is the single source of truth (Ground Truth #2 — no floating
+-- balance kept in two places). Balance = balance_after of the latest row,
+-- with SUM(amount_sats) as the reconciliation check. Credits are prepaid,
+-- single-purpose, non-withdrawable service credit (never a wallet).
+--
+-- Phase 1 of the build: table + read + atomic write primitive. Top-up
+-- (Lightning) and usage metering land in later phases and call cat_credit_append.
+-- ============================================================================
+
+create table if not exists public.cat_credit_entries (
+  id            uuid primary key default uuid_generate_v4(),
+  -- Monotonic insertion order. created_at is NOT reliable for "latest entry"
+  -- (now() is transaction-stable, so entries posted in one txn/tick tie, and a
+  -- random-uuid tiebreaker picks the wrong row). seq orders the ledger exactly.
+  seq           bigint generated always as identity,
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  kind          text not null check (kind in ('topup', 'usage', 'grant', 'refund', 'adjustment')),
+  amount_sats   bigint not null,            -- signed: + topup/grant/refund, − usage
+  balance_after bigint not null,            -- running balance, set atomically on insert
+  ref           text,                       -- lightning payment hash (topup) | cat_messages.id (usage)
+  metadata      jsonb,                      -- { model, inputTokens, outputTokens, costBtc, rateSats }
+  created_at    timestamptz not null default now()
+);
+
+-- Idempotency: a given payment hash / message can only ever post once per kind.
+create unique index if not exists cat_credit_entries_kind_ref
+  on public.cat_credit_entries (kind, ref) where ref is not null;
+
+-- Per-user history / latest-balance lookup (ordered by the monotonic seq).
+create index if not exists cat_credit_entries_user_seq
+  on public.cat_credit_entries (user_id, seq desc);
+
+-- Row-level security: a user can READ their own ledger (for the history view).
+-- Writes go only through cat_credit_append (SECURITY DEFINER) — there is no
+-- user insert/update/delete policy, so the ledger is append-only and
+-- tamper-proof from the client even though it's user-readable.
+alter table public.cat_credit_entries enable row level security;
+
+drop policy if exists cat_credit_entries_select_own on public.cat_credit_entries;
+create policy cat_credit_entries_select_own on public.cat_credit_entries
+  for select using (user_id = auth.uid());
+
+-- Current balance for a user (0 if no entries). RLS-respecting.
+create or replace function public.cat_credit_balance(p_user_id uuid)
+returns bigint
+language sql
+stable
+set search_path = public
+as $$
+  select coalesce(
+    (select balance_after
+       from public.cat_credit_entries
+      where user_id = p_user_id
+      order by seq desc
+      limit 1),
+    0
+  );
+$$;
+
+-- Atomic ledger append. Serializes per-user with an advisory lock, computes the
+-- new running balance, refuses to let a usage debit go negative, and inserts.
+-- SECURITY DEFINER so the server can post entries that RLS would otherwise block
+-- — callers must be trusted server code (service-role / server route). Returns
+-- the new balance.
+create or replace function public.cat_credit_append(
+  p_user_id uuid,
+  p_kind text,
+  p_amount_sats bigint,
+  p_ref text default null,
+  p_metadata jsonb default null
+)
+returns bigint
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_current bigint;
+  v_new bigint;
+begin
+  -- Serialize concurrent appends for this user so balance_after is consistent.
+  perform pg_advisory_xact_lock(hashtext(p_user_id::text));
+
+  v_current := public.cat_credit_balance(p_user_id);
+  v_new := v_current + p_amount_sats;
+
+  if v_new < 0 then
+    raise exception 'insufficient_credits' using errcode = 'check_violation';
+  end if;
+
+  insert into public.cat_credit_entries (user_id, kind, amount_sats, balance_after, ref, metadata)
+  values (p_user_id, p_kind, p_amount_sats, v_new, p_ref, p_metadata);
+
+  return v_new;
+end;
+$$;
+
+-- Lock the append function down: only the service role may call it (server-side
+-- top-up / metering). Clients read via RLS-selected rows + cat_credit_balance.
+revoke all on function public.cat_credit_append(uuid, text, bigint, text, jsonb) from public, anon, authenticated;


### PR DESCRIPTION
Phase 1 of Bitcoin-paid frontier-model access (spec: docs/architecture/CAT_CREDITS.md). Foundation only — no spending or top-up yet.

## What
- **Migration `cat_credit_entries`** — sats-denominated append-only ledger (signed `amount_sats` + running `balance_after`), the **single source of truth** for balance. RLS read-own; client can't insert/update/delete (append-only, tamper-proof). Idempotency `unique(kind, ref)`.
- A monotonic **`seq`** orders the ledger — I caught a real bug in box testing where `created_at` ties within a transaction and a random-UUID tiebreaker returned the *wrong* latest balance (1000 instead of 700). `seq desc` fixes it.
- **`cat_credit_append`** (SECURITY DEFINER, revoked from anon/authenticated) — atomic, per-user-serialized, refuses to overdraw. **`cat_credit_balance`** reads it.
- **`credits.ts`** service + **GET /api/cat/credits** + **CatCreditsPanel** on Settings → AI (balance in sats/Bitcoin-Orange + display-currency equiv + history; "Top up" disabled pending Phase 2 infra).

## Verified
- Migration applied + functionally tested on the box: append, balance, **overdraw rejection**, and `seq` ordering all correct.
- tsc clean, eslint clean, 554/554 unit tests. Graceful degradation (missing table → balance 0).

## Not in this PR
- **Phase 2 (Lightning top-up) is blocked on infra** — OrangeCat has no platform-side Lightning *receiving* setup today (all invoicing is seller-side). Needs a platform BTCPay store / NWC / LNbits + webhook ingestion + env. Flagged separately for a founder decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)