### PR TITLE
fix(copy): SSOT for frontier-model names + re-theme support band

### DIFF
--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -17,6 +17,7 @@
 import Link from 'next/link';
 import { ArrowLeft, Bot, Check, Server, Terminal, AlertCircle } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
+import { CAT_FRONTIER_MODELS_OR } from '@/config/cat-plans';
 import { useRequireAuth } from '@/hooks/useAuth';
 import { useAISettings } from '@/hooks/useAISettings';
 import Loading from '@/components/Loading';
@@ -93,7 +94,7 @@ export default function AISettingsPage() {
                 Capability: <span className="font-medium text-fg-secondary">Capable</span> — great
                 for chat, drafting, and suggestions. Discovery, matchmaking, and multi-step tasks
                 work best on a <span className="font-medium text-fg-secondary">frontier</span> model
-                — add a Claude, GPT-4o, or Grok key below to unlock them.
+                — add a {CAT_FRONTIER_MODELS_OR} key below to unlock them.
               </p>
             </div>
           </div>
@@ -119,7 +120,8 @@ export default function AISettingsPage() {
               </div>
               <p className="mt-1 text-sm text-fg-secondary">
                 Use any provider — direct or aggregator. You pay them, OrangeCat never sees your
-                bill. Want Claude or GPT-4o? Add an OpenRouter key — one key fronts all 200+ models.
+                bill. Want {CAT_FRONTIER_MODELS_OR}? Add an OpenRouter key — one key fronts all 200+
+                models.
               </p>
             </div>
           </div>

--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -3,7 +3,12 @@ import Link from 'next/link';
 import { Check, Sparkles, Cat as CatIcon } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import { PageHeading } from '@/components/layout/PageHeading';
-import { CAT_PLANS, type CatPlan } from '@/config/cat-plans';
+import {
+  CAT_PLANS,
+  CAT_FRONTIER_MODELS_LIST,
+  CAT_FRONTIER_MODELS_OR,
+  type CatPlan,
+} from '@/config/cat-plans';
 import { ROUTES } from '@/config/routes';
 import { cn } from '@/lib/utils';
 
@@ -51,9 +56,9 @@ export default function PricingPage() {
           </h2>
           <div className="space-y-4 text-fg-primary">
             <p>
-              The destination is <strong>Pro</strong>: frontier models — Claude, GPT, Grok — fully
-              managed by OrangeCat, no keys, no setup. The kind of effortless AI a serious company
-              runs on.
+              The destination is <strong>Pro</strong>: frontier models — {CAT_FRONTIER_MODELS_LIST}{' '}
+              — fully managed by OrangeCat, no keys, no setup. The kind of effortless AI a serious
+              company runs on.
             </p>
             <p>
               We&apos;re not there yet, and we won&apos;t pretend otherwise. OrangeCat doesn&apos;t
@@ -64,8 +69,8 @@ export default function PricingPage() {
             <ul className="space-y-3 pl-4">
               <li>
                 <strong className="text-fg-primary">Bring your own key</strong> — the real path to
-                frontier models <em>today</em>. Your key, your bill, zero markup. Cat runs Claude or
-                GPT for you right now.
+                frontier models <em>today</em>. Your key, your bill, zero markup. Cat runs{' '}
+                {CAT_FRONTIER_MODELS_OR} for you right now.
               </li>
               <li>
                 <strong className="text-fg-primary">Back us in Bitcoin</strong> — believe in where

--- a/src/app/(public)/support/page.tsx
+++ b/src/app/(public)/support/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { ArrowRight, Bitcoin, KeyRound, Sparkles, Check } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import { ROUTES } from '@/config/routes';
+import { CAT_FRONTIER_MODELS_LIST, CAT_FRONTIER_MODELS_OR } from '@/config/cat-plans';
 import { FoundingSupporterDonation } from '@/components/support/FoundingSupporterDonation';
 
 export const metadata = {
@@ -41,7 +42,7 @@ export default function SupportPage() {
         <section className="mx-auto mt-16 max-w-2xl space-y-4 text-fg-primary">
           <h2 className="font-heading text-2xl font-bold tracking-display">Why Bitcoin, why now</h2>
           <p>
-            The destination is <strong>Pro</strong>: frontier models — Claude, GPT-4o, Grok —
+            The destination is <strong>Pro</strong>: frontier models — {CAT_FRONTIER_MODELS_LIST} —
             managed entirely by OrangeCat, no keys, no setup. The effortless AI a serious company
             runs on.
           </p>
@@ -97,16 +98,19 @@ export default function SupportPage() {
         </section>
 
         {/* BYOK — the works-today path */}
-        <section className="mx-auto mt-16 max-w-2xl rounded-lg bg-surface-public p-8 text-fg-inverted">
+        <section className="mx-auto mt-16 max-w-2xl rounded-lg border border-accent-warm/30 bg-accent-warm/5 p-8 text-fg-primary">
           <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start gap-3">
-              <KeyRound className="mt-1 h-6 w-6 flex-shrink-0" aria-hidden="true" />
+              <KeyRound
+                className="mt-1 h-6 w-6 flex-shrink-0 text-accent-warm"
+                aria-hidden="true"
+              />
               <div>
                 <h2 className="font-heading text-xl font-bold tracking-display">
                   Want frontier models right now?
                 </h2>
-                <p className="mt-1 max-w-md text-fg-inverted/70">
-                  Bring your own key. Cat runs Claude, GPT-4o, or Grok for you today — your key,
+                <p className="mt-1 max-w-md text-fg-secondary">
+                  Bring your own key. Cat runs {CAT_FRONTIER_MODELS_OR} for you today — your key,
                   your bill, zero markup. No waiting on us.
                 </p>
               </div>

--- a/src/config/cat-plans.ts
+++ b/src/config/cat-plans.ts
@@ -57,6 +57,18 @@ export const CAT_WIRED_PROVIDERS = [
   'xAI (Grok)',
 ] as const;
 
+/**
+ * SSOT for the frontier models named in marketing copy (pricing, support,
+ * settings). Brand-level on purpose — never a specific version like "GPT-4o",
+ * which reads as stale the moment a new model ships. Change here once and every
+ * page updates; do NOT hardcode this list in page copy.
+ */
+export const CAT_FRONTIER_MODELS = ['Claude', 'GPT', 'Grok'] as const;
+/** "Claude, GPT, Grok" */
+export const CAT_FRONTIER_MODELS_LIST = CAT_FRONTIER_MODELS.join(', ');
+/** "Claude, GPT, or Grok" */
+export const CAT_FRONTIER_MODELS_OR = `${CAT_FRONTIER_MODELS.slice(0, -1).join(', ')}, or ${CAT_FRONTIER_MODELS[CAT_FRONTIER_MODELS.length - 1]}`;
+
 export const CAT_PLANS: CatPlan[] = [
   {
     id: 'free',
@@ -79,7 +91,7 @@ export const CAT_PLANS: CatPlan[] = [
     priceCopy: 'CHF 0 / mo to OrangeCat',
     bullets: [
       `Six providers wired direct: ${CAT_WIRED_PROVIDERS.join(', ')}`,
-      'Want Claude / GPT-4o / Gemini? OpenRouter fronts 200+ models with one key',
+      'Want Claude / GPT / Gemini? OpenRouter fronts 200+ models with one key',
       'Cat routes through your key — OrangeCat never sees your bill, never marks it up',
       'Keys encrypted at rest, scrubbed from logs, never echoed back to the client',
     ],
@@ -94,7 +106,7 @@ export const CAT_PLANS: CatPlan[] = [
     // Franc price as the future anchor; the card makes clear it's not live yet.
     priceCopy: 'CHF 19 / mo · founding access',
     bullets: [
-      'Frontier models (Claude, GPT-4o, Grok) managed by OrangeCat — no keys, no setup',
+      `Frontier models (${CAT_FRONTIER_MODELS_LIST}) managed by OrangeCat — no keys, no setup`,
       'Higher limits, smarter defaults, full agentic Cat (discovery, matchmaking, multi-step)',
       'Fiat billing is coming — until then, back us in Bitcoin as a founding supporter',
       'Founding supporters get recognition and first access the day Pro goes live',


### PR DESCRIPTION
The "Claude, GPT-4o, Grok" line was hardcoded prose in 4 places (pricing, support, settings/ai, cat-plans) — fixing one left the others stale. Now SSOT: `CAT_FRONTIER_MODELS` in cat-plans + `_LIST`/`_OR` helpers, brand-level (no stale version), consumed everywhere. Support's always-dark `bg-surface-public` band re-themed to match pricing. Technical GPT-4o model identifiers left as-is. tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)