### PR TITLE
fix(ui): breadcrumb alignment + converge page-title treatment (SSOT)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -333,7 +333,10 @@
   }
 
   .oc-page-title {
-    @apply mb-0 text-xl font-semibold leading-tight text-foreground sm:text-2xl;
+    /* Same heading character as the canonical <PageHeading> (font-heading +
+       tracking-display + bold) so dashboard and public titles match. Scale is
+       a touch tighter (no md:text-4xl) to suit denser dashboard layouts. */
+    @apply mb-0 font-heading text-2xl font-bold leading-tight tracking-display text-foreground sm:text-3xl;
   }
 
   .oc-page-subtitle {

--- a/src/components/ui/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb.tsx
@@ -27,15 +27,15 @@ export function Breadcrumb({ items, className = '' }: BreadcrumbProps) {
     >
       <Link
         href={ROUTES.DASHBOARD.HOME}
-        className="flex items-center gap-1 hover:text-foreground transition-colors"
+        className="flex items-center gap-1.5 hover:text-foreground transition-colors"
       >
-        <Home className="h-3.5 w-3.5" />
-        <span className="sr-only sm:not-sr-only">Home</span>
+        <Home className="h-3.5 w-3.5 shrink-0" />
+        <span>Home</span>
       </Link>
 
       {items.map((item, i) => (
         <span key={i} className="flex items-center gap-1.5">
-          <ChevronRight className="h-3.5 w-3.5 text-muted-dim dark:text-muted-foreground" />
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
           {item.href ? (
             <Link href={item.href} className="hover:text-foreground transition-colors">
               {item.label}


### PR DESCRIPTION
A consistency audit found the "frankenstein" chrome isn't competing breadcrumb code (the `Breadcrumb` component is the sole SSOT across 14 sites) — it's inconsistent treatment. First systemic fixes:

- **Breadcrumb.tsx**: even gap rhythm (Home was `gap-1` vs `gap-1.5` separators), Home label always shown (was `sr-only` on mobile → edge shifted across breakpoints), one separator color (was a light/dark fork), `shrink-0` icons. Fixes the misaligned look across all 14 breadcrumbs.
- **`oc-page-title`**: adopt the canonical `<PageHeading>` character (font-heading + tracking-display + bold) so dashboard titles match public ones (they were semibold/no-heading-font). One CSS change, every page.

The audit documented the bigger work (no single `PageHeader` primitive → 5 header structures + ~62 ad-hoc `<h1>`; breadcrumb spacing forked none/mb-4/mb-6) for a follow-up consolidation. tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)