### PR TITLE
fix(currency): app-wide sats sweep — remove remaining user-facing sats

### DIFF
--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -162,7 +162,7 @@ const FAQ_SECTIONS: FaqSection[] = [
       {
         question: 'What currencies are displayed?',
         answer:
-          'You can choose your preferred display currency (CHF, USD, EUR, GBP, or Bitcoin/sats) in your profile settings. All amounts are stored in BTC internally for precision, then converted for display using live exchange rates. This means you always see amounts in the currency you understand best.',
+          'You can choose your preferred display currency (CHF, USD, EUR, GBP, or Bitcoin) in your profile settings. All amounts are stored in BTC internally for precision, then converted for display using live exchange rates. This means you always see amounts in the currency you understand best.',
       },
     ],
   },

--- a/src/components/create/DynamicSidebar.tsx
+++ b/src/components/create/DynamicSidebar.tsx
@@ -87,10 +87,6 @@ function CurrencyBreakdown({ amount, currency }: { amount: number; currency: str
           <span className="text-fg-secondary">Bitcoin (BTC)</span>
           <span className="font-mono font-semibold">₿ {btc.toFixed(8)}</span>
         </div>
-        <div className="flex justify-between">
-          <span className="text-fg-secondary">Lightning (sats)</span>
-          <span className="font-mono font-semibold">{fmt(Math.round(btc * 100_000_000), 0)}</span>
-        </div>
         <div className="border-t border-subtle pt-2 space-y-1 text-xs">
           <div className="flex justify-between text-fg-secondary">
             <span>USD</span>

--- a/src/components/nostr/NostrConnectionCard.tsx
+++ b/src/components/nostr/NostrConnectionCard.tsx
@@ -5,9 +5,9 @@ import Button from '@/components/ui/Button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import Input from '@/components/ui/Input';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
-import { CurrencyDisplay } from '@/components/ui/CurrencyDisplay';
 import { shortenNpub } from '@/lib/nostr';
 import { useNostrConnectionCard } from './useNostrConnectionCard';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 
 export function NostrConnectionCard() {
   const {
@@ -39,6 +39,9 @@ export function NostrConnectionCard() {
     handleCancelNpub,
     handleCopyNpub,
   } = useNostrConnectionCard();
+  // NWC returns the balance in sats; render it in the user's display currency
+  // (CHF/BTC) — the platform never shows sats.
+  const { formatSats } = useDisplayCurrency();
 
   return (
     <Card>
@@ -124,11 +127,9 @@ export function NostrConnectionCard() {
                     <div className="flex items-center gap-2 p-2 rounded-md bg-status-positive-subtle border border-status-positive/20">
                       <Wallet className="h-4 w-4 text-status-positive" />
                       <span className="text-sm font-medium text-status-positive">Balance:</span>
-                      <CurrencyDisplay
-                        amount={balanceSats}
-                        currency="SATS"
-                        className="text-sm font-semibold text-status-positive"
-                      />
+                      <span className="text-sm font-semibold text-status-positive">
+                        {formatSats(balanceSats)}
+                      </span>
                     </div>
                   )}
                   {balanceLoading && (


### PR DESCRIPTION
Swept the app for user-facing sats after the never-sats change. Real hits fixed:
- **NostrConnectionCard**: NWC wallet balance was `<CurrencyDisplay currency="SATS">` (forced sats) → now `formatSats(balanceSats)` → user's display currency (CHF/BTC).
- **DynamicSidebar** (create "Amount Breakdown"): dropped the "Lightning (sats)" row; Bitcoin (BTC) stays.
- **faq** copy: "…or Bitcoin/sats" → "…or Bitcoin".

Non-issues confirmed: `BitcoinWalletStatsCompact` uses the hook's `formatSats` (now CHF/BTC); `PriceDisplay` shows BTC+fiat (its "sats" are comments); internal `sats` vars / `satsToBitcoin` are protocol-level. tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)