### PR TITLE
fix(cat): post_to_timeline now actually posts (use user id)

### DIFF
--- a/__tests__/unit/cat/action-executor-columns.test.ts
+++ b/__tests__/unit/cat/action-executor-columns.test.ts
@@ -880,7 +880,10 @@ describe('Cat action-executor — correct DB column names', () => {
       expect(insert!.event_type).toBe('post');
       expect(insert!.event_subtype).toBe('text');
       expect(insert!.subject_type).toBe('profile');
-      expect(insert!.actor_id).toBe(ACTOR_ID);
+      // timeline_events.actor_id holds the USER id, not the actor id (the INSERT RLS
+      // policy is `auth.uid() = actor_id` and the feed views join it → profiles.id).
+      // Inserting the distinct actor id fails RLS — so this must be the user id.
+      expect(insert!.actor_id).toBe(USER_ID);
 
       // title is a truncated version of content; description is the full text
       expect(insert!.title).toBe(content);

--- a/src/services/cat/handlers/communication.ts
+++ b/src/services/cat/handlers/communication.ts
@@ -3,12 +3,17 @@ import { isValidEntityType } from '@/config/entity-registry';
 import type { ActionHandler } from './types';
 
 export const communicationHandlers: Record<string, ActionHandler> = {
-  post_to_timeline: async (supabase, _userId, actorId, params) => {
+  post_to_timeline: async (supabase, userId, _actorId, params) => {
     // timeline_events schema: event_type, event_subtype, subject_type (all required),
     // title (required), description (text), content (jsonb { text: ... }).
     // An entity is LINKED via subject_type/subject_id — the post is "about" that
     // entity — so "promote my project" surfaces the project on the feed instead of
     // an unlinked blurb. Plain posts subject the author's own profile.
+    //
+    // IMPORTANT: despite the name, timeline_events.actor_id holds the USER id, not the
+    // actor id — the INSERT RLS policy is `WITH CHECK (auth.uid() = actor_id)` and the
+    // feed/enriched views join actor_id → profiles.id. Inserting the (distinct) actor id
+    // here fails RLS, which is why posting silently never worked. Use userId.
     const text = (params.content as string) || '';
     const title = text.length > 100 ? text.slice(0, 97) + '…' : text;
 
@@ -19,7 +24,7 @@ export const communicationHandlers: Record<string, ActionHandler> = {
     const { data, error } = await supabase
       .from(DATABASE_TABLES.TIMELINE_EVENTS)
       .insert({
-        actor_id: actorId,
+        actor_id: userId,
         event_type: 'post',
         event_subtype: linkEntity ? 'promotion' : 'text',
         subject_type: linkEntity ? entityType : 'profile',


### PR DESCRIPTION
Investigating the timeline `actor_id` naming issue surfaced a **real bug**.

`timeline_events.actor_id` holds the **user id**, not an actor id — enforced by the INSERT RLS `WITH CHECK (auth.uid() = actor_id)` and the feed/enriched views that join `actor_id → profiles.id`. Confirmed against prod data: **0/1359** timeline rows match `actors.id`, all match `profiles.id`, and `actors.id ≠ user_id` for all 47 actors.

`post_to_timeline` inserted the distinct actor id (from `getUserActorId`), so every insert **violated RLS and silently failed** — 'promote' never posted, before or after the entity-linking work (#301). Now inserts the user id, with a doc comment at the insert site. Updated the unit test that asserted the old (buggy) behavior.

**Deliberately not renaming the column** — `actor_id` is entrenched (RLS, `enriched_timeline_events`, the feed RPCs, indexes, 1359 rows); a cosmetic rename touches the primary feed for zero functional gain and high regression risk.

Type-check + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)