### PR TITLE
feat(create): skip template-picker step when Cat prefilled a draft

### DIFF
--- a/src/components/create/useEntityCreationWizard.ts
+++ b/src/components/create/useEntityCreationWizard.ts
@@ -39,8 +39,17 @@ export function useEntityCreationWizard<T extends Record<string, unknown>>({
   const hasTemplates = (config.templates?.length ?? 0) > 0;
   const isTemplateOnlyMode = !hasWizard && hasTemplates && !initialData;
 
-  const [currentStep, setCurrentStep] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  // When Cat (or any deep link) supplies a prefilled draft, skip the optional
+  // template-picker step and land straight on the first content step — the
+  // template is irrelevant once the fields are already drafted. Manual creates
+  // (no prefill) still open on the picker, and "Previous" from step 1 lets a
+  // prefilled user reach the templates anyway, so nothing is lost.
+  const skipTemplateStep = wizardSteps[0]?.id === 'template' && !!initialData;
+
+  const [currentStep, setCurrentStep] = useState(skipTemplateStep ? 1 : 0);
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(
+    skipTemplateStep ? new Set([0]) : new Set()
+  );
   const [selectedTemplate, setSelectedTemplate] = useState<EntityTemplate<T> | null>(null);
   const [formInitialValues, setFormInitialValues] = useState<Partial<T> | undefined>(initialData);
   const [showTemplateSelection, setShowTemplateSelection] = useState(isTemplateOnlyMode);


### PR DESCRIPTION
Completes the 'describe → click Create → review → publish' flow (pairs with #291). When the create wizard opens with a prefilled draft (Cat's Create card / any deep link with field params), the optional template-picker step is skipped — the user lands directly on the prefilled first content step instead of an irrelevant template gallery + an extra Next.

- Only skips when step 0 is the template step **and** a prefill is present.
- Manual creates (no prefill) still open on the picker — unchanged.
- Template step marked complete; 'Previous' still reaches the templates, so nothing's lost.

tsc + eslint clean, 554/554 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)