### PR TITLE
chore(ssot): backfill DATABASE_TABLES for raw table literals

### DIFF
--- a/src/app/api/admin/reindex-embeddings/route.ts
+++ b/src/app/api/admin/reindex-embeddings/route.ts
@@ -21,6 +21,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextResponse } from 'next/server';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { embeddingsEnabled, embedTexts } from '@/services/ai/embeddings';
 import { ENTITY_STATUS } from '@/config/database-constants';
@@ -103,7 +104,7 @@ async function reconcileOne(
 
   if (type === 'profile') {
     const { data } = await supabase
-      .from('profiles')
+      .from(DATABASE_TABLES.PROFILES)
       .select(
         'id, username, name, bio, location_city, updated_at, last_active_at, verification_status'
       )
@@ -113,7 +114,7 @@ async function reconcileOne(
       const text = [data.name, data.bio, data.location_city].filter(Boolean).join('. ').trim();
       if (text) {
         const { count: followers } = await supabase
-          .from('follows')
+          .from(DATABASE_TABLES.FOLLOWS)
           .select('id', { count: 'exact', head: true })
           .eq('following_id', data.id);
         item = {
@@ -162,7 +163,11 @@ async function reconcileOne(
   }
 
   if (!item) {
-    await supabase.from('content_embeddings').delete().eq('entity_type', type).eq('entity_id', id);
+    await supabase
+      .from(DATABASE_TABLES.CONTENT_EMBEDDINGS)
+      .delete()
+      .eq('entity_type', type)
+      .eq('entity_id', id);
     return { indexed: 0, pruned: 1, failed: 0 };
   }
 
@@ -170,7 +175,7 @@ async function reconcileOne(
   if (!vec) {
     return { indexed: 0, pruned: 0, failed: 1 };
   }
-  const { error } = await supabase.from('content_embeddings').upsert(
+  const { error } = await supabase.from(DATABASE_TABLES.CONTENT_EMBEDDINGS).upsert(
     [
       {
         entity_type: item.entity_type,
@@ -232,7 +237,7 @@ export async function POST(request: Request) {
 
   // Follower counts (one query) → per-profile connection signal.
   const followerCount = new Map<string, number>();
-  const { data: follows } = await supabase.from('follows').select('following_id');
+  const { data: follows } = await supabase.from(DATABASE_TABLES.FOLLOWS).select('following_id');
   for (const f of follows ?? []) {
     if (f.following_id) {
       followerCount.set(f.following_id, (followerCount.get(f.following_id) ?? 0) + 1);
@@ -240,7 +245,7 @@ export async function POST(request: Request) {
   }
 
   const { data: profiles } = await supabase
-    .from('profiles')
+    .from(DATABASE_TABLES.PROFILES)
     .select(
       'id, username, name, bio, location_city, updated_at, last_active_at, verification_status'
     )
@@ -314,7 +319,7 @@ export async function POST(request: Request) {
 
   // ── 2. Load what's already indexed (key → last-embedded source timestamp) ────
   const { data: existingRows } = await supabase
-    .from('content_embeddings')
+    .from(DATABASE_TABLES.CONTENT_EMBEDDINGS)
     .select('entity_type, entity_id, updated_at');
   const existing = new Map<string, string | null>();
   for (const r of existingRows ?? []) {
@@ -358,7 +363,7 @@ export async function POST(request: Request) {
       .filter((r): r is NonNullable<typeof r> => r !== null);
     if (rows.length > 0) {
       const { error } = await supabase
-        .from('content_embeddings')
+        .from(DATABASE_TABLES.CONTENT_EMBEDDINGS)
         .upsert(rows, { onConflict: 'entity_type,entity_id' });
       if (error) {
         logger.error('content_embeddings upsert failed', { error }, 'Reindex');
@@ -380,7 +385,7 @@ export async function POST(request: Request) {
       continue;
     }
     const { error } = await supabase
-      .from('content_embeddings')
+      .from(DATABASE_TABLES.CONTENT_EMBEDDINGS)
       .update({ quality_score: it.quality })
       .eq('entity_type', it.entity_type)
       .eq('entity_id', it.entity_id);
@@ -394,7 +399,7 @@ export async function POST(request: Request) {
   for (const k of toPrune) {
     const [etype, eid] = k.split(':');
     const { error } = await supabase
-      .from('content_embeddings')
+      .from(DATABASE_TABLES.CONTENT_EMBEDDINGS)
       .delete()
       .eq('entity_type', etype)
       .eq('entity_id', eid);

--- a/src/app/api/cat/nudges/route.ts
+++ b/src/app/api/cat/nudges/route.ts
@@ -8,6 +8,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextResponse } from 'next/server';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { createServerClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { generateNudges } from '@/services/cat/nudges';
@@ -29,7 +30,7 @@ export async function GET() {
   const db = createAdminClient() as any;
 
   const { data: existing } = await db
-    .from('user_nudges')
+    .from(DATABASE_TABLES.USER_NUDGES)
     .select('id, nudge_type, title, body, cta_label, cta_url, score, generated_at')
     .eq('user_id', user.id)
     .eq('status', 'active')
@@ -40,7 +41,7 @@ export async function GET() {
   let stale = !existing?.length || Date.now() - newest > STALE_MS;
   if (!stale) {
     const { data: prof } = await db
-      .from('profiles')
+      .from(DATABASE_TABLES.PROFILES)
       .select('updated_at')
       .eq('id', user.id)
       .maybeSingle();
@@ -57,16 +58,20 @@ export async function GET() {
   try {
     const fresh = await generateNudges(db, user.id);
     const { data: dismissedRows } = await db
-      .from('user_nudges')
+      .from(DATABASE_TABLES.USER_NUDGES)
       .select('dedupe_key')
       .eq('user_id', user.id)
       .eq('status', 'dismissed');
     const dismissed = new Set((dismissedRows ?? []).map((r: any) => r.dedupe_key));
     const toStore = fresh.filter(n => !dismissed.has(n.dedupe_key));
 
-    await db.from('user_nudges').delete().eq('user_id', user.id).eq('status', 'active');
+    await db
+      .from(DATABASE_TABLES.USER_NUDGES)
+      .delete()
+      .eq('user_id', user.id)
+      .eq('status', 'active');
     if (toStore.length > 0) {
-      await db.from('user_nudges').upsert(
+      await db.from(DATABASE_TABLES.USER_NUDGES).upsert(
         toStore.map(n => ({
           user_id: user.id,
           nudge_type: n.nudge_type,
@@ -84,7 +89,7 @@ export async function GET() {
     }
 
     const { data: stored } = await db
-      .from('user_nudges')
+      .from(DATABASE_TABLES.USER_NUDGES)
       .select('id, nudge_type, title, body, cta_label, cta_url, score, generated_at')
       .eq('user_id', user.id)
       .eq('status', 'active')
@@ -110,7 +115,7 @@ export async function POST(request: Request) {
   }
   const db = createAdminClient() as any;
   await db
-    .from('user_nudges')
+    .from(DATABASE_TABLES.USER_NUDGES)
     .update({ status: 'dismissed', dismissed_at: new Date().toISOString() })
     .eq('user_id', user.id)
     .eq('id', body.id);

--- a/src/app/api/stakeholders/[id]/route.ts
+++ b/src/app/api/stakeholders/[id]/route.ts
@@ -9,6 +9,7 @@
  */
 
 import { z } from 'zod';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import {
   apiSuccess,
@@ -76,7 +77,7 @@ export const PATCH = withAuth(async (request: AuthenticatedRequest, context: unk
     }
 
     const { data, error } = await supabase
-      .from('stakeholder_relationships')
+      .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
       .update(updates)
       .eq('id', id)
       .select('*')
@@ -112,7 +113,7 @@ export const DELETE = withAuth(async (request: AuthenticatedRequest, context: un
     // Verify the row exists + is visible under RLS before delete so we
     // can return a meaningful 404 instead of a silent 0-rows-affected.
     const { data: existing, error: existingErr } = await supabase
-      .from('stakeholder_relationships')
+      .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
       .select('id')
       .eq('id', id)
       .maybeSingle();
@@ -125,7 +126,10 @@ export const DELETE = withAuth(async (request: AuthenticatedRequest, context: un
       return apiNotFound('Stakeholder relationship not found');
     }
 
-    const { error } = await supabase.from('stakeholder_relationships').delete().eq('id', id);
+    const { error } = await supabase
+      .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
+      .delete()
+      .eq('id', id);
 
     if (error) {
       logger.error('Failed to delete stakeholder relationship', error, 'StakeholdersAPI');

--- a/src/app/api/stakeholders/route.ts
+++ b/src/app/api/stakeholders/route.ts
@@ -25,6 +25,7 @@
  */
 
 import { z } from 'zod';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import {
   apiSuccess,
@@ -95,7 +96,7 @@ export const GET = withAuth(async (request: AuthenticatedRequest) => {
     }
 
     let query = supabase
-      .from('stakeholder_relationships')
+      .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
       .select('*')
       .eq('from_project_id', fromProjectId)
       .order('updated_at', { ascending: false });
@@ -145,7 +146,7 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
     // RLS would block writes for the wrong actor; we set it explicitly
     // here so the row is well-formed up front.
     const { data: actorRow, error: actorErr } = await supabase
-      .from('actors')
+      .from(DATABASE_TABLES.ACTORS)
       .select('id')
       .eq('user_id', user.id)
       .eq('actor_type', 'user')
@@ -190,7 +191,7 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
     };
 
     const { data: inserted, error: insertErr } = await supabase
-      .from('stakeholder_relationships')
+      .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
       .insert(row)
       .select('*')
       .single();

--- a/src/components/ai-chat/AIChatMessage.tsx
+++ b/src/components/ai-chat/AIChatMessage.tsx
@@ -69,7 +69,7 @@ export function AIChatMessage({
             <span className="text-xs text-fg-tertiary">({message.tokens_used} tokens)</span>
           )}
         </div>
-        <div className="prose prose-sm max-w-none text-fg-primary whitespace-pre-wrap">
+        <div className="prose prose-sm max-w-none text-fg-primary whitespace-pre-wrap break-words">
           {message.content}
         </div>
         {!isUser && message.cost_btc && message.cost_btc > 0 && (

--- a/src/components/bookings/BookEntityDialog.tsx
+++ b/src/components/bookings/BookEntityDialog.tsx
@@ -21,6 +21,7 @@
  */
 
 import { useState } from 'react';
+import { API_ROUTES } from '@/config/api-routes';
 import { toast } from 'sonner';
 import { Calendar, Loader2 } from 'lucide-react';
 import {
@@ -119,7 +120,7 @@ export function BookEntityDialog({
 
     setSubmitting(true);
     try {
-      const res = await fetch('/api/bookings', {
+      const res = await fetch(API_ROUTES.BOOKINGS.BASE, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -154,6 +154,24 @@ export const DATABASE_TABLES = {
   // Entity Tables (for direct access when not using entity-registry)
   USER_ASSETS: 'assets',
   AI_ASSISTANTS: 'ai_assistants',
+
+  // Cat nudges
+  USER_NUDGES: 'user_nudges',
+
+  // Search / embeddings
+  CONTENT_EMBEDDINGS: 'content_embeddings',
+
+  // Collaboration
+  PROJECT_ROLES: 'project_roles',
+
+  // Plans
+  USER_PLANS: 'user_plans',
+
+  // OAuth provider ("Login with OrangeCat")
+  OAUTH_CLIENTS: 'oauth_clients',
+  OAUTH_AUTH_CODES: 'oauth_auth_codes',
+  OAUTH_REFRESH_TOKENS: 'oauth_refresh_tokens',
+  OAUTH_USER_GRANTS: 'oauth_user_grants',
 } as const;
 
 // Timeline tables shorthand (for backward compatibility with timeline services)

--- a/src/hooks/useAISettings.ts
+++ b/src/hooks/useAISettings.ts
@@ -175,7 +175,7 @@ export function useAISettings() {
             : prev.preferences;
         return { ...prev, keys: reordered, preferences };
       });
-      const res = await fetch('/api/user/api-keys', {
+      const res = await fetch(API_ROUTES.USER.API_KEYS, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ order: orderedIds }),

--- a/src/hooks/useProfileTheme.ts
+++ b/src/hooks/useProfileTheme.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useCallback, useRef } from 'react';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { useTheme } from 'next-themes';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/lib/supabase/browser';
@@ -45,7 +46,7 @@ export function useProfileTheme() {
       }
       const currentPrefs = (profileRef.current?.preferences as Record<string, unknown>) ?? {};
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error } = await (supabase.from('profiles') as any)
+      const { error } = await (supabase.from(DATABASE_TABLES.PROFILES) as any)
         .update({ preferences: { ...currentPrefs, theme: newTheme } })
         .eq('id', user.id);
       if (error && process.env.NODE_ENV === 'development') {

--- a/src/lib/api/entityGetByIdHandler.ts
+++ b/src/lib/api/entityGetByIdHandler.ts
@@ -13,6 +13,7 @@
  */
 
 import { NextRequest } from 'next/server';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { createServerClient } from '@/lib/supabase/server';
 import {
   apiSuccess,
@@ -165,7 +166,7 @@ async function isCallerOwner(
   }
   if (row.actor_id) {
     const { data } = await supabase
-      .from('actors')
+      .from(DATABASE_TABLES.ACTORS)
       .select('id')
       .eq('id', row.actor_id as string)
       .eq('user_id', userId)

--- a/src/services/auth/oauthProvider.ts
+++ b/src/services/auth/oauthProvider.ts
@@ -11,6 +11,7 @@
  * See src/lib/oauth/config.ts (SSOT) and docs/architecture/PLATFORM_AND_COLLABORATION.md.
  */
 import { createHash, randomBytes } from 'node:crypto';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { SignJWT } from 'jose';
 import { createAdminClient } from '@/lib/supabase/admin';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
@@ -39,7 +40,7 @@ export interface OAuthClient {
 
 export async function getClient(clientId: string): Promise<OAuthClient | null> {
   const { data } = await adminDb()
-    .from('oauth_clients')
+    .from(DATABASE_TABLES.OAUTH_CLIENTS)
     .select('*')
     .eq('client_id', clientId)
     .is('disabled_at', null)
@@ -79,7 +80,7 @@ export async function createAuthCode(params: {
   const code = randomToken(32);
   const expiresAt = new Date(Date.now() + OAUTH_TTL.authCode * 1000).toISOString();
   const { error } = await adminDb()
-    .from('oauth_auth_codes')
+    .from(DATABASE_TABLES.OAUTH_AUTH_CODES)
     .insert({
       code_hash: sha256(code),
       client_id: params.clientId,
@@ -116,7 +117,7 @@ export async function consumeAuthCode(
 ): Promise<ConsumedCode | null> {
   const db = adminDb();
   const { data } = await db
-    .from('oauth_auth_codes')
+    .from(DATABASE_TABLES.OAUTH_AUTH_CODES)
     .select('*')
     .eq('code_hash', sha256(code))
     .maybeSingle();
@@ -143,7 +144,7 @@ export async function consumeAuthCode(
 
   // Single-use: conditional update guards against a concurrent second redeem.
   const { data: claimed } = await db
-    .from('oauth_auth_codes')
+    .from(DATABASE_TABLES.OAUTH_AUTH_CODES)
     .update({ consumed_at: new Date().toISOString() })
     .eq('id', data.id)
     .is('consumed_at', null)
@@ -180,7 +181,7 @@ export async function profileClaims(
     return {};
   }
   const { data: profile } = await adminDb()
-    .from('profiles')
+    .from(DATABASE_TABLES.PROFILES)
     .select('username, name, avatar_url, email')
     .eq('id', userId)
     .maybeSingle();
@@ -243,7 +244,7 @@ export async function issueTokens(params: {
   if (params.withRefresh !== false) {
     refresh_token = randomToken(32);
     const { error } = await adminDb()
-      .from('oauth_refresh_tokens')
+      .from(DATABASE_TABLES.OAUTH_REFRESH_TOKENS)
       .insert({
         token_hash: sha256(refresh_token),
         client_id: params.client.client_id,
@@ -275,7 +276,7 @@ export async function rotateRefreshToken(
 ): Promise<TokenResponse | null> {
   const db = adminDb();
   const { data } = await db
-    .from('oauth_refresh_tokens')
+    .from(DATABASE_TABLES.OAUTH_REFRESH_TOKENS)
     .select('*')
     .eq('token_hash', sha256(refreshToken))
     .maybeSingle();
@@ -289,7 +290,7 @@ export async function rotateRefreshToken(
 
   // Revoke (rotate) — conditional to avoid double-rotation races.
   const { data: revoked } = await db
-    .from('oauth_refresh_tokens')
+    .from(DATABASE_TABLES.OAUTH_REFRESH_TOKENS)
     .update({ revoked_at: new Date().toISOString(), last_used_at: new Date().toISOString() })
     .eq('id', data.id)
     .is('revoked_at', null)
@@ -316,7 +317,7 @@ export async function hasRememberedGrant(
   scopes: string[]
 ): Promise<boolean> {
   const { data } = await adminDb()
-    .from('oauth_user_grants')
+    .from(DATABASE_TABLES.OAUTH_USER_GRANTS)
     .select('scopes')
     .eq('user_id', userId)
     .eq('client_id', clientId)
@@ -334,7 +335,7 @@ export async function recordGrant(
   scopes: string[]
 ): Promise<void> {
   await adminDb()
-    .from('oauth_user_grants')
+    .from(DATABASE_TABLES.OAUTH_USER_GRANTS)
     .upsert(
       { user_id: userId, client_id: clientId, scopes, granted_at: new Date().toISOString() },
       { onConflict: 'user_id,client_id' }

--- a/src/services/billing/getUserPlan.ts
+++ b/src/services/billing/getUserPlan.ts
@@ -14,6 +14,7 @@
  */
 
 import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { logger } from '@/utils/logger';
 
 export type PaidTier = 'free' | 'pro';
@@ -43,7 +44,7 @@ const FREE_PLAN: UserPlan = {
  */
 export async function getUserPlan(supabase: AnySupabaseClient, userId: string): Promise<UserPlan> {
   const { data, error } = await supabase
-    .from('user_plans')
+    .from(DATABASE_TABLES.USER_PLANS)
     .select('tier, daily_limit, expires_at')
     .eq('user_id', userId)
     .maybeSingle();

--- a/src/services/cat/nudges.ts
+++ b/src/services/cat/nudges.ts
@@ -14,6 +14,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { ROUTES } from '@/config/routes';
 import { DEFAULT_FREE_MODEL_ID } from '@/config/ai-models';
 import { createOpenRouterService } from '@/services/ai';
@@ -45,7 +46,7 @@ const usernameFromUrl = (url: string): string | null => {
 
 export async function generateNudges(supabase: any, userId: string): Promise<Nudge[]> {
   const { data: profile } = await supabase
-    .from('profiles')
+    .from(DATABASE_TABLES.PROFILES)
     .select('id, username, name, bio, location_city')
     .eq('id', userId)
     .maybeSingle();
@@ -57,7 +58,7 @@ export async function generateNudges(supabase: any, userId: string): Promise<Nud
 
   // ── User's own entities (active + drafts) ──────────────────────────────────
   const { data: actor } = await supabase
-    .from('actors')
+    .from(DATABASE_TABLES.ACTORS)
     .select('id')
     .eq('user_id', userId)
     .eq('actor_type', 'user')

--- a/src/services/collaboration/projectRoles.ts
+++ b/src/services/collaboration/projectRoles.ts
@@ -7,6 +7,8 @@
  * type, so we use the codebase's loose AnySupabaseClient (as elsewhere).
  */
 import { createServerClient } from '@/lib/supabase/server';
+import { getTableName } from '@/config/entity-registry';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import {
   isEngagementType,
@@ -54,7 +56,7 @@ export interface ListFilters {
 /** Public collaborator board — open roles across all projects, newest first. */
 export async function listOpenRoles(filters: ListFilters = {}): Promise<ProjectRole[]> {
   let q = (await db())
-    .from('project_roles')
+    .from(DATABASE_TABLES.PROJECT_ROLES)
     .select(SELECT)
     .eq('status', 'open')
     .order('created_at', { ascending: false })
@@ -75,7 +77,7 @@ export async function listOpenRoles(filters: ListFilters = {}): Promise<ProjectR
 /** All roles for one project (owner sees all statuses via RLS; others see open). */
 export async function getRolesForProject(projectId: string): Promise<ProjectRole[]> {
   const { data, error } = await (await db())
-    .from('project_roles')
+    .from(DATABASE_TABLES.PROJECT_ROLES)
     .select(SELECT)
     .eq('project_id', projectId)
     .order('created_at', { ascending: false });
@@ -113,7 +115,7 @@ export async function createRole(input: CreateRoleInput, userId: string): Promis
   const sb = await db();
   // App-layer ownership check (RLS is the backstop).
   const { data: project } = await sb
-    .from('projects')
+    .from(getTableName('project'))
     .select('id, user_id')
     .eq('id', input.projectId)
     .maybeSingle();
@@ -125,7 +127,7 @@ export async function createRole(input: CreateRoleInput, userId: string): Promis
   }
 
   const { data, error } = await sb
-    .from('project_roles')
+    .from(DATABASE_TABLES.PROJECT_ROLES)
     .insert({
       project_id: input.projectId,
       role_title: roleTitle,
@@ -148,7 +150,7 @@ export async function updateRoleStatus(
 ): Promise<ProjectRole> {
   const sb = await db();
   const { data: role } = await sb
-    .from('project_roles')
+    .from(DATABASE_TABLES.PROJECT_ROLES)
     .select('id, project_id, projects(user_id)')
     .eq('id', roleId)
     .maybeSingle();
@@ -160,7 +162,7 @@ export async function updateRoleStatus(
   }
 
   const { data, error } = await sb
-    .from('project_roles')
+    .from(DATABASE_TABLES.PROJECT_ROLES)
     .update({ status, updated_at: new Date().toISOString() })
     .eq('id', roleId)
     .select(SELECT)

--- a/src/services/timeline/externalPublish.ts
+++ b/src/services/timeline/externalPublish.ts
@@ -21,6 +21,7 @@
  * it to auth.uid()), despite the column name — see the home-feed work.
  */
 import { createAdminClient } from '@/lib/supabase/admin';
+import { getTableName } from '@/config/entity-registry';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { logger } from '@/utils/logger';
 import { EXTERNAL_PUBLISH_META, type ExternalPublishInput } from '@/config/external-publish';
@@ -64,7 +65,11 @@ async function assertOwnsProject(
   projectId: string,
   userId: string
 ): Promise<'ok' | 'subject_not_found' | 'forbidden'> {
-  const { data } = await db.from('projects').select('user_id').eq('id', projectId).maybeSingle();
+  const { data } = await db
+    .from(getTableName('project'))
+    .select('user_id')
+    .eq('id', projectId)
+    .maybeSingle();
   if (!data) {
     return 'subject_not_found';
   }


### PR DESCRIPTION
Audit roadmap quick-win — restore the table-name SSOT on code that bypassed it. Behavior-preserving; tsc 0; drift gate green.

- 8 new non-entity consts in `database-tables.ts` (USER_NUDGES, CONTENT_EMBEDDINGS, PROJECT_ROLES, USER_PLANS, OAUTH_*).
- Every raw `.from('literal')` in app code → `DATABASE_TABLES.*` (incl. profiles/actors/follows/stakeholder_relationships). **Zero raw table literals remain** in src/ app code.
- `.from('projects')` (entity table) → `getTableName('project')` per the registry convention.
- 2 `fetch('/api/...')` → `API_ROUTES`; 6 others left for follow-up (need new API_ROUTES entries — listed in the audit report).
- `AIChatMessage`: `break-words` for long-token wrap (the LOW mobile finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)