### PR TITLE
fix(db): remediate 9 of 14 drifted tables on the box

### DIFF
--- a/scripts/db/audit-schema-drift.mjs
+++ b/scripts/db/audit-schema-drift.mjs
@@ -58,27 +58,18 @@ const MISSING_TABLE_ALLOW = new Set([
   'information_schema.tables',
   'pg_tables',
   'pg_proc',
-  // (b) KNOWN DRIFT — these tables are referenced by app code but are NOT on the
-  //     self-host box (surfaced 2026-06-27 when this missing-table check was added;
-  //     the box silently drifted from supabase/migrations/*, the same root cause as
-  //     the ai_conversations/ai_messages outage). Allowlisted so the deploy gate
-  //     stays GREEN for the existing backlog while still failing on any NEW missing
-  //     table. REMEDIATION = apply each table's create migration to the box (then
-  //     remove it from this list). Tracked: these features 500 in prod until fixed.
-  'group_invitations',
-  'loan_collateral',
-  'project_support',
-  'project_support_stats',
+  // (b) KNOWN DRIFT — tables referenced by app code that have NO create migration
+  //     anywhere in supabase/migrations (surfaced 2026-06-27). Unlike the tables
+  //     already remediated, these were never defined — the code addresses a table
+  //     that doesn't exist in the schema SSOT at all (likely dead/abandoned feature
+  //     code or a stale name). Allowlisted so the deploy gate stays GREEN while they
+  //     are triaged; RESOLUTION = delete the dead code OR author a real migration,
+  //     then remove from this list. Do NOT just create these blindly.
   'project_updates',
-  'research_progress_updates',
-  'research_votes',
-  'research_contributions',
+  'audit_logs',
+  'loan_collateral',
   'channel_waitlist',
   'wallet_ownerships',
-  'user_presence',
-  'typing_indicators',
-  'audit_logs',
-  'contracts',
 ]);
 
 const FILTER_OPS = new Set([

--- a/scripts/db/live-schema.json
+++ b/scripts/db/live-schema.json
@@ -317,6 +317,21 @@
     "updated_at",
     "quality_score"
   ],
+  "contracts": [
+    "id",
+    "party_a_actor_id",
+    "party_b_actor_id",
+    "contract_type",
+    "terms",
+    "status",
+    "proposal_id",
+    "created_by",
+    "created_at",
+    "updated_at",
+    "activated_at",
+    "completed_at",
+    "terminated_at"
+  ],
   "contributions": [
     "id",
     "payment_intent_id",
@@ -499,6 +514,20 @@
     "enabled_at",
     "enabled_by"
   ],
+  "group_invitations": [
+    "id",
+    "group_id",
+    "user_id",
+    "email",
+    "token",
+    "role",
+    "message",
+    "status",
+    "invited_by",
+    "expires_at",
+    "responded_at",
+    "created_at"
+  ],
   "group_members": [
     "id",
     "group_id",
@@ -523,7 +552,8 @@
     "voting_ends_at",
     "executed_at",
     "created_at",
-    "updated_at"
+    "updated_at",
+    "is_public"
   ],
   "group_votes": ["id", "proposal_id", "voter_id", "vote", "voting_power", "voted_at"],
   "group_wallets": [
@@ -915,6 +945,31 @@
     "created_at",
     "updated_at"
   ],
+  "project_support": [
+    "id",
+    "project_id",
+    "user_id",
+    "support_type",
+    "amount_btc",
+    "transaction_hash",
+    "lightning_invoice",
+    "display_name",
+    "message",
+    "is_anonymous",
+    "reaction_emoji",
+    "created_at",
+    "updated_at"
+  ],
+  "project_support_stats": [
+    "project_id",
+    "total_bitcoin_btc",
+    "total_signatures",
+    "total_messages",
+    "total_reactions",
+    "total_supporters",
+    "last_support_at",
+    "updated_at"
+  ],
   "projects": [
     "id",
     "user_id",
@@ -939,6 +994,20 @@
     "actor_id",
     "is_test",
     "show_on_profile"
+  ],
+  "research_contributions": [
+    "id",
+    "research_entity_id",
+    "user_id",
+    "amount_btc",
+    "funding_model",
+    "message",
+    "anonymous",
+    "lightning_invoice",
+    "onchain_tx",
+    "created_at",
+    "status",
+    "confirmed_at"
   ],
   "research_entities": [
     "id",
@@ -976,6 +1045,29 @@
     "metadata",
     "actor_id",
     "show_on_profile"
+  ],
+  "research_progress_updates": [
+    "id",
+    "research_entity_id",
+    "user_id",
+    "title",
+    "description",
+    "milestone_achieved",
+    "funding_released",
+    "attachments",
+    "created_at",
+    "votes_up",
+    "votes_down",
+    "total_votes"
+  ],
+  "research_votes": [
+    "id",
+    "research_entity_id",
+    "user_id",
+    "vote_type",
+    "choice",
+    "weight",
+    "created_at"
   ],
   "schema_migrations": ["filename", "applied_at"],
   "shipping_addresses": [
@@ -1181,6 +1273,7 @@
     "created_at",
     "updated_at"
   ],
+  "typing_indicators": ["id", "conversation_id", "user_id", "started_at", "expires_at"],
   "user_ai_preferences": [
     "id",
     "user_id",
@@ -1278,6 +1371,7 @@
     "created_at",
     "updated_at"
   ],
+  "user_presence": ["user_id", "status", "last_seen_at", "updated_at"],
   "user_products": [
     "id",
     "user_id",

--- a/supabase/migrations/20260627000001_remediate_drifted_research_project_support.sql
+++ b/supabase/migrations/20260627000001_remediate_drifted_research_project_support.sql
@@ -1,0 +1,118 @@
+-- Remediate self-host drift for research sub-tables + project_support money columns.
+--
+-- These tables/columns were referenced by app code but missing/sats-only on the box
+-- (surfaced by the deploy schema-drift gate, 2026-06-27). The original create
+-- migrations couldn't replay on the drifted box (20250107000000 references
+-- research_entities.funding_goal_sats, since renamed to _btc), and the Phase B
+-- sats→btc migration (20260404000006) never covered project_support/research_*.
+-- This migration is idempotent and fresh-box-safe.
+
+-- ── Research sub-tables (research_entities already exists) ───────────────────
+CREATE TABLE IF NOT EXISTS research_progress_updates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  research_entity_id UUID NOT NULL REFERENCES research_entities(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  milestone_achieved BOOLEAN DEFAULT false,
+  funding_released BIGINT DEFAULT 0 CHECK (funding_released >= 0),
+  attachments TEXT[] DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  votes_up INTEGER DEFAULT 0,
+  votes_down INTEGER DEFAULT 0,
+  total_votes INTEGER GENERATED ALWAYS AS (votes_up + votes_down) STORED
+);
+
+CREATE TABLE IF NOT EXISTS research_votes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  research_entity_id UUID NOT NULL REFERENCES research_entities(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  vote_type TEXT NOT NULL CHECK (vote_type IN ('direction', 'priority', 'impact', 'continuation')),
+  choice TEXT NOT NULL,
+  weight DECIMAL(5,2) DEFAULT 1.00,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE (research_entity_id, user_id, vote_type)
+);
+
+CREATE TABLE IF NOT EXISTS research_contributions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  research_entity_id UUID NOT NULL REFERENCES research_entities(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES profiles(id) ON DELETE SET NULL,
+  amount_btc NUMERIC(18,8) NOT NULL CHECK (amount_btc > 0),
+  funding_model TEXT NOT NULL CHECK (funding_model IN ('donation', 'subscription', 'milestone', 'royalty')),
+  message TEXT,
+  anonymous BOOLEAN DEFAULT false,
+  lightning_invoice TEXT,
+  onchain_tx TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'failed')),
+  confirmed_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Fresh-box reconcile: if the original migration created research_contributions
+-- with a legacy amount_sats, convert it to amount_btc.
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_schema='public' AND table_name='research_contributions'
+               AND column_name='amount_sats') THEN
+    ALTER TABLE research_contributions
+      ALTER COLUMN amount_sats TYPE NUMERIC(18,8) USING COALESCE(amount_sats,0)::numeric / 100000000.0;
+    ALTER TABLE research_contributions RENAME COLUMN amount_sats TO amount_btc;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_research_progress_entity_id ON research_progress_updates(research_entity_id);
+CREATE INDEX IF NOT EXISTS idx_research_progress_created_at ON research_progress_updates(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_research_votes_entity_id ON research_votes(research_entity_id);
+CREATE INDEX IF NOT EXISTS idx_research_votes_user_id ON research_votes(user_id);
+CREATE INDEX IF NOT EXISTS idx_research_contributions_entity_id ON research_contributions(research_entity_id);
+CREATE INDEX IF NOT EXISTS idx_research_contributions_user_id ON research_contributions(user_id);
+CREATE INDEX IF NOT EXISTS idx_research_contributions_status ON research_contributions(status);
+
+ALTER TABLE research_progress_updates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE research_votes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE research_contributions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "research_progress public read" ON research_progress_updates;
+CREATE POLICY "research_progress public read" ON research_progress_updates FOR SELECT
+  USING (EXISTS (SELECT 1 FROM research_entities WHERE id = research_entity_id AND is_public = true)
+         OR EXISTS (SELECT 1 FROM research_entities WHERE id = research_entity_id AND user_id = auth.uid()));
+DROP POLICY IF EXISTS "research_progress owner write" ON research_progress_updates;
+CREATE POLICY "research_progress owner write" ON research_progress_updates FOR INSERT
+  WITH CHECK (EXISTS (SELECT 1 FROM research_entities WHERE id = research_entity_id AND user_id = auth.uid()));
+
+DROP POLICY IF EXISTS "research_votes public read" ON research_votes;
+CREATE POLICY "research_votes public read" ON research_votes FOR SELECT
+  USING (EXISTS (SELECT 1 FROM research_entities WHERE id = research_entity_id AND is_public = true));
+DROP POLICY IF EXISTS "research_votes auth insert" ON research_votes;
+CREATE POLICY "research_votes auth insert" ON research_votes FOR INSERT
+  WITH CHECK (auth.uid() IS NOT NULL
+              AND EXISTS (SELECT 1 FROM research_entities WHERE id = research_entity_id AND is_public = true));
+DROP POLICY IF EXISTS "research_votes own update" ON research_votes;
+CREATE POLICY "research_votes own update" ON research_votes FOR UPDATE USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "research_contrib read" ON research_contributions;
+CREATE POLICY "research_contrib read" ON research_contributions FOR SELECT
+  USING (auth.uid() = user_id
+         OR EXISTS (SELECT 1 FROM research_entities WHERE id = research_entity_id AND user_id = auth.uid()));
+DROP POLICY IF EXISTS "research_contrib insert" ON research_contributions;
+CREATE POLICY "research_contrib insert" ON research_contributions FOR INSERT
+  WITH CHECK (EXISTS (SELECT 1 FROM research_entities WHERE id = research_entity_id AND is_public = true));
+DROP POLICY IF EXISTS "research_contrib own update" ON research_contributions;
+CREATE POLICY "research_contrib own update" ON research_contributions FOR UPDATE USING (auth.uid() = user_id);
+
+-- ── project_support / project_support_stats: sats → btc (Phase B missed these) ─
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_schema='public' AND table_name='project_support' AND column_name='amount_sats') THEN
+    ALTER TABLE project_support
+      ALTER COLUMN amount_sats TYPE NUMERIC(18,8) USING COALESCE(amount_sats,0)::numeric / 100000000.0;
+    ALTER TABLE project_support RENAME COLUMN amount_sats TO amount_btc;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_schema='public' AND table_name='project_support_stats' AND column_name='total_bitcoin_sats') THEN
+    ALTER TABLE project_support_stats
+      ALTER COLUMN total_bitcoin_sats TYPE NUMERIC(18,8) USING COALESCE(total_bitcoin_sats,0)::numeric / 100000000.0;
+    ALTER TABLE project_support_stats RENAME COLUMN total_bitcoin_sats TO total_bitcoin_btc;
+  END IF;
+END $$;


