### PR TITLE
fix(chat): valid calc in viewport-lock height (composer no longer floats)

### DIFF
--- a/src/components/ai-chat/ModernChatPanel/index.tsx
+++ b/src/components/ai-chat/ModernChatPanel/index.tsx
@@ -203,7 +203,7 @@ export function ModernChatPanel({
       className={cn(
         'oc-chat-layout',
         !isFocus && 'min-h-[34rem] rounded-md border border-subtle',
-        !isFocus && 'h-[calc(100dvh-15.5rem)] sm:h-[calc(100dvh-13rem)]',
+        !isFocus && 'h-[calc(100dvh_-_15.5rem)] sm:h-[calc(100dvh_-_13rem)]',
         className
       )}
     >

--- a/src/components/timeline/ProjectSelectionModal.tsx
+++ b/src/components/timeline/ProjectSelectionModal.tsx
@@ -56,7 +56,7 @@ export default function ProjectSelectionModal({
       </div>
 
       {/* Content */}
-      <div className="overflow-y-auto max-h-[calc(100dvh-60px)]">
+      <div className="overflow-y-auto max-h-[calc(100dvh_-_60px)]">
         {/* Everyone option (default - always selected) */}
         <div className="px-4 py-4 border-b border-default">
           <button

--- a/src/config/layout-chrome.ts
+++ b/src/config/layout-chrome.ts
@@ -18,8 +18,14 @@ export const APP_HEADER_HEIGHT_DESKTOP = '4rem' as const;
 /**
  * Tailwind classes for a column that fills the viewport below the fixed header.
  * Use on chat-style surfaces (Cat, messages, ai-chat).
+ *
+ * NOTE: the underscores are REQUIRED. Tailwind converts `_` → space inside
+ * arbitrary values, yielding valid `calc(100dvh - 4rem)`. Without them the CSS is
+ * `calc(100dvh-4rem)` — invalid, silently dropped — so the height never applies
+ * and chat surfaces collapse to content height (composer floats, page scrolls).
  */
-export const APP_CONTENT_HEIGHT_CLASS = 'h-[calc(100dvh-3.5rem)] sm:h-[calc(100dvh-4rem)]' as const;
+export const APP_CONTENT_HEIGHT_CLASS =
+  'h-[calc(100dvh_-_3.5rem)] sm:h-[calc(100dvh_-_4rem)]' as const;
 
 /** Max width for chat message columns (ChatGPT-style readable measure) */
 export const CHAT_CONTENT_MAX_WIDTH_CLASS = 'max-w-3xl' as const;


### PR DESCRIPTION
**Root cause of the floating composer + scrolling chat.** The height SSOT `APP_CONTENT_HEIGHT_CLASS` was `h-[calc(100dvh-3.5rem)]` — no spaces around `-`. Tailwind emits `calc(100dvh-3.5rem)` (invalid CSS → dropped), so every chat surface collapsed to content height: composer floated mid-page, the page scrolled, the conversation rail scrolled away.

Tailwind turns `_` into a space in arbitrary values, so the fix is `h-[calc(100dvh_-_4rem)]` → valid `calc(100dvh - 4rem)`. **Verified live in the browser**: the chat wrapper goes 2820px (content) → 857px (viewport − header); composer pins, rail stays put.

Fixed the SSOT const (5 consumers incl. messaging), the embedded ModernChatPanel variant, and one ProjectSelectionModal max-height with the identical bug. CI can't catch invalid Tailwind arbitrary values, so this was browser-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)