### PR TITLE
fix(ui): draft preview (no owner 404) + Discover tile overflow/heights + header symmetry

### DIFF
--- a/src/components/entity/variants/GenericPublicCard.tsx
+++ b/src/components/entity/variants/GenericPublicCard.tsx
@@ -69,8 +69,8 @@ export function GenericPublicCard({
     <Link href={href}>
       <Card className="oc-card-link h-full">
         <CardHeader className="pb-3">
-          <div className="flex items-start justify-between">
-            <div className="flex items-center gap-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               <div className="oc-icon-tile h-8 w-8 flex-shrink-0">
                 {Icon && <Icon className="w-4 h-4 text-fg-secondary" />}
               </div>

--- a/src/components/entity/variants/InvestmentCard.tsx
+++ b/src/components/entity/variants/InvestmentCard.tsx
@@ -59,9 +59,9 @@ export function InvestmentCard({ investment, viewMode = 'grid' }: InvestmentCard
     <Link href={`${ENTITY_REGISTRY['investment'].publicBasePath}/${investment.id}`}>
       <Card className="oc-card-link h-full">
         <CardHeader className="pb-3">
-          <div className="flex items-start justify-between">
-            <div className="flex items-center gap-2">
-              <div className="oc-icon-tile h-8 w-8">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="oc-icon-tile h-8 w-8 flex-shrink-0">
                 <TrendingUp className="w-4 h-4 text-status-positive" />
               </div>
               <div className="flex-1 min-w-0">

--- a/src/components/entity/variants/LoanCard.tsx
+++ b/src/components/entity/variants/LoanCard.tsx
@@ -70,9 +70,9 @@ export function LoanCard({ loan, viewMode = 'grid' }: LoanCardProps) {
     <Link href={`${ENTITY_REGISTRY['loan'].publicBasePath}/${loan.id}`}>
       <Card className="oc-card-link h-full">
         <CardHeader className="pb-3">
-          <div className="flex items-start justify-between">
-            <div className="flex items-center gap-2">
-              <div className="oc-icon-tile h-8 w-8">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="oc-icon-tile h-8 w-8 flex-shrink-0">
                 <DollarSign className="w-4 h-4 text-fg-primary" />
               </div>
               <div className="flex-1 min-w-0">

--- a/src/components/public/PublicEntityDetailPage.tsx
+++ b/src/components/public/PublicEntityDetailPage.tsx
@@ -148,18 +148,39 @@ export default async function PublicEntityDetailPage({
   const Icon = meta.icon;
 
   const supabase = await createServerClient();
-  const { data, error } = await supabase
-    .from(getTableName(config.entityType))
+  const table = getTableName(config.entityType);
+  const visibilityCol = config.visibilityFilter?.column ?? 'status';
+  const visibilityVal = config.visibilityFilter?.value ?? STATUS.PRODUCTS.ACTIVE;
+
+  const { data: publicData } = await supabase
+    .from(table)
     .select('*')
     .eq('id', id)
-    .eq(
-      config.visibilityFilter?.column ?? 'status',
-      config.visibilityFilter?.value ?? STATUS.PRODUCTS.ACTIVE
-    )
+    .eq(visibilityCol, visibilityVal)
     .single();
 
-  const entity = data as EntityData | null;
-  if (error || !entity) {
+  let entity = publicData as EntityData | null;
+  let isOwnerPreview = false;
+
+  // Not publicly visible (e.g. a draft). Let the OWNER preview it — the dashboard
+  // "View public page" link would otherwise hit a bare 404 for unpublished
+  // entities. Verify ownership before showing; never leak a draft to anyone else.
+  if (!entity) {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user) {
+      const { data: ownData } = await supabase.from(table).select('*').eq('id', id).single();
+      const candidate = ownData as EntityData | null;
+      const candidateOwner = candidate ? await fetchEntityOwner(supabase, candidate) : null;
+      if (candidate && candidateOwner?.user_id && candidateOwner.user_id === user.id) {
+        entity = candidate;
+        isOwnerPreview = true;
+      }
+    }
+  }
+
+  if (!entity) {
     notFound();
   }
 
@@ -196,6 +217,13 @@ export default async function PublicEntityDetailPage({
     <>
       <JsonLdScript data={jsonLd} />
       <div className={`min-h-screen oc-mobile-action-stack-padding ${pageSurface}`}>
+        {isOwnerPreview && (
+          <div className="border-b border-accent-warm/30 bg-accent-warm/10 px-4 py-2.5 text-center text-sm text-fg-primary">
+            Preview — this {meta.name.toLowerCase()} is{' '}
+            <span className="font-medium capitalize">{entity.status}</span> and only visible to you.
+            Publish it to make this page public.
+          </div>
+        )}
         <div className="bg-surface-base border-b border-default">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
             <Breadcrumb

--- a/src/components/ui/ProfileCard.tsx
+++ b/src/components/ui/ProfileCard.tsx
@@ -20,7 +20,7 @@ export default function ProfileCard({ profile, viewMode = 'grid' }: ProfileCardP
   const displayName = profile.name || profile.username || 'Anonymous';
 
   const TypeBadge = () => (
-    <div className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-muted text-fg-secondary border border-border-subtle">
+    <div className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-surface-raised text-fg-secondary border border-border-subtle">
       <Users className="w-3 h-3 mr-1" />
       Person
     </div>
@@ -31,7 +31,7 @@ export default function ProfileCard({ profile, viewMode = 'grid' }: ProfileCardP
       <Card className="p-4 oc-card-link">
         <div className="flex items-center gap-4">
           <Link href={ROUTES.PROFILES.VIEW(profile.username || profile.id)}>
-            <div className="relative w-12 h-12 rounded-full overflow-hidden bg-muted flex-shrink-0">
+            <div className="relative w-12 h-12 rounded-full overflow-hidden bg-surface-raised flex-shrink-0">
               {profile.avatar_url ? (
                 <Image
                   src={profile.avatar_url}
@@ -51,17 +51,17 @@ export default function ProfileCard({ profile, viewMode = 'grid' }: ProfileCardP
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
               <Link href={ROUTES.PROFILES.VIEW(profile.username || profile.id)}>
-                <h3 className="font-semibold text-foreground hover:underline underline-offset-4 truncate">
+                <h3 className="font-semibold text-fg-primary hover:underline underline-offset-4 truncate">
                   {displayName}
                 </h3>
               </Link>
               <TypeBadge />
             </div>
             {profile.username && (
-              <p className="text-sm text-muted-foreground truncate">@{profile.username}</p>
+              <p className="text-sm text-fg-secondary truncate">@{profile.username}</p>
             )}
             {profile.bio && (
-              <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{profile.bio}</p>
+              <p className="text-sm text-fg-secondary mt-1 line-clamp-2">{profile.bio}</p>
             )}
           </div>
 
@@ -80,10 +80,10 @@ export default function ProfileCard({ profile, viewMode = 'grid' }: ProfileCardP
 
   // Grid view
   return (
-    <Card className="p-6 oc-card-link">
+    <Card className="h-full p-6 oc-card-link">
       <div className="text-center">
         <Link href={ROUTES.PROFILES.VIEW(profile.username || profile.id)}>
-          <div className="relative w-20 h-20 rounded-full overflow-hidden bg-muted mx-auto mb-4">
+          <div className="relative w-20 h-20 rounded-full overflow-hidden bg-surface-raised mx-auto mb-4">
             {profile.avatar_url ? (
               <Image
                 src={profile.avatar_url}
@@ -100,19 +100,17 @@ export default function ProfileCard({ profile, viewMode = 'grid' }: ProfileCardP
 
         <div className="flex items-center justify-center gap-2 mb-2">
           <Link href={ROUTES.PROFILES.VIEW(profile.username || profile.id)}>
-            <h3 className="font-semibold text-foreground hover:underline underline-offset-4">
+            <h3 className="font-semibold text-fg-primary hover:underline underline-offset-4">
               {displayName}
             </h3>
           </Link>
           <TypeBadge />
         </div>
 
-        {profile.username && (
-          <p className="text-sm text-muted-foreground mb-3">@{profile.username}</p>
-        )}
+        {profile.username && <p className="text-sm text-fg-secondary mb-3">@{profile.username}</p>}
 
         {profile.bio && (
-          <p className="text-sm text-muted-foreground mb-4 line-clamp-3">{profile.bio}</p>
+          <p className="text-sm text-fg-secondary mb-4 line-clamp-3">{profile.bio}</p>
         )}
 
         <Link href={ROUTES.PROFILES.VIEW(profile.username || profile.id)}>

--- a/src/components/ui/UserProfileDropdown.tsx
+++ b/src/components/ui/UserProfileDropdown.tsx
@@ -226,7 +226,7 @@ export default function UserProfileDropdown({
         onClick={toggle}
         onKeyDown={handleTriggerKeyDown}
         disabled={isProfileLoading}
-        className="flex items-center space-x-1.5 sm:space-x-2 md:space-x-3 text-foreground hover:bg-muted transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 rounded-lg px-1.5 sm:px-2 md:px-3 py-1.5 sm:py-2 md:py-2.5 min-h-9 sm:min-h-10 md:min-h-11 disabled:opacity-50"
+        className="flex h-11 items-center gap-1.5 rounded-md px-1.5 text-fg-secondary transition-colors hover:bg-surface-raised focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 disabled:opacity-50 sm:h-10 sm:gap-2 sm:px-2"
         aria-haspopup="menu"
         aria-expanded={isOpen}
         aria-label="User menu"

--- a/src/constants/header.ts
+++ b/src/constants/header.ts
@@ -33,8 +33,10 @@ export const HEADER_SPACING = {
   CONTAINER_PADDING: 'px-3 sm:px-4 md:px-6',
   /** Gap between items */
   ITEM_GAP: 'gap-2 sm:gap-3',
-  /** Gap between action buttons - increased on mobile for better touch targets */
-  ACTION_GAP: 'gap-2.5 sm:gap-2',
+  /** Gap between icon action buttons. Tighter than ITEM_GAP (icon-only 44/40px
+   *  targets) but growing with the breakpoint like it — the old 'gap-2.5 sm:gap-2'
+   *  shrank on desktop, fighting the left cluster's rhythm and reading asymmetric. */
+  ACTION_GAP: 'gap-1.5 sm:gap-2',
   /** Max width */
   MAX_WIDTH: 'max-w-7xl',
 } as const;


### PR DESCRIPTION
Three structural fixes from the design audit:

1. **Draft → 404 (functional)**: `PublicEntityDetailPage` filtered `status=active` → `notFound()`, so a draft's public URL (incl. the dashboard "View public page" link) 404'd for its own owner. Now the authenticated **owner** sees a preview with a "only visible to you — publish to make public" banner; drafts are never leaked to non-owners (ownership verified).
2. **Discover tiles**: added `min-w-0` to the icon+title wrapper in Loan/Investment/Generic cards (long titles were pushing the status badge out → overflow); `ProfileCard` got `h-full` (uneven row heights) + migrated off legacy tokens.
3. **Header symmetry**: unified `ACTION_GAP` direction (it shrank on desktop while the left cluster grew); rebuilt the user-menu avatar trigger on the rail's geometry (rounded-md, h-11 sm:h-10, semantic tokens).

tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)