### PR TITLE
fix(cat,ui): matchmaking 404, entity-type SSOT, mobile headings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,7 +18,7 @@
 2. **Pseudonymous by default** — real identity is opt-in, never required. Any pseudonymous actor is a full economic participant.
 3. **Any currency** — Bitcoin/Lightning is native and preferred, but any payment method — local or global (Twint, PayPal, Venmo, bank transfers, and regional fiat equivalents worldwide) — is a first-class citizen. Meet users where they are.
 4. **Full economic spectrum** — from gift (no strings) to loan (some strings) to investment (more strings). All forms of value coordination belong on this platform.
-5. **Private where needed, transparent where chosen** — E2E encrypted messaging, Nostr as the censorship-resistant layer, Bitcoin's on-chain transparency available when appropriate.
+5. **Private where needed, transparent where chosen** — the privacy goal (E2E-encrypted messaging and Nostr as the censorship-resistant layer) is on the roadmap, **not yet shipped**: direct messages are currently stored as plaintext (realtime, but server-readable). Bitcoin's on-chain transparency is available when appropriate. Do not describe messaging as encrypted until it actually is.
 6. **Entities are the Cat's world model** — every entity type represents a form of economic or governance activity. The richer the entity structure, the smarter the Cat can be.
 
 ### Entity Economic Taxonomy

--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { getPublishedPosts, getFeaturedPost, getAllTags } from '@/lib/blog';
 import BlogClientWrapper from '@/components/blog/BlogClientWrapper';
