### PR TITLE
feat(entity): detail-page quick wins + per-entity primary-action SSOT

### DIFF
--- a/docs/specs/economic-agent-capability.md
+++ b/docs/specs/economic-agent-capability.md
@@ -1,0 +1,118 @@
+# Spec: Cat as Economic Agent — "What can I offer?"
+
+**Status**: Proposed
+**Date**: 2026-06-29
+
+> Cat reasons over what it knows about you + live platform demand, and proposes
+> grounded, spectrum-spanning, publishable ways to participate economically —
+> then carries them to a real transaction. This is the core of "your AI economic
+> agent," not a feature bolted onto a marketplace.
+
+---
+
+## 1. Why (first principles)
+
+Most people sit on **latent economic value they can't see or won't act on** — a
+skill, an asset, a network, a half-built thing. A résumé is passive; LinkedIn shows
+you to recruiters for jobs. OrangeCat's promise is different and bigger: an agent
+that **actively turns who you are into income, funding, and opportunity**, across
+the full economic spectrum, continuously.
+
+The value is real **only if** suggestions are grounded and specific. The failure
+modes (and the guardrails that kill them) are first-class requirements, not caveats:
+
+| Failure mode                   | Guardrail                                                                                                                                                                                                      |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Generic ("you could consult!") | Every suggestion is a **packaged offer** with title, scope, price, and a draft listing                                                                                                                         |
+| Fabricated demand              | Suggestions cite **real signals** (on-platform searches/requests, comparable listings, matchable counterparties) or are flagged speculative. Never invent demand (cf. the earlier "Cat invented personas" bug) |
+| Hustle-pressure                | **Opt-in**, calibrated; respects users who are here to fund/learn/govern, not sell                                                                                                                             |
+| Cold-start (no buyers yet)     | Lean on **packaging + drafting** value early; matchmaking value grows with network density. Be honest about which is which                                                                                     |
+| Real-identity assumption       | **Pseudonymous by default**; user chooses what becomes public                                                                                                                                                  |
+
+## 2. What it does
+
+A capability Cat can invoke (and offer proactively at the right moments):
+**given everything it knows about you, propose concrete ways to participate
+economically, ranked, grounded, and one approval from being live.**
+
+### Inputs (Cat's world model)
+
+- **Profile** — bio, background, skills, location, links.
+- **Documents** (`document` entity = "structured context for the Cat") — e.g. a
+  pasted LinkedIn/CV, portfolio, notes.
+- **Memories** (`cat_memories`) — durable facts learned over time.
+- **Existing entities** — what you already offer (avoid duplicates; suggest gaps).
+- **Live demand signals** — recent platform searches, unmet `search_platform`
+  queries, comparable active listings + their prices, open requests. _(This source
+  is the main new dependency — see §4.)_
+
+### Reasoning
+
+1. Extract your **latent assets**: skills, experiences, assets, audiences, outputs.
+2. Map each asset to the **economic spectrum** — not just "sell a service":
+   - skill → `service` (for hire) · output → `product` · venture → `project` (fundable)
+   - asset → `asset` (rent/sell) · expertise → `research`/`document` · capital → `investment`/`loan`
+   - audience/community → `group`/`circle` · cause you care about → `cause`
+3. **Ground & rank** each candidate offer against demand signals + comparables.
+   Score = fit × demand × ease-to-publish. Drop the ungrounded.
+4. **Package** the survivors: title, scope/what's-included, suggested price (in CHF,
+   payable in Bitcoin/any currency), and a one-line rationale citing the signal.
+
+### Output
+
+A short, ranked set of **proposed offers**, each a reviewable card:
+
+```
+💼  "Ship-your-Next.js-app review"  ·  Service  ·  CHF 120 / 60 min
+    Why: 3 people searched "next.js performance" this week; you've shipped 4 such apps.
+    Confidence: grounded (real demand)        [ Edit ]  [ Publish ]
+```
+
+Each card is a `prefill_entity_form` draft → one tap publishes a real entity → it
+enters search + matchmaking → you get paid. The agent **closes the loop**, it
+doesn't just ideate.
+
+## 3. UX / where it shows up
+
+- **Explicit**: "What can I offer?" / "Help me make money with what I have" → Cat
+  runs the capability and returns the ranked cards.
+- **Proactive (opt-in, calibrated)**: after a profile/LinkedIn import, after adding
+  a document, or as an occasional nudge — _offered_, dismissible, never pushy.
+- **Honest framing**: each card shows confidence (grounded vs speculative). Cat says
+  what it's unsure about rather than overselling.
+
+## 4. Build (reuses existing primitives)
+
+Already exist: `prefill_entity_form` (single-entity drafting), the `document` entity
+type, semantic memory (`cat_memories` + pgvector), `search_platform`, the entity
+registry, the payment engine.
+
+Gaps to build:
+
+1. **Profile/document import → world model**: an `update_profile` / enrich action
+   (Cat currently can't write the profile) + auto-saving a paste as a `document`.
+2. **Multi-entity prefill**: let one blob yield **several** ranked offer drafts
+   (today prefill is one-at-a-time and keyword-gated).
+3. **Demand-signal source**: a lightweight service exposing recent searches / unmet
+   queries / comparable-listing stats for grounding (the one real new dependency).
+4. **The "offer engine" handler**: a Cat capability that runs the §2 reasoning over
+   inputs + signals and emits ranked offer cards.
+5. **Guardrail prompts/tests**: grounded-only, confidence-flagged, opt-in — with a
+   regression test that it never fabricates demand.
+
+### Sequencing
+
+1. Profile/document import (enrich profile + save `document`) — unlocks the world model.
+2. Multi-entity prefill from a blob — immediate, packaging-led value (works pre-liquidity).
+3. Demand-signal grounding + ranking — turns suggestions from plausible to evidenced.
+4. Proactive, calibrated surfacing — once quality is proven.
+
+## 5. Acceptance
+
+- Given a populated profile/document, Cat returns ≥3 **specific, packaged,
+  publishable** offers spanning more than one entity type.
+- Each cites a real signal or is explicitly flagged speculative — **zero fabricated
+  demand** (tested).
+- One tap on a card publishes a real entity that enters search/matchmaking.
+- Opt-in; never shown to a user who's signalled they don't want to sell.
+- Pseudonymous-safe; user controls what's public.

--- a/docs/specs/entity-detail-redesign.md
+++ b/docs/specs/entity-detail-redesign.md
@@ -1,0 +1,160 @@
+# Spec: Entity Detail Page Redesign
+
+**Status**: Proposed
+**Date**: 2026-06-29
+**Problem owner**: founder (flagged the service detail page as "useless and ugly")
+
+---
+
+## 1. The problem (first principles)
+
+A detail page exists for **one reason**: so a specific person can take a specific
+action. Today our pages don't know who's looking or what they should do, so they
+render a **debug dump of database columns**.
+
+The service page the founder saw (the dashboard/owner view, `EntityDetailPage` →
+`makeDefaultDetailFields`):
+
+```
+International Cooperation, Translation, or Research Service   ← breadcrumb crumb
+International Cooperation, Translation, or Research Service   ← h1 (duplicated)
+<AI-generated description>                                    ← subtitle
+Status      active            Created   6/29/2026, 8:47:27 PM
+Category    Translation        Updated  6/29/2026, 8:47:31 PM
+Pricing     CHF 50.00/hour
+Location    Remote
+```
+
+What's wrong, concretely:
+
+| Issue                                             | Why it's wrong (ground truth)                                 |
+| ------------------------------------------------- | ------------------------------------------------------------- |
+| Title rendered twice (breadcrumb crumb + h1)      | Redundant; wastes the most valuable space                     |
+| `Status: active` shown as a value                 | Internal state, not something a viewer acts on                |
+| `Created` / `Updated` timestamps as primary facts | Meaningless to a buyer; they answer no question anyone has    |
+| Flat `label → value` grid (Object.entries dump)   | A spreadsheet, not a page. No hierarchy, no story             |
+| No provider / identity / trust                    | Who is Anja? Why trust her? Buried in prose                   |
+| **No action.** Only "Edit" (owner)                | The page's entire purpose — let someone transact — is missing |
+| Description = generic "Description" card          | Doesn't frame the offer or its value                          |
+
+The founder's question — _"what exactly would a user do with it? how would they
+act?"_ — has no answer on the current page. **That is the bug.**
+
+## 2. The insight: intent is already in the taxonomy
+
+We don't have to guess the action. The entity economic taxonomy (`.claude/CLAUDE.md`)
+already defines what each entity is _for_ — so each has exactly one primary verb:
+
+| Entity                     | Who lands here | The ONE action             |
+| -------------------------- | -------------- | -------------------------- |
+| service                    | a buyer        | **Book / Hire** → pay      |
+| product                    | a buyer        | **Buy** → pay              |
+| project / cause / research | a supporter    | **Fund**                   |
+| event                      | an attendee    | **RSVP / Get ticket**      |
+| loan                       | a lender       | **Review & lend**          |
+| investment                 | an investor    | **Review & invest**        |
+| asset                      | a renter/buyer | **Rent / Buy**             |
+| ai_assistant               | a user         | **Chat**                   |
+| group / circle             | a person       | **Join / Request to join** |
+| wishlist                   | a giver        | **Gift an item**           |
+
+So the primary action is a **property of the entity type**, and belongs in the
+registry SSOT — not hardcoded per page.
+
+## 3. The solution — one intent-driven detail experience
+
+### Product lens — purpose per surface
+
+There are two viewers of the same entity. They are **not** two pages; they are one
+layout with a mode:
+
+1. **Visitor (public)** — _understand → trust → act_. Sell the offer, establish the
+   provider's credibility, and put the primary action one tap away.
+2. **Owner (dashboard)** — _preview → manage → grow_. The owner should see **exactly
+   what buyers see**, plus a management bar (Edit · Share · Status · Stats) and a
+   "This is your live listing" framing. The current separate flat-dump view is
+   **deleted** — it taught owners their listing looks like a database row.
+
+### UX lens — information hierarchy (top → bottom)
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ [cover image OR type icon]   Service · Translation          │  ← context, not a badge soup
+│ International Cooperation, Translation & Research            │  ← title ONCE
+│ 👤 Anja Dräger · ex-diplomat · FR/EN  →profile              │  ← provider + 1-line credibility
+│ CHF 50/hr · Remote · ~1 day response                        │  ← key facts as an inline strip
+│ ┌──────────────────────────┐                                │
+│ │  Book this service  ⚡    │  ← PRIMARY action, above fold │
+│ └──────────────────────────┘     (sticky on mobile)         │
+├────────────────────────────────────────────────────────────┤
+│ About this service                                           │  ← description as a real section
+│ <readable prose, the offer + what's included>                │
+│                                                              │
+│ What you get / How it works  (entity-specific slots)         │
+│                                                              │
+│ About Anja  — other listings, verification, languages        │  ← trust
+└────────────────────────────────────────────────────────────┘
+```
+
+Rules:
+
+- **Title once.** Breadcrumb's last crumb is muted/non-link or dropped.
+- **No `Status:`/`Created`/`Updated` as content.** At most a subtle "Listed 29 Jun"
+  line. Internal status drives availability, not a displayed field.
+- **Facts are a designed strip**, not a label/value table — only the 3–5 facts a
+  buyer actually weighs (price, location/delivery, duration, availability).
+- Primary CTA is visible **above the fold** and sticky on mobile (the sticky bar
+  already exists — wire it to the real verb, not a generic "Support").
+- Empty/missing fields are **omitted**, never shown as "—".
+
+### Engineering lens — SSOT / DRY / SoC
+
+One system, config-driven. No per-entity page code, no Object.entries dumps.
+
+1. **Extend the registry** with detail intent (the only new SSOT):
+   ```ts
+   // entity-registry.ts — per entity
+   detail: {
+     ctaLabel: 'Book this service',     // the economic verb
+     descriptionTitle: 'About this service',
+     ownerLabel: 'Provider',
+   }
+   ```
+   `paymentPattern` (contribution vs fixed_price) already exists and selects the
+   transaction flow.
+2. **Per-entity `factStrip(entity)`** lives in that entity's config
+   (`src/config/entity-configs/*`) — returns the 3–5 buyer-relevant facts. Replaces
+   `makeDefaultDetailFields`'s blind column dump. SSOT for "what matters" per type.
+3. **One detail layout** (`PublicEntityDetailPage` is 90% there). Owner view becomes
+   `<PublicEntityDetailPage mode="owner" />` — same layout + a management bar slot.
+   **Delete** `EntityDetailPage.makeDefaultDetailFields` and the dashboard's flat grid.
+4. **Reuse** `PublicEntityPaymentSection` (already the transaction engine) for the CTA.
+5. **Demote timestamps**: `PublicEntityTimestamps` → at most a one-line "Listed" in
+   the provider area; remove from the primary column.
+6. **SoC**: page = layout; registry = intent; entity config = facts; payment section
+   = transaction. Adding a new entity still touches ~2 files.
+
+Litmus: _"Can a new team member explain it in one sentence?"_ → "Every entity renders
+through one intent-driven detail layout; what differs (CTA verb, facts, copy) comes
+from the registry + that entity's config."
+
+## 4. Rollout
+
+1. **Quick wins (ship first, low risk):** drop the breadcrumb title-dup; remove
+   `Status`/`Created`/`Updated` from the owner flat view; add the real primary CTA;
+   surface the provider. Immediately makes the page answer "what do I do here?".
+2. **Owner = public + management bar:** delete the flat dump; route owners to the
+   real layout in `mode="owner"`.
+3. **Fact strips + intent registry:** move per-type facts into config; add
+   `meta.detail`.
+4. **Polish:** trust block (other listings, verification), "Listed" line, empty-state
+   omission, visual pass against the design tokens.
+
+## 5. Acceptance
+
+- A logged-out visitor on any entity sees: title once, provider + credibility, the
+  3–5 facts that matter, and **one obvious primary action above the fold**.
+- An owner sees their **live listing as buyers see it** + a manage bar — never a
+  column dump.
+- Zero `created_at`/`updated_at`/`Status:` rendered as primary content.
+- Adding a new entity type requires no new detail-page code.

--- a/src/components/entity/EntityDetailPage.tsx
+++ b/src/components/entity/EntityDetailPage.tsx
@@ -4,7 +4,7 @@ import { getOrCreateUserActor } from '@/services/actors/getOrCreateUserActor';
 import EntityDetailLayout from '@/components/entity/EntityDetailLayout';
 import Link from 'next/link';
 import { Button } from '@/components/ui/Button';
-import { getTableName, type EntityType } from '@/config/entity-registry';
+import { getTableName, getEntityMetadata, type EntityType } from '@/config/entity-registry';
 import type { EntityConfig, BaseEntity } from '@/types/entity';
 import { PLATFORM_DEFAULT_CURRENCY, isSupportedCurrency } from '@/config/currencies';
 import { DATABASE_TABLES } from '@/config/database-tables';
@@ -94,7 +94,6 @@ function makeDefaultDetailFields<T extends BaseEntity>(
     'fulfillment_type',
     'duration_minutes',
   ];
-  const rightFields = ['created_at', 'updated_at', 'published_at'];
 
   if (entity.status) {
     left.push({
@@ -129,24 +128,11 @@ function makeDefaultDetailFields<T extends BaseEntity>(
 
     if (leftFields.some(field => key.includes(field))) {
       left.push({ label, value: formattedValue });
-    } else if (rightFields.some(field => key.includes(field))) {
-      right.push({ label, value: formattedValue });
     }
   });
 
-  if (entity.created_at) {
-    right.push({
-      label: 'Created',
-      value: new Date(entity.created_at).toLocaleString(),
-    });
-  }
-  if (entity.updated_at) {
-    right.push({
-      label: 'Updated',
-      value: new Date(entity.updated_at).toLocaleString(),
-    });
-  }
-
+  // Intentionally NO created_at/updated_at: raw timestamps are noise on a detail
+  // page — they answer no question a viewer (or the owner) actually has.
   return { left, right };
 }
 
@@ -217,28 +203,23 @@ export default async function EntityDetailPage<T extends BaseEntity>({
     right: rawFields.right ?? [],
   };
 
-  // Auto-append timestamps when makeDetailFields didn't already include them
-  if (makeDetailFields) {
-    const hasCreated = fields.right.some(f => f.label === 'Created');
-    const hasUpdated = fields.right.some(f => f.label === 'Updated');
-    if (!hasCreated && entity.created_at) {
-      fields.right.push({ label: 'Created', value: new Date(entity.created_at).toLocaleString() });
-    }
-    if (!hasUpdated && entity.updated_at) {
-      fields.right.push({ label: 'Updated', value: new Date(entity.updated_at).toLocaleString() });
-    }
-  }
-
+  // The owner's listing as buyers see it is the source of truth — give them a
+  // direct path to it (and to editing). No raw timestamps.
+  const publicHref = `${getEntityMetadata(entityType).publicBasePath}/${entityId}`;
   const headerActions = (
-    <Link href={config.editPath(entityId)}>
-      <Button>Edit</Button>
-    </Link>
+    <div className="flex items-center gap-2">
+      <Link href={publicHref}>
+        <Button variant="outline">View public page</Button>
+      </Link>
+      <Link href={config.editPath(entityId)}>
+        <Button>Edit</Button>
+      </Link>
+    </div>
   );
 
-  const breadcrumbItems = [
-    { label: config.namePlural, href: config.listPath },
-    { label: entity.title || 'Untitled' },
-  ];
+  // Breadcrumb ends at the entity type — the page title is already the h1, so
+  // repeating it as the last crumb just doubles the heading.
+  const breadcrumbItems = [{ label: config.namePlural, href: config.listPath }];
 
   return (
     <EntityDetailLayout

--- a/src/components/public/PublicEntityDetailPage.tsx
+++ b/src/components/public/PublicEntityDetailPage.tsx
@@ -18,8 +18,8 @@ import { generateEntityJsonLd, JsonLdScript } from '@/lib/seo/structured-data';
 import EntityShare from '@/components/sharing/EntityShare';
 import PublicEntityOwnerCard from '@/components/public/PublicEntityOwnerCard';
 import PublicEntityHero from '@/components/public/PublicEntityHero';
-import PublicEntityTimestamps from '@/components/public/PublicEntityTimestamps';
 import { PublicEntityPaymentSection } from '@/components/payment';
+import { getEntityPrimaryCta } from '@/config/entity-cta';
 import { resolveSellerReceiveInfo, type SellerReceiveInfo } from '@/domain/payments';
 import { currencyConverter } from '@/services/currency';
 import { type CurrencyCode } from '@/config/currencies';
@@ -199,10 +199,7 @@ export default async function PublicEntityDetailPage({
         <div className="bg-surface-base border-b border-default">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
             <Breadcrumb
-              items={[
-                { label: meta.namePlural, href: meta.publicBasePath || ROUTES.DISCOVER },
-                { label: entity.title },
-              ]}
+              items={[{ label: meta.namePlural, href: meta.publicBasePath || ROUTES.DISCOVER }]}
               className="mb-4"
             />
             <div className="flex items-start justify-between">
@@ -294,12 +291,6 @@ export default async function PublicEntityDetailPage({
                   />
                 </div>
               )}
-
-              <PublicEntityTimestamps
-                createdAt={entity.created_at}
-                updatedAt={entity.updated_at}
-                createdLabel={config.createdLabel}
-              />
             </div>
           </div>
         </div>
@@ -328,12 +319,13 @@ function MobileStickyCTA({ config, entity }: { config: EntityDetailConfig; entit
   if (config.mobileStickyCTA) {
     return <StickyBar href={config.mobileStickyCTA.href} label={config.mobileStickyCTA.label} />;
   }
-  // Default: anchor to the payment section. Suppressed when there
-  // isn't one and the entity hasn't provided its own.
+  // Default: anchor to the payment section with the entity's own primary verb
+  // (SSOT in entity-cta.ts) — "Book this service", "Fund this project", etc. —
+  // instead of a generic "Support". Suppressed when there's no payment section.
   if (config.showPaymentSection === false) {
     return null;
   }
-  return <StickyBar href="#pay" label="Support" />;
+  return <StickyBar href="#pay" label={getEntityPrimaryCta(config.entityType)} />;
 }
 
 function StickyBar({ href, label }: { href: string; label: string }) {

--- a/src/config/entity-cta.ts
+++ b/src/config/entity-cta.ts
@@ -1,0 +1,43 @@
+/**
+ * Entity primary actions (SSOT)
+ *
+ * Every entity is different, but each has exactly ONE primary action a visitor
+ * should take on its detail page — its economic verb, from the entity economic
+ * taxonomy (see .claude/CLAUDE.md). That per-entity difference lives here, in one
+ * place, so detail pages stay generic and adding/retuning an entity touches config,
+ * not page code.
+ */
+
+import type { EntityType } from '@/config/entity-registry';
+
+export const ENTITY_PRIMARY_CTA: Record<EntityType, string> = {
+  // Exchange — market transaction
+  product: 'Buy now',
+  service: 'Book this service',
+  // Funding (no strings) — donation/gift
+  cause: 'Donate',
+  research: 'Fund this research',
+  wishlist: 'Gift an item',
+  // Funding (soft strings) — milestone accountability
+  project: 'Fund this project',
+  // Lending / Investing
+  loan: 'Review & lend',
+  investment: 'Review & invest',
+  // Assets
+  asset: 'Rent or buy',
+  // Time-bound coordination
+  event: 'RSVP',
+  // AI services
+  ai_assistant: 'Chat',
+  // Governance / community
+  group: 'Join',
+  circle: 'Join',
+  // Cat context / wallets (no public transaction verb)
+  document: 'View',
+  wallet: 'Send',
+};
+
+/** The primary-action label for an entity type. */
+export function getEntityPrimaryCta(type: EntityType): string {
+  return ENTITY_PRIMARY_CTA[type] ?? 'View';
+}


### PR DESCRIPTION
First batch fixing the "useless and ugly" entity detail pages. Applies to **all** entities; per-entity differences come from config (SSOT), shared fixes in the generic components.

- **entity-cta.ts (new SSOT)**: each entity's one primary action — service "Book this service", project "Fund this project", event "RSVP", asset "Rent or buy"…
- **Owner view**: dropped the raw `created_at`/`updated_at` dump; added **"View public page"** (see your listing as buyers do) next to Edit; breadcrumb no longer repeats the title.
- **Public view**: removed the timestamps card; breadcrumb title-dup fixed; mobile primary CTA uses the entity's own verb, not a generic "Support".

Plus the two specs framing the bigger work (`docs/specs/entity-detail-redesign.md`, `docs/specs/economic-agent-capability.md`). tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)