### PR TITLE
feat(cat): Cat Credits Lightning top-up (Phase 2) + BTC canonical-unit fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,13 @@ NEXT_PUBLIC_LIGHTNING_ADDRESS="your-username@getalby.com"
 # BTCPAY_STORE_ID=""
 # BTCPAY_API_KEY=""
 
+# Platform receiving wallet for Cat Credits top-ups (NWC connection string).
+# This is OrangeCat's OWN wallet, used only to RECEIVE credit purchases — it is
+# unrelated to users' (non-custodial) wallets. When unset, Lightning top-up is
+# disabled and the rest of Cat Credits is unaffected. NWC is an abstraction, so
+# this can point at a hosted wallet now or a self-hosted LNbits/BTCPay node later.
+# PLATFORM_NWC_URI="nostr+walletconnect://<pubkey>?relay=...&secret=..."
+
 # Encryption keys (generate with: openssl rand -hex 32)
 # API_KEY_ENCRYPTION_SECRET=""
 # PAYMENT_ENCRYPTION_KEY=""

--- a/docs/architecture/CAT_CREDITS.md
+++ b/docs/architecture/CAT_CREDITS.md
@@ -1,7 +1,15 @@
 # Cat Credits — Bitcoin-paid access to frontier models
 
-**Status:** Spec / proposal (not built). Authored 2026-06-25.
+**Status:** Phases 1–2 built (ledger + Lightning top-up). Authored 2026-06-25.
 **Companion to:** the Settings → AI "sovereignty ladder" (Free → BYOK → Local) and the in-chat upgrade nudge (shipped).
+
+## Decisions (locked 2026-06-25)
+
+- **Denomination: BTC** (canonical unit, `NUMERIC(18,8)` = 1-sat precision). Sats appear ONLY at the Lightning protocol boundary (the `makeInvoice` call). _"Sats" are not a product concept._
+- **Pricing: near-cost pass-through** — credits ≈ wholesale + a small disclosed spread; OC's margin is Supporter + platform activity, never inference markup.
+- **Receive backend: platform NWC wallet** (`PLATFORM_NWC_URI`) — OC's own receiving wallet, abstracted so it can later point at self-hosted LNbits/BTCPay with no code change. Reuses the existing NWC client + polling-settlement pattern. (BTCPay/LNbits remain the "at scale / max sovereignty" graduation.)
+- **Model backend (Phase 3): OpenRouter** = all models, one key/bill — _pending a TOS check on reselling_.
+- **User funds stay non-custodial.** OC's receiving wallet only ever holds OC's own credit revenue; a user's credit balance is prepaid, non-withdrawable service credit (an entitlement to inference), not a holding of their bitcoin.
 
 ---
 
@@ -25,7 +33,7 @@ Cat Credits closes that gap: the user pays **OrangeCat in Bitcoin/Lightning**, O
 ## 2. Guiding principles (non-negotiable)
 
 1. **Near cost, transparently.** Credits are priced at or barely above wholesale. OC's margin is **Supporter + platform activity, never inference markup** — the Settings page already promises "OrangeCat earns from platform activity, not your AI bill." Keep that promise. Disclose the rate.
