### PR TITLE
feat(audit): log every entity creation to audit_logs

### DIFF
--- a/src/lib/api/auditLog.ts
+++ b/src/lib/api/auditLog.ts
@@ -36,6 +36,11 @@ export const AUDIT_ACTIONS = {
   PROFILE_UPDATED: 'PROFILE_UPDATED',
   PROFILE_DELETED: 'PROFILE_DELETED',
 
+  // Entities (generic — any registry entity type; the specific type is in entityType)
+  ENTITY_CREATED: 'ENTITY_CREATED',
+  ENTITY_UPDATED: 'ENTITY_UPDATED',
+  ENTITY_DELETED: 'ENTITY_DELETED',
+
   // Projects
   PROJECT_CREATED: 'PROJECT_CREATED',
   PROJECT_UPDATED: 'PROJECT_UPDATED',
@@ -76,7 +81,9 @@ type AuditAction = (typeof AUDIT_ACTIONS)[keyof typeof AUDIT_ACTIONS];
 interface AuditLogEntry {
   action: AuditAction;
   userId: string | null;
-  entityType?: 'profile' | 'project' | 'wallet' | 'post' | 'donation' | 'other';
+  /** Any registry entity type (product, service, project, …) or profile/wallet/etc.
+   *  Stored in the audit_logs.entity_type text column. */
+  entityType?: string;
   entityId?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   metadata?: Record<string, any>;

--- a/src/lib/api/entityPostHandler.ts
+++ b/src/lib/api/entityPostHandler.ts
@@ -54,6 +54,7 @@ import {
   waitForIdempotencyResult,
 } from '@/services/idempotency/idempotencyResults';
 import { enqueueWebhookEvent } from '@/services/webhooks/deliveryService';
+import { auditLog, AUDIT_ACTIONS } from '@/lib/api/auditLog';
 
 // Type for the awaited Supabase client
 type SupabaseClient = Awaited<ReturnType<typeof createServerClient>>;
@@ -313,6 +314,21 @@ export function createEntityPostHandler(config: EntityPostHandlerConfig) {
         }
       }
 
+      // Fire-and-forget audit trail for every successful entity creation. Never
+      // blocks or fails the response (auditLog swallows its own errors). One place
+      // here covers all 10+ factory-based create routes (DRY).
+      const recordAudit = (entityId: string): void => {
+        void auditLog({
+          action: AUDIT_ACTIONS.ENTITY_CREATED,
+          userId,
+          entityType,
+          entityId,
+          metadata: { actorId: resolvedActor.id, source: auth.source },
+          ipAddress: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || undefined,
+          userAgent: request.headers.get('user-agent') || undefined,
+        });
+      };
+
       // Use custom creation function if provided (for domain services).
       // Pass the resolved actor on the body's `_resolved_actor_id` side
       // channel — domain/base/entityService.ts unwraps it.
@@ -324,6 +340,7 @@ export function createEntityPostHandler(config: EntityPostHandlerConfig) {
         };
         const entity = await createEntity(userId, bodyForCreate, supabase);
         logger.info(`${meta.name} created successfully`, { [`${entityType}Id`]: entity.id });
+        recordAudit(entity.id as string);
         // Fire-and-forget: never block the user response on webhook
         // enqueue. enqueueWebhookEvent swallows its own errors.
         void enqueueWebhookEvent({
@@ -417,6 +434,7 @@ export function createEntityPostHandler(config: EntityPostHandlerConfig) {
 
       const createdEntity = entity as { id: string } & Record<string, unknown>;
       logger.info(`${meta.name} created successfully`, { [`${entityType}Id`]: createdEntity.id });
+      recordAudit(createdEntity.id);
 
       // Link wallet to entity if _wallet_id was provided (non-fatal)
       if (walletIdForLink && createdEntity.id) {


### PR DESCRIPTION
`audit_logs` existed but had **zero callers** — dormant infrastructure. This wires the `auditLog()` helper into the generic entity POST handler so every entity created through the factory (all 10+ create routes) writes an audit row.

- Fire-and-forget (`void`) at both success paths (custom `createEntity` + default insert); `auditLog` swallows its own errors so it never blocks/fails creation.
- Records `ENTITY_CREATED`, the entity type + id, resolved actor, auth source, and request IP / user-agent.
- `auditLog.ts`: added generic `ENTITY_CREATED/UPDATED/DELETED` actions and widened `entityType` to `string` (the `audit_logs.entity_type` column is text). No existing callers to break.

Single chokepoint = DRY (covers product/service/project/cause/event/asset/loan/investment/research/wishlist…).

Type-check clean. Will verify in-browser post-deploy by creating an entity and checking the audit row lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)