### PR TITLE
feat(circle): add circle as a full entity type

### DIFF
--- a/scripts/db/live-schema.json
+++ b/scripts/db/live-schema.json
@@ -302,6 +302,21 @@
     "updated_at"
   ],
   "channel_waitlist": ["id", "email", "user_id", "source", "referrer", "created_at"],
+  "circles": [
+    "id",
+    "actor_id",
+    "title",
+    "description",
+    "category",
+    "visibility",
+    "cover_image_url",
+    "tags",
+    "status",
+    "member_count",
+    "is_test",
+    "created_at",
+    "updated_at"
+  ],
   "community_timeline_no_duplicates": [
     "id",
     "event_type",

--- a/src/app/(authenticated)/dashboard/circles/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/circles/[id]/page.tsx
@@ -1,0 +1,27 @@
+import EntityDetailPage from '@/components/entity/EntityDetailPage';
+import { circleEntityConfig, type CircleListItem } from '@/config/entities/circles';
+import { capitalize } from '@/utils/string';
+
+interface CircleDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function CircleDetailPage({ params }: CircleDetailPageProps) {
+  const { id } = await params;
+
+  return (
+    <EntityDetailPage<CircleListItem>
+      config={circleEntityConfig}
+      entityId={id}
+      requireAuth={false}
+      makeDetailFields={circle => ({
+        left: [
+          { label: 'Category', value: circle.category || '—' },
+          { label: 'Visibility', value: capitalize(circle.visibility || 'public') },
+          { label: 'Members', value: String(circle.member_count ?? 0) },
+        ],
+        right: [],
+      })}
+    />
+  );
+}

--- a/src/app/(authenticated)/dashboard/circles/create/page.tsx
+++ b/src/app/(authenticated)/dashboard/circles/create/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { EntityCreateEditPage } from '@/components/create/EntityCreateEditPage';
+import { circleConfig } from '@/config/entity-configs';
+import type { CircleFormData } from '@/lib/validation';
+
+export default function CreateCirclePage() {
+  return <EntityCreateEditPage<CircleFormData> entityType="circle" config={circleConfig} />;
+}

--- a/src/app/(authenticated)/dashboard/circles/page.tsx
+++ b/src/app/(authenticated)/dashboard/circles/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import EntityDashboardPage from '@/components/entity/EntityDashboardPage';
+import { circleEntityConfig, type CircleListItem } from '@/config/entities/circles';
+
+/**
+ * Circles Dashboard Page — create and manage lightweight communities.
+ */
+export default function CirclesPage() {
+  return (
+    <EntityDashboardPage<CircleListItem>
+      config={circleEntityConfig}
+      title="My Circles"
+      description="Create and manage lightweight communities for people who share an interest"
+      createButtonLabel="Start a Circle"
+    />
+  );
+}

--- a/src/app/api/circles/[id]/route.ts
+++ b/src/app/api/circles/[id]/route.ts
@@ -1,0 +1,32 @@
+/**
+ * Circle CRUD API Routes (GET/PUT/DELETE by id).
+ * Generic CRUD handler; entity metadata from entity-registry (SSOT).
+ */
+
+import { circleSchema } from '@/lib/validation';
+import { createEntityCrudHandlers } from '@/lib/api/entityCrudHandler';
+import {
+  createUpdatePayloadBuilder,
+  commonFieldMappings,
+  entityTransforms,
+} from '@/lib/api/buildUpdatePayload';
+
+const buildCircleUpdatePayload = createUpdatePayloadBuilder([
+  { from: 'title' },
+  { from: 'description', transform: entityTransforms.emptyStringToNull },
+  { from: 'category', transform: entityTransforms.emptyStringToNull },
+  { from: 'visibility' },
+  { from: 'cover_image_url', transform: entityTransforms.emptyStringToNull },
+  commonFieldMappings.arrayField('tags', []),
+  { from: 'status', default: 'active' },
+]);
+
+const { GET, PUT, DELETE } = createEntityCrudHandlers({
+  entityType: 'circle',
+  schema: circleSchema,
+  buildUpdatePayload: buildCircleUpdatePayload,
+  ownershipField: 'actor_id',
+  useActorOwnership: true,
+});
+
+export { GET, PUT, DELETE };

--- a/src/app/api/circles/route.ts
+++ b/src/app/api/circles/route.ts
@@ -1,0 +1,21 @@
+/**
+ * Circle API Routes — list + create.
+ * Generic handlers; entity metadata from entity-registry (SSOT).
+ */
+
+import { circleSchema } from '@/lib/validation';
+import { createEntityListHandler } from '@/lib/api/entityListHandler';
+import { createEntityPostHandler } from '@/lib/api/entityPostHandler';
+
+// GET /api/circles - the authenticated actor's circles (plus public ones via RLS).
+export const GET = createEntityListHandler({
+  entityType: 'circle',
+  userIdField: 'actor_id',
+});
+
+// POST /api/circles - create a circle (actor-owned).
+export const POST = createEntityPostHandler({
+  entityType: 'circle',
+  schema: circleSchema,
+  useActorOwnership: true,
+});

--- a/src/app/api/profiles/[userId]/entities/[entityType]/route.ts
+++ b/src/app/api/profiles/[userId]/entities/[entityType]/route.ts
@@ -38,6 +38,7 @@ const ENTITY_COLUMNS: Record<EntityType, string> = {
     'id, title, description, event_type, category, start_date, end_date, venue_name, venue_city, is_online, status, ticket_price, is_free, currency, created_at',
   wallet: 'id, label, wallet_type, address, is_active, created_at',
   group: 'id, name, slug, description, is_public, created_at',
+  circle: 'id, title, description, category, visibility, tags, member_count, created_at',
   research:
     'id, title, description, field, methodology, expected_outcome, funding_goal_btc, funding_raised_btc, status, created_at',
   wishlist:
@@ -58,6 +59,7 @@ const USER_ID_FIELD: Record<EntityType, string> = {
   event: 'actor_id',
   wallet: 'profile_id',
   group: 'created_by',
+  circle: 'actor_id',
   research: 'user_id',
   wishlist: 'actor_id',
   document: 'actor_id',

--- a/src/app/circles/[id]/page.tsx
+++ b/src/app/circles/[id]/page.tsx
@@ -1,0 +1,45 @@
+import { Metadata } from 'next';
+import { generateEntityMetadata } from '@/lib/seo/metadata';
+import PublicEntityDetailPage, {
+  fetchEntityForMetadata,
+  type EntityDetailConfig,
+} from '@/components/public/PublicEntityDetailPage';
+import { Badge } from '@/components/ui/badge';
+import { ROUTES } from '@/config/routes';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+const config: EntityDetailConfig = {
+  entityType: 'circle',
+  ownerLabel: 'Created by',
+  descriptionTitle: 'About this Circle',
+  metadataSelect: 'title, description',
+  getViewRoute: id => ROUTES.CIRCLES.VIEW(id),
+  renderHeaderExtra: entity =>
+    entity.category ? (
+      <Badge variant="outline" className="capitalize">
+        {entity.category as string}
+      </Badge>
+    ) : null,
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const entity = await fetchEntityForMetadata('circle', id, 'title, description');
+  if (!entity) {
+    return { title: 'Circle Not Found' };
+  }
+  return generateEntityMetadata({
+    type: 'circle',
+    id,
+    title: entity.title,
+    description: entity.description,
+  });
+}
+
+export default async function PublicCirclePage({ params }: PageProps) {
+  const { id } = await params;
+  return <PublicEntityDetailPage id={id} config={config} />;
+}

--- a/src/app/circles/page.tsx
+++ b/src/app/circles/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+import { ROUTES } from '@/config/routes';
+
+export default function CirclesPage() {
+  redirect(ROUTES.DISCOVER_TYPE('circles'));
+}

--- a/src/config/entities/circles.tsx
+++ b/src/config/entities/circles.tsx
@@ -1,0 +1,62 @@
+/**
+ * CIRCLE ENTITY CONFIGURATION
+ *
+ * Configuration for displaying circles in list views and the dashboard.
+ */
+
+import { EntityConfig } from '@/types/entity';
+import { ENTITY_REGISTRY } from '@/config/entity-registry';
+
+export interface CircleListItem {
+  id: string;
+  title: string;
+  description: string | null;
+  category: string | null;
+  visibility: string;
+  tags: string[];
+  member_count: number;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export const circleEntityConfig: EntityConfig<CircleListItem> = {
+  name: ENTITY_REGISTRY['circle'].name,
+  namePlural: ENTITY_REGISTRY['circle'].namePlural,
+  colorTheme: ENTITY_REGISTRY['circle'].colorTheme,
+
+  listPath: ENTITY_REGISTRY['circle'].basePath,
+  detailPath: id => `${ENTITY_REGISTRY['circle'].basePath}/${id}`,
+  createPath: ENTITY_REGISTRY['circle'].createPath,
+  editPath: id => `${ENTITY_REGISTRY['circle'].createPath}?edit=${id}`,
+
+  entityType: ENTITY_REGISTRY['circle'].type,
+  apiEndpoint: ENTITY_REGISTRY['circle'].apiEndpoint,
+
+  makeHref: item => `${ENTITY_REGISTRY['circle'].basePath}/${item.id}`,
+
+  makeCardProps: item => ({
+    badge: item.category || 'Circle',
+    status: item.visibility === 'private' ? 'private' : 'active',
+    showEditButton: true,
+    editHref: `${ENTITY_REGISTRY['circle'].createPath}?edit=${item.id}`,
+    metadata: (
+      <div className="flex flex-wrap gap-2 text-xs text-fg-secondary">
+        {item.category && <span>{item.category}</span>}
+        <span className="capitalize">{item.visibility}</span>
+        {item.member_count > 0 && <span>{item.member_count} members</span>}
+      </div>
+    ),
+  }),
+
+  emptyState: {
+    title: 'No circles yet',
+    description: 'Start a circle to gather people around a shared interest.',
+  },
+
+  gridCols: {
+    mobile: 1,
+    tablet: 2,
+    desktop: 3,
+  },
+};

--- a/src/config/entity-configs/circle-config.ts
+++ b/src/config/entity-configs/circle-config.ts
@@ -1,0 +1,104 @@
+/**
+ * CIRCLE ENTITY CONFIGURATION (FORM)
+ *
+ * Form structure for creating a circle — a lightweight community (no treasury or
+ * governance, unlike a group).
+ */
+
+import { CircleDashed } from 'lucide-react';
+import { circleSchema, type CircleFormData } from '@/lib/validation';
+import type { FieldGroup } from '@/components/create/types';
+import { createEntityConfig } from './base-config-factory';
+
+const fieldGroups: FieldGroup[] = [
+  {
+    id: 'basic',
+    title: 'Basic Information',
+    description: 'Name your circle and describe what it’s about',
+    fields: [
+      {
+        name: 'title',
+        label: 'Circle Name',
+        type: 'text',
+        placeholder: 'e.g., Bitcoin Builders Berlin',
+        required: true,
+        colSpan: 2,
+      },
+      {
+        name: 'description',
+        label: 'Description',
+        type: 'textarea',
+        placeholder: 'What is this circle about? Who is it for?',
+        rows: 5,
+        colSpan: 2,
+      },
+    ],
+  },
+  {
+    id: 'settings',
+    title: 'Settings',
+    description: 'Categorize your circle and choose who can see it',
+    fields: [
+      {
+        name: 'category',
+        label: 'Topic / Category',
+        type: 'text',
+        placeholder: 'e.g., Bitcoin, Art, Local',
+        colSpan: 1,
+      },
+      {
+        name: 'visibility',
+        label: 'Visibility',
+        type: 'select',
+        required: true,
+        options: [
+          { value: 'public', label: 'Public' },
+          { value: 'unlisted', label: 'Unlisted' },
+          { value: 'private', label: 'Private' },
+        ],
+        colSpan: 1,
+      },
+      {
+        name: 'tags',
+        label: 'Tags',
+        type: 'tags',
+        placeholder: 'Add tags (press Enter after each)',
+        colSpan: 2,
+      },
+    ],
+  },
+];
+
+export const circleConfig = createEntityConfig<CircleFormData>({
+  entityType: 'circle',
+  name: 'Circle',
+  namePlural: 'Circles',
+  icon: CircleDashed,
+  colorTheme: 'tiffany',
+  pageTitle: 'Start a Circle',
+  pageDescription: 'Create a lightweight community for people who share an interest.',
+  formTitle: 'Circle Details',
+  formDescription: 'Tell people what your circle is about',
+  fieldGroups,
+  validationSchema: circleSchema,
+  defaultValues: {
+    title: '',
+    description: '',
+    category: '',
+    visibility: 'public',
+    tags: [],
+    status: 'active',
+  },
+  guidanceContent: {},
+  defaultGuidance: {
+    title: 'Build your community',
+    description:
+      'Circles are lightweight communities — no treasury or governance, just people who share an interest.',
+    features: [
+      { icon: '🔵', text: 'Gather people around a shared interest' },
+      { icon: '🌍', text: 'Public, unlisted, or private' },
+      { icon: '🏷️', text: 'Tag and categorize so others can discover it' },
+    ],
+  },
+  successMessage: 'Circle created.',
+});

--- a/src/config/entity-configs/get-config.ts
+++ b/src/config/entity-configs/get-config.ts
@@ -23,13 +23,13 @@ import { groupConfig } from './group-config';
 import { wishlistConfig } from './wishlist-config';
 import { researchWizardConfig } from './research-wizard-config';
 import { documentFormConfig } from './document-form-config';
+import { circleConfig } from './circle-config';
 
 /**
  * Map of entity types to their configurations
  *
  * Note: Only includes entity types that are defined in ENTITY_TYPES
- * from entity-registry.ts. Some configs (circle, organization) exist
- * but their entity types are not in the registry.
+ * from entity-registry.ts.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ENTITY_CONFIGS: Partial<Record<EntityType, EntityConfig<any>>> = {
@@ -46,6 +46,7 @@ const ENTITY_CONFIGS: Partial<Record<EntityType, EntityConfig<any>>> = {
   wishlist: wishlistConfig,
   research: researchWizardConfig,
   document: documentFormConfig,
+  circle: circleConfig,
 };
 
 /**

--- a/src/config/entity-configs/index.ts
+++ b/src/config/entity-configs/index.ts
@@ -23,6 +23,7 @@ export { wishlistConfig } from './wishlist-config';
 export { researchWizardConfig } from './research-wizard-config';
 export type { ResearchWizardFormData } from './research-wizard-config';
 export { documentFormConfig } from './document-form-config';
+export { circleConfig } from './circle-config';
 
 // Re-export types
 export type { EntityConfig, FieldGroup, FieldConfig } from '@/components/create/types';

--- a/src/config/entity-registry.ts
+++ b/src/config/entity-registry.ts
@@ -35,6 +35,7 @@ import {
   FileText,
   TrendingUp,
   FlaskConical,
+  CircleDashed,
 } from 'lucide-react';
 
 // ==================== ENTITY TYPES ====================
@@ -50,6 +51,7 @@ export const ENTITY_TYPES = [
   'cause',
   'ai_assistant',
   'group',
+  'circle',
   'asset',
   'loan',
   'investment',
@@ -270,6 +272,25 @@ export const ENTITY_REGISTRY: Record<EntityType, EntityMetadata> = {
     createActionLabel: 'Start a community group',
     category: 'community',
     createPriority: 1,
+    paymentPattern: 'none',
+  },
+  circle: {
+    type: 'circle',
+    name: 'Circle',
+    namePlural: 'Circles',
+    tableName: 'circles',
+    userIdField: 'actor_id',
+    icon: CircleDashed,
+    colorTheme: 'tiffany',
+    basePath: '/dashboard/circles',
+    createPath: '/dashboard/circles/create',
+    publicBasePath: '/circles',
+    apiEndpoint: '/api/circles',
+    hasTemplates: false,
+    description: 'Lightweight communities and interest circles',
+    createActionLabel: 'Start a circle',
+    category: 'community',
+    createPriority: 2,
     paymentPattern: 'none',
   },
 

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -308,6 +308,9 @@ export const ROUTES = {
   CAUSES: {
     VIEW: (id: string) => `${ENTITY_REGISTRY['cause'].publicBasePath}/${id}`,
   },
+  CIRCLES: {
+    VIEW: (id: string) => `${ENTITY_REGISTRY['circle'].publicBasePath}/${id}`,
+  },
   LOANS: {
     VIEW: (id: string) => `${ENTITY_REGISTRY['loan'].publicBasePath}/${id}`,
   },
@@ -361,6 +364,8 @@ export const ROUTES = {
     SERVICES_CREATE: ENTITY_REGISTRY['service'].createPath,
     CAUSES: ENTITY_REGISTRY['cause'].basePath,
     CAUSES_CREATE: ENTITY_REGISTRY['cause'].createPath,
+    CIRCLES: ENTITY_REGISTRY['circle'].basePath,
+    CIRCLES_CREATE: ENTITY_REGISTRY['circle'].createPath,
     AI_ASSISTANTS: ENTITY_REGISTRY['ai_assistant'].basePath,
     AI_ASSISTANTS_CREATE: ENTITY_REGISTRY['ai_assistant'].createPath,
     WISHLISTS: ENTITY_REGISTRY['wishlist'].basePath,

--- a/src/lib/validation/circles.ts
+++ b/src/lib/validation/circles.ts
@@ -1,0 +1,21 @@
+/**
+ * Circle validation — lightweight community structures.
+ */
+
+import { z } from 'zod';
+import { optionalText } from './base';
+
+export const CIRCLE_VISIBILITIES = ['public', 'unlisted', 'private'] as const;
+export const CIRCLE_STATUSES = ['draft', 'active', 'paused', 'archived'] as const;
+
+export const circleSchema = z.object({
+  title: z.string().min(1, 'Name is required').max(100, 'Name must be at most 100 characters'),
+  description: optionalText(1000),
+  category: optionalText(50),
+  visibility: z.enum(CIRCLE_VISIBILITIES).default('public'),
+  cover_image_url: optionalText(),
+  tags: z.array(z.string()).optional().default([]),
+  status: z.enum(CIRCLE_STATUSES).default('active'),
+});
+
+export type CircleFormData = z.infer<typeof circleSchema>;

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -15,4 +15,5 @@ export * from './ai';
 export * from './wishlist';
 export * from './documents';
 export * from './groups';
+export * from './circles';
 export * from './proposals';

--- a/src/types/cat.ts
+++ b/src/types/cat.ts
@@ -31,6 +31,7 @@ export const CAT_CREATABLE_ENTITY_TYPES = [
   'research',
   'wishlist',
   'group',
+  'circle',
   'ai_assistant',
   'document',
 ] as const satisfies readonly EntityType[];

--- a/supabase/migrations/20260628000000_create_circles.sql
+++ b/supabase/migrations/20260628000000_create_circles.sql
@@ -1,0 +1,48 @@
+-- Circles: lightweight community structures (lighter than groups — no shared
+-- wallet or governance, just a discoverable community owned by its creator's actor).
+-- Idempotent / fresh-box-safe.
+
+CREATE TABLE IF NOT EXISTS circles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_id uuid NOT NULL REFERENCES actors(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text,
+  category text,
+  visibility text NOT NULL DEFAULT 'public' CHECK (visibility IN ('public', 'unlisted', 'private')),
+  cover_image_url text,
+  tags text[] DEFAULT '{}',
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('draft', 'active', 'paused', 'archived')),
+  member_count integer NOT NULL DEFAULT 0,
+  is_test boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_circles_actor ON circles(actor_id);
+CREATE INDEX IF NOT EXISTS idx_circles_visibility ON circles(visibility) WHERE visibility = 'public';
+CREATE INDEX IF NOT EXISTS idx_circles_category ON circles(category);
+
+ALTER TABLE circles ENABLE ROW LEVEL SECURITY;
+
+-- Public circles are world-readable; an owner sees all of their own.
+DROP POLICY IF EXISTS "circles public or owner read" ON circles;
+CREATE POLICY "circles public or owner read" ON circles FOR SELECT
+  USING (
+    visibility = 'public'
+    OR actor_id IN (SELECT id FROM actors WHERE user_id = auth.uid())
+  );
+
+-- Owners (the actor's user) create / update / delete their own circles.
+DROP POLICY IF EXISTS "circles owner insert" ON circles;
+CREATE POLICY "circles owner insert" ON circles FOR INSERT
+  WITH CHECK (actor_id IN (SELECT id FROM actors WHERE user_id = auth.uid()));
+DROP POLICY IF EXISTS "circles owner update" ON circles;
+CREATE POLICY "circles owner update" ON circles FOR UPDATE
+  USING (actor_id IN (SELECT id FROM actors WHERE user_id = auth.uid()));
+DROP POLICY IF EXISTS "circles owner delete" ON circles;
+CREATE POLICY "circles owner delete" ON circles FOR DELETE
+  USING (actor_id IN (SELECT id FROM actors WHERE user_id = auth.uid()));
+
+DROP TRIGGER IF EXISTS trg_circles_updated_at ON circles;
+CREATE TRIGGER trg_circles_updated_at BEFORE UPDATE ON circles
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
A **circle** is a lightweight community structure — lighter than a `group` (no shared wallet/governance), just a discoverable community owned by its creator's actor. Built end-to-end on the registry-driven pattern (only 2 exhaustive maps needed a manual entry).

- Migration `20260628000000`: `circles` table (actor-owned, visibility, RLS, trigger) — applied to box
- Registry, validation, API (factory list/create/CRUD), create+dashboard configs, 5 pages (generic Entity* + config), Cat creatable, ROUTES
- Type-check 0 errors; schema-drift gate green against the box

🤖 Generated with [Claude Code](https://claude.com/claude-code)