### PR TITLE
fix(chat): make viewport-lock a real CSS utility (composer was still floating)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -392,6 +392,23 @@
     @apply flex min-h-0 flex-col overflow-hidden bg-background;
   }
 
+  /*
+   * Fills the viewport below the fixed app header (chat surfaces: Cat, messages).
+   * Real CSS, NOT a Tailwind arbitrary class — the value lives in a .ts const
+   * (APP_CONTENT_HEIGHT_CLASS) that Tailwind's content scanner doesn't extract,
+   * so the generated `h-[calc(...)]` rule was always missing and chat surfaces
+   * collapsed to content height (composer floated, page scrolled). Header height
+   * is 56px (pt-14) on mobile, 64px (sm:pt-16) on >=sm — keep in sync with AppShell.
+   */
+  .app-content-height {
+    height: calc(100dvh - 3.5rem);
+  }
+  @media (min-width: 640px) {
+    .app-content-height {
+      height: calc(100dvh - 4rem);
+    }
+  }
+
   .oc-chat-toolbar {
     @apply flex flex-shrink-0 items-center justify-between gap-3 border-b border-border-subtle px-3 py-2 sm:px-4;
   }

--- a/src/config/layout-chrome.ts
+++ b/src/config/layout-chrome.ts
@@ -16,16 +16,17 @@ export const APP_HEADER_HEIGHT_MOBILE = '3.5rem' as const;
 export const APP_HEADER_HEIGHT_DESKTOP = '4rem' as const;
 
 /**
- * Tailwind classes for a column that fills the viewport below the fixed header.
+ * Class for a column that fills the viewport below the fixed header.
  * Use on chat-style surfaces (Cat, messages, ai-chat).
  *
- * NOTE: the underscores are REQUIRED. Tailwind converts `_` → space inside
- * arbitrary values, yielding valid `calc(100dvh - 4rem)`. Without them the CSS is
- * `calc(100dvh-4rem)` — invalid, silently dropped — so the height never applies
- * and chat surfaces collapse to content height (composer floats, page scrolls).
+ * This is a REAL CSS utility defined in globals.css (.app-content-height), NOT a
+ * Tailwind arbitrary value. Tailwind's content scanner doesn't extract class
+ * strings referenced only from this .ts const, so an `h-[calc(...)]` here never
+ * generated a rule — the height silently didn't apply and chat surfaces collapsed
+ * to content height (composer floated, whole page scrolled). The globals.css
+ * utility is always present and handles the responsive header offset (56/64px).
  */
-export const APP_CONTENT_HEIGHT_CLASS =
-  'h-[calc(100dvh_-_3.5rem)] sm:h-[calc(100dvh_-_4rem)]' as const;
+export const APP_CONTENT_HEIGHT_CLASS = 'app-content-height' as const;
 
 /** Max width for chat message columns (ChatGPT-style readable measure) */
 export const CHAT_CONTENT_MAX_WIDTH_CLASS = 'max-w-3xl' as const;


### PR DESCRIPTION
Browser testing caught that the previous fix didn't actually work. The deployed CSS has the inline `h-[calc(100dvh_-_15.5rem)]` (written in a .tsx) but **not** the `APP_CONTENT_HEIGHT_CLASS` values — **Tailwind's content scanner doesn't extract class strings that live only in a .ts config const**, so that rule was never generated. The chat wrapper stayed at content height (2820px vs ~805px), so the composer floated, the page scrolled, and the rail scrolled away.

Fix: `.app-content-height` as a **real CSS utility in globals.css** (compiled wholesale, no JIT extraction) with the responsive 56/64px header offset; `APP_CONTENT_HEIGHT_CLASS` now points at it. Fixes all 5 consumers (Cat, messaging, CatSecondaryPanel, skeletons). Verified live that this calc locks the wrapper to viewport−header. tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)