+import { PageHeading } from '@/components/layout/PageHeading';
 
 export const metadata: Metadata = {
   title: 'Blog',
@@ -18,7 +19,7 @@ export default function BlogPage() {
     <div className="min-h-screen pt-20">
       <div className="container mx-auto px-4">
         <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold mb-4">OrangeCat Blog</h1>
+          <PageHeading className="mb-4">OrangeCat Blog</PageHeading>
           <p className="text-xl text-fg-secondary max-w-3xl mx-auto">
             Insights, guides, and stories about economic freedom, Bitcoin, and building on OrangeCat
           </p>

--- a/src/app/(public)/categories/page.tsx
+++ b/src/app/(public)/categories/page.tsx
@@ -4,6 +4,7 @@ import { categories } from '@/config/categories';
 import Link from 'next/link';
 import { Palette, Code, GraduationCap, Building2, Heart, ArrowRight } from 'lucide-react';
 import Button from '@/components/ui/Button';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { ROUTES } from '@/config/routes';
@@ -32,9 +33,7 @@ export default function CategoriesPage() {
     <div className="min-h-screen pt-20">
       <div className="container mx-auto px-4">
         <div className="text-center mb-16">
-          <h1 className="font-heading tracking-display text-4xl font-bold mb-4">
-            Find Your Community
-          </h1>
+          <PageHeading className="mb-4">Find Your Community</PageHeading>
           <p className="text-xl text-fg-secondary max-w-2xl mx-auto">
             Whether you&apos;re a creator, builder, educator, or organization, OrangeCat helps you
             exchange, fund, lend, invest, and govern—without gatekeepers.

--- a/src/app/(public)/docs/page.tsx
+++ b/src/app/(public)/docs/page.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { ENTITY_REGISTRY, ENTITY_TYPES as ENTITY_TYPE_KEYS } from '@/config/entity-registry';
 import Button from '@/components/ui/Button';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { ROUTES } from '@/config/routes';
 
 export const metadata: Metadata = {
@@ -37,9 +38,7 @@ export default function DocsPage() {
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="text-center mb-14">
-          <h1 className="font-heading tracking-display text-4xl font-bold text-fg-primary mb-4">
-            Platform Documentation
-          </h1>
+          <PageHeading className="mb-4">Platform Documentation</PageHeading>
           <p className="text-xl text-fg-secondary max-w-2xl mx-auto">
             How OrangeCat works — the AI agent, entity system, payments, and security.
           </p>

--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { ChevronDown, Bot, Coins, Users, Shield, Zap, HelpCircle } from 'lucide-react';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { cn } from '@/lib/utils';
 
 interface FaqItem {
@@ -252,7 +253,7 @@ export default function FAQPage() {
       {/* Header */}
       <div className="border-b border-default bg-surface-page py-16 px-4">
         <div className="max-w-3xl mx-auto text-center">
-          <h1 className="text-4xl font-bold text-fg-primary mb-4">Frequently Asked Questions</h1>
+          <PageHeading className="mb-4">Frequently Asked Questions</PageHeading>
           <p className="text-xl text-fg-secondary max-w-2xl mx-auto">
             Everything you need to know about OrangeCat — your AI economic agent.
           </p>

--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { Check, Sparkles, Cat as CatIcon } from 'lucide-react';
 import Button from '@/components/ui/Button';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { CAT_PLANS, type CatPlan } from '@/config/cat-plans';
 import { ROUTES } from '@/config/routes';
 import { cn } from '@/lib/utils';
@@ -28,9 +29,7 @@ export default function PricingPage() {
           <div className="mb-4 flex justify-center">
             <CatIcon className="h-16 w-16 text-fg-secondary" />
           </div>
-          <h1 className="mb-4 font-heading text-4xl font-bold tracking-display text-fg-primary">
-            Your AI, your bill, your choice
-          </h1>
+          <PageHeading className="mb-4">Your AI, your bill, your choice</PageHeading>
           <p className="mx-auto max-w-2xl text-xl text-fg-secondary">
             Cat works any way you want. Free out of the box, or bring your own key from six wired
             providers — OpenAI, OpenRouter, Together, Groq, DeepSeek, xAI. OrangeCat doesn&apos;t

--- a/src/app/(public)/security/page.tsx
+++ b/src/app/(public)/security/page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { Shield, Lock, Eye, Server, Key, AlertTriangle } from 'lucide-react';
 import Button from '@/components/ui/Button';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { ROUTES } from '@/config/routes';
 
 export const metadata = {
@@ -88,9 +89,7 @@ export default function SecurityPage() {
           <div className="flex justify-center mb-4">
             <Shield className="w-16 h-16 text-fg-secondary" />
           </div>
-          <h1 className="font-heading tracking-display text-4xl font-bold text-fg-primary mb-4">
-            Security &amp; Privacy
-          </h1>
+          <PageHeading className="mb-4">Security &amp; Privacy</PageHeading>
           <p className="text-xl text-fg-secondary">
             Your security and privacy are our top priorities at OrangeCat
           </p>

--- a/src/app/(public)/status/page.tsx
+++ b/src/app/(public)/status/page.tsx
@@ -1,6 +1,7 @@
 import { CheckCircle, AlertTriangle, XCircle, Clock } from 'lucide-react';
 import Link from 'next/link';
 import { checkHealth } from '@/lib/health';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { ROUTES } from '@/config/routes';
 import type { ServiceStatus } from '@/lib/health';
 
@@ -82,9 +83,7 @@ export default async function StatusPage() {
       <div className="max-w-4xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="text-center mb-12">
-          <h1 className="font-heading tracking-display text-4xl font-bold text-fg-primary mb-4">
-            System Status
-          </h1>
+          <PageHeading className="mb-4">System Status</PageHeading>
           <p className="text-xl text-fg-secondary">Current status of OrangeCat platform services</p>
           <p className="text-sm text-fg-tertiary mt-2">Last checked: {checkedAt}</p>
         </div>

--- a/src/app/api/admin/reindex-embeddings/route.ts
+++ b/src/app/api/admin/reindex-embeddings/route.ts
@@ -24,6 +24,7 @@ import { NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { embeddingsEnabled, embedTexts } from '@/services/ai/embeddings';
 import { ENTITY_STATUS } from '@/config/database-constants';
+import { getEntityMetadata, type EntityType } from '@/config/entity-registry';
 import { logger } from '@/utils/logger';
 
 export const dynamic = 'force-dynamic';
@@ -73,11 +74,20 @@ const causeQuality = (o: { updatedAt?: string | null; raised?: number; goal?: nu
 const EMBED_BATCH = 96;
 const key = (t: string, id: string) => `${t}:${id}`;
 
-const ENTITY_CFG: Record<string, { table: string; basePath: string }> = {
-  product: { table: 'user_products', basePath: '/products' },
-  service: { table: 'user_services', basePath: '/services' },
-  cause: { table: 'user_causes', basePath: '/causes' },
-};
+/** Entity types whose public rows are embedded into the search corpus.
+ *  The allow-list is a deliberate scope decision; table + path come from the registry SSOT. */
+const INDEXABLE_ENTITY_TYPES = [
+  'product',
+  'service',
+  'cause',
+] as const satisfies readonly EntityType[];
+
+const ENTITY_CFG: Record<string, { table: string; basePath: string }> = Object.fromEntries(
+  INDEXABLE_ENTITY_TYPES.map(t => {
+    const meta = getEntityMetadata(t);
+    return [t, { table: meta.tableName, basePath: meta.publicBasePath }];
+  })
+);
 
 /**
  * Reconcile ONE row (called near-instantly by the DB trigger on a write).

--- a/src/components/layout/PageHeading.tsx
+++ b/src/components/layout/PageHeading.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/utils';
+
+interface PageHeadingProps {
+  children: React.ReactNode;
+  /** Extra classes for the heading (e.g. text alignment). Never override the responsive scale. */
+  className?: string;
+}
+
+/**
+ * Canonical page H1 — SSOT for the top-level heading scale, font, and tracking.
+ * Mobile-first by construction (`text-2xl` → `sm:text-3xl` → `md:text-4xl`) so every
+ * page that uses it looks right on small screens. Public/marketing and detail pages should
+ * use this instead of hand-rolling `text-4xl` headings (which don't scale down on phones).
+ */
+export function PageHeading({ children, className }: PageHeadingProps) {
+  return (
+    <h1
+      className={cn(
+        'font-heading tracking-display text-2xl sm:text-3xl md:text-4xl font-bold text-fg-primary break-words',
+        className
+      )}
+    >
+      {children}
+    </h1>
+  );
+}

--- a/src/components/messaging/MessagePanel.tsx
+++ b/src/components/messaging/MessagePanel.tsx
@@ -88,7 +88,7 @@ export default function MessagePanel({
         className={cn(
           'flex flex-col border-r border-subtle bg-surface-raised/30 transition-transform duration-300 ease-in-out',
           selectedConversationId ? 'hidden md:flex md:w-80' : 'flex w-full md:w-80',
-          fullPage && 'w-[23rem]'
+          fullPage && 'w-full md:w-[23rem]'
         )}
       >
         <div className="flex items-center justify-between border-b border-subtle bg-surface-page p-4">

--- a/src/components/project/ProjectHeader.tsx
+++ b/src/components/project/ProjectHeader.tsx
@@ -88,9 +88,11 @@ export default function ProjectHeader({
 
   return (
     <div className="mb-6">
-      <div className="flex items-start justify-between gap-4 mb-4">
-        <div className="flex-1">
-          <h1 className="text-4xl font-bold text-fg-primary mb-3">{project.title}</h1>
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
+        <div className="flex-1 min-w-0">
+          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-fg-primary mb-3 break-words">
+            {project.title}
+          </h1>
 
           {/* Categories - Show prominently for quick project understanding */}
           {(project.category || (project.tags && project.tags.length > 0)) && (

--- a/src/services/cat/platform-search.ts
+++ b/src/services/cat/platform-search.ts
@@ -11,7 +11,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { AnySupabaseClient } from '@/lib/supabase/types';
-import { getTableName } from '@/config/entity-registry';
+import { getTableName, getEntityMetadata } from '@/config/entity-registry';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { ENTITY_STATUS } from '@/config/database-constants';
 import { embeddingsEnabled, embedText } from '@/services/ai/embeddings';
@@ -37,6 +37,10 @@ export interface SearchResult {
 }
 
 const MAX_RESULTS_PER_TYPE = 5;
+
+/** Public detail-page base path for an entity type — SSOT is the registry, never a literal. */
+const pubPath = (type: Parameters<typeof getEntityMetadata>[0]): string =>
+  getEntityMetadata(type).publicBasePath;
 
 /**
  * Search the platform for users and entities.
@@ -96,19 +100,40 @@ export async function searchPlatform(
       ? searchProfiles(supabase, tokens, results)
       : Promise.resolve(),
     type === 'all' || type === 'projects'
-      ? searchTable(supabase, getTableName('project'), 'projects', '/fund', tokens, results)
+      ? searchTable(
+          supabase,
+          getTableName('project'),
+          'projects',
+          pubPath('project'),
+          tokens,
+          results
+        )
       : Promise.resolve(),
     type === 'all' || type === 'causes'
-      ? searchTable(supabase, getTableName('cause'), 'causes', '/causes', tokens, results)
+      ? searchTable(supabase, getTableName('cause'), 'causes', pubPath('cause'), tokens, results)
       : Promise.resolve(),
     type === 'all' || type === 'products'
-      ? searchTable(supabase, getTableName('product'), 'products', '/products', tokens, results)
+      ? searchTable(
+          supabase,
+          getTableName('product'),
+          'products',
+          pubPath('product'),
+          tokens,
+          results
+        )
       : Promise.resolve(),
     type === 'all' || type === 'services'
-      ? searchTable(supabase, getTableName('service'), 'services', '/services', tokens, results)
+      ? searchTable(
+          supabase,
+          getTableName('service'),
+          'services',
+          pubPath('service'),
+          tokens,
+          results
+        )
       : Promise.resolve(),
     type === 'all' || type === 'events'
-      ? searchTable(supabase, getTableName('event'), 'events', '/events', tokens, results)
+      ? searchTable(supabase, getTableName('event'), 'events', pubPath('event'), tokens, results)
       : Promise.resolve(),
   ]);
 

--- a/src/services/cat/tool-use.ts
+++ b/src/services/cat/tool-use.ts
@@ -19,6 +19,7 @@ import { searchPlatform, type SearchType } from './platform-search';
 import { generateFormPrefill } from '@/lib/ai/form-prefill-service';
 import { getEntityConfig } from '@/config/entity-configs/get-config';
 import { isValidEntityType, type EntityType } from '@/config/entity-registry';
+import { CAT_CREATABLE_ENTITY_TYPES } from '@/types/cat';
 
 /** Standard chat message (system/user/assistant) */
 export type { OpenRouterMessage as ChatMessage };
@@ -177,18 +178,13 @@ function hasCreateIntent(message: string): boolean {
   return CREATE_INTENT_PATTERNS.some(re => re.test(message));
 }
 
-const PREFILLABLE_ENTITY_TYPES = [
-  'product',
-  'service',
-  'project',
-  'cause',
-  'event',
-  'asset',
-  'loan',
-  'investment',
-  'research',
-  'wishlist',
-] as const;
+/** Entity types Cat can DRAFT via the prefill tool. Derived from the creatable SSOT so the
+ *  two lists can't drift. `group` is creatable but not prefillable — it uses a `name`, not the
+ *  form-field prefill flow. Add an entry here only by removing it from this exclusion set. */
+const NON_PREFILLABLE_ENTITY_TYPES = new Set<string>(['group']);
+const PREFILLABLE_ENTITY_TYPES = CAT_CREATABLE_ENTITY_TYPES.filter(
+  t => !NON_PREFILLABLE_ENTITY_TYPES.has(t)
+);
 
 const PLATFORM_TOOL_DEFINITION = [
   {

--- a/src/types/cat.ts
+++ b/src/types/cat.ts
@@ -14,26 +14,12 @@ import type { EntityType } from '@/config/entity-registry';
 import type { WalletBehaviorType, WalletCategory, BudgetPeriod } from '@/types/wallet';
 
 /**
- * Entity types that Cat can suggest creating.
- * Subset of the full EntityType from the entity registry.
+ * SSOT for the entity types Cat can suggest creating — a subset of the registry's EntityType.
+ * Every consumer (the `CatCreatableEntityType` type, the prefill list in tool-use.ts, the
+ * response parser, the action enum) derives from THIS array so the set can never drift.
+ * `satisfies readonly EntityType[]` guarantees each entry is a real registry type.
  */
-type CatCreatableEntityType = Extract<
-  EntityType,
-  | 'product'
-  | 'service'
-  | 'project'
-  | 'cause'
-  | 'event'
-  | 'asset'
-  | 'loan'
-  | 'investment'
-  | 'research'
-  | 'wishlist'
-  | 'group'
->;
-
-/** All entity types Cat can create, as a runtime array for validation */
-export const CAT_CREATABLE_ENTITY_TYPES: CatCreatableEntityType[] = [
+export const CAT_CREATABLE_ENTITY_TYPES = [
   'product',
   'service',
   'project',
@@ -45,7 +31,11 @@ export const CAT_CREATABLE_ENTITY_TYPES: CatCreatableEntityType[] = [
   'research',
   'wishlist',
   'group',
-];
+  'ai_assistant',
+  'document',
+] as const satisfies readonly EntityType[];
+
+type CatCreatableEntityType = (typeof CAT_CREATABLE_ENTITY_TYPES)[number];
 
 /**
  * An action suggesting entity creation, embedded as ```action JSON blocks in AI responses.


### PR DESCRIPTION
Fixes surfaced by the Cat / architecture / responsive audit.

## Changes
- **fix(cat): matchmaking links 404** — `platform-search` hardcoded `/fund/${id}` (no such route). Now sources every public path from `ENTITY_REGISTRY.publicBasePath` via a `pubPath` helper → fixes the link and removes route SSOT drift.
- **fix(messaging): mobile overflow** — `MessagePanel` conversation pane no longer overflows ≤368px phones (`w-[23rem]` → `w-full md:w-[23rem]`).
- **refactor(cat): single SSOT for creatable entity types** — `CAT_CREATABLE_ENTITY_TYPES` is now the one canonical array; the type and tool-use's `PREFILLABLE_ENTITY_TYPES` derive from it. Enables `ai_assistant` (fully wired) and `document` (card+prefill deep-link to the existing create form). `group` stays creatable-but-not-prefillable via an explicit exclusion set.
- **refactor(search): dedup** — `reindex-embeddings` no longer keeps a second copy of the entity→{table,basePath} map; derives from the registry.
- **feat(ui): `<PageHeading>` primitive** — SSOT for the responsive H1 scale; applied to 7 public pages (pricing/faq/docs/blog/security/status/categories) + responsive/stacking `ProjectHeader`.
- **docs:** corrected the messaging privacy claim — E2E/Nostr is roadmap, not shipped (DMs are plaintext today).

## Verification
- `tsc --noEmit --incremental false`: **0 errors**
- Pre-push hooks (lint, E2E) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)