### PR TITLE
feat(cat): Grok-style conversation rail + viewport-locked composer

### DIFF
--- a/src/app/(authenticated)/dashboard/cat/page.tsx
+++ b/src/app/(authenticated)/dashboard/cat/page.tsx
@@ -16,12 +16,23 @@ import { useCatQuota } from '@/components/ai-chat/ModernChatPanel/hooks/useCatQu
 import { CatChatToolbar } from '@/components/ai-chat/CatChatToolbar';
 import { CatSecondaryPanel } from '@/components/ai-chat/CatSecondaryPanel';
 import { isCatHubTab, type CatHubTab } from '@/config/cat-hub';
+import { APP_CONTENT_HEIGHT_CLASS } from '@/config/layout-chrome';
+import { useConversations } from '@/components/ai-chat/ModernChatPanel/hooks/useConversations';
+import { ConversationRail } from '@/components/ai-chat/ModernChatPanel/components/ConversationRail';
 
 export default function CatHubPage() {
   const { user, isLoading } = useRequireAuth();
   const searchParams = useSearchParams();
   const [activeTab, setActiveTab] = useState<CatHubTab>('chat');
   const { quota, refresh: refreshQuota } = useCatQuota();
+  const {
+    conversations,
+    activeId,
+    refresh: refreshConversations,
+    selectConversation,
+    newConversation,
+    deleteConversation,
+  } = useConversations();
 
   useEffect(() => {
     const tab = searchParams?.get('tab');
@@ -48,18 +59,31 @@ export default function CatHubPage() {
   }
 
   return (
-    // h-full (not a 100dvh calc): fill the flex-resolved <main> height so the
-    // composer pins to the bottom. The dvh calc was collapsing to content height
-    // on this route, floating the composer halfway up the page.
-    <div className="oc-chat-layout h-full min-h-0">
-      <CatChatToolbar activePanel="chat" quota={quota} />
-      <ModernChatPanel
-        variant="focus"
-        initialMessage={initialMessage}
-        isNewUser={isNewUser}
-        onMessageSent={refreshQuota}
-        className="min-h-0 flex-1"
+    // Viewport-lock the chat to the region below the fixed header (the mobile
+    // bottom nav is hidden on this route — see getRouteChrome). This bounds the
+    // column to an absolute height, so a growing textarea scrolls the thread
+    // instead of pushing the composer off-screen. `h-full` collapsed to content
+    // height because the AppShell chain is min-h-screen (no bounded ancestor).
+    <div className={`relative flex min-h-0 ${APP_CONTENT_HEIGHT_CLASS}`}>
+      <ConversationRail
+        conversations={conversations}
+        activeId={activeId}
+        onSelect={selectConversation}
+        onNew={newConversation}
+        onDelete={deleteConversation}
       />
+      <div className="oc-chat-layout min-h-0 min-w-0 flex-1">
+        <CatChatToolbar activePanel="chat" quota={quota} />
+        <ModernChatPanel
+          variant="focus"
+          conversationId={activeId}
+          onConversationStarted={refreshConversations}
+          initialMessage={initialMessage}
+          isNewUser={isNewUser}
+          onMessageSent={refreshQuota}
+          className="min-h-0 flex-1"
+        />
+      </div>
     </div>
   );
 }

--- a/src/app/api/cat/conversations/[id]/route.ts
+++ b/src/app/api/cat/conversations/[id]/route.ts
@@ -1,0 +1,63 @@
+/**
+ * Cat Conversation (by id) API
+ *
+ * GET    /api/cat/conversations/[id]  - Messages for one conversation (switching)
+ * DELETE /api/cat/conversations/[id]  - Delete the conversation and its messages
+ */
+
+import { getMessagesForDisplay, deleteConversation } from '@/services/cat/conversation-history';
+import {
+  apiSuccess,
+  apiRateLimited,
+  apiNotFound,
+  handleApiError,
+} from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import { validateUUID, getValidationError } from '@/lib/api/validation';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export const GET = withAuth(async (request: AuthenticatedRequest, context: RouteParams) => {
+  const { id } = await context.params;
+  const invalid = getValidationError(validateUUID(id, 'conversation ID'));
+  if (invalid) {
+    return invalid;
+  }
+
+  const { user, supabase } = request;
+  try {
+    // getMessagesForDisplay enforces ownership (returns [] for a foreign id).
+    const messages = await getMessagesForDisplay(supabase, user.id, id);
+    return apiSuccess(messages);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const DELETE = withAuth(async (request: AuthenticatedRequest, context: RouteParams) => {
+  const { id } = await context.params;
+  const invalid = getValidationError(validateUUID(id, 'conversation ID'));
+  if (invalid) {
+    return invalid;
+  }
+
+  const { user, supabase } = request;
+
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
+  try {
+    const ok = await deleteConversation(supabase, user.id, id);
+    if (!ok) {
+      return apiNotFound('Conversation not found');
+    }
+    return apiSuccess({ success: true });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/src/app/api/cat/conversations/route.ts
+++ b/src/app/api/cat/conversations/route.ts
@@ -1,0 +1,37 @@
+/**
+ * Cat Conversations API
+ *
+ * GET  /api/cat/conversations  - List the user's conversations (rail)
+ * POST /api/cat/conversations  - Start a new conversation, returns { id }
+ */
+
+import { listConversations, createConversation } from '@/services/cat/conversation-history';
+import { apiSuccess, apiRateLimited, handleApiError } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+  try {
+    const conversations = await listConversations(supabase, user.id);
+    return apiSuccess({ conversations });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
+  try {
+    const id = await createConversation(supabase, user.id);
+    return apiSuccess({ id });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/src/app/api/cat/history/route.ts
+++ b/src/app/api/cat/history/route.ts
@@ -33,7 +33,9 @@ export const DELETE = withAuth(async (request: AuthenticatedRequest) => {
   }
 
   try {
-    await clearDefaultConversation(supabase, user.id);
+    // Clears the given conversation's messages, or the default when omitted.
+    const conversationId = new URL(request.url).searchParams.get('conversationId');
+    await clearDefaultConversation(supabase, user.id, conversationId);
     return apiSuccess({ success: true });
   } catch (error) {
     return handleApiError(error);

--- a/src/components/ai-chat/ModernChatPanel/components/ConversationRail.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/ConversationRail.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+/**
+ * CONVERSATION RAIL — Grok/ChatGPT-style left list of Cat conversations.
+ *
+ * Desktop (md+): an always-visible fixed-width column.
+ * Mobile: a slide-over drawer toggled by a floating button (the chat area owns
+ * the full width otherwise).
+ */
+
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+import { Plus, MessageSquare, Trash2, PanelLeft, X } from 'lucide-react';
+import type { ConversationSummary } from '../hooks/useConversations';
+
+interface ConversationRailProps {
+  conversations: ConversationSummary[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  onDelete: (id: string) => void;
+}
+
+function railTitle(c: ConversationSummary): string {
+  return c.title?.trim() || 'New chat';
+}
+
+function RailBody({ conversations, activeId, onSelect, onNew, onDelete }: ConversationRailProps) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="p-2">
+        <button
+          type="button"
+          onClick={onNew}
+          className="flex w-full items-center gap-2 rounded-lg border border-subtle bg-surface-base px-3 py-2 text-sm font-medium text-fg-primary transition-colors hover:bg-surface-raised"
+        >
+          <Plus className="h-4 w-4" />
+          New chat
+        </button>
+      </div>
+
+      <nav className="min-h-0 flex-1 space-y-0.5 overflow-y-auto px-2 pb-2">
+        {conversations.length === 0 ? (
+          <p className="px-3 py-4 text-xs text-fg-tertiary">No conversations yet.</p>
+        ) : (
+          conversations.map(c => {
+            const isActive = c.id === activeId;
+            return (
+              <div
+                key={c.id}
+                className={cn(
+                  'group flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors',
+                  isActive
+                    ? 'bg-surface-raised text-fg-primary'
+                    : 'text-fg-secondary hover:bg-surface-raised/60'
+                )}
+              >
+                <button
+                  type="button"
+                  onClick={() => onSelect(c.id)}
+                  className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                >
+                  <MessageSquare className="h-4 w-4 flex-shrink-0 opacity-70" />
+                  <span className="truncate">{railTitle(c)}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDelete(c.id)}
+                  className="flex-shrink-0 rounded p-1 text-fg-tertiary opacity-0 transition-opacity hover:text-status-negative group-hover:opacity-100"
+                  aria-label={`Delete ${railTitle(c)}`}
+                  title="Delete conversation"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            );
+          })
+        )}
+      </nav>
+    </div>
+  );
+}
+
+export function ConversationRail(props: ConversationRailProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <>
+      {/* Desktop column */}
+      <aside className="hidden w-64 flex-shrink-0 border-r border-subtle bg-surface-page md:flex md:flex-col">
+        <RailBody {...props} />
+      </aside>
+
+      {/* Mobile trigger */}
+      <button
+        type="button"
+        onClick={() => setMobileOpen(true)}
+        className="absolute left-2 top-2 z-20 flex h-9 w-9 items-center justify-center rounded-lg border border-subtle bg-surface-base text-fg-secondary transition-colors hover:bg-surface-raised md:hidden"
+        aria-label="Show conversations"
+      >
+        <PanelLeft className="h-4 w-4" />
+      </button>
+
+      {/* Mobile drawer */}
+      {mobileOpen && (
+        <div className="fixed inset-0 z-40 md:hidden">
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setMobileOpen(false)}
+            aria-hidden
+          />
+          <aside className="absolute left-0 top-0 flex h-full w-72 max-w-[80vw] flex-col border-r border-subtle bg-surface-page shadow-xl">
+            <div className="flex items-center justify-between px-3 py-2">
+              <span className="text-sm font-semibold text-fg-primary">Chats</span>
+              <button
+                type="button"
+                onClick={() => setMobileOpen(false)}
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-fg-secondary hover:bg-surface-raised"
+                aria-label="Close"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1">
+              <RailBody
+                {...props}
+                onSelect={id => {
+                  props.onSelect(id);
+                  setMobileOpen(false);
+                }}
+                onNew={() => {
+                  props.onNew();
+                  setMobileOpen(false);
+                }}
+              />
+            </div>
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ai-chat/ModernChatPanel/hooks/useChatHistory.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useChatHistory.ts
@@ -3,14 +3,29 @@ import { API_ROUTES } from '@/config/api-routes';
 import { logger } from '@/utils/logger';
 import type { Message } from '../types';
 
-export function useChatHistory(setMessages: React.Dispatch<React.SetStateAction<Message[]>>) {
+/**
+ * Loads chat history for the active conversation. When `conversationId` is given
+ * it loads that conversation (and reloads on switch); otherwise the user's
+ * default conversation. Clears the view immediately on switch so messages from
+ * the previous conversation don't linger while the next loads.
+ */
+export function useChatHistory(
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>,
+  conversationId?: string | null
+) {
   const [isLoadingHistory, setIsLoadingHistory] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
     setIsLoadingHistory(true);
+    // Switching conversations: drop the old thread right away.
+    setMessages([]);
 
-    fetch(API_ROUTES.CAT.HISTORY)
+    const url = conversationId
+      ? API_ROUTES.CAT.CONVERSATION(conversationId)
+      : API_ROUTES.CAT.HISTORY;
+
+    fetch(url)
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         if (cancelled || !data?.data?.length) {
@@ -45,7 +60,7 @@ export function useChatHistory(setMessages: React.Dispatch<React.SetStateAction<
     return () => {
       cancelled = true;
     };
-  }, [setMessages]);
+  }, [setMessages, conversationId]);
 
   return { isLoadingHistory };
 }

--- a/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
@@ -60,6 +60,8 @@ function readLocale(): string {
 
 interface UseChatMessagesOptions {
   selectedModel: string;
+  /** Active conversation. Omitted/null → the user's default conversation. */
+  conversationId?: string | null;
   onPendingResult?: () => void;
   /**
    * Fires once per send attempt after the request settles (success, error,
@@ -67,12 +69,19 @@ interface UseChatMessagesOptions {
    * the platform's daily counter without a page reload.
    */
   onMessageSent?: () => void;
+  /**
+   * Fires after the FIRST message of a brand-new conversation is sent, so the
+   * rail can refresh (the conversation gets its auto-title server-side).
+   */
+  onConversationStarted?: () => void;
 }
 
 export function useChatMessages({
   selectedModel,
+  conversationId,
   onPendingResult,
   onMessageSent,
+  onConversationStarted,
 }: UseChatMessagesOptions) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -83,9 +92,11 @@ export function useChatMessages({
   onPendingResultRef.current = onPendingResult;
   const onMessageSentRef = useRef(onMessageSent);
   onMessageSentRef.current = onMessageSent;
+  const onConversationStartedRef = useRef(onConversationStarted);
+  onConversationStartedRef.current = onConversationStarted;
   const preferredCurrency = useUserCurrency();
 
-  const { isLoadingHistory } = useChatHistory(setMessages);
+  const { isLoadingHistory } = useChatHistory(setMessages, conversationId);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -133,6 +144,7 @@ export function useChatMessages({
             preferredCurrency,
             locale: readLocale(),
             lastVisitedPath: readLastVisitedPath(),
+            conversationId: conversationId ?? undefined,
           }),
           signal: abortController.signal,
         });
@@ -289,18 +301,23 @@ export function useChatMessages({
         abortControllerRef.current = null;
         setIsLoading(false);
         onMessageSentRef.current?.();
+        // Refresh the rail: titles (first message) + recency ordering.
+        onConversationStartedRef.current?.();
       }
     },
-    [isLoading, selectedModel, preferredCurrency]
+    [isLoading, selectedModel, preferredCurrency, conversationId]
   );
 
   const clearChat = useCallback(() => {
     setMessages([]);
     setError(null);
-    fetch(API_ROUTES.CAT.HISTORY, { method: 'DELETE' }).catch((err: unknown) => {
+    const url = conversationId
+      ? `${API_ROUTES.CAT.HISTORY}?conversationId=${encodeURIComponent(conversationId)}`
+      : API_ROUTES.CAT.HISTORY;
+    fetch(url, { method: 'DELETE' }).catch((err: unknown) => {
       logger.warn('Failed to clear server history', { err }, 'useChatMessages');
     });
-  }, []);
+  }, [conversationId]);
 
   const setErrorState = useCallback((err: string | null) => {
     setError(err);

--- a/src/components/ai-chat/ModernChatPanel/hooks/useConversations.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useConversations.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from 'react';
+import { API_ROUTES } from '@/config/api-routes';
+import { logger } from '@/utils/logger';
+
+export interface ConversationSummary {
+  id: string;
+  title: string | null;
+  is_default: boolean;
+  updated_at: string;
+}
+
+/**
+ * Manages the user's Cat conversation list for the rail: load, switch, start a
+ * new chat, and delete. The active id drives which conversation the chat panel
+ * loads/sends to. On first load the most-recently-updated conversation is active
+ * (null until we know — the panel falls back to the default conversation).
+ */
+export function useConversations() {
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(API_ROUTES.CAT.CONVERSATIONS);
+      if (!res.ok) {
+        return;
+      }
+      const data = await res.json();
+      const list: ConversationSummary[] = data?.data?.conversations ?? [];
+      setConversations(list);
+      // Adopt an active id on first load (most recent) if none is set yet.
+      setActiveId(prev => prev ?? list[0]?.id ?? null);
+    } catch (err) {
+      logger.warn('Failed to load conversations', { err }, 'useConversations');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const selectConversation = useCallback((id: string) => {
+    setActiveId(id);
+  }, []);
+
+  const newConversation = useCallback(async () => {
+    try {
+      const res = await fetch(API_ROUTES.CAT.CONVERSATIONS, { method: 'POST' });
+      if (!res.ok) {
+        return;
+      }
+      const data = await res.json();
+      const id: string | undefined = data?.data?.id;
+      if (id) {
+        setActiveId(id);
+        await refresh();
+      }
+    } catch (err) {
+      logger.warn('Failed to start new conversation', { err }, 'useConversations');
+    }
+  }, [refresh]);
+
+  const deleteConversation = useCallback(
+    async (id: string) => {
+      // Optimistic: drop it from the list immediately.
+      setConversations(prev => prev.filter(c => c.id !== id));
+      setActiveId(prev => {
+        if (prev !== id) {
+          return prev;
+        }
+        // Was active → fall back to the next most-recent, or default (null).
+        const remaining = conversations.filter(c => c.id !== id);
+        return remaining[0]?.id ?? null;
+      });
+      try {
+        await fetch(API_ROUTES.CAT.CONVERSATION(id), { method: 'DELETE' });
+      } catch (err) {
+        logger.warn('Failed to delete conversation', { err }, 'useConversations');
+      }
+      await refresh();
+    },
+    [conversations, refresh]
+  );
+
+  return {
+    conversations,
+    activeId,
+    isLoading,
+    refresh,
+    selectConversation,
+    newConversation,
+    deleteConversation,
+  };
+}

--- a/src/components/ai-chat/ModernChatPanel/index.tsx
+++ b/src/components/ai-chat/ModernChatPanel/index.tsx
@@ -36,6 +36,10 @@ interface ModernChatPanelProps {
    * page reload. Composed alongside the internal post-send wiring.
    */
   onMessageSent?: () => void;
+  /** Active conversation to load/send to. Omitted/null → default conversation. */
+  conversationId?: string | null;
+  /** Fires after each send so the conversation rail can refresh title + order. */
+  onConversationStarted?: () => void;
   className?: string;
 }
 
@@ -47,6 +51,8 @@ export function ModernChatPanel({
   onModelSelect,
   onLoadingChange,
   onMessageSent,
+  conversationId,
+  onConversationStarted,
   className,
 }: ModernChatPanelProps = {}) {
   const router = useRouter();
@@ -93,11 +99,13 @@ export function ModernChatPanel({
     addSystemMessage,
   } = useChatMessages({
     selectedModel,
+    conversationId,
     onPendingResult: () => refreshPendingActionsRef.current?.(),
     onMessageSent: () => {
       refreshQuota();
       onMessageSent?.();
     },
+    onConversationStarted,
   });
 
   const { suggestions, hasContext, isLoadingSuggestions } = useSuggestions();

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -19,6 +19,8 @@ export const API_ROUTES = {
     CREDITS_TOPUP: '/api/cat/credits/topup',
     MEMORIES: '/api/cat/memories',
     NUDGES: '/api/cat/nudges',
+    CONVERSATIONS: '/api/cat/conversations',
+    CONVERSATION: (id: string) => `/api/cat/conversations/${id}`,
   },
   INTEGRATION_KEYS: {
     BASE: '/api/integration-keys',

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -21,7 +21,7 @@ import { buildReplyLanguageDirective } from '@/services/cat/reply-language';
 import { getCatFewShotExamplesText } from '@/services/cat/few-shot-examples';
 import { parseActionsFromResponse } from '@/services/cat/response-parser';
 import {
-  getOrCreateDefaultConversation,
+  resolveConversationIdOrDefault,
   getMessagesForContext,
   saveMessages,
 } from '@/services/cat/conversation-history';
@@ -45,6 +45,8 @@ export const catChatBodySchema = z.object({
   message: z.string().min(1).max(AI_MESSAGE_MAX_CHARS),
   model: z.string().optional(),
   stream: z.boolean().optional(),
+  /** Target conversation. Omitted → the user's default conversation. */
+  conversationId: z.string().uuid().optional(),
   /**
    * Runtime session hints from the client. Optional and untrusted — the server
    * validates each field. Drive Cat's locale, price quoting, and recent-page
@@ -180,6 +182,7 @@ export async function orchestrateCatChat(
     preferredCurrency,
     locale,
     lastVisitedPath,
+    conversationId: requestedConversationId,
   } = body;
 
   // Resolve provider, BYOK keys, model, and platform limits
@@ -238,8 +241,12 @@ export async function orchestrateCatChat(
   let conversationId: string | null = null;
   let historyMessages: Array<{ role: 'user' | 'assistant'; content: string }> = [];
   try {
-    conversationId = await getOrCreateDefaultConversation(supabase, user.id);
-    historyMessages = await getMessagesForContext(supabase, user.id);
+    conversationId = await resolveConversationIdOrDefault(
+      supabase,
+      user.id,
+      requestedConversationId
+    );
+    historyMessages = await getMessagesForContext(supabase, user.id, conversationId);
   } catch {
     /* Non-fatal — continue without history */
   }

--- a/src/services/cat/conversation-history.ts
+++ b/src/services/cat/conversation-history.ts
@@ -1,13 +1,15 @@
 /**
  * Cat Conversation History Service
  *
- * Manages persistent chat history for My Cat AI.
- * Each user has a default conversation that accumulates across sessions.
+ * Manages persistent chat history for My Cat AI. Supports multiple named
+ * conversations per user (Grok/ChatGPT-style), plus a default one used when no
+ * conversation is specified (back-compat with the single-thread UI).
  *
  * Design:
- * - One default conversation per user
- * - Last N messages injected into LLM context for continuity
+ * - Many conversations per user; one flagged is_default
+ * - Last N messages of the ACTIVE conversation injected into LLM context
  * - Messages saved after each exchange (non-blocking on the response path)
+ * - A conversation's title is auto-set from its first user message
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -22,6 +24,9 @@ const HISTORY_INJECTION_LIMIT = 20;
 /** Max messages to return for UI history display */
 const HISTORY_DISPLAY_LIMIT = 50;
 
+/** Max length of an auto-generated conversation title. */
+const TITLE_MAX_LENGTH = 60;
+
 interface StoredMessage {
   id: string;
   role: 'user' | 'assistant';
@@ -30,6 +35,13 @@ interface StoredMessage {
   provider?: string | null;
   token_count?: number | null;
   created_at: string;
+}
+
+export interface ConversationSummary {
+  id: string;
+  title: string | null;
+  is_default: boolean;
+  updated_at: string;
 }
 
 /**
@@ -67,6 +79,90 @@ export async function getOrCreateDefaultConversation(
 }
 
 /**
+ * Resolve the conversation to operate on: the requested one (if it exists and
+ * belongs to the user), otherwise null so callers can fall back to the default.
+ * Guards against acting on another user's conversation id.
+ */
+export async function resolveOwnedConversationId(
+  supabase: AnySupabaseClient,
+  userId: string,
+  conversationId?: string | null
+): Promise<string | null> {
+  if (!conversationId) {
+    return null;
+  }
+  const { data } = await supabase
+    .from(DATABASE_TABLES.CAT_CONVERSATIONS)
+    .select('id')
+    .eq('id', conversationId)
+    .eq('user_id', userId)
+    .single();
+  return data?.id ?? null;
+}
+
+/**
+ * Resolve to a usable conversation id: the requested+owned one, else the default
+ * (created on demand). Use on the write path so a message always lands somewhere.
+ */
+export async function resolveConversationIdOrDefault(
+  supabase: AnySupabaseClient,
+  userId: string,
+  conversationId?: string | null
+): Promise<string> {
+  const owned = await resolveOwnedConversationId(supabase, userId, conversationId);
+  return owned ?? (await getOrCreateDefaultConversation(supabase, userId));
+}
+
+/** List the user's conversations, most-recently-updated first. */
+export async function listConversations(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<ConversationSummary[]> {
+  const { data } = await supabase
+    .from(DATABASE_TABLES.CAT_CONVERSATIONS)
+    .select('id, title, is_default, updated_at')
+    .eq('user_id', userId)
+    .order('updated_at', { ascending: false });
+  return (data as ConversationSummary[]) ?? [];
+}
+
+/** Create a fresh (non-default) conversation and return its id. */
+export async function createConversation(
+  supabase: AnySupabaseClient,
+  userId: string,
+  title?: string | null
+): Promise<string> {
+  const { data, error } = await supabase
+    .from(DATABASE_TABLES.CAT_CONVERSATIONS)
+    .insert({ user_id: userId, is_default: false, title: title ?? null })
+    .select('id')
+    .single();
+  if (error || !data) {
+    throw new Error(`Failed to create conversation: ${error?.message}`);
+  }
+  return data.id;
+}
+
+/** Delete a conversation (and its messages) the user owns. Returns success. */
+export async function deleteConversation(
+  supabase: AnySupabaseClient,
+  userId: string,
+  conversationId: string
+): Promise<boolean> {
+  const owned = await resolveOwnedConversationId(supabase, userId, conversationId);
+  if (!owned) {
+    return false;
+  }
+  await supabase.from(DATABASE_TABLES.CAT_MESSAGES).delete().eq('conversation_id', owned);
+  const { error } = await supabase
+    .from(DATABASE_TABLES.CAT_CONVERSATIONS)
+    .delete()
+    .eq('id', owned)
+    .eq('user_id', userId);
+  return !error;
+}
+
+/**
  * Saves a batch of messages to a conversation.
  * Used to save user + assistant message pair after each exchange.
  */
@@ -94,6 +190,36 @@ export async function saveMessages(
 
   await supabase.from(DATABASE_TABLES.CAT_MESSAGES).insert(rows);
   // Ignore errors — history is best-effort, never blocks responses
+
+  // Keep the conversation fresh for rail ordering, and name an untitled
+  // conversation from its first user message (Grok/ChatGPT behaviour).
+  const firstUser = messages.find(m => m.role === 'user')?.content;
+  await bumpConversation(supabase, conversationId, firstUser);
+}
+
+/**
+ * Touch a conversation's updated_at (for recency ordering) and, if it has no
+ * title yet, set it from the given text. Best-effort.
+ */
+export async function bumpConversation(
+  supabase: AnySupabaseClient,
+  conversationId: string,
+  titleFrom?: string
+): Promise<void> {
+  const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  const title = titleFrom?.trim();
+  if (title) {
+    const { data: row } = await supabase
+      .from(DATABASE_TABLES.CAT_CONVERSATIONS)
+      .select('title')
+      .eq('id', conversationId)
+      .single();
+    if (row && !row.title) {
+      patch.title =
+        title.length > TITLE_MAX_LENGTH ? `${title.slice(0, TITLE_MAX_LENGTH).trimEnd()}…` : title;
+    }
+  }
+  await supabase.from(DATABASE_TABLES.CAT_CONVERSATIONS).update(patch).eq('id', conversationId);
 }
 
 /**
@@ -103,9 +229,12 @@ export async function saveMessages(
 export async function getMessagesForContext(
   supabase: AnySupabaseClient,
   userId: string,
+  conversationIdArg?: string | null,
   limit: number = HISTORY_INJECTION_LIMIT
 ): Promise<Array<{ role: 'user' | 'assistant'; content: string }>> {
-  const conversationId = await getDefaultConversationId(supabase, userId);
+  const conversationId =
+    (await resolveOwnedConversationId(supabase, userId, conversationIdArg)) ??
+    (await getDefaultConversationId(supabase, userId));
   if (!conversationId) {
     return [];
   }
@@ -132,9 +261,12 @@ export async function getMessagesForContext(
 export async function getMessagesForDisplay(
   supabase: AnySupabaseClient,
   userId: string,
+  conversationIdArg?: string | null,
   limit: number = HISTORY_DISPLAY_LIMIT
 ): Promise<StoredMessage[]> {
-  const conversationId = await getDefaultConversationId(supabase, userId);
+  const conversationId =
+    (await resolveOwnedConversationId(supabase, userId, conversationIdArg)) ??
+    (await getDefaultConversationId(supabase, userId));
   if (!conversationId) {
     return [];
   }
@@ -154,13 +286,17 @@ export async function getMessagesForDisplay(
 }
 
 /**
- * Deletes all messages in the user's default conversation (clear chat).
+ * Deletes all messages in a conversation (clear chat). Defaults to the user's
+ * default conversation when none is given.
  */
 export async function clearDefaultConversation(
   supabase: AnySupabaseClient,
-  userId: string
+  userId: string,
+  conversationIdArg?: string | null
 ): Promise<void> {
-  const conversationId = await getDefaultConversationId(supabase, userId);
+  const conversationId =
+    (await resolveOwnedConversationId(supabase, userId, conversationIdArg)) ??
+    (await getDefaultConversationId(supabase, userId));
   if (!conversationId) {
     return;
   }


### PR DESCRIPTION
Addresses the founder's chat feedback: the composer slid off-screen on long input, and there was no conversation list.

**1. Composer overflow** — the AppShell chain is `min-h-screen` (no bounded ancestor), so the page's `h-full` collapsed to content height and the growing textarea pushed the composer below the fold. Now viewport-locked via `APP_CONTENT_HEIGHT_CLASS` → thread scrolls, composer pinned.

**2. Conversation rail (Grok-style)** — the UI only loaded a single default conversation despite `cat_conversations` supporting many. Added: service fns (list/create/delete/resolve + auto-title + recency bump), APIs (`/api/cat/conversations` GET/POST, `/[id]` GET/DELETE, conversationId on chat+history), hooks (`useConversations`, conversation-aware history/send), and `ConversationRail` (desktop column + mobile drawer, New chat, active highlight, delete). Single-thread users keep working via default-conversation fallback.

tsc 0 · schema-drift green · lint clean. No migration (columns already exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)