-2. **Denominated in sats, 1:1.** A sat of credit = a sat paid. No funny-money "credits" abstraction. Balance shown in sats (+ fiat equiv via `useDisplayCurrency`). Honest and Bitcoin-native.
+2. **Denominated in BTC (canonical unit).** Balance is real BTC (`NUMERIC(18,8)`), shown via `useDisplayCurrency` (BTC or the user's currency). No funny-money "credits" abstraction. Sats appear only at the Lightning protocol boundary.
 3. **Prepaid, single-purpose, non-withdrawable, non-refundable service credit.** Credits buy Cat inference and nothing else; they can never be cashed out or transferred. This is the key design constraint that keeps it _prepaid service credit_ (like buying API credits) rather than _stored value / a wallet_ — materially lowering custody/money-transmission exposure. **Flag for legal review regardless.**
 4. **Ledger is the source of truth.** Balance is derived from an append-only ledger, never a free-floating mutable number (Ground Truth #2 — no state in two places).
 5. **Graceful, never hard-fail.** Out of credits → fall back to the free model + offer top-up. Never a dead end.
@@ -37,17 +45,18 @@ Cat Credits closes that gap: the user pays **OrangeCat in Bitcoin/Lightning**, O
 ### `cat_credit_entries` (append-only ledger — SSOT)
 
 ```
-id              uuid pk
-user_id         uuid not null → auth.users (RLS: read own)
-kind            text  -- 'topup' | 'usage' | 'grant' | 'refund' | 'adjustment'
-amount_sats     bigint not null  -- signed: + topup/grant/refund, − usage
-balance_after   bigint not null  -- denormalized running balance (set in txn)
-ref             text  -- lightning payment hash (topup) | cat_messages.id (usage)
-metadata        jsonb -- { model, inputTokens, outputTokens, costBtc, rateSats }
-created_at      timestamptz default now()
+id                uuid pk
+seq               bigint identity   -- monotonic order (created_at ties within a txn)
+user_id           uuid not null → auth.users (RLS: read own)
+kind              text  -- 'topup' | 'usage' | 'grant' | 'refund' | 'adjustment'
+amount_btc        numeric(18,8) not null  -- signed: + topup/grant/refund, − usage
+balance_after_btc numeric(18,8) not null  -- running balance (set atomically)
+ref               text  -- lightning payment hash (topup) | cat_messages.id (usage)
+metadata          jsonb
+created_at        timestamptz default now()
 
 unique (kind, ref) where ref is not null   -- idempotency: a payment/message credits once
-index (user_id, created_at desc)
+index (user_id, seq desc)
 ```
 
 - **Balance** = `balance_after` of the latest row (O(1) read), with `SUM(amount_sats)` as the reconciliation check. Optionally a thin `cat_credit_balances` cache row, rebuilt from the ledger — but the ledger is truth.

--- a/src/app/api/cat/credits/route.ts
+++ b/src/app/api/cat/credits/route.ts
@@ -9,17 +9,20 @@
  */
 
 import { getCreditBalance, listCreditEntries } from '@/services/cat/credits';
+import { platformReceiveEnabled } from '@/lib/bitcoin/platform-wallet';
 import { apiSuccess, handleApiError } from '@/lib/api/standardResponse';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 
 export const GET = withAuth(async (request: AuthenticatedRequest) => {
   const { user, supabase } = request;
   try {
-    const [balanceSats, entries] = await Promise.all([
+    const [balanceBtc, entries] = await Promise.all([
       getCreditBalance(supabase, user.id),
       listCreditEntries(supabase, user.id),
     ]);
-    return apiSuccess({ balanceSats, entries });
+    // topupEnabled tells the UI whether to offer Lightning top-up (only when a
+    // platform receiving wallet is configured — otherwise the button stays off).
+    return apiSuccess({ balanceBtc, entries, topupEnabled: platformReceiveEnabled() });
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/app/api/cat/credits/topup/route.ts
+++ b/src/app/api/cat/credits/topup/route.ts
@@ -1,0 +1,67 @@
+/**
+ * Cat Credits — Lightning top-up API
+ *
+ * POST /api/cat/credits/topup        { amountBtc }  → issue an invoice
+ * GET  /api/cat/credits/topup?id=ID                 → poll settlement status
+ *
+ * Gated on a configured platform receiving wallet (PLATFORM_NWC_URI). When
+ * unset, returns 503 — the UI keeps top-up disabled. See
+ * docs/architecture/CAT_CREDITS.md.
+ */
+
+import { z } from 'zod';
+import {
+  initiateTopUp,
+  checkTopUp,
+  MIN_TOPUP_BTC,
+  MAX_TOPUP_BTC,
+} from '@/services/cat/credit-topup';
+import { platformReceiveEnabled } from '@/lib/bitcoin/platform-wallet';
+import { apiSuccess, apiError, apiRateLimited, handleApiError } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+
+const bodySchema = z.object({
+  amountBtc: z.number().positive().max(MAX_TOPUP_BTC).min(MIN_TOPUP_BTC),
+});
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  const { user } = request;
+
+  if (!platformReceiveEnabled()) {
+    return apiError('Lightning top-up is not available yet', 'TOPUP_DISABLED', 503);
+  }
+
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
+  try {
+    const parsed = bodySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return apiError('Invalid top-up amount', 'BAD_REQUEST', 400);
+    }
+    const invoice = await initiateTopUp(user.id, parsed.data.amountBtc);
+    if (!invoice) {
+      return apiError('Could not create a top-up invoice', 'TOPUP_FAILED', 502);
+    }
+    return apiSuccess(invoice);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  const { user } = request;
+  const id = new URL(request.url).searchParams.get('id');
+  if (!id) {
+    return apiError('Provide ?id=<topupId>', 'BAD_REQUEST', 400);
+  }
+  try {
+    const status = await checkTopUp(user.id, id);
+    return apiSuccess(status);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/src/components/ai/CatCreditsPanel.tsx
+++ b/src/components/ai/CatCreditsPanel.tsx
@@ -3,22 +3,23 @@
 /**
  * CatCreditsPanel — your Bitcoin-paid Cat credit balance + ledger history.
  *
- * Phase 1: read-only. Shows the sats balance (the canonical unit — Bitcoin
- * Orange applies) with the user's display-currency equivalent, plus the ledger.
- * "Top up" is shown but disabled until platform Lightning-receiving infra is
- * provisioned (Phase 2). See docs/architecture/CAT_CREDITS.md.
+ * Balance is BTC (canonical unit), shown via the user's display currency. Top-up
+ * (Lightning) is offered only when the platform receiving wallet is configured
+ * (topupEnabled); otherwise the button stays disabled. See
+ * docs/architecture/CAT_CREDITS.md.
  */
 
 import { useCallback, useEffect, useState } from 'react';
 import { Coins, Loader2, AlertCircle, ArrowDownLeft, ArrowUpRight } from 'lucide-react';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { logger } from '@/utils/logger';
+import { TopUpDialog } from './TopUpDialog';
 
 interface CreditEntry {
   id: string;
   kind: 'topup' | 'usage' | 'grant' | 'refund' | 'adjustment';
-  amount_sats: number;
-  balance_after: number;
+  amount_btc: number;
+  balance_after_btc: number;
   created_at: string;
 }
 
@@ -31,11 +32,13 @@ const KIND_LABELS: Record<CreditEntry['kind'], string> = {
 };
 
 export function CatCreditsPanel() {
-  const { formatSats } = useDisplayCurrency();
-  const [balanceSats, setBalanceSats] = useState(0);
+  const { formatAmountBtc } = useDisplayCurrency();
+  const [balanceBtc, setBalanceBtc] = useState(0);
   const [entries, setEntries] = useState<CreditEntry[]>([]);
+  const [topupEnabled, setTopupEnabled] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [topUpOpen, setTopUpOpen] = useState(false);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -46,8 +49,9 @@ export function CatCreditsPanel() {
         throw new Error('Failed to load credits');
       }
       const json = await res.json();
-      setBalanceSats(json?.data?.balanceSats ?? 0);
+      setBalanceBtc(json?.data?.balanceBtc ?? 0);
       setEntries((json?.data?.entries ?? []) as CreditEntry[]);
+      setTopupEnabled(!!json?.data?.topupEnabled);
     } catch (err) {
       logger.error('Failed to load cat credits', err, 'CatCredits');
       setError('Could not load your credits. Try again.');
@@ -83,21 +87,22 @@ export function CatCreditsPanel() {
             <Loader2 className="mt-1 h-5 w-5 animate-spin text-fg-secondary" />
           ) : (
             <p className="mt-0.5 text-2xl font-semibold text-bitcoinOrange">
-              {balanceSats.toLocaleString('en-US')}{' '}
-              <span className="text-base font-normal text-fg-secondary">sats</span>
+              {formatAmountBtc(balanceBtc)}
             </p>
-          )}
-          {!isLoading && balanceSats > 0 && (
-            <p className="text-xs text-fg-tertiary">≈ {formatSats(balanceSats)}</p>
           )}
         </div>
         <button
           type="button"
-          disabled
-          title="Lightning top-up is coming soon"
-          className="cursor-not-allowed rounded-md border border-subtle px-4 py-2 text-sm font-medium text-fg-tertiary opacity-60"
+          onClick={() => setTopUpOpen(true)}
+          disabled={!topupEnabled}
+          title={topupEnabled ? 'Top up with Lightning' : 'Lightning top-up is coming soon'}
+          className={
+            topupEnabled
+              ? 'rounded-md bg-bitcoinOrange px-4 py-2 text-sm font-medium text-white hover:bg-bitcoinOrange/90'
+              : 'cursor-not-allowed rounded-md border border-subtle px-4 py-2 text-sm font-medium text-fg-tertiary opacity-60'
+          }
         >
-          Top up (soon)
+          {topupEnabled ? 'Top up' : 'Top up (soon)'}
         </button>
       </div>
 
@@ -117,12 +122,13 @@ export function CatCreditsPanel() {
         </div>
       ) : isLoading ? null : entries.length === 0 ? (
         <p className="text-sm text-fg-tertiary">
-          No credit activity yet. Once top-up is live, your purchases and Cat usage show here.
+          No credit activity yet. {topupEnabled ? 'Top up' : 'Once top-up is live'} to run Cat on
+          frontier models; purchases and usage will show here.
         </p>
       ) : (
         <ul className="divide-y divide-border-subtle">
           {entries.map(e => {
-            const credit = e.amount_sats >= 0;
+            const credit = e.amount_btc >= 0;
             return (
               <li key={e.id} className="flex items-center justify-between py-2 text-sm">
                 <span className="flex items-center gap-2 text-fg-primary">
@@ -137,13 +143,23 @@ export function CatCreditsPanel() {
                   </span>
                 </span>
                 <span className={credit ? 'text-status-positive' : 'text-fg-secondary'}>
-                  {credit ? '+' : ''}
-                  {e.amount_sats.toLocaleString('en-US')} sats
+                  {credit ? '+' : '−'}
+                  {formatAmountBtc(Math.abs(e.amount_btc))}
                 </span>
               </li>
             );
           })}
         </ul>
+      )}
+
+      {topUpOpen && (
+        <TopUpDialog
+          onClose={() => setTopUpOpen(false)}
+          onSuccess={() => {
+            setTopUpOpen(false);
+            void load();
+          }}
+        />
       )}
     </section>
   );

--- a/src/components/ai/TopUpDialog.tsx
+++ b/src/components/ai/TopUpDialog.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+/**
+ * TopUpDialog — buy Cat Credits over Lightning.
+ *
+ * Pick an amount → POST issues a platform invoice → show the bolt11 as a QR +
+ * copy → poll settlement → on payment, credit lands and the panel refreshes.
+ * Amounts are BTC (canonical), shown in the user's display currency.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Loader2, Copy, Check, X, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { toast } from 'sonner';
+import Button from '@/components/ui/Button';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { logger } from '@/utils/logger';
+
+/** Preset amounts in BTC (1-sat precision): 10k / 50k / 100k sats. */
+const PRESETS_BTC = [0.0001, 0.0005, 0.001];
+const POLL_MS = 3000;
+
+interface Invoice {
+  topupId: string;
+  bolt11: string;
+  amountBtc: number;
+}
+
+interface TopUpDialogProps {
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function TopUpDialog({ onClose, onSuccess }: TopUpDialogProps) {
+  const { formatAmountBtc } = useDisplayCurrency();
+  const [invoice, setInvoice] = useState<Invoice | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [expired, setExpired] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const create = useCallback(async (amountBtc: number) => {
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/cat/credits/topup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amountBtc }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json?.data?.bolt11) {
+        throw new Error(json?.error?.message || 'Could not create invoice');
+      }
+      setInvoice({
+        topupId: json.data.topupId,
+        bolt11: json.data.bolt11,
+        amountBtc: json.data.amountBtc,
+      });
+    } catch (err) {
+      logger.error('Top-up create failed', err, 'CatCredits');
+      setError(err instanceof Error ? err.message : 'Could not create invoice');
+    } finally {
+      setCreating(false);
+    }
+  }, []);
+
+  // Poll settlement once an invoice exists.
+  useEffect(() => {
+    if (!invoice) {
+      return;
+    }
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/cat/credits/topup?id=${encodeURIComponent(invoice.topupId)}`);
+        const json = await res.json();
+        const status = json?.data?.status;
+        if (status === 'paid') {
+          stopPolling();
+          toast.success('Credits added — thanks!');
+          onSuccess();
+        } else if (status === 'expired') {
+          stopPolling();
+          setExpired(true);
+        }
+      } catch {
+        // transient — keep polling
+      }
+    }, POLL_MS);
+    return stopPolling;
+  }, [invoice, onSuccess, stopPolling]);
+
+  const copy = async () => {
+    if (!invoice) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(invoice.bolt11);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard blocked — user can select manually
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-md rounded-lg border border-default bg-surface-base p-6 shadow-lg">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-fg-primary">Top up Cat Credits</h3>
+          <button
+            type="button"
+            onClick={() => {
+              stopPolling();
+              onClose();
+            }}
+            aria-label="Close"
+            className="rounded p-1 text-fg-tertiary hover:bg-surface-raised hover:text-fg-primary"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {!invoice ? (
+          <>
+            <p className="mb-3 text-sm text-fg-secondary">
+              Choose an amount to add. You&apos;ll pay a Lightning invoice from any wallet.
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              {PRESETS_BTC.map(amt => (
+                <button
+                  key={amt}
+                  type="button"
+                  disabled={creating}
+                  onClick={() => create(amt)}
+                  className="rounded-md border border-subtle bg-surface-raised/30 px-3 py-3 text-sm font-medium text-fg-primary hover:border-strong hover:bg-surface-raised disabled:opacity-50"
+                >
+                  {formatAmountBtc(amt)}
+                </button>
+              ))}
+            </div>
+            {creating && (
+              <div className="mt-3 flex items-center gap-2 text-sm text-fg-secondary">
+                <Loader2 className="h-4 w-4 animate-spin" /> Creating invoice…
+              </div>
+            )}
+            {error && (
+              <div className="mt-3 flex items-center gap-2 text-sm text-status-negative">
+                <AlertCircle className="h-4 w-4" /> {error}
+              </div>
+            )}
+          </>
+        ) : expired ? (
+          <div className="flex flex-col items-center gap-3 py-4 text-center">
+            <AlertCircle className="h-8 w-8 text-status-warning" />
+            <p className="text-sm text-fg-secondary">
+              This invoice expired before payment. Start a new top-up.
+            </p>
+            <Button
+              onClick={() => {
+                setInvoice(null);
+                setExpired(false);
+              }}
+            >
+              New invoice
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-3">
+            <p className="text-sm text-fg-secondary">
+              Pay {formatAmountBtc(invoice.amountBtc)} with any Lightning wallet:
+            </p>
+            <div className="rounded-md bg-white p-3">
+              <QRCodeSVG value={invoice.bolt11.toUpperCase()} size={200} />
+            </div>
+            <button
+              type="button"
+              onClick={copy}
+              className="inline-flex items-center gap-1.5 rounded-md border border-subtle px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-raised"
+            >
+              {copied ? (
+                <Check className="h-4 w-4 text-status-positive" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+              {copied ? 'Copied' : 'Copy invoice'}
+            </button>
+            <div className="flex items-center gap-2 text-sm text-fg-tertiary">
+              <Loader2 className="h-4 w-4 animate-spin" /> Waiting for payment…
+            </div>
+            <p className="flex items-center gap-1 text-xs text-fg-tertiary">
+              <CheckCircle2 className="h-3 w-3" /> Credits land automatically once paid.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default TopUpDialog;

--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -146,6 +146,7 @@ export const DATABASE_TABLES = {
   CAT_PENDING_ACTIONS: 'cat_pending_actions',
   CAT_MEMORIES: 'cat_memories',
   CAT_CREDIT_ENTRIES: 'cat_credit_entries',
+  CAT_CREDIT_TOPUPS: 'cat_credit_topups',
 
   // Messaging Views
   MESSAGE_DETAILS: 'message_details',

--- a/src/lib/bitcoin/platform-wallet.ts
+++ b/src/lib/bitcoin/platform-wallet.ts
@@ -1,0 +1,40 @@
+/**
+ * Platform receiving wallet (for Cat Credits top-ups).
+ *
+ * OrangeCat receives credit purchases into a wallet it controls, configured via
+ * a single NWC connection string (PLATFORM_NWC_URI). NWC is an abstraction, so
+ * this can point at a hosted wallet now and a self-hosted LNbits/BTCPay node
+ * later with no code change. When unset, top-up is simply disabled (the rest of
+ * Cat Credits — balance, history, metering — is unaffected).
+ *
+ * This is OC's OWN revenue wallet. It is unrelated to users' wallets, which stay
+ * non-custodial (OC never holds user funds). A user's credit balance is prepaid
+ * service credit, not a holding of their bitcoin.
+ */
+
+import { NWCClient, isValidNWCUri } from '@/lib/nostr/nwc';
+
+/** The platform NWC connection string, or undefined if not configured. */
+export function getPlatformNwcUri(): string | undefined {
+  const uri = process.env.PLATFORM_NWC_URI?.trim();
+  return uri && isValidNWCUri(uri) ? uri : undefined;
+}
+
+/** True when a platform receiving wallet is configured (top-up available). */
+export function platformReceiveEnabled(): boolean {
+  return !!getPlatformNwcUri();
+}
+
+/**
+ * A connected NWC client for the platform wallet, or null if not configured.
+ * Caller is responsible for `disconnect()`.
+ */
+export async function getPlatformNwcClient(): Promise<NWCClient | null> {
+  const uri = getPlatformNwcUri();
+  if (!uri) {
+    return null;
+  }
+  const client = new NWCClient(uri);
+  await client.connect();
+  return client;
+}

--- a/src/services/cat/credit-topup.ts
+++ b/src/services/cat/credit-topup.ts
@@ -1,0 +1,192 @@
+/**
+ * Cat Credits — Lightning top-up (Phase 2).
+ *
+ * A user buys credits by paying a Lightning invoice issued from OrangeCat's own
+ * receiving wallet (platform NWC). On settlement we post a `topup` entry to the
+ * cat_credit_entries ledger — idempotent via unique(kind, ref=payment_hash).
+ *
+ * Amounts are BTC end to end (canonical unit); sats appear ONLY when calling the
+ * Lightning protocol (makeInvoice takes sats). Settlement is detected by polling
+ * lookupInvoice — the same pattern OC already uses for seller payments — so no
+ * webhook infra is needed. All server-only (uses the service-role client).
+ *
+ * Gated on PLATFORM_NWC_URI: when unset, initiate/check report "not enabled" and
+ * the rest of Cat Credits is unaffected. See docs/architecture/CAT_CREDITS.md.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getAdminClient } from '@/lib/supabase/admin';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { getPlatformNwcClient, platformReceiveEnabled } from '@/lib/bitcoin/platform-wallet';
+import { appendCreditEntry, getCreditBalance } from '@/services/cat/credits';
+import { logger } from '@/utils/logger';
+
+/** Top-up bounds in BTC (1-sat precision). 0.00001 BTC = 1k sats … 0.01 BTC = 1M sats. */
+export const MIN_TOPUP_BTC = 0.00001;
+export const MAX_TOPUP_BTC = 0.01;
+/** Invoice validity. */
+const INVOICE_EXPIRY_SECONDS = 3600;
+const SATS_PER_BTC = 100_000_000;
+
+export interface TopUpInvoice {
+  topupId: string;
+  bolt11: string;
+  paymentHash: string;
+  amountBtc: number;
+  expiresAt: string;
+}
+
+export type TopUpStatus =
+  | { status: 'pending' }
+  | { status: 'paid'; balanceBtc: number }
+  | { status: 'expired' }
+  | { status: 'not_found' }
+  | { status: 'not_enabled' };
+
+/** Round a BTC amount to 8 dp (1-sat precision) — guards float drift. */
+function toBtc8(n: number): number {
+  return Math.round(n * SATS_PER_BTC) / SATS_PER_BTC;
+}
+
+/**
+ * Issue a Lightning invoice from the platform wallet for `amountBtc` and record
+ * a pending top-up tied to the user. Returns null if top-up isn't enabled or the
+ * amount is out of bounds.
+ */
+export async function initiateTopUp(
+  userId: string,
+  amountBtc: number
+): Promise<TopUpInvoice | null> {
+  if (!platformReceiveEnabled()) {
+    return null;
+  }
+  const amount = toBtc8(amountBtc);
+  if (!(amount >= MIN_TOPUP_BTC) || amount > MAX_TOPUP_BTC) {
+    return null;
+  }
+
+  const client = await getPlatformNwcClient();
+  if (!client) {
+    return null;
+  }
+
+  try {
+    // Sats only here — the Lightning protocol boundary.
+    const sats = Math.round(amount * SATS_PER_BTC);
+    const invoice = await client.makeInvoice(
+      sats,
+      'OrangeCat — Cat Credits top-up',
+      INVOICE_EXPIRY_SECONDS
+    );
+
+    const expiresAt = new Date(Date.now() + INVOICE_EXPIRY_SECONDS * 1000).toISOString();
+    const admin = getAdminClient() as unknown as AnySupabaseClient;
+    const { data, error } = await admin
+      .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
+      .insert({
+        user_id: userId,
+        amount_btc: amount,
+        payment_hash: invoice.payment_hash,
+        bolt11: invoice.invoice,
+        expires_at: expiresAt,
+      })
+      .select('id')
+      .single();
+
+    if (error || !data) {
+      logger.error('Failed to record top-up', { error }, 'CatCredits');
+      return null;
+    }
+
+    return {
+      topupId: (data as { id: string }).id,
+      bolt11: invoice.invoice,
+      paymentHash: invoice.payment_hash,
+      amountBtc: amount,
+      expiresAt,
+    };
+  } catch (err) {
+    logger.error('initiateTopUp threw', { err }, 'CatCredits');
+    return null;
+  } finally {
+    client.disconnect();
+  }
+}
+
+/**
+ * Poll a pending top-up: if the invoice has settled, credit the ledger (once)
+ * and mark it paid. Crediting goes to the top-up's recorded owner, never the
+ * caller, so a poller can't claim someone else's payment.
+ */
+export async function checkTopUp(userId: string, topupId: string): Promise<TopUpStatus> {
+  if (!platformReceiveEnabled()) {
+    return { status: 'not_enabled' };
+  }
+
+  const admin = getAdminClient() as unknown as AnySupabaseClient;
+  const { data: row } = await admin
+    .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
+    .select('id, user_id, amount_btc, payment_hash, status, expires_at')
+    .eq('id', topupId)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (!row) {
+    return { status: 'not_found' };
+  }
+  const topup = row as {
+    id: string;
+    user_id: string;
+    amount_btc: number;
+    payment_hash: string;
+    status: string;
+    expires_at: string;
+  };
+
+  if (topup.status === 'paid') {
+    return { status: 'paid', balanceBtc: await getCreditBalance(admin, topup.user_id) };
+  }
+  if (topup.status === 'expired') {
+    return { status: 'expired' };
+  }
+
+  const client = await getPlatformNwcClient();
+  if (!client) {
+    return { status: 'not_enabled' };
+  }
+
+  try {
+    const invoice = await client.lookupInvoice(topup.payment_hash);
+    if (invoice.settled_at) {
+      // Credit the OWNER (idempotent on payment_hash), then mark paid.
+      await appendCreditEntry(admin, topup.user_id, {
+        kind: 'topup',
+        amountBtc: topup.amount_btc,
+        ref: topup.payment_hash,
+        metadata: { source: 'lightning', topupId: topup.id },
+      });
+      await admin
+        .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
+        .update({ status: 'paid', paid_at: new Date().toISOString() })
+        .eq('id', topup.id);
+      return { status: 'paid', balanceBtc: await getCreditBalance(admin, topup.user_id) };
+    }
+  } catch (err) {
+    // Transient relay/lookup failure — report pending; client polls again.
+    logger.warn('checkTopUp lookup failed', { err }, 'CatCredits');
+    return { status: 'pending' };
+  } finally {
+    client.disconnect();
+  }
+
+  // Not settled yet — expire it if the window passed.
+  if (new Date(topup.expires_at).getTime() < Date.now()) {
+    await admin
+      .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
+      .update({ status: 'expired' })
+      .eq('id', topup.id);
+    return { status: 'expired' };
+  }
+  return { status: 'pending' };
+}

--- a/src/services/cat/credits.ts
+++ b/src/services/cat/credits.ts
@@ -24,8 +24,10 @@ export type CreditEntryKind = 'topup' | 'usage' | 'grant' | 'refund' | 'adjustme
 export interface CreditEntry {
   id: string;
   kind: CreditEntryKind;
-  amount_sats: number;
-  balance_after: number;
+  /** BTC (canonical unit). Signed: + topup/grant/refund, − usage. */
+  amount_btc: number;
+  /** Running balance in BTC after this entry. */
+  balance_after_btc: number;
   ref: string | null;
   metadata: Record<string, unknown> | null;
   created_at: string;
@@ -35,7 +37,7 @@ export interface CreditEntry {
 const HISTORY_LIMIT = 100;
 
 /**
- * Current credit balance in sats (0 on any failure — missing table, RLS, etc.).
+ * Current credit balance in BTC (0 on any failure — missing table, RLS, etc.).
  * Never throws; callers treat unavailable as "no credits".
  */
 export async function getCreditBalance(
@@ -63,7 +65,7 @@ export async function listCreditEntries(
   try {
     const { data, error } = await supabase
       .from(DATABASE_TABLES.CAT_CREDIT_ENTRIES)
-      .select('id, kind, amount_sats, balance_after, ref, metadata, created_at')
+      .select('id, kind, amount_btc, balance_after_btc, ref, metadata, created_at')
       .eq('user_id', userId)
       .order('seq', { ascending: false })
       .limit(HISTORY_LIMIT);
@@ -87,14 +89,14 @@ export async function listCreditEntries(
  * anon/authenticated so a normal user client cannot post entries. Used by the
  * top-up (Lightning settlement) and usage-metering paths.
  *
- * @returns the new balance in sats, or null on failure (incl. insufficient credits).
+ * @returns the new balance in BTC, or null on failure (incl. insufficient credits).
  */
 export async function appendCreditEntry(
   serviceSupabase: AnySupabaseClient,
   userId: string,
   entry: {
     kind: CreditEntryKind;
-    amountSats: number;
+    amountBtc: number;
     ref?: string | null;
     metadata?: Record<string, unknown> | null;
   }
@@ -103,7 +105,7 @@ export async function appendCreditEntry(
     const { data, error } = await serviceSupabase.rpc('cat_credit_append', {
       p_user_id: userId,
       p_kind: entry.kind,
-      p_amount_sats: entry.amountSats,
+      p_amount_btc: entry.amountBtc,
       p_ref: entry.ref ?? null,
       p_metadata: entry.metadata ?? null,
     });

--- a/supabase/migrations/20260625130000_cat_credit_topups.sql
+++ b/supabase/migrations/20260625130000_cat_credit_topups.sql
@@ -1,0 +1,39 @@
+-- ============================================================================
+-- Cat Credits Phase 2: pending Lightning top-ups (cat_credit_topups)
+-- ============================================================================
+-- Maps a platform-issued Lightning invoice → the user who should be credited
+-- when it settles. Without this map, a settled payment_hash couldn't be tied
+-- back to the right buyer (and a poller could try to claim someone else's
+-- payment). On settlement the server posts a `topup` entry to the
+-- cat_credit_entries ledger (idempotent via unique(kind, ref=payment_hash)).
+--
+-- Receiving backend is a platform NWC wallet (PLATFORM_NWC_URI) — abstracted,
+-- so it can later point at self-hosted LNbits/BTCPay with no code change.
+-- See docs/architecture/CAT_CREDITS.md.
+-- ============================================================================
+
+create table if not exists public.cat_credit_topups (
+  id            uuid primary key default uuid_generate_v4(),
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  -- BTC is the canonical unit platform-wide (NUMERIC(18,8) = 1-sat precision).
+  -- Sats appear ONLY at the Lightning protocol boundary (the makeInvoice call).
+  amount_btc    numeric(18, 8) not null check (amount_btc > 0),
+  payment_hash  text not null unique,         -- the invoice's payment hash
+  bolt11        text not null,                -- the invoice to pay
+  status        text not null default 'pending' check (status in ('pending', 'paid', 'expired')),
+  created_at    timestamptz not null default now(),
+  expires_at    timestamptz not null,
+  paid_at       timestamptz
+);
+
+create index if not exists cat_credit_topups_user_created
+  on public.cat_credit_topups (user_id, created_at desc);
+
+-- RLS: a user can read their own top-ups (to poll status). Writes are
+-- server-only (service role) — the invoice is created and settled by trusted
+-- server code, so there are no client insert/update policies.
+alter table public.cat_credit_topups enable row level security;
+
+drop policy if exists cat_credit_topups_select_own on public.cat_credit_topups;
+create policy cat_credit_topups_select_own on public.cat_credit_topups
+  for select using (user_id = auth.uid());

--- a/supabase/migrations/20260625140000_cat_credits_to_btc.sql
+++ b/supabase/migrations/20260625140000_cat_credits_to_btc.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- Cat Credits: convert ledger from sats to BTC (canonical-unit fix)
+-- ============================================================================
+-- 20260625120000 introduced cat_credit_entries in sats (amount_sats /
+-- balance_after bigint), violating the platform rule that BTC is the canonical
+-- unit (NUMERIC(18,8); "sats" don't exist as a product concept — they're a
+-- Lightning protocol detail only). This converts the ledger + its functions to
+-- BTC. Safe: no rows exist yet (every balance is 0).
+--
+-- NUMERIC(18,8) gives 1-sat precision, ample for metering inference. Sats now
+-- appear ONLY at the Lightning protocol boundary (the makeInvoice call).
+-- ============================================================================
+
+alter table public.cat_credit_entries rename column amount_sats to amount_btc;
+alter table public.cat_credit_entries
+  alter column amount_btc type numeric(18, 8) using amount_btc::numeric;
+
+alter table public.cat_credit_entries rename column balance_after to balance_after_btc;
+alter table public.cat_credit_entries
+  alter column balance_after_btc type numeric(18, 8) using balance_after_btc::numeric;
+
+-- Functions returned/took bigint; recreate them in BTC. Drop first (return-type
+-- and arg-type changes require it).
+drop function if exists public.cat_credit_balance(uuid);
+drop function if exists public.cat_credit_append(uuid, text, bigint, text, jsonb);
+
+create or replace function public.cat_credit_balance(p_user_id uuid)
+returns numeric
+language sql
+stable
+set search_path = public
+as $$
+  select coalesce(
+    (select balance_after_btc
+       from public.cat_credit_entries
+      where user_id = p_user_id
+      order by seq desc
+      limit 1),
+    0
+  );
+$$;
+
+create or replace function public.cat_credit_append(
+  p_user_id uuid,
+  p_kind text,
+  p_amount_btc numeric,
+  p_ref text default null,
+  p_metadata jsonb default null
+)
+returns numeric
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_current numeric;
+  v_new numeric;
+begin
+  perform pg_advisory_xact_lock(hashtext(p_user_id::text));
+
+  v_current := public.cat_credit_balance(p_user_id);
+  v_new := v_current + p_amount_btc;
+
+  if v_new < 0 then
+    raise exception 'insufficient_credits' using errcode = 'check_violation';
+  end if;
+
+  insert into public.cat_credit_entries (user_id, kind, amount_btc, balance_after_btc, ref, metadata)
+  values (p_user_id, p_kind, p_amount_btc, v_new, p_ref, p_metadata);
+
+  return v_new;
+end;
+$$;
+
+revoke all on function public.cat_credit_append(uuid, text, numeric, text, jsonb) from public, anon, authenticated;


### PR DESCRIPTION
Phase 2 of Bitcoin-paid frontier access (spec: docs/architecture/CAT_CREDITS.md), plus a correctness fix.

## BTC canonical-unit fix
Phase 1 shipped the ledger in **sats** (`_sats`/`bigint`), violating the platform rule that **BTC is the canonical unit** (sats aren't a product concept). Converted `cat_credit_entries` + its functions to `NUMERIC(18,8)` BTC (`amount_btc`/`balance_after_btc`); UI shows via `useDisplayCurrency`. **Sats now appear only at the Lightning protocol boundary** (`makeInvoice`). No data existed → clean conversion (migration `20260625140000`).

## Phase 2 — Lightning top-up
- **`cat_credit_topups`** maps a platform invoice → the user to credit on settlement (a poller can't claim someone else's payment). RLS read-own, server-only writes.
- **Platform receiving wallet** via `PLATFORM_NWC_URI` (`lib/bitcoin/platform-wallet.ts`) — OC's *own* wallet, abstracted (swap to LNbits/BTCPay later, no code change). Unset → top-up disabled, rest of Credits unaffected.
- **`credit-topup.ts`**: `initiateTopUp` (issue invoice) + `checkTopUp` (poll `lookup_invoice` → idempotent `topup` ledger entry on settlement) — reuses the existing NWC client + OC's polling-settlement pattern. **No webhook infra needed.**
- POST/GET `/api/cat/credits/topup`; `CatCreditsPanel` + `TopUpDialog` (QR + copy + poll). Button enabled only when `topupEnabled`.

User funds stay **non-custodial**; OC's wallet holds only OC's credit revenue; a credit balance is prepaid, non-withdrawable service credit.

## Verified
Migrations applied + **BTC ledger functionally tested on the box** (append, balance, overdraw rejection). tsc clean, eslint clean, 554/554 tests.

## ⚠️ Before top-up goes live (founder action)
Provision a platform NWC wallet + set `PLATFORM_NWC_URI` on the box, then do **one real top-up test** (can't be e2e-tested without a live wallet). Until then the button stays disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)