### PR TITLE
fix(payment): pay-panel quick-amount chips show BTC, not sats

### DIFF
--- a/src/components/payment/PublicPayPanel.tsx
+++ b/src/components/payment/PublicPayPanel.tsx
@@ -23,6 +23,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { cn } from '@/lib/utils';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { displayBTC } from '@/services/currency';
 
 interface PublicPayPanelProps {
   entityTitle: string;
@@ -46,7 +47,11 @@ interface PublicPayPanelProps {
 }
 
 /** Quick-pick contribution amounts (BTC). Small/Medium/Large, like the dashboard. */
-const SUGGESTED_BTC = [0.001, 0.005, 0.01] as const;
+const SUGGESTED_BTC = [
+  { btc: 0.001, label: 'Small' },
+  { btc: 0.005, label: 'Medium' },
+  { btc: 0.01, label: 'Large' },
+] as const;
 
 function truncateMiddle(value: string, head = 12, tail = 10): string {
   return value.length <= head + tail + 1 ? value : `${value.slice(0, head)}…${value.slice(-tail)}`;
@@ -123,7 +128,7 @@ export function PublicPayPanel({
               Choose an amount, or send any in your wallet.
             </p>
             <div className="grid grid-cols-3 gap-2">
-              {SUGGESTED_BTC.map(btc => {
+              {SUGGESTED_BTC.map(({ btc, label }) => {
                 const active = selectedBtc === btc;
                 return (
                   <button
@@ -139,16 +144,16 @@ export function PublicPayPanel({
                     )}
                   >
                     <span className="block text-sm font-semibold text-fg-primary">
-                      {formatAmountBtc(btc)}
+                      {displayBTC(btc)}
                     </span>
-                    <span className="block text-xs">{formatPrice(btc, 'BTC')}</span>
+                    <span className="block text-xs">{label}</span>
                   </button>
                 );
               })}
             </div>
             {selectedBtc !== null && !isOnchain && (
               <p className="text-xs text-fg-tertiary">
-                Lightning wallets ask for the amount — enter {formatAmountBtc(selectedBtc)} when
+                Lightning wallets ask for the amount — enter {displayBTC(selectedBtc)} when
                 prompted.
               </p>
             )}


### PR DESCRIPTION
Browser verification of the polished `PublicPayPanel` (logged out) caught a bug: the quick-amount chips showed **"100,000 sat / 100,000 sat"** — sats (logged-out users default to a SATS display pref, so `formatAmountBtc`/`formatPrice` both yield sats) and duplicated.

Fix: render each chip with `displayBTC()` (forces canonical BTC — "0.001 BTC", immune to the sats default) + a Small/Medium/Large label; same for the Lightning amount hint. No sats, no duplication. tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)