### PR TITLE
feat(cat): post_to_timeline actually links the promoted entity

### DIFF
--- a/src/config/cat-actions.ts
+++ b/src/config/cat-actions.ts
@@ -619,7 +619,14 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
         name: 'entity_id',
         type: 'entity_id',
         required: false,
-        description: 'Entity to link/promote',
+        description: 'Entity to link/promote (pass entity_type too)',
+      },
+      {
+        name: 'entity_type',
+        type: 'string',
+        required: false,
+        description:
+          'Type of the linked entity (project, product, cause, event, …) — required when entity_id is set',
       },
     ],
     examples: [

--- a/src/services/cat/handlers/communication.ts
+++ b/src/services/cat/handlers/communication.ts
@@ -1,24 +1,35 @@
 import { DATABASE_TABLES } from '@/config/database-tables';
+import { isValidEntityType } from '@/config/entity-registry';
 import type { ActionHandler } from './types';
 
 export const communicationHandlers: Record<string, ActionHandler> = {
   post_to_timeline: async (supabase, _userId, actorId, params) => {
     // timeline_events schema: event_type, event_subtype, subject_type (all required),
-    // title (required), description (text), content (jsonb { text: ... })
-    // No entity_id column — not timeline_posts (which doesn't exist).
+    // title (required), description (text), content (jsonb { text: ... }).
+    // An entity is LINKED via subject_type/subject_id — the post is "about" that
+    // entity — so "promote my project" surfaces the project on the feed instead of
+    // an unlinked blurb. Plain posts subject the author's own profile.
     const text = (params.content as string) || '';
     const title = text.length > 100 ? text.slice(0, 97) + '…' : text;
+
+    const entityId = params.entity_id as string | undefined;
+    const entityType = params.entity_type as string | undefined;
+    const linkEntity = !!entityId && !!entityType && isValidEntityType(entityType);
 
     const { data, error } = await supabase
       .from(DATABASE_TABLES.TIMELINE_EVENTS)
       .insert({
         actor_id: actorId,
         event_type: 'post',
-        event_subtype: 'text',
-        subject_type: 'profile',
+        event_subtype: linkEntity ? 'promotion' : 'text',
+        subject_type: linkEntity ? entityType : 'profile',
+        subject_id: linkEntity ? entityId : null,
         title,
         description: text,
-        content: { text },
+        content: {
+          text,
+          ...(linkEntity ? { linked_entity: { type: entityType, id: entityId } } : {}),
+        },
         visibility: (params.visibility as string) || 'public',
       })
       .select()
@@ -28,9 +39,12 @@ export const communicationHandlers: Record<string, ActionHandler> = {
       return { success: false, error: error.message };
     }
     const snippet = text.length > 60 ? text.slice(0, 57) + '…' : text;
+    const displayMessage = linkEntity
+      ? `📢 Promoted your ${entityType} to the timeline: "${snippet}"`
+      : `📢 Posted to timeline: "${snippet}"`;
     return {
       success: true,
-      data: { ...data, displayMessage: `📢 Posted to timeline: "${snippet}"` },
+      data: { ...data, displayMessage },
     };
   },
 

--- a/supabase/migrations/20260627000003_timeline_subject_type_allow_entities.sql
+++ b/supabase/migrations/20260627000003_timeline_subject_type_allow_entities.sql
@@ -1,0 +1,17 @@
+-- Let any registry entity type be a timeline_events.subject — so Cat's
+-- post_to_timeline can actually LINK the entity it promotes (project, product,
+-- cause, event, …) instead of discarding entity_id. The old CHECK only allowed
+-- {project, profile, organization, transaction, comment, event, achievement,
+-- system}, which silently blocked linking products/causes/services/etc.
+-- Idempotent: drop + recreate the named constraint.
+
+ALTER TABLE timeline_events DROP CONSTRAINT IF EXISTS timeline_events_subject_type_check;
+
+ALTER TABLE timeline_events ADD CONSTRAINT timeline_events_subject_type_check
+  CHECK (subject_type = ANY (ARRAY[
+    -- non-entity subjects (kept from the original constraint)
+    'profile', 'organization', 'transaction', 'comment', 'achievement', 'system',
+    -- all registry entity types (src/config/entity-registry.ts ENTITY_TYPES)
+    'wallet', 'project', 'product', 'service', 'cause', 'ai_assistant', 'group',
+    'asset', 'loan', 'investment', 'event', 'research', 'wishlist', 'document'
+  ]::text[]));


### PR DESCRIPTION
Cat's `post_to_timeline` accepted an `entity_id` but **discarded it** ("No entity_id column") — so "promote my project" produced an unlinked text blurb (flagged in the original audit).

## Fix
- timeline_events links an entity via the existing **`subject_type`/`subject_id`** columns. The `subject_type` CHECK only allowed `{project, profile, organization, …}`, silently blocking product/cause/service/etc. **Migration `20260627000003`** broadens it to every registry entity type (idempotent). Applied to the box.
- Handler: when `entity_id` + `entity_type` are passed (valid registry type), sets `subject_type`/`subject_id` to the entity + records `linked_entity` in content; else a plain profile-subject post as before. `event_type` stays `'post'` (feed RPCs filter on it).
- Added the `entity_type` param to the cat-actions definition so Cat passes it.

Projects already render richly on the feed (`enriched_timeline_events` handles project subjects), so **promoting a project now surfaces a real linked card**; other types store the structural link for richer rendering later.

Type-check clean. Migration applied; the deploy's drift gate verifies the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)