### PR DESCRIPTION
The deploy schema-drift gate (#297) surfaced 14 tables the code queries that are missing on the self-host box. This remediates the **9 that have defined create migrations** by applying them to the box, then de-allowlists them so the gate now actively protects them.

## Remediated (applied to box + verified by re-audit)
group_invitations · contracts (also fixes `group_proposals.is_public`) · project_support · project_support_stats · research_progress_updates · research_votes · research_contributions · user_presence · typing_indicators

## How
The original create migrations were either backfilled-as-applied-but-never-run, or conflicted with later renames (`20250107000000` references `research_entities.funding_goal_sats`, since →`_btc`). So:
- **New migration `20260627000001`** creates the 3 research sub-tables at current schema (`amount_btc`) and completes the sats→btc rename for `project_support`/`project_support_stats` that Phase B (`20260404000006`) skipped. Idempotent + fresh-box-safe.
- group_invitations / contracts-retry / the `typing_indicators`+`user_presence` slice of `fix_messaging_schema` applied directly (all `IF NOT EXISTS`-guarded; the messaging slice avoids touching the working conversations/messages tables).

## Remaining (5) — NOT in this PR
`project_updates, audit_logs, loan_collateral, channel_waitlist, wallet_ownerships` have **no create migration anywhere** — net-new tables needing schema/RLS design (audit_logs is security-sensitive; wallet_ownerships is a swallowed legacy fallback). Kept allowlisted pending a design decision.

## Verification
- Auditor green against a fresh box dump with only the 5 orphans allowlisted
- `live-schema.json` refreshed from the box (113 tables/views)
- This PR's deploy re-runs the gate against the box

🤖 Generated with [Claude Code](https://claude.com/claude-code)