### PR TITLE
fix(ui): pricing page bugs + full-width entity-form fields

### DIFF
--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -51,9 +51,9 @@ export default function PricingPage() {
           </h2>
           <div className="space-y-4 text-fg-primary">
             <p>
-              The destination is <strong>Pro</strong>: frontier models — Claude, GPT-4o, Grok —
-              fully managed by OrangeCat, no keys, no setup. The kind of effortless AI a serious
-              company runs on.
+              The destination is <strong>Pro</strong>: frontier models — Claude, GPT, Grok — fully
+              managed by OrangeCat, no keys, no setup. The kind of effortless AI a serious company
+              runs on.
             </p>
             <p>
               We&apos;re not there yet, and we won&apos;t pretend otherwise. OrangeCat doesn&apos;t
@@ -65,7 +65,7 @@ export default function PricingPage() {
               <li>
                 <strong className="text-fg-primary">Bring your own key</strong> — the real path to
                 frontier models <em>today</em>. Your key, your bill, zero markup. Cat runs Claude or
-                GPT-4o for you right now.
+                GPT for you right now.
               </li>
               <li>
                 <strong className="text-fg-primary">Back us in Bitcoin</strong> — believe in where
@@ -77,13 +77,16 @@ export default function PricingPage() {
         </section>
 
         {/* Founding supporter CTA band */}
-        <section id="founding" className="mb-12 rounded-lg bg-surface-public p-8 text-fg-inverted">
+        <section
+          id="founding"
+          className="mb-12 rounded-lg border border-accent-warm/30 bg-accent-warm/5 p-8 text-fg-primary"
+        >
           <div className="text-center">
-            <Sparkles className="mx-auto mb-4 h-10 w-10" aria-hidden="true" />
+            <Sparkles className="mx-auto mb-4 h-10 w-10 text-accent-warm" aria-hidden="true" />
             <h2 className="mb-3 font-heading text-2xl font-bold tracking-display">
-              Found the permissionless economy
+              Help found the permissionless economy
             </h2>
-            <p className="mx-auto mb-6 max-w-2xl text-fg-inverted/70">
+            <p className="mx-auto mb-6 max-w-2xl text-fg-secondary">
               We&apos;re building toward a world where anyone can earn, fund, and govern without
               gatekeepers. Fiat billing is coming — until then, back OrangeCat in Bitcoin and get
               first access to Pro the day it&apos;s live.

--- a/src/components/create/EntityForm/components/FormFieldGroups.tsx
+++ b/src/components/create/EntityForm/components/FormFieldGroups.tsx
@@ -55,7 +55,11 @@ export function FormFieldGroups<T extends Record<string, unknown>>({
             </div>
 
             {group.fields && group.fields.length > 0 && (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              // Single-column, full-width fields. A 2-up grid halved every input
+              // (~half width on desktop), which cramped long titles/text and
+              // couldn't be widened. Single-column forms are the best-practice
+              // default — faster to complete and readable at any text length.
+              <div className="space-y-4">
                 {group.fields.map(field => {
                   if (!isFieldVisible(field)) {
                     return null;
@@ -65,10 +69,7 @@ export function FormFieldGroups<T extends Record<string, unknown>>({
                   const aiConfidence = aiGeneratedFields.confidence[field.name] || 0.7;
 
                   return (
-                    <div
-                      key={field.name}
-                      className={`${field.colSpan === 2 ? 'md:col-span-2' : ''} ${isAIGenerated ? 'relative' : ''}`}
-                    >
+                    <div key={field.name} className={isAIGenerated ? 'relative' : ''}>
                       {isAIGenerated && <AIGeneratedIndicator confidence={aiConfidence} />}
                       <div
                         className={


### PR DESCRIPTION
**Pricing page**: dropped obsolete "GPT-4o" → brand-level "GPT"; the founding band used `bg-surface-public` (hard-coded near-black in BOTH `:root` and `.dark` → always dark) with an outline button whose `fg-primary` text was invisible on it — re-themed to a warm-accent surface that respects the theme, both CTAs legible; "Found the…" → "Help found the…".

**Entity forms**: `FormFieldGroups` put every field in a 2-up grid (half-width, cramped, bad with long text). Now single-column, full-width — the best-practice default. tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)