### PR TITLE
fix(chat): move viewport-lock to plain CSS (was purged from @layer)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -392,23 +392,6 @@
     @apply flex min-h-0 flex-col overflow-hidden bg-background;
   }
 
-  /*
-   * Fills the viewport below the fixed app header (chat surfaces: Cat, messages).
-   * Real CSS, NOT a Tailwind arbitrary class — the value lives in a .ts const
-   * (APP_CONTENT_HEIGHT_CLASS) that Tailwind's content scanner doesn't extract,
-   * so the generated `h-[calc(...)]` rule was always missing and chat surfaces
-   * collapsed to content height (composer floated, page scrolled). Header height
-   * is 56px (pt-14) on mobile, 64px (sm:pt-16) on >=sm — keep in sync with AppShell.
-   */
-  .app-content-height {
-    height: calc(100dvh - 3.5rem);
-  }
-  @media (min-width: 640px) {
-    .app-content-height {
-      height: calc(100dvh - 4rem);
-    }
-  }
-
   .oc-chat-toolbar {
     @apply flex flex-shrink-0 items-center justify-between gap-3 border-b border-border-subtle px-3 py-2 sm:px-4;
   }
@@ -879,5 +862,23 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+/*
+ * Fills the viewport below the fixed app header (chat surfaces: Cat, messages).
+ * PLAIN CSS, intentionally OUTSIDE any @layer: classes inside @layer components
+ * are purged by Tailwind unless the name is found in scanned content, and this
+ * class is referenced only via a .ts const (APP_CONTENT_HEIGHT_CLASS) that the
+ * scanner doesn't extract — so a layered/arbitrary version was purged/never
+ * generated and chat surfaces collapsed to content height (composer floated,
+ * page scrolled). Header is 56px (pt-14) mobile / 64px (sm:pt-16) >=sm.
+ */
+.app-content-height {
+  height: calc(100dvh - 3.5rem);
+}
+@media (min-width: 640px) {
+  .app-content-height {
+    height: calc(100dvh - 4rem);
   }
 }


### PR DESCRIPTION
Browser verification caught that the @layer-components version of `.app-content-height` was **absent from the deployed CSS**: Tailwind purges `@layer components` classes whose names aren't found in scanned content, and this class is referenced only via the `.ts` const (which the scanner doesn't extract) — the same root cause behind the failed arbitrary-value attempts.

Fix: define `.app-content-height` as **plain CSS outside any @layer** (PostCSS passes it through unconditionally). Verified live by injecting the exact rule — the chat wrapper locks to 805px (viewport − 64px header) and the composer pins to the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)