### PR TITLE
fix(currency): never display sats; logged-out defaults to CHF/BTC

### DIFF
--- a/src/config/currencies.ts
+++ b/src/config/currencies.ts
@@ -40,7 +40,10 @@ export const CURRENCY_METADATA: Record<
   SATS: { label: 'Satoshis', symbol: 'sat', precision: 0 },
 };
 
-export const currencySelectOptions = CURRENCY_CODES.map(code => ({
+// SATS stays a valid code for internal/Lightning-protocol use, but is never
+// offered as a user-facing DISPLAY currency — the platform never shows amounts
+// in sats (always a fiat currency or BTC).
+export const currencySelectOptions = CURRENCY_CODES.filter(code => code !== 'SATS').map(code => ({
   value: code,
   label: CURRENCY_METADATA[code].label,
 }));

--- a/src/hooks/useDisplayCurrency.ts
+++ b/src/hooks/useDisplayCurrency.ts
@@ -107,9 +107,11 @@ export function useDisplayCurrency(): UseDisplayCurrencyReturn {
       const btc = satsToBitcoin(sats);
       const fiatAmount = convertFromBTC(btc, displayCurrency);
 
-      // If rates not loaded yet, fall back to sats
+      // Rates not loaded yet (e.g. logged-out visitors) → fall back to BTC, the
+      // canonical unit — NEVER sats. Showing sats here was why public pages
+      // rendered "100,000 sat" before rates arrived.
       if (isLoading || fiatAmount === 0) {
-        return formatRawSats(sats);
+        return formatCurrency(btc, 'BTC', { showSymbol, compact });
       }
 
       const fiatFormatted = formatCurrency(fiatAmount, displayCurrency, { showSymbol, compact });

--- a/src/hooks/useUserCurrency.ts
+++ b/src/hooks/useUserCurrency.ts
@@ -28,7 +28,14 @@ export function useUserCurrency(): Currency {
     | string
     | undefined;
 
-  if (profileCurrency && isSupportedCurrency(profileCurrency)) {
+  // SATS is a Lightning protocol unit, not a user-facing display currency — we
+  // never display amounts in sats. Honor any legacy SATS preference as the
+  // default (CHF) instead.
+  if (
+    profileCurrency &&
+    isSupportedCurrency(profileCurrency) &&
+    profileCurrency.toUpperCase() !== 'SATS'
+  ) {
     return profileCurrency as Currency;
   }
 


### PR DESCRIPTION
**Root cause** of sats on public pages: `formatSats()` (behind `formatAmountBtc`/`formatPrice`) converts BTC→fiat, but when conversion rates aren't loaded — e.g. logged-out visitors — it fell back to **raw sats**. So amounts rendered "100,000 sat" regardless of the CHF default until rates arrived.

Per "never use sats":
- `formatSats`: rates-not-loaded fallback now renders **BTC** (canonical unit), never sats.
- `useUserCurrency`: legacy `SATS` preference → default **CHF** (sats is a protocol unit, not a display currency).
- `currencies.ts`: `SATS` dropped from `currencySelectOptions` (settings picker) so it can't be selected; stays a valid code for internal/Lightning use.

Logged-out default is CHF; if rates are unavailable it shows BTC. Never sats. tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)