### PR TITLE
feat(ai-assistant): wire chat UI + Cat Credits charging

### DIFF
--- a/src/app/ai-assistants/[id]/page.tsx
+++ b/src/app/ai-assistants/[id]/page.tsx
@@ -8,6 +8,7 @@ import PublicEntityDetailPage, {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/badge';
 import PriceDisplay from '@/components/public/PriceDisplay';
+import AiAssistantChat from '@/components/ai-assistants/AiAssistantChat';
 import { ROUTES } from '@/config/routes';
 
 interface PageProps {
@@ -69,6 +70,14 @@ const config: EntityDetailConfig = {
 
     return (
       <>
+        <AiAssistantChat
+          assistantId={entity.id as string}
+          assistantName={(entity.title as string) || 'this assistant'}
+          assistantAvatar={entity.avatar_url as string | null | undefined}
+          welcomeMessage={welcome}
+          pricing={pricing}
+        />
+
         {(pricing.isFree || pricing.amount > 0) && (
           <Card>
             <CardHeader>

--- a/src/components/ai-assistants/AiAssistantChat.tsx
+++ b/src/components/ai-assistants/AiAssistantChat.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+/**
+ * Public chat with a user-created AI assistant.
+ *
+ * Lazily creates a conversation on the first message, then streams the exchange
+ * through the existing /conversations/[convId]/messages endpoint (which meters
+ * Cat Credits server-side). Handles the unauthenticated and out-of-credits cases
+ * with clear, actionable CTAs.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import Link from 'next/link';
+import { MessageSquare } from 'lucide-react';
+import { AIChatMessage, AIChatInput, type AIMessage } from '@/components/ai-chat';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import Button from '@/components/ui/Button';
+import { API_ROUTES } from '@/config/api-routes';
+import { ROUTES } from '@/config/routes';
+import { useAuth } from '@/hooks/useAuth';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { logger } from '@/utils/logger';
+
+interface AiAssistantChatProps {
+  assistantId: string;
+  assistantName: string;
+  assistantAvatar?: string | null;
+  welcomeMessage?: string | null;
+  pricing: { isFree: boolean; amount: number; suffix: string };
+}
+
+interface ApiEnvelope<T> {
+  success: boolean;
+  data?: T;
+  error?: { code: string; message: string; details?: unknown };
+}
+
+export default function AiAssistantChat({
+  assistantId,
+  assistantName,
+  assistantAvatar,
+  welcomeMessage,
+  pricing,
+}: AiAssistantChatProps) {
+  const { isAuthenticated } = useAuth();
+  const { formatAmountBtc } = useDisplayCurrency();
+  const [messages, setMessages] = useState<AIMessage[]>([]);
+  const [convId, setConvId] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [creditsNeeded, setCreditsNeeded] = useState<{ balance: number; required: number } | null>(
+    null
+  );
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [messages, sending]);
+
+  const ensureConversation = useCallback(async (): Promise<string> => {
+    if (convId) {
+      return convId;
+    }
+    const res = await fetch(API_ROUTES.AI_ASSISTANTS.CONVERSATIONS(assistantId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const json = (await res.json()) as ApiEnvelope<{ id: string }>;
+    if (!res.ok || !json.data?.id) {
+      throw new Error(json.error?.message || 'Could not start a conversation');
+    }
+    setConvId(json.data.id);
+    return json.data.id;
+  }, [assistantId, convId]);
+
+  const send = useCallback(
+    async (content: string) => {
+      setError(null);
+      setCreditsNeeded(null);
+      const optimistic: AIMessage = {
+        id: `temp-${Date.now()}`,
+        role: 'user',
+        content,
+        created_at: new Date().toISOString(),
+      };
+      setMessages(prev => [...prev, optimistic]);
+      setSending(true);
+      try {
+        const cid = await ensureConversation();
+        const res = await fetch(API_ROUTES.AI_ASSISTANTS.CONVERSATION_MESSAGES(assistantId, cid), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content }),
+        });
+        const json = (await res.json()) as ApiEnvelope<{
+          userMessage: AIMessage;
+          assistantMessage: AIMessage;
+        }>;
+
+        if (res.status === 402) {
+          const d = (json.error?.details ?? {}) as {
+            currentBalance?: number;
+            requiredAmount?: number;
+          };
+          setCreditsNeeded({ balance: d.currentBalance ?? 0, required: d.requiredAmount ?? 0 });
+          setMessages(prev => prev.filter(m => m.id !== optimistic.id));
+          return;
+        }
+        if (!res.ok || !json.data) {
+          throw new Error(json.error?.message || 'Failed to send message');
+        }
+        // Replace the optimistic bubble with the persisted pair.
+        setMessages(prev => [
+          ...prev.filter(m => m.id !== optimistic.id),
+          json.data!.userMessage,
+          json.data!.assistantMessage,
+        ]);
+      } catch (err) {
+        logger.error('Assistant chat send failed', err, 'AiAssistantChat');
+        setMessages(prev => prev.filter(m => m.id !== optimistic.id));
+        setError(err instanceof Error ? err.message : 'Something went wrong. Please try again.');
+      } finally {
+        setSending(false);
+      }
+    },
+    [assistantId, ensureConversation]
+  );
+
+  const priceLabel = pricing.isFree
+    ? 'Free to chat'
+    : `${formatAmountBtc(pricing.amount)}${pricing.suffix} · paid from your Cat Credits`;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <MessageSquare className="h-5 w-5 text-accent-warm" />
+          Chat with {assistantName}
+        </CardTitle>
+        <p className="text-sm text-fg-secondary">{priceLabel}</p>
+      </CardHeader>
+      <CardContent>
+        {!isAuthenticated ? (
+          <div className="flex flex-col items-center gap-3 py-8 text-center">
+            <p className="text-sm text-fg-secondary">Sign in to chat with this assistant.</p>
+            <Link href={ROUTES.AUTH_LOGIN}>
+              <Button variant="accent">Sign in to chat</Button>
+            </Link>
+          </div>
+        ) : (
+          <div className="flex flex-col">
+            <div
+              ref={scrollRef}
+              className="flex flex-col gap-0 max-h-[28rem] overflow-y-auto rounded-md border border-subtle bg-surface-base"
+            >
+              {welcomeMessage && messages.length === 0 && (
+                <AIChatMessage
+                  message={{
+                    id: 'welcome',
+                    role: 'assistant',
+                    content: welcomeMessage,
+                    created_at: new Date().toISOString(),
+                  }}
+                  assistantName={assistantName}
+                  assistantAvatar={assistantAvatar}
+                />
+              )}
+              {messages.length === 0 && !welcomeMessage && (
+                <p className="px-4 py-8 text-center text-sm text-fg-tertiary">
+                  Say hello to start the conversation.
+                </p>
+              )}
+              {messages.map(m => (
+                <AIChatMessage
+                  key={m.id}
+                  message={m}
+                  assistantName={assistantName}
+                  assistantAvatar={assistantAvatar}
+                />
+              ))}
+              {sending && (
+                <p className="px-4 py-3 text-sm text-fg-tertiary">{assistantName} is typing…</p>
+              )}
+            </div>
+
+            {creditsNeeded && (
+              <div className="mt-3 rounded-md border border-subtle bg-surface-raised p-3 text-sm">
+                <p className="text-fg-primary">
+                  Not enough Cat Credits — you need {formatAmountBtc(creditsNeeded.required)} and
+                  have {formatAmountBtc(creditsNeeded.balance)}.
+                </p>
+                <Link href={ROUTES.SETTINGS_AI} className="mt-2 inline-block">
+                  <Button variant="accent" size="sm">
+                    Top up Cat Credits
+                  </Button>
+                </Link>
+              </div>
+            )}
+            {error && <p className="mt-3 text-sm text-status-negative">{error}</p>}
+
+            <div className="mt-3">
+              <AIChatInput
+                onSend={send}
+                disabled={sending}
+                placeholder={`Message ${assistantName}…`}
+              />
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/config/entity-configs/ai-assistant-config.ts
+++ b/src/config/entity-configs/ai-assistant-config.ts
@@ -157,7 +157,7 @@ const fieldGroups: FieldGroup[] = [
     id: 'payment',
     title: 'Bitcoin & Payments',
     description:
-      'Wallet for receiving donations to your assistant. Per-message charging is not currently active.',
+      'Wallet for receiving donations. Per-message pricing is charged from the chatter’s Cat Credits — you keep 95% as spendable credits.',
     customComponent: WalletSelectorField,
     fields: [
       { name: 'bitcoin_address', label: 'Bitcoin Address', type: 'bitcoin_address' },

--- a/src/services/ai/assistant-charge.ts
+++ b/src/services/ai/assistant-charge.ts
@@ -1,0 +1,165 @@
+/**
+ * AI Assistant Charging
+ *
+ * Wires user-created `ai_assistant` chat to the Cat Credits ledger:
+ * a paid assistant debits the chatter's prepaid Cat Credits and credits the
+ * creator's 95% share as spendable Cat Credits (platform keeps 5%).
+ *
+ * v1 scope: `free` (no charge) and `per_message` (full price, pre-authorized).
+ * `per_token` / `subscription` are not metered yet → charge 0. The ledger is the
+ * source of truth (append-only, atomic, overdraw-safe); `ai_assistants.total_revenue`
+ * is a best-effort denormalized counter for creator stats.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getCreditBalance, appendCreditEntry } from '@/services/cat/credits';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { logger } from '@/utils/logger';
+
+/** Creator keeps 95% of the message price as spendable Cat Credits; platform keeps 5%. */
+const CREATOR_SHARE = 0.95;
+
+/**
+ * A per-message charge above this is almost certainly a misconfigured / un-divided legacy
+ * sats value sitting in a BTC column (the sats→BTC rename renamed the column but did NOT
+ * divide by 1e8). Refuse to bill it rather than drain a user's balance.
+ */
+const SANE_MAX_CHARGE_BTC = 0.01;
+
+/** Round to satoshi precision (the ledger column is numeric(18,8)). */
+const roundBtc = (n: number): number => Math.round(n * 1e8) / 1e8;
+
+export interface ChargeableAssistant {
+  pricing_model: string;
+  price_per_message: number | null;
+}
+
+/**
+ * What the chatter owes the creator for one message, in BTC.
+ * Free messages, free/per_token/subscription pricing, and misconfigured prices all → 0.
+ */
+export function computeCreatorChargeBtc(
+  assistant: ChargeableAssistant,
+  usesFreeMessage: boolean
+): number {
+  if (usesFreeMessage) {
+    return 0;
+  }
+  // v1 meters per_message only; free / per_token / subscription cost nothing yet.
+  if (assistant.pricing_model !== 'per_message') {
+    return 0;
+  }
+  const price = Number(assistant.price_per_message ?? 0);
+  if (!Number.isFinite(price) || price <= 0) {
+    return 0;
+  }
+  if (price > SANE_MAX_CHARGE_BTC) {
+    logger.warn(
+      'AI assistant price_per_message exceeds sane max — skipping charge (likely misscaled legacy value)',
+      { price },
+      'AIAssistantCharge'
+    );
+    return 0;
+  }
+  return roundBtc(price);
+}
+
+/**
+ * Does the payer have enough Cat Credits to cover `chargeBtc`?
+ * Returns the balance so the caller can build an INSUFFICIENT_CREDITS response.
+ */
+export async function checkAffordability(
+  admin: SupabaseClient,
+  payerUserId: string,
+  chargeBtc: number
+): Promise<{ ok: true } | { ok: false; balance: number }> {
+  const balance = await getCreditBalance(admin, payerUserId);
+  return balance >= chargeBtc ? { ok: true } : { ok: false, balance };
+}
+
+/**
+ * Settle a served message: debit the payer (authoritative, overdraw-safe, idempotent on the
+ * message id) then credit the creator's share (best-effort, non-atomic in v1 — if the payout
+ * append fails the platform simply retains the share, which is reconcilable from the ledger).
+ */
+export async function settleAssistantCharge(
+  admin: SupabaseClient,
+  args: {
+    payerUserId: string;
+    creatorUserId: string;
+    assistantId: string;
+    messageId: string;
+    chargeBtc: number;
+    model: string;
+    totalTokens: number;
+  }
+): Promise<void> {
+  const { payerUserId, creatorUserId, assistantId, messageId, chargeBtc, model, totalTokens } =
+    args;
+
+  // 1. Debit the payer. Idempotent on (kind, ref) = ('usage', messageId).
+  const newBalance = await appendCreditEntry(admin, payerUserId, {
+    kind: 'usage',
+    amountBtc: -chargeBtc,
+    ref: messageId,
+    metadata: { assistantId, model, totalTokens },
+  });
+  if (newBalance === null) {
+    // Balance was pre-checked, so this is a rare race (concurrent spend), a duplicate retry,
+    // or a transient DB error. The message is already served; do NOT pay the creator if the
+    // payer wasn't debited.
+    logger.warn(
+      'AI assistant charge debit returned null — message already served, creator not paid',
+      { payerUserId, assistantId, messageId, chargeBtc },
+      'AIAssistantCharge'
+    );
+    return;
+  }
+
+  // 2. Credit the creator's 95% share as spendable Cat Credits (best-effort).
+  const creatorShare = roundBtc(chargeBtc * CREATOR_SHARE);
+  if (creatorUserId && creatorUserId !== payerUserId && creatorShare > 0) {
+    const credited = await appendCreditEntry(admin, creatorUserId, {
+      kind: 'grant',
+      amountBtc: creatorShare,
+      ref: `${messageId}:creator`,
+      metadata: { assistantId, source: 'assistant_revenue', grossBtc: chargeBtc },
+    });
+    if (credited === null) {
+      logger.warn(
+        'AI assistant creator payout failed — platform retains share (reconcilable from ledger)',
+        { creatorUserId, assistantId, messageId, creatorShare },
+        'AIAssistantCharge'
+      );
+    }
+  }
+
+  // 3. Bump the denormalized creator-revenue counter (best-effort; ledger remains the SSOT).
+  await bumpAssistantRevenue(admin, assistantId, chargeBtc);
+}
+
+async function bumpAssistantRevenue(
+  admin: SupabaseClient,
+  assistantId: string,
+  amountBtc: number
+): Promise<void> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data } = await (admin.from(DATABASE_TABLES.AI_ASSISTANTS) as any)
+      .select('total_revenue, total_messages')
+      .eq('id', assistantId)
+      .single();
+    const nextRevenue = roundBtc(Number(data?.total_revenue ?? 0) + amountBtc);
+    const nextMessages = Number(data?.total_messages ?? 0) + 1;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (admin.from(DATABASE_TABLES.AI_ASSISTANTS) as any)
+      .update({ total_revenue: nextRevenue, total_messages: nextMessages })
+      .eq('id', assistantId);
+  } catch (err) {
+    logger.warn(
+      'Failed to bump assistant revenue counter',
+      { assistantId, err },
+      'AIAssistantCharge'
+    );
+  }
+}

--- a/src/services/ai/sendMessage.ts
+++ b/src/services/ai/sendMessage.ts
@@ -24,6 +24,12 @@ import {
   getFreeModels,
 } from '@/config/ai-models';
 import { createAutoRouter } from '@/services/ai/auto-router';
+import { getAdminClient } from '@/lib/supabase/admin';
+import {
+  computeCreatorChargeBtc,
+  checkAffordability,
+  settleAssistantCharge,
+} from '@/services/ai/assistant-charge';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -143,10 +149,23 @@ export async function sendAiMessage(
     freeMessagesPerDay
   );
 
-  // 8. AI assistants are free for now — the credits/charging system was scaffolded
-  // but never wired to a real backing store. Strip the charge math; keep
-  // free-messages-per-day quota as the only spending dial.
-  const creatorCharge = 0;
+  // 8. Compute the creator's per-message charge (BTC) and pre-authorize it against the
+  //    user's Cat Credits balance BEFORE calling the model, so we can return a clean
+  //    INSUFFICIENT_CREDITS without serving a message. Free messages / non-per_message
+  //    pricing cost nothing (see assistant-charge.ts).
+  const creatorCharge = computeCreatorChargeBtc(assistant, usesFreeMessage);
+  const admin = creatorCharge > 0 ? getAdminClient() : null;
+  if (admin && creatorCharge > 0) {
+    const affordability = await checkAffordability(admin, userId, creatorCharge);
+    if (!affordability.ok) {
+      return {
+        code: 'INSUFFICIENT_CREDITS',
+        currentBalance: affordability.balance,
+        requiredAmount: creatorCharge,
+        shortfall: creatorCharge - affordability.balance,
+      };
+    }
+  }
 
   // 9. Store user message
   const userMsgResult = await storeUserMessage(supabase, convId, content);
@@ -192,9 +211,23 @@ export async function sendAiMessage(
   }
   const assistantMessage = aiMsgResult.message;
 
-  // 12. Post-message side effects (creator-charge block stripped — see #8)
+  // 12. Post-message side effects.
   if (!hasByok) {
     await keyService.incrementPlatformUsage(userId, 1, aiResponse.totalTokens);
+  }
+
+  // 12b. Settle the charge: debit the payer's Cat Credits, credit the creator's 95% share.
+  //      Pre-authorized in step 8; idempotent on the assistant message id.
+  if (admin && creatorCharge > 0) {
+    await settleAssistantCharge(admin, {
+      payerUserId: userId,
+      creatorUserId: assistant.user_id,
+      assistantId: assistant.id,
+      messageId: (assistantMessage as { id: string }).id,
+      chargeBtc: creatorCharge,
+      model: aiResponse.model,
+      totalTokens: aiResponse.totalTokens,
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Makes the `ai_assistant` entity real end-to-end. Previously: a chat engine existed but nothing invoked it, and monetization was a `creatorCharge = 0` stub.

## Chat UI
- New `AiAssistantChat` client component on the public assistant page (`/ai-assistants/[id]`). Lazily creates a conversation and runs the exchange through the existing `/conversations/[convId]/messages` endpoint. Reuses `AIChatMessage`/`AIChatInput`, mobile-first, semantic tokens.
- Handles **unauthenticated** (sign-in CTA) and **out-of-credits** (HTTP 402 → top-up CTA) states.

## Cat Credits charging (`src/services/ai/assistant-charge.ts`)
- Replaces the stub in `sendMessage.ts`. v1 meters `free` (no charge) and `per_message` (full price, **pre-authorized** against the payer's Cat Credits before calling the model → clean `INSUFFICIENT_CREDITS`, no serve-then-fail). `per_token`/`subscription` chat free for now (structured to extend).
- Debit payer (`kind: 'usage'`, idempotent on message id, overdraw-safe via the existing atomic RPC); credit creator's **95%** share as spendable Cat Credits (`kind: 'grant'`); platform keeps 5%; best-effort `total_revenue` counter bump.
- **Safety guard:** a computed charge > 0.01 BTC is treated as a misconfigured/legacy-sats value and skipped (protects against the un-divided sats→BTC data gap).
- Updated the form copy (was "per-message charging is not currently active").

## Caveat (not a blocker)
Funding a Cat Credits balance needs Lightning top-up, gated on `PLATFORM_NWC_URI` (not yet provisioned). **Free assistants work fully today; paid assistants are wired and ready but need that wallet before users can fund.**

## Verification
- Full repo type-check: **0 errors**
- RLS verified: any authed user can converse with any active assistant; credit RPCs use the service-role client

🤖 Generated with [Claude Code](https://claude.com/claude-code)