### PR TITLE
fix(db): remediate final 5 drifted tables — backlog now empty

### DIFF
--- a/scripts/db/audit-schema-drift.mjs
+++ b/scripts/db/audit-schema-drift.mjs
@@ -53,23 +53,14 @@ const ALLOW = new Set([
 // A genuinely-missing app table (e.g. ai_conversations drifting off the box) must
 // NOT be added here — that's exactly the silent drift this check exists to catch.
 const MISSING_TABLE_ALLOW = new Set([
-  // (a) not app tables — introspection / system catalogs
+  // Not app tables — introspection / system catalogs. (The 2026-06-27 known-drift
+  // backlog of 14 missing tables has been fully remediated: 9 by replaying their
+  // create migrations, 4 by new migrations 20260627000001/2, and wallet_ownerships
+  // by removing its dead fallback. The gate now blocks on ANY missing table.)
   'information_schema.columns',
   'information_schema.tables',
   'pg_tables',
   'pg_proc',
-  // (b) KNOWN DRIFT — tables referenced by app code that have NO create migration
-  //     anywhere in supabase/migrations (surfaced 2026-06-27). Unlike the tables
-  //     already remediated, these were never defined — the code addresses a table
-  //     that doesn't exist in the schema SSOT at all (likely dead/abandoned feature
-  //     code or a stale name). Allowlisted so the deploy gate stays GREEN while they
-  //     are triaged; RESOLUTION = delete the dead code OR author a real migration,
-  //     then remove from this list. Do NOT just create these blindly.
-  'project_updates',
-  'audit_logs',
-  'loan_collateral',
-  'channel_waitlist',
-  'wallet_ownerships',
 ]);
 
 const FILTER_OPS = new Set([

--- a/scripts/db/live-schema.json
+++ b/scripts/db/live-schema.json
@@ -157,6 +157,19 @@
     "show_on_profile",
     "is_test"
   ],
+  "audit_logs": [
+    "id",
+    "action",
+    "user_id",
+    "entity_type",
+    "entity_id",
+    "metadata",
+    "ip_address",
+    "user_agent",
+    "success",
+    "error_message",
+    "created_at"
+  ],
   "availability_slots": [
     "id",
     "service_id",
@@ -288,6 +301,7 @@
     "created_at",
     "updated_at"
   ],
+  "channel_waitlist": ["id", "email", "user_id", "source", "referrer", "created_at"],
   "community_timeline_no_duplicates": [
     "id",
     "event_type",
@@ -647,6 +661,16 @@
     "is_test"
   ],
   "loan_categories": ["id", "name", "description", "icon", "is_active", "created_at", "updated_at"],
+  "loan_collateral": [
+    "id",
+    "loan_id",
+    "asset_id",
+    "owner_id",
+    "pledged_value",
+    "currency",
+    "status",
+    "created_at"
+  ],
   "loan_offers": [
     "id",
     "loan_id",
@@ -970,6 +994,7 @@
     "last_support_at",
     "updated_at"
   ],
+  "project_updates": ["id", "project_id", "type", "title", "content", "amount_btc", "created_at"],
   "projects": [
     "id",
     "user_id",

--- a/src/app/profiles/[username]/page.tsx
+++ b/src/app/profiles/[username]/page.tsx
@@ -210,22 +210,11 @@ export default async function PublicProfilePage({ params }: PageProps) {
     })) as { data: Array<{ is_active: boolean }> | null };
     walletCount = walletData ? walletData.filter(w => w.is_active).length : 0;
   } catch {
-    // Fallback: try querying wallet_ownerships table directly
-    try {
-      const { count } = await (
-        supabase
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .from(DATABASE_TABLES.WALLET_OWNERSHIPS) as any
-      )
-        .select('*', { count: 'exact', head: true })
-        .eq('owner_type', 'profile')
-        .eq('owner_id', profile.id)
-        .eq('is_active', true);
-      walletCount = count || 0;
-    } catch {
-      // Wallet architecture not fully migrated - this is expected during transition
-      // walletCount remains 0
-    }
+    // get_entity_wallets is the current wallet architecture; if it errs we just show
+    // 0 (legacy receive addresses are still counted below). The old wallet_ownerships
+    // fallback was removed — that table was never migrated onto the box and the
+    // try/catch silently swallowed its absence, so it never contributed a count.
+    walletCount = 0;
   }
 
   // A profile's legacy single bitcoin_address / lightning_address is a real way to

--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -50,7 +50,6 @@ export const DATABASE_TABLES = {
 
   // Wallets & Transactions
   WALLETS: 'wallets',
-  WALLET_OWNERSHIPS: 'wallet_ownerships',
   ENTITY_WALLETS: 'entity_wallets',
   TRANSACTIONS: 'transactions',
 

--- a/supabase/migrations/20260627000002_create_orphan_feature_tables.sql
+++ b/supabase/migrations/20260627000002_create_orphan_feature_tables.sql
@@ -1,0 +1,92 @@
+-- Create 4 feature tables the app code references but that had NO create migration
+-- anywhere (surfaced by the deploy schema-drift gate, 2026-06-27). Schemas are derived
+-- from each table's actual insert/select in the code; RLS is a conservative default
+-- (append-only / owner-scoped) following the codebase's established patterns.
+-- Idempotent (CREATE TABLE IF NOT EXISTS + DROP POLICY IF EXISTS).
+
+-- ── channel_waitlist ── (src/app/api/waitlist/route.ts) ──────────────────────
+-- Public waitlist signups; may be anonymous (user_id nullable). Email is PII →
+-- append-only, no public read.
+CREATE TABLE IF NOT EXISTS channel_waitlist (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email text NOT NULL,
+  user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  source text DEFAULT 'channel_page',
+  referrer text,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE (email)
+);
+CREATE INDEX IF NOT EXISTS idx_channel_waitlist_created_at ON channel_waitlist(created_at DESC);
+ALTER TABLE channel_waitlist ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "anyone can join the waitlist" ON channel_waitlist;
+CREATE POLICY "anyone can join the waitlist" ON channel_waitlist FOR INSERT WITH CHECK (true);
+-- No SELECT policy → rows readable only via the service role (protects emails).
+
+-- ── loan_collateral ── (src/app/api/loan-collateral/route.ts) ────────────────
+-- Links an asset pledged as collateral to a loan; owner-scoped. loan_id/asset_id
+-- left without FKs (their owning tables are resolved via the entity registry and
+-- ownership is validated in the route, not the schema).
+CREATE TABLE IF NOT EXISTS loan_collateral (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  loan_id uuid NOT NULL,
+  asset_id uuid NOT NULL,
+  owner_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  pledged_value numeric,
+  currency text,
+  status text DEFAULT 'pending' CHECK (status IN ('pending', 'active', 'released', 'liquidated')),
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_loan_collateral_loan ON loan_collateral(loan_id);
+CREATE INDEX IF NOT EXISTS idx_loan_collateral_asset ON loan_collateral(asset_id);
+CREATE INDEX IF NOT EXISTS idx_loan_collateral_owner ON loan_collateral(owner_id);
+ALTER TABLE loan_collateral ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "owner reads own collateral" ON loan_collateral;
+CREATE POLICY "owner reads own collateral" ON loan_collateral FOR SELECT USING (owner_id = auth.uid());
+DROP POLICY IF EXISTS "owner pledges own collateral" ON loan_collateral;
+CREATE POLICY "owner pledges own collateral" ON loan_collateral FOR INSERT WITH CHECK (owner_id = auth.uid());
+DROP POLICY IF EXISTS "owner updates own collateral" ON loan_collateral;
+CREATE POLICY "owner updates own collateral" ON loan_collateral FOR UPDATE USING (owner_id = auth.uid());
+
+-- ── project_updates ── (src/app/api/projects/[id]/updates/route.ts) ──────────
+-- Activity/updates posted against a project. The read route already gates by
+-- project status, so public read is fine; writes require an authenticated user.
+CREATE TABLE IF NOT EXISTS project_updates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  type text,
+  title text,
+  content text,
+  amount_btc numeric(18,8),
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_project_updates_project ON project_updates(project_id, created_at DESC);
+ALTER TABLE project_updates ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "project updates public read" ON project_updates;
+CREATE POLICY "project updates public read" ON project_updates FOR SELECT USING (true);
+DROP POLICY IF EXISTS "authenticated can post updates" ON project_updates;
+CREATE POLICY "authenticated can post updates" ON project_updates FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+
+-- ── audit_logs ── (src/lib/api/auditLog.ts) ─────────────────────────────────
+-- Append-only security/audit trail. entity_id is text (callers pass ids of mixed
+-- shapes). Sensitive → insert allowed, but NO read policy (service-role only).
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  action text NOT NULL,
+  user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  entity_type text,
+  entity_id text,
+  metadata jsonb DEFAULT '{}',
+  ip_address text,
+  user_agent text,
+  success boolean DEFAULT true,
+  error_message text,
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_user ON audit_logs(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs(action);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_entity ON audit_logs(entity_type, entity_id);
+ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "append audit rows" ON audit_logs;
+CREATE POLICY "append audit rows" ON audit_logs FOR INSERT WITH CHECK (true);
+-- No SELECT/UPDATE/DELETE policy → the trail is append-only and readable only via
+-- the service role.


### PR DESCRIPTION
Completes the schema-drift remediation surfaced by the deploy gate (#297). The 5 orphan tables (no create migration anywhere) are resolved → **the known-drift allowlist is now empty**.

## Created (new migration `20260627000002`, applied to box)
Schemas derived from each table's actual insert/select; conservative RLS:
- **channel_waitlist** — append-only, no public read (emails are PII)
- **loan_collateral** — owner-scoped read/write
- **project_updates** — public read (route already gates by project status), authed write
- **audit_logs** — append-only, no read policy (service-role only)

## Removed as dead code
- **wallet_ownerships** — a swallowed try/catch fallback behind the current `get_entity_wallets` RPC, querying a table that never existed (always 0). Removed the fallback + the orphan `DATABASE_TABLES.WALLET_OWNERSHIPS` constant.

## Result
`audit-schema-drift.mjs` known-drift allowlist is now **empty** — the deploy gate blocks on ANY missing table. Auditor green against a fresh box dump with zero allowlisted app tables. `live-schema.json` refreshed (117 tables/views). Type-check clean.

All 14 originally-missing tables now present (or their dead code removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)