### PR TITLE
feat(pricing): premium pricing + Bitcoin founding-supporter flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ GITHUB_TOKEN="ghp_your_personal_access_token"
 # BITCOIN / LIGHTNING (Required for payments)
 # ============================================================================
 BITCOIN_NETWORK="testnet"
+# OrangeCat's OWN receiving addresses — power the founding-supporter donation on
+# /support (rendered as QR + copy). Until set to real values, /support shows a
+# graceful "opens shortly" state instead of a placeholder address.
 NEXT_PUBLIC_BITCOIN_ADDRESS="bitcoin:bc1q...?message=OrangeCat%20Donation"
 NEXT_PUBLIC_LIGHTNING_ADDRESS="your-username@getalby.com"
 # NEXT_PUBLIC_LIGHTNING_NODE_URL=""

--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { Check, Sparkles, Cat as CatIcon } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import { CAT_PLANS, type CatPlan } from '@/config/cat-plans';
+import { ROUTES } from '@/config/routes';
 import { cn } from '@/lib/utils';
 
 export const metadata = {
@@ -44,55 +45,57 @@ export default function PricingPage() {
           ))}
         </div>
 
-        {/* Why pay? — intentionally open-ended */}
+        {/* Where this is going — honest about the fiat gap */}
         <section className="mb-16 rounded-lg border border-default bg-surface-base p-8">
-          <h2 className="mb-4 text-2xl font-semibold text-fg-primary">What Pro will be</h2>
+          <h2 className="mb-4 font-heading text-2xl font-bold tracking-display text-fg-primary">
+            Where this is going
+          </h2>
           <div className="space-y-4 text-fg-primary">
             <p>
-              We haven&apos;t decided. There are three plausible directions for what you&apos;d be
-              paying for, and we&apos;d rather hear from you before we lock one in:
+              The destination is <strong>Pro</strong>: frontier models — Claude, GPT-4o, Grok —
+              fully managed by OrangeCat, no keys, no setup. The kind of effortless AI a serious
+              company runs on.
+            </p>
+            <p>
+              We&apos;re not there yet, and we won&apos;t pretend otherwise. OrangeCat doesn&apos;t
+              have fiat payment rails — we can&apos;t bill your francs, and we can&apos;t pay the
+              inference providers in fiat. So until those rails exist, there are two honest ways to
+              get more:
             </p>
             <ul className="space-y-3 pl-4">
               <li>
-                <strong className="text-fg-primary">More Cat.</strong> Higher daily limits, better
-                default models — you pay OrangeCat, we pay the provider.
+                <strong className="text-fg-primary">Bring your own key</strong> — the real path to
+                frontier models <em>today</em>. Your key, your bill, zero markup. Cat runs Claude or
+                GPT-4o for you right now.
               </li>
               <li>
-                <strong className="text-fg-primary">Platform features.</strong> Unlimited entities,
-                Cat autonomous actions, verified badge, priority discovery — none of which touch the
-                AI bill.
-              </li>
-              <li>
-                <strong className="text-fg-primary">No subscription at all.</strong> OrangeCat earns
-                a small fee on transactions that happen on the platform (sales, funding, loans). AI
-                stays free for everyone, forever. Bitcoin-aligned: we win when you win.
+                <strong className="text-fg-primary">Back us in Bitcoin</strong> — believe in where
+                this is heading? Become a founding supporter. It&apos;s a donation, not a
+                subscription — and supporters get first access the day Pro ships.
               </li>
             </ul>
-            <p>
-              Most likely some mix. Until then: Free + BYOK cover real use today. Cat works for
-              everyone right now, no card on file, no commitment.
-            </p>
           </div>
         </section>
 
-        {/* Waitlist */}
-        <section id="waitlist" className="mb-12 rounded-lg bg-surface-public p-8 text-fg-inverted">
+        {/* Founding supporter CTA band */}
+        <section id="founding" className="mb-12 rounded-lg bg-surface-public p-8 text-fg-inverted">
           <div className="text-center">
             <Sparkles className="mx-auto mb-4 h-10 w-10" aria-hidden="true" />
             <h2 className="mb-3 font-heading text-2xl font-bold tracking-display">
-              Shape what Pro becomes
+              Found the permissionless economy
             </h2>
             <p className="mx-auto mb-6 max-w-2xl text-fg-inverted/70">
-              No commitment, no payment details. Tell us which of the three directions above (or
-              something else) would make you actually pay. We read every reply.
+              We&apos;re building toward a world where anyone can earn, fund, and govern without
+              gatekeepers. Fiat billing is coming — until then, back OrangeCat in Bitcoin and get
+              first access to Pro the day it&apos;s live.
             </p>
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
-              <a href="mailto:hello@orangecat.ch?subject=Cat%20Pro%20waitlist">
+              <Link href={ROUTES.SUPPORT}>
                 <Button variant="accent" size="lg">
-                  Email the waitlist
+                  Become a founding supporter
                 </Button>
-              </a>
-              <Link href="/dashboard/cat">
+              </Link>
+              <Link href={ROUTES.DASHBOARD.CAT}>
                 <Button variant="outline" size="lg">
                   Try Cat free
                 </Button>
@@ -104,8 +107,8 @@ export default function PricingPage() {
         {/* Footer note */}
         <div className="text-center text-sm text-fg-secondary">
           <p>
-            Whatever Pro becomes, payments will be Bitcoin/Lightning-native — no card-on-file
-            required. The price isn&apos;t committed until you tell us what works.
+            Payments are Bitcoin/Lightning-native — no card-on-file, ever. When fiat billing lands,
+            Pro will price honestly and founding supporters come first.
           </p>
         </div>
       </div>

--- a/src/app/(public)/support/page.tsx
+++ b/src/app/(public)/support/page.tsx
@@ -1,0 +1,132 @@
+import Link from 'next/link';
+import { ArrowRight, Bitcoin, KeyRound, Sparkles, Check } from 'lucide-react';
+import Button from '@/components/ui/Button';
+import { ROUTES } from '@/config/routes';
+import { FoundingSupporterDonation } from '@/components/support/FoundingSupporterDonation';
+
+export const metadata = {
+  title: 'Become a founding supporter',
+  description:
+    'OrangeCat is building toward fully managed, permissionless AI and economic participation. Back it in Bitcoin as a founding supporter — and use Cat with your own key today.',
+};
+
+/**
+ * /support — founding-supporter page. Honest framing: OrangeCat has no fiat
+ * rails yet, so the "pay us" path is a Bitcoin donation (not redeemable
+ * inference). BYOK is the real way to get frontier models today. Premium,
+ * x.ai-aligned, on the semantic design tier (monochrome + warm accent +
+ * Bitcoin Orange for the BTC-specific surface only).
+ */
+export default function SupportPage() {
+  return (
+    <div className="min-h-screen bg-surface-page">
+      <div className="mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8 lg:py-24">
+        {/* Hero */}
+        <div className="mx-auto max-w-3xl text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-default bg-surface-base px-4 py-1.5 text-xs font-medium uppercase tracking-caps text-fg-secondary">
+            <Sparkles className="h-3.5 w-3.5 text-bitcoinOrange" />
+            Founding supporters
+          </span>
+          <h1 className="mt-6 font-heading text-4xl font-bold tracking-display text-fg-primary sm:text-5xl lg:text-6xl">
+            Back the permissionless economy
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-lg text-fg-secondary sm:text-xl">
+            OrangeCat is building toward a world where anyone — any person, pseudonym, or AI — can
+            earn, fund, lend, and govern without gatekeepers, in any currency. We&apos;re early, and
+            we&apos;d rather be honest about it than polished about it.
+          </p>
+        </div>
+
+        {/* Honest narrative */}
+        <section className="mx-auto mt-16 max-w-2xl space-y-4 text-fg-primary">
+          <h2 className="font-heading text-2xl font-bold tracking-display">Why Bitcoin, why now</h2>
+          <p>
+            The destination is <strong>Pro</strong>: frontier models — Claude, GPT-4o, Grok —
+            managed entirely by OrangeCat, no keys, no setup. The effortless AI a serious company
+            runs on.
+          </p>
+          <p>
+            We&apos;re not there yet, and we won&apos;t pretend otherwise.{' '}
+            <strong>OrangeCat has no fiat payment rails</strong> — we can&apos;t bill your francs,
+            and we can&apos;t pay the inference providers in fiat. So a franc subscription
+            isn&apos;t something we can honestly take your money for today.
+          </p>
+          <p>
+            What we <em>can</em> do is build in the open and let the people who believe in it help
+            fund the road there. If that&apos;s you, back OrangeCat in Bitcoin. It&apos;s a donation
+            — not a subscription, not redeemable inference — and it directly funds the path to
+            managed AI and a censorship-resistant economy.
+          </p>
+        </section>
+
+        {/* Donation */}
+        <section className="mx-auto mt-12 max-w-2xl">
+          <div className="rounded-lg border border-bitcoinOrange/30 bg-surface-base p-6 sm:p-8">
+            <div className="mb-6 flex items-center gap-3">
+              <div className="rounded-md bg-surface-raised p-2">
+                <Bitcoin className="h-5 w-5 text-bitcoinOrange" />
+              </div>
+              <div>
+                <h2 className="font-heading text-xl font-bold tracking-display text-fg-primary">
+                  Support in Bitcoin
+                </h2>
+                <p className="text-sm text-fg-secondary">
+                  Any amount. Lightning is instant and near-free; on-chain suits larger gifts.
+                </p>
+              </div>
+            </div>
+            <FoundingSupporterDonation />
+          </div>
+
+          {/* What founding supporters get */}
+          <ul className="mt-6 grid gap-3 sm:grid-cols-3">
+            {[
+              'Recognition as a founding supporter',
+              'First access the day Pro goes live',
+              'You fund a permissionless economy',
+            ].map(perk => (
+              <li
+                key={perk}
+                className="flex items-start gap-2 rounded-lg border border-default bg-surface-base p-4 text-sm text-fg-primary"
+              >
+                <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-status-positive" />
+                <span>{perk}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* BYOK — the works-today path */}
+        <section className="mx-auto mt-16 max-w-2xl rounded-lg bg-surface-public p-8 text-fg-inverted">
+          <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <KeyRound className="mt-1 h-6 w-6 flex-shrink-0" aria-hidden="true" />
+              <div>
+                <h2 className="font-heading text-xl font-bold tracking-display">
+                  Want frontier models right now?
+                </h2>
+                <p className="mt-1 max-w-md text-fg-inverted/70">
+                  Bring your own key. Cat runs Claude, GPT-4o, or Grok for you today — your key,
+                  your bill, zero markup. No waiting on us.
+                </p>
+              </div>
+            </div>
+            <Link href={ROUTES.SETTINGS_AI} className="flex-shrink-0">
+              <Button variant="accent" size="lg" className="gap-2">
+                Add your key
+                <ArrowRight className="h-4 w-4" />
+              </Button>
+            </Link>
+          </div>
+        </section>
+
+        {/* Footer note */}
+        <p className="mx-auto mt-10 max-w-2xl text-center text-sm text-fg-secondary">
+          Founding support is a voluntary Bitcoin donation to OrangeCat — non-refundable, and not a
+          purchase of services. When fiat billing and managed Pro go live, founding supporters come
+          first.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/support/FoundingSupporterDonation.tsx
+++ b/src/components/support/FoundingSupporterDonation.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+/**
+ * FoundingSupporterDonation — back OrangeCat in Bitcoin.
+ *
+ * Shows OrangeCat's OWN receiving addresses (Lightning + on-chain) as QR codes
+ * with copy, read from NEXT_PUBLIC_LIGHTNING_ADDRESS / NEXT_PUBLIC_BITCOIN_ADDRESS.
+ * This is a DONATION (no spendable balance, no metering) — the honest path while
+ * OC has no fiat rails. Static address, so it works with zero NWC infra.
+ *
+ * When no real address is configured (env still placeholder), it degrades to a
+ * graceful "coming soon" state rather than showing a fake address. Bitcoin Orange
+ * is used per the Bitcoin-only rule.
+ */
+
+import { useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Bitcoin, Zap, Copy, Check, Clock } from 'lucide-react';
+import { toast } from 'sonner';
+
+/** A placeholder/unset address shouldn't be presented as real. */
+function isConfigured(addr?: string): boolean {
+  if (!addr) {
+    return false;
+  }
+  const a = addr.trim();
+  return a.length > 0 && !/your-username|bc1q\.\.\.|example\.com|<.+>/i.test(a);
+}
+
+/** Strip the bitcoin: URI scheme + query for a readable on-chain address. */
+function displayOnchain(raw: string): string {
+  return raw
+    .replace(/^bitcoin:/i, '')
+    .split('?')[0]
+    .trim();
+}
+
+interface TileProps {
+  kind: 'lightning' | 'onchain';
+  /** Value encoded in the QR (a wallet-openable URI). */
+  qrValue: string;
+  /** Value copied + shown to the user. */
+  display: string;
+  label: string;
+  sub: string;
+}
+
+function AddressTile({ kind, qrValue, display, label, sub }: TileProps) {
+  const [copied, setCopied] = useState(false);
+  const Icon = kind === 'lightning' ? Zap : Bitcoin;
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(display);
+      setCopied(true);
+      toast.success(`${label} address copied`);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error('Could not copy — select the address manually');
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center rounded-lg border border-default bg-surface-base p-6">
+      <div className="mb-4 flex items-center gap-2 self-start">
+        <Icon className="h-5 w-5 text-bitcoinOrange" />
+        <div>
+          <p className="text-sm font-semibold text-fg-primary">{label}</p>
+          <p className="text-xs text-fg-secondary">{sub}</p>
+        </div>
+      </div>
+
+      <div className="mb-4 rounded-lg border border-default bg-white p-3">
+        <QRCodeSVG value={qrValue} size={196} level="M" includeMargin={false} />
+      </div>
+
+      <button
+        type="button"
+        onClick={copy}
+        title="Click to copy"
+        className="flex w-full items-center justify-center gap-2 rounded-md border border-subtle bg-surface-raised/40 px-3 py-2 text-xs font-mono text-fg-primary hover:bg-surface-raised"
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 flex-shrink-0 text-status-positive" />
+        ) : (
+          <Copy className="h-3.5 w-3.5 flex-shrink-0 text-fg-tertiary" />
+        )}
+        <span className="truncate">{display}</span>
+      </button>
+    </div>
+  );
+}
+
+export function FoundingSupporterDonation() {
+  const lightning = process.env.NEXT_PUBLIC_LIGHTNING_ADDRESS;
+  const bitcoin = process.env.NEXT_PUBLIC_BITCOIN_ADDRESS;
+  const lnOk = isConfigured(lightning);
+  const onOk = isConfigured(bitcoin);
+
+  if (!lnOk && !onOk) {
+    return (
+      <div className="flex flex-col items-center rounded-lg border border-default bg-surface-base p-10 text-center">
+        <div className="mb-4 rounded-full bg-surface-raised p-3">
+          <Clock className="h-6 w-6 text-bitcoinOrange" />
+        </div>
+        <h3 className="font-heading text-xl font-bold tracking-display text-fg-primary">
+          Founding support opens shortly
+        </h3>
+        <p className="mt-2 max-w-md text-sm text-fg-secondary">
+          We&apos;re finalizing OrangeCat&apos;s receiving wallet. Check back soon to back the
+          platform in Bitcoin — or start using Cat with your own key today.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 sm:grid-cols-2">
+      {lnOk && (
+        <AddressTile
+          kind="lightning"
+          qrValue={`lightning:${lightning!.trim()}`}
+          display={lightning!.trim()}
+          label="Lightning"
+          sub="Instant · lowest fees · recommended"
+        />
+      )}
+      {onOk && (
+        <AddressTile
+          kind="onchain"
+          qrValue={
+            bitcoin!.trim().startsWith('bitcoin:') ? bitcoin!.trim() : `bitcoin:${bitcoin!.trim()}`
+          }
+          display={displayOnchain(bitcoin!)}
+          label="Bitcoin"
+          sub="On-chain · for larger amounts"
+        />
+      )}
+    </div>
+  );
+}
+
+export default FoundingSupporterDonation;

--- a/src/config/cat-plans.ts
+++ b/src/config/cat-plans.ts
@@ -4,12 +4,11 @@
  * Three plans, honest about what's shipped:
  *   - free → what every user gets today (10 msgs/day on free models)
  *   - byok → already implemented; zero platform cost; recommended for power users
- *   - pro  → waitlist only. The Pro card is intentionally vague about WHAT
- *            you'd be paying for — the business model isn't decided yet
- *            (could be more Cat capacity, could be platform features like
- *            entity caps + verified badge, could be transaction fees, could
- *            be all of the above). The waitlist exists to collect signal
- *            before any irreversible decision is made.
+ *   - pro  → managed frontier AI, not live yet. OrangeCat has no fiat rails
+ *            yet (can't bill francs or pay inference providers in fiat), so the
+ *            franc price is a future anchor and the CTA routes to /support:
+ *            back OrangeCat in Bitcoin as a founding supporter (a donation, NOT
+ *            redeemable inference) + use BYOK to get frontier models today.
  *
  * The /pricing page and QuotaMeter both read from this file. If the daily
  * limit changes, update CAT_FREE_DAILY_LIMIT here and api-key-service.ts in
@@ -86,20 +85,22 @@ export const CAT_PLANS: CatPlan[] = [
     ],
     cta: { label: 'Add your key', href: ROUTES.SETTINGS_AI, variant: 'accent' },
     status: 'available',
-    badge: 'Most freedom',
+    badge: 'Available now',
   },
   {
     id: 'pro',
     name: 'Pro',
-    tagline: 'Shape it with us',
-    priceCopy: 'No price yet — waitlist first',
+    tagline: 'Managed frontier AI — zero setup',
+    // Franc price as the future anchor; the card makes clear it's not live yet.
+    priceCopy: 'CHF 19 / mo · founding access',
     bullets: [
-      'What you pay for is still open: more Cat capacity, platform features, both',
-      'OrangeCat earns when you earn — likely transaction fees, not AI markup',
-      'Bitcoin-aligned: Lightning or BTC payments, no card-on-file required',
-      'Until Pro ships, Free + BYOK cover real use — Cat works for everyone today',
+      'Frontier models (Claude, GPT-4o, Grok) managed by OrangeCat — no keys, no setup',
+      'Higher limits, smarter defaults, full agentic Cat (discovery, matchmaking, multi-step)',
+      'Fiat billing is coming — until then, back us in Bitcoin as a founding supporter',
+      'Founding supporters get recognition and first access the day Pro goes live',
     ],
-    cta: { label: 'Join the waitlist', href: '#waitlist', variant: 'outline' },
+    cta: { label: 'Become a founding supporter', href: ROUTES.SUPPORT, variant: 'outline' },
     status: 'coming-soon',
+    badge: 'Founding access',
   },
 ];

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -281,6 +281,7 @@ export const ROUTES = {
   DOCS: '/docs',
   FAQ: '/faq',
   PRICING: '/pricing',
+  SUPPORT: '/support',
   TECHNOLOGY: '/technology',
   PRIVACY: '/privacy',
   TERMS: '/terms',


### PR DESCRIPTION
Reframes the upgrade story around an honest constraint: **OrangeCat has no fiat rails yet** (can't bill francs or pay inference providers in fiat). So the "pay us" path is a **Bitcoin donation** (founding supporter), and **BYOK is the real way to get frontier models today**.

## /pricing
Tiers reframed via the `CAT_PLANS` SSOT: BYOK badged **"Available now"** (the works-today frontier path), **Pro = "Founding access"** with a franc anchor (CHF 19/mo) clearly not-live-yet, CTA → `/support`. Narrative section rewritten to state the fiat gap plainly and offer the two honest paths.

## /support (new)
Premium founding-supporter page — honest "why Bitcoin, why now" copy, a clean BTC donation (Lightning + on-chain QR + copy via `FoundingSupporterDonation`, reading OC's own `NEXT_PUBLIC_*_ADDRESS` env, **graceful when unset**), founding-supporter perks, and a BYOK band for frontier-right-now.

Donation = a static-address gift (no invoice/metering) — works with **zero NWC infra**, unlike the Cat Credits top-up.

## Design
Built on the semantic design tier (monochrome + warm `#ff5c00` accent + Bitcoin Orange for the BTC surface only), display type, x.ai-aligned — **zero hardcoded hex**. tsc + eslint clean, 554/554 tests. No migration.

## ⚠️ Founder action to light up donations
Set `NEXT_PUBLIC_LIGHTNING_ADDRESS` / `NEXT_PUBLIC_BITCOIN_ADDRESS` to OrangeCat's real wallet on the box (build-time env). Until then `/support` shows a graceful "opens shortly" state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)