### PR TITLE
feat(deploy): schema-drift gate — fail deploy on code↔box DB drift

### DIFF
--- a/scripts/db/audit-schema-drift.mjs
+++ b/scripts/db/audit-schema-drift.mjs
@@ -21,7 +21,11 @@ import fs from 'fs';
 import path from 'path';
 
 const ROOT = process.cwd();
-const schema = JSON.parse(fs.readFileSync('scripts/db/live-schema.json', 'utf8'));
+// Default to the committed snapshot; the deploy pipeline points this at a FRESH
+// dump of the live box (scripts/db/dump-live-schema.sh) so drift is checked
+// against the real post-migration schema, not a snapshot that can itself be stale.
+const SCHEMA_PATH = process.env.LIVE_SCHEMA_PATH || 'scripts/db/live-schema.json';
+const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
 const tableCols = Object.fromEntries(Object.entries(schema).map(([t, c]) => [t, new Set(c)]));
 
 // DATABASE_TABLES.CONST -> 'table_name'
@@ -41,6 +45,40 @@ const ALLOW = new Set([
   'wishlist_feedback.user_id', // table keys on actor_id; needs actor resolution
   'wishlist_fulfillment_proofs.user_id', // proofs have no owner column — product decision
   'group_proposals.is_public', // proposals have no public flag
+]);
+
+// Tables a resolvable `.from()` addresses by a concrete name that are EXPECTED to
+// be absent from public.information_schema.columns (so the missing-table check
+// below doesn't false-positive): cross-schema tables, RPC-only relations, etc.
+// A genuinely-missing app table (e.g. ai_conversations drifting off the box) must
+// NOT be added here — that's exactly the silent drift this check exists to catch.
+const MISSING_TABLE_ALLOW = new Set([
+  // (a) not app tables — introspection / system catalogs
+  'information_schema.columns',
+  'information_schema.tables',
+  'pg_tables',
+  'pg_proc',
+  // (b) KNOWN DRIFT — these tables are referenced by app code but are NOT on the
+  //     self-host box (surfaced 2026-06-27 when this missing-table check was added;
+  //     the box silently drifted from supabase/migrations/*, the same root cause as
+  //     the ai_conversations/ai_messages outage). Allowlisted so the deploy gate
+  //     stays GREEN for the existing backlog while still failing on any NEW missing
+  //     table. REMEDIATION = apply each table's create migration to the box (then
+  //     remove it from this list). Tracked: these features 500 in prod until fixed.
+  'group_invitations',
+  'loan_collateral',
+  'project_support',
+  'project_support_stats',
+  'project_updates',
+  'research_progress_updates',
+  'research_votes',
+  'research_contributions',
+  'channel_waitlist',
+  'wallet_ownerships',
+  'user_presence',
+  'typing_indicators',
+  'audit_logs',
+  'contracts',
 ]);
 
 const FILTER_OPS = new Set([
@@ -144,7 +182,21 @@ for (const file of walk(path.join(ROOT, 'src'))) {
   while ((fm = fromRe.exec(text))) froms.push({ idx: fm.index, arg: fm[1], end: fromRe.lastIndex });
   for (let i = 0; i < froms.length; i++) {
     const table = resolveTable(froms[i].arg);
-    if (!table || !tableCols[table]) continue; // unknown/dynamic/view → skip
+    if (!table) continue; // dynamic/variable/computed table name → can't verify
+    if (!tableCols[table]) {
+      // Resolved to a concrete table the live schema doesn't have → drift (this is
+      // the ai_conversations-class failure: code addresses a table that silently
+      // never made it onto the box). Skipped silently before; now surfaced.
+      if (!MISSING_TABLE_ALLOW.has(table)) {
+        findings.push({
+          file: path.relative(ROOT, file),
+          line: lineOf(text, froms[i].end),
+          table,
+          col: '(table missing from live schema)',
+        });
+      }
+      continue;
+    }
     const cols = tableCols[table];
     const windowEnd = i + 1 < froms.length ? froms[i + 1].idx : Math.min(text.length, froms[i].end + 1200);
     const win = text.slice(froms[i].end, windowEnd);

--- a/scripts/db/dump-live-schema.sh
+++ b/scripts/db/dump-live-schema.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Dump the self-host's LIVE public schema as { "table": ["col", ...] } JSON —
+# the exact format audit-schema-drift.mjs consumes (scripts/db/live-schema.json).
+#
+# The static snapshot in the repo goes stale; the deploy pipeline calls this to
+# get the box's ACTUAL schema (after applying pending migrations) and gate the
+# release on a fresh drift check. Includes views (information_schema.columns
+# covers them), so a missing real table is genuinely missing.
+#
+# Usage:
+#   scripts/db/dump-live-schema.sh > /tmp/live-schema.json
+#   OC_BOX=root@host scripts/db/dump-live-schema.sh > out.json
+#
+# Config: OC_BOX (default root@167.233.22.31), OC_DB_CONTAINER (default supabase-db).
+set -euo pipefail
+
+OC_BOX="${OC_BOX:-root@167.233.22.31}"
+OC_DB_CONTAINER="${OC_DB_CONTAINER:-supabase-db}"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=12)
+
+read -r -d '' SQL <<'EOSQL' || true
+SELECT COALESCE(
+  json_object_agg(table_name, cols),
+  '{}'::json
+)
+FROM (
+  SELECT table_name, json_agg(column_name ORDER BY ordinal_position) AS cols
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+  GROUP BY table_name
+) t;
+EOSQL
+
+ssh "${SSH_OPTS[@]}" "$OC_BOX" \
+  "docker exec -i $OC_DB_CONTAINER psql -U postgres -d postgres -tAc \"$(printf '%s' "$SQL" | tr '\n' ' ')\""

--- a/scripts/db/live-schema.json
+++ b/scripts/db/live-schema.json
@@ -45,7 +45,36 @@
     "updated_at",
     "published_at",
     "total_withdrawn_btc",
-    "actor_id"
+    "actor_id",
+    "show_on_profile",
+    "allowed_models",
+    "default_model",
+    "min_model_tier"
+  ],
+  "ai_conversations": [
+    "id",
+    "assistant_id",
+    "user_id",
+    "title",
+    "status",
+    "total_messages",
+    "total_tokens_used",
+    "total_cost_btc",
+    "last_message_at",
+    "created_at",
+    "updated_at"
+  ],
+  "ai_cost_analytics": [
+    "assistant_id",
+    "assistant_title",
+    "creator_id",
+    "total_messages",
+    "total_tokens",
+    "total_cost_btc",
+    "total_api_cost_btc",
+    "total_creator_earnings_btc",
+    "avg_cost_per_message",
+    "unique_users"
   ],
   "ai_creator_earnings": [
     "id",
@@ -71,6 +100,19 @@
     "created_at",
     "updated_at",
     "net_amount_btc"
+  ],
+  "ai_messages": [
+    "id",
+    "conversation_id",
+    "role",
+    "content",
+    "tokens_used",
+    "cost_btc",
+    "model_used",
+    "metadata",
+    "created_at",
+    "api_cost_btc",
+    "creator_markup_btc"
   ],
   "asset_availability": [
     "id",
@@ -175,6 +217,38 @@
     "created_at"
   ],
   "cat_conversations": ["id", "user_id", "title", "is_default", "created_at", "updated_at"],
+  "cat_credit_entries": [
+    "id",
+    "seq",
+    "user_id",
+    "kind",
+    "amount_btc",
+    "balance_after_btc",
+    "ref",
+    "metadata",
+    "created_at"
+  ],
+  "cat_credit_topups": [
+    "id",
+    "user_id",
+    "amount_btc",
+    "payment_hash",
+    "bolt11",
+    "status",
+    "created_at",
+    "expires_at",
+    "paid_at"
+  ],
+  "cat_memories": [
+    "id",
+    "user_id",
+    "content",
+    "embedding",
+    "source",
+    "source_conversation_id",
+    "created_at",
+    "updated_at"
+  ],
   "cat_messages": [
     "id",
     "conversation_id",
@@ -383,9 +457,11 @@
     "created_at",
     "updated_at",
     "actor_id",
-    "is_test"
+    "is_test",
+    "show_on_profile"
   ],
   "follows": ["id", "follower_id", "following_id", "created_at"],
+  "github_repo_cache": ["user_id", "handle", "repos", "fetched_at"],
   "group_activities": [
     "id",
     "group_id",
@@ -609,7 +685,8 @@
     "desired_rate",
     "loan_type",
     "amount",
-    "is_test"
+    "is_test",
+    "show_on_profile"
   ],
   "message_details": [
     "id",
@@ -860,7 +937,8 @@
     "creator_id",
     "group_id",
     "actor_id",
-    "is_test"
+    "is_test",
+    "show_on_profile"
   ],
   "research_entities": [
     "id",
@@ -896,8 +974,10 @@
     "is_featured",
     "search_vector",
     "metadata",
-    "actor_id"
+    "actor_id",
+    "show_on_profile"
   ],
+  "schema_migrations": ["filename", "applied_at"],
   "shipping_addresses": [
     "id",
     "user_id",
@@ -1155,7 +1235,8 @@
     "created_at",
     "updated_at",
     "actor_id",
-    "is_test"
+    "is_test",
+    "show_on_profile"
   ],
   "user_documents": [
     "id",
@@ -1217,7 +1298,8 @@
     "updated_at",
     "group_id",
     "actor_id",
-    "is_test"
+    "is_test",
+    "show_on_profile"
   ],
   "user_services": [
     "id",
@@ -1239,7 +1321,8 @@
     "updated_at",
     "group_id",
     "actor_id",
-    "is_test"
+    "is_test",
+    "show_on_profile"
   ],
   "wallets": [
     "id",
@@ -1410,6 +1493,7 @@
     "cover_image_url",
     "created_at",
     "updated_at",
-    "is_test"
+    "is_test",
+    "show_on_profile"
   ]
 }

--- a/scripts/deploy-selfhost.sh
+++ b/scripts/deploy-selfhost.sh
@@ -98,6 +98,29 @@ for mig in supabase/migrations/*.sql; do
 done
 echo "  migrations up to date"
 
+echo "=== schema-drift gate (deployed code vs LIVE box schema) ==="
+# Migrations applying is necessary but not sufficient: the box can still lack an
+# object the code needs — e.g. a migration that was backfilled-as-applied but never
+# actually ran (the ai_conversations outage), or a manual DB change. Dump the box's
+# REAL post-migration schema and fail the deploy if the code references a table/
+# column that isn't there, BEFORE the swap — turning silent prod 500s into a loud
+# deploy-time stop. Known pre-existing gaps are allowlisted in audit-schema-drift.mjs
+# so this only blocks on NEW drift. A dump failure is non-fatal (don't block deploys
+# on an ssh hiccup).
+LIVE_SCHEMA_TMP="$(mktemp)"
+if OC_BOX="$OC_BOX" bash scripts/db/dump-live-schema.sh > "$LIVE_SCHEMA_TMP" 2>/dev/null && [ -s "$LIVE_SCHEMA_TMP" ]; then
+  if ! LIVE_SCHEMA_PATH="$LIVE_SCHEMA_TMP" node scripts/db/audit-schema-drift.mjs; then
+    rm -f "$LIVE_SCHEMA_TMP"
+    echo "ERROR: schema drift — deployed code references DB objects missing from the box (above)." >&2
+    echo "       Add the missing migration (or allowlist if intentional). Aborting deploy; live release untouched." >&2
+    exit 1
+  fi
+  rm -f "$LIVE_SCHEMA_TMP"
+else
+  rm -f "$LIVE_SCHEMA_TMP"
+  echo "WARN: could not dump live schema for the drift gate — skipping (non-fatal)." >&2
+fi
+
 echo "=== boot-test + atomic swap + health-check (with rollback) ==="
 ssh "${SSH_OPTS[@]}" "$OC_BOX" \
   "BASE='$OC_APP_BASE' SVC='$OC_SERVICE' PORT='$OC_PORT' BOOT='$OC_BOOT_PORT' HEALTH='$OC_HEALTH' bash -s" <<'REMOTE'

--- a/src/services/ai/assistant-charge.ts
+++ b/src/services/ai/assistant-charge.ts
@@ -146,14 +146,13 @@ async function bumpAssistantRevenue(
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data } = await (admin.from(DATABASE_TABLES.AI_ASSISTANTS) as any)
-      .select('total_revenue, total_messages')
+      .select('total_revenue')
       .eq('id', assistantId)
       .single();
     const nextRevenue = roundBtc(Number(data?.total_revenue ?? 0) + amountBtc);
-    const nextMessages = Number(data?.total_messages ?? 0) + 1;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (admin.from(DATABASE_TABLES.AI_ASSISTANTS) as any)
-      .update({ total_revenue: nextRevenue, total_messages: nextMessages })
+      .update({ total_revenue: nextRevenue })
       .eq('id', assistantId);
   } catch (err) {
     logger.warn(


### PR DESCRIPTION
Makes the **migration auto-apply** system reliable. It already applies pending migrations, but that's necessary-not-sufficient — the box can still lack an object the code needs (a migration backfilled-as-applied but never run = the `ai_conversations` outage, or a manual change). Until now that surfaced as **silent prod 500s**. This turns drift into a **loud deploy-time stop**.

## What's added
- **`scripts/db/dump-live-schema.sh`** — dumps the box's real public schema (incl. views) as the `{table:[cols]}` JSON the auditor consumes.
- **`scripts/db/audit-schema-drift.mjs`** — (1) `LIVE_SCHEMA_PATH` env so it runs against a fresh box dump, not the stale committed snapshot; (2) **missing-table check** — a resolvable `.from()` to a table absent from the live schema is now flagged instead of silently skipped (the exact gap that hid `ai_conversations`).
- **`scripts/deploy-selfhost.sh`** — after applying migrations and **before the swap**, dump the live schema + run the auditor; abort on drift (live release untouched). Dump failure is non-fatal.
- **`scripts/db/live-schema.json`** — refreshed from the box (104 tables/views).

## Real backlog this surfaced
The check found **14 tables the code queries that are MISSING on the box** (group_invitations, project_support(_stats), project_updates, research_*, contracts, user_presence, typing_indicators, audit_logs, loan_collateral, channel_waitlist, wallet_ownerships) — those features 500 in prod. Allowlisted as **documented KNOWN DRIFT** so the gate stays green for the backlog while failing on any *new* drift. Remediation = apply each create migration (follow-up).

## Also fixes
A bug this check caught in new code: `assistant-charge` bumped `ai_assistants.total_messages`, which isn't a column on the box (only `total_revenue` is) — the update silently failed; now only `total_revenue` is bumped.

## Verification
- Auditor green against a fresh box dump (gate is safe — passes now, fails only on new drift)
- `audit:schema` green vs refreshed committed snapshot; deploy + dump scripts syntax-checked; type-check clean
- The deploy of this PR will itself exercise the new gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)