### PR TITLE
fix(cat): make credits sats→BTC migration idempotent (unblocks deploy)

### DIFF
--- a/supabase/migrations/20260625140000_cat_credits_to_btc.sql
+++ b/supabase/migrations/20260625140000_cat_credits_to_btc.sql
@@ -11,11 +11,30 @@
 -- appear ONLY at the Lightning protocol boundary (the makeInvoice call).
 -- ============================================================================
 
-alter table public.cat_credit_entries rename column amount_sats to amount_btc;
+-- Idempotent: the column rename only happens if the old column still exists, so
+-- this is safe to re-run (the deploy pipeline auto-applies migrations, and the
+-- conversion may already have been applied directly). Renames first, then the
+-- type widening (which is a no-op if already numeric(18,8)).
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'cat_credit_entries'
+      and column_name = 'amount_sats'
+  ) then
+    alter table public.cat_credit_entries rename column amount_sats to amount_btc;
+  end if;
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'cat_credit_entries'
+      and column_name = 'balance_after'
+  ) then
+    alter table public.cat_credit_entries rename column balance_after to balance_after_btc;
+  end if;
+end $$;
+
 alter table public.cat_credit_entries
   alter column amount_btc type numeric(18, 8) using amount_btc::numeric;
-
-alter table public.cat_credit_entries rename column balance_after to balance_after_btc;
 alter table public.cat_credit_entries
   alter column balance_after_btc type numeric(18, 8) using balance_after_btc::numeric;
 


### PR DESCRIPTION
The Phase 2 deploy (#286) failed: the deploy pipeline **auto-applies pending migrations**, and `20260625140000_cat_credits_to_btc.sql` had a bare `ALTER ... RENAME COLUMN amount_sats` that errored ("column amount_sats does not exist") because the conversion was already applied directly to the box → deploy aborted (live release untouched).

Fix: guard the renames behind an `information_schema` existence check so the migration is safe to re-run regardless of prior state. **Verified re-runnable against the live (already-converted) box.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)