### PR TITLE
fix(ui): mobile-responsive group filter selects

### DIFF
--- a/src/components/groups/events/EventsList.tsx
+++ b/src/components/groups/events/EventsList.tsx
@@ -143,7 +143,7 @@ export function EventsList({ groupId, groupSlug, canCreateEvent = false }: Event
 
       <div className="flex items-center gap-4">
         <Select value={statusFilter} onValueChange={v => setStatusFilter(v as EventStatusFilter)}>
-          <SelectTrigger className="w-[180px]">
+          <SelectTrigger className="w-full sm:w-[180px]">
             <SelectValue placeholder="Filter by status" />
           </SelectTrigger>
           <SelectContent>

--- a/src/components/groups/proposals/ProposalsList.tsx
+++ b/src/components/groups/proposals/ProposalsList.tsx
@@ -159,7 +159,7 @@ export function ProposalsList({
             value={statusFilter}
             onValueChange={value => setStatusFilter(value as ProposalStatusFilter)}
           >
-            <SelectTrigger className="w-[140px]">
+            <SelectTrigger className="w-full sm:w-[140px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
The proposals + events filter `SelectTrigger`s had fixed widths (`w-[140px]` / `w-[180px]`) with no mobile fallback — cramped on narrow screens. Now `w-full sm:w-[…]` (fill on mobile, fixed at sm+). Clears the last items from the mobile-first audit's select-width findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)