### PR TITLE
chore(ssot): route component fetches through API_ROUTES

### DIFF
--- a/src/components/ai/CatCreditsPanel.tsx
+++ b/src/components/ai/CatCreditsPanel.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Coins, Loader2, AlertCircle, ArrowDownLeft, ArrowUpRight } from 'lucide-react';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { logger } from '@/utils/logger';
+import { API_ROUTES } from '@/config/api-routes';
 import { TopUpDialog } from './TopUpDialog';
 
 interface CreditEntry {
@@ -44,7 +45,7 @@ export function CatCreditsPanel() {
     setIsLoading(true);
     setError(null);
     try {
-      const res = await fetch('/api/cat/credits');
+      const res = await fetch(API_ROUTES.CAT.CREDITS);
       if (!res.ok) {
         throw new Error('Failed to load credits');
       }

--- a/src/components/ai/CatMemoryManager.tsx
+++ b/src/components/ai/CatMemoryManager.tsx
@@ -13,6 +13,7 @@ import { Brain, Trash2, Loader2, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import Button from '@/components/ui/Button';
 import { logger } from '@/utils/logger';
+import { API_ROUTES } from '@/config/api-routes';
 
 interface Memory {
   id: string;
@@ -32,7 +33,7 @@ export function CatMemoryManager() {
     setIsLoading(true);
     setError(null);
     try {
-      const res = await fetch('/api/cat/memories');
+      const res = await fetch(API_ROUTES.CAT.MEMORIES);
       if (!res.ok) {
         throw new Error('Failed to load memories');
       }
@@ -53,7 +54,7 @@ export function CatMemoryManager() {
   const handleDelete = useCallback(async (id: string) => {
     setDeletingId(id);
     try {
-      const res = await fetch(`/api/cat/memories?id=${encodeURIComponent(id)}`, {
+      const res = await fetch(`${API_ROUTES.CAT.MEMORIES}?id=${encodeURIComponent(id)}`, {
         method: 'DELETE',
       });
       if (!res.ok) {
@@ -72,7 +73,7 @@ export function CatMemoryManager() {
   const handleClearAll = useCallback(async () => {
     setIsClearing(true);
     try {
-      const res = await fetch('/api/cat/memories?all=true', { method: 'DELETE' });
+      const res = await fetch(`${API_ROUTES.CAT.MEMORIES}?all=true`, { method: 'DELETE' });
       if (!res.ok) {
         throw new Error('clear failed');
       }

--- a/src/components/ai/TopUpDialog.tsx
+++ b/src/components/ai/TopUpDialog.tsx
@@ -15,6 +15,7 @@ import { toast } from 'sonner';
 import Button from '@/components/ui/Button';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { logger } from '@/utils/logger';
+import { API_ROUTES } from '@/config/api-routes';
 
 /** Preset amounts in BTC (1-sat precision): 10k / 50k / 100k sats. */
 const PRESETS_BTC = [0.0001, 0.0005, 0.001];
@@ -53,7 +54,7 @@ export function TopUpDialog({ onClose, onSuccess }: TopUpDialogProps) {
     setCreating(true);
     setError(null);
     try {
-      const res = await fetch('/api/cat/credits/topup', {
+      const res = await fetch(API_ROUTES.CAT.CREDITS_TOPUP, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ amountBtc }),
@@ -82,7 +83,9 @@ export function TopUpDialog({ onClose, onSuccess }: TopUpDialogProps) {
     }
     pollRef.current = setInterval(async () => {
       try {
-        const res = await fetch(`/api/cat/credits/topup?id=${encodeURIComponent(invoice.topupId)}`);
+        const res = await fetch(
+          `${API_ROUTES.CAT.CREDITS_TOPUP}?id=${encodeURIComponent(invoice.topupId)}`
+        );
         const json = await res.json();
         const status = json?.data?.status;
         if (status === 'paid') {

--- a/src/components/dashboard/CatNudges.tsx
+++ b/src/components/dashboard/CatNudges.tsx
@@ -9,6 +9,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Sparkles, X, ArrowRight } from 'lucide-react';
+import { API_ROUTES } from '@/config/api-routes';
 
 interface Nudge {
   id: string;
@@ -24,7 +25,7 @@ export function CatNudges() {
 
   useEffect(() => {
     let on = true;
-    fetch('/api/cat/nudges')
+    fetch(API_ROUTES.CAT.NUDGES)
       .then(r => (r.ok ? r.json() : null))
       .then(d => {
         if (on && d?.success) {
@@ -46,7 +47,7 @@ export function CatNudges() {
     // reappear on next load (the dismissal wasn't persisted).
     const prev = nudges;
     setNudges(n => n?.filter(x => x.id !== id) ?? null);
-    fetch('/api/cat/nudges', {
+    fetch(API_ROUTES.CAT.NUDGES, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'dismiss', id }),

--- a/src/components/settings/IntegrationKeysCard.tsx
+++ b/src/components/settings/IntegrationKeysCard.tsx
@@ -17,6 +17,7 @@ import { logger } from '@/utils/logger';
 import IntegrationKeyMintForm from '@/components/settings/IntegrationKeyMintForm';
 import IntegrationKeyRow from '@/components/settings/IntegrationKeyRow';
 import PlaintextRevealCard from '@/components/settings/PlaintextRevealCard';
+import { API_ROUTES } from '@/config/api-routes';
 
 export interface IntegrationKey {
   id: string;
@@ -91,7 +92,7 @@ export default function IntegrationKeysCard({ actors, defaultActorId }: Props) {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch('/api/integration-keys', { credentials: 'include' });
+        const res = await fetch(API_ROUTES.INTEGRATION_KEYS.BASE, { credentials: 'include' });
         if (!res.ok) {
           throw new Error(`Failed to load keys (${res.status})`);
         }
@@ -135,7 +136,7 @@ export default function IntegrationKeysCard({ actors, defaultActorId }: Props) {
       if (isTest) {
         body.is_test = true;
       }
-      const res = await fetch('/api/integration-keys', {
+      const res = await fetch(API_ROUTES.INTEGRATION_KEYS.BASE, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -165,7 +166,7 @@ export default function IntegrationKeysCard({ actors, defaultActorId }: Props) {
       return;
     }
     try {
-      const res = await fetch(`/api/integration-keys/${key.id}`, {
+      const res = await fetch(API_ROUTES.INTEGRATION_KEYS.BY_ID(key.id), {
         method: 'DELETE',
         credentials: 'include',
       });
@@ -191,7 +192,7 @@ export default function IntegrationKeysCard({ actors, defaultActorId }: Props) {
     }
     setError(null);
     try {
-      const res = await fetch(`/api/integration-keys/${key.id}/rotate`, {
+      const res = await fetch(`${API_ROUTES.INTEGRATION_KEYS.BY_ID(key.id)}/rotate`, {
         method: 'POST',
         credentials: 'include',
       });

--- a/src/components/settings/WebhookEndpointsCard.tsx
+++ b/src/components/settings/WebhookEndpointsCard.tsx
@@ -23,6 +23,7 @@ import { logger } from '@/utils/logger';
 import WebhookEndpointMintForm from '@/components/settings/WebhookEndpointMintForm';
 import WebhookEndpointRow, { type WebhookEndpoint } from '@/components/settings/WebhookEndpointRow';
 import PlaintextRevealCard from '@/components/settings/PlaintextRevealCard';
+import { API_ROUTES } from '@/config/api-routes';
 
 interface MintResponse {
   data: { endpoint: WebhookEndpoint; secret: string };
@@ -80,7 +81,7 @@ export default function WebhookEndpointsCard({ actors, defaultActorId }: Props) 
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch('/api/webhook-endpoints', { credentials: 'include' });
+        const res = await fetch(API_ROUTES.WEBHOOK_ENDPOINTS.BASE, { credentials: 'include' });
         if (!res.ok) {
           throw new Error(`Failed to load endpoints (${res.status})`);
         }
@@ -118,7 +119,7 @@ export default function WebhookEndpointsCard({ actors, defaultActorId }: Props) 
       if (selectedEvents.size > 0) {
         body.event_types = Array.from(selectedEvents);
       }
-      const res = await fetch('/api/webhook-endpoints', {
+      const res = await fetch(API_ROUTES.WEBHOOK_ENDPOINTS.BASE, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -147,7 +148,7 @@ export default function WebhookEndpointsCard({ actors, defaultActorId }: Props) 
       return;
     }
     try {
-      const res = await fetch(`/api/webhook-endpoints/${endpoint.id}`, {
+      const res = await fetch(API_ROUTES.WEBHOOK_ENDPOINTS.BY_ID(endpoint.id), {
         method: 'DELETE',
         credentials: 'include',
       });

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -15,6 +15,18 @@ export const API_ROUTES = {
     PERMISSIONS: '/api/cat/permissions',
     ACTIONS: '/api/cat/actions',
     QUOTA: '/api/cat/quota',
+    CREDITS: '/api/cat/credits',
+    CREDITS_TOPUP: '/api/cat/credits/topup',
+    MEMORIES: '/api/cat/memories',
+    NUDGES: '/api/cat/nudges',
+  },
+  INTEGRATION_KEYS: {
+    BASE: '/api/integration-keys',
+    BY_ID: (id: string) => `/api/integration-keys/${id}`,
+  },
+  WEBHOOK_ENDPOINTS: {
+    BASE: '/api/webhook-endpoints',
+    BY_ID: (id: string) => `/api/webhook-endpoints/${id}`,
   },
   MESSAGES: {
     BASE: '/api/messages',


### PR DESCRIPTION
Completes the SSOT backfill follow-up (the 6 fetches left unconverted in #307). Added `API_ROUTES` entries (CAT.CREDITS/CREDITS_TOPUP/MEMORIES/NUDGES, INTEGRATION_KEYS.{BASE,BY_ID}, WEBHOOK_ENDPOINTS.{BASE,BY_ID}) and swapped the hardcoded `fetch('/api/...')` strings in CatCreditsPanel, TopUpDialog, CatMemoryManager, CatNudges, IntegrationKeysCard, WebhookEndpointsCard. Query strings/ids/methods preserved — behavior-preserving. tsc 0; no hardcoded /api/ fetch strings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)