### PR TITLE
refactor(discover): converge loan/investment/generic tiles onto EntityCard

### DIFF
--- a/src/components/entity/variants/GenericPublicCard.tsx
+++ b/src/components/entity/variants/GenericPublicCard.tsx
@@ -2,8 +2,9 @@
 
 import Link from 'next/link';
 import { formatRelativeTime } from '@/utils/dates';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/badge';
+import { EntityCard } from '@/components/entity/EntityCard';
 import { ENTITY_REGISTRY, type EntityType } from '@/config/entity-registry';
 
 export interface GenericPublicEntity {
@@ -66,41 +67,26 @@ export function GenericPublicCard({
   }
 
   return (
-    <Link href={href}>
-      <Card className="oc-card-link h-full">
-        <CardHeader className="pb-3">
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2">
-              <div className="oc-icon-tile h-8 w-8 flex-shrink-0">
-                {Icon && <Icon className="w-4 h-4 text-fg-secondary" />}
-              </div>
-              <div className="flex-1 min-w-0">
-                <CardTitle className="text-base truncate">{entity.title}</CardTitle>
-                <CardDescription className="text-xs">
-                  {formatRelativeTime(entity.created_at)}
-                </CardDescription>
-              </div>
-            </div>
-            {entity.status && (
-              <Badge variant="secondary" className="capitalize text-xs flex-shrink-0">
-                {entity.status}
-              </Badge>
-            )}
-          </div>
-        </CardHeader>
-
-        <CardContent className="space-y-2">
-          {entity.description && (
-            <p className="text-sm text-fg-secondary line-clamp-3">{entity.description}</p>
-          )}
-          {category && (
-            <Badge variant="outline" className="text-xs capitalize">
-              {category.replace(/_/g, ' ')}
-            </Badge>
-          )}
-        </CardContent>
-      </Card>
-    </Link>
+    <EntityCard
+      id={entity.id}
+      title={entity.title}
+      description={entity.description}
+      href={href}
+      headerSlot={
+        entity.status ? (
+          <Badge variant="secondary" className="text-xs capitalize">
+            {entity.status}
+          </Badge>
+        ) : null
+      }
+      metadata={
+        category ? (
+          <Badge variant="outline" className="text-xs capitalize">
+            {category.replace(/_/g, ' ')}
+          </Badge>
+        ) : null
+      }
+    />
   );
 }
 

--- a/src/components/entity/variants/InvestmentCard.tsx
+++ b/src/components/entity/variants/InvestmentCard.tsx
@@ -2,9 +2,10 @@
 
 import Link from 'next/link';
 import { TrendingUp, Percent, Shield } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
+import { EntityCard } from '@/components/entity/EntityCard';
 import { formatRelativeTime } from '@/utils/dates';
 import type { Investment } from '@/types/investments';
 import { formatCurrency as formatCurrencyFn } from '@/services/currency';
@@ -56,82 +57,67 @@ export function InvestmentCard({ investment, viewMode = 'grid' }: InvestmentCard
   }
 
   return (
-    <Link href={`${ENTITY_REGISTRY['investment'].publicBasePath}/${investment.id}`}>
-      <Card className="oc-card-link h-full">
-        <CardHeader className="pb-3">
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2">
-              <div className="oc-icon-tile h-8 w-8 flex-shrink-0">
-                <TrendingUp className="w-4 h-4 text-status-positive" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <CardTitle className="text-base truncate">{investment.title}</CardTitle>
-                <CardDescription className="text-xs">
-                  Listed {formatRelativeTime(investment.created_at)}
-                </CardDescription>
-              </div>
-            </div>
-            <Badge variant="secondary" className="capitalize text-xs">
-              {INVESTMENT_TYPE_LABELS[investment.investment_type] ?? investment.investment_type}
-            </Badge>
+    <EntityCard
+      id={investment.id}
+      title={investment.title}
+      description={investment.description}
+      href={`${ENTITY_REGISTRY['investment'].publicBasePath}/${investment.id}`}
+      headerSlot={
+        <Badge variant="secondary" className="text-xs capitalize">
+          {INVESTMENT_TYPE_LABELS[investment.investment_type] ?? investment.investment_type}
+        </Badge>
+      }
+      progressSlot={
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-fg-secondary">Raised</span>
+            {/* Green only when something's actually been raised — a zero
+                rendered green reads as a positive metric it isn't. */}
+            <span
+              className={`font-semibold ${
+                Number(investment.total_raised) > 0 ? 'text-status-positive' : 'text-fg-primary'
+              }`}
+            >
+              {formatAmount(investment.total_raised)}
+            </span>
           </div>
-        </CardHeader>
-
-        <CardContent className="space-y-3">
-          {investment.description && (
-            <p className="text-sm text-fg-secondary line-clamp-2">{investment.description}</p>
-          )}
-
-          <div className="space-y-2">
-            <div className="flex justify-between items-center">
-              <span className="text-sm text-fg-secondary">Raised</span>
-              {/* Green only when something's actually been raised — a zero
-                  rendered green reads as a positive metric it isn't. */}
-              <span
-                className={`font-semibold ${
-                  Number(investment.total_raised) > 0 ? 'text-status-positive' : 'text-fg-primary'
-                }`}
-              >
-                {formatAmount(investment.total_raised)}
-              </span>
-            </div>
-            <Progress value={progress} className="h-1.5" />
-            <div className="flex justify-between text-xs text-fg-secondary">
-              <span>{progress}% funded</span>
-              <span>{formatAmount(investment.target_amount)} goal</span>
-            </div>
+          <Progress value={progress} className="h-1.5" />
+          <div className="flex justify-between text-xs text-fg-secondary">
+            <span>{progress}% funded</span>
+            <span>{formatAmount(investment.target_amount)} goal</span>
           </div>
-
-          <div className="flex items-center justify-between text-sm">
-            {investment.expected_return_rate !== null &&
-              investment.expected_return_rate !== undefined && (
-                <div className="flex items-center gap-1">
-                  <Percent className="h-3 w-3 text-fg-tertiary" />
-                  <span>{investment.expected_return_rate}% expected return</span>
-                </div>
-              )}
-            {investment.risk_level && (
-              <span
-                className={`text-xs font-medium px-2 py-0.5 rounded-full flex items-center gap-1 ${
-                  INVESTMENT_RISK_COLORS[investment.risk_level] ??
-                  'bg-surface-raised text-fg-primary border-default'
-                }`}
-              >
-                <Shield className="h-3 w-3" />
-                {investment.risk_level} risk
-              </span>
+        </div>
+      }
+      metricsSlot={
+        <div className="flex items-center justify-between text-sm">
+          {investment.expected_return_rate !== null &&
+            investment.expected_return_rate !== undefined && (
+              <div className="flex items-center gap-1">
+                <Percent className="h-3 w-3 text-fg-tertiary" />
+                <span>{investment.expected_return_rate}% expected return</span>
+              </div>
             )}
-          </div>
-
-          {investment.term_months !== null && investment.term_months !== undefined && (
-            <p className="text-xs text-fg-secondary">
-              {investment.term_months}-month term · min{' '}
-              {formatAmount(investment.minimum_investment)}
-            </p>
+          {investment.risk_level && (
+            <span
+              className={`text-xs font-medium px-2 py-0.5 rounded-full flex items-center gap-1 ${
+                INVESTMENT_RISK_COLORS[investment.risk_level] ??
+                'bg-surface-raised text-fg-primary border-default'
+              }`}
+            >
+              <Shield className="h-3 w-3" />
+              {investment.risk_level} risk
+            </span>
           )}
-        </CardContent>
-      </Card>
-    </Link>
+        </div>
+      }
+      footerSlot={
+        investment.term_months !== null && investment.term_months !== undefined ? (
+          <p className="text-xs text-fg-secondary">
+            {investment.term_months}-month term · min {formatAmount(investment.minimum_investment)}
+          </p>
+        ) : null
+      }
+    />
   );
 }
 

--- a/src/components/entity/variants/LoanCard.tsx
+++ b/src/components/entity/variants/LoanCard.tsx
@@ -11,9 +11,10 @@
 
 import Link from 'next/link';
 import { DollarSign, Percent, TrendingUp, User } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
+import { EntityCard } from '@/components/entity/EntityCard';
 import { formatRelativeTime } from '@/utils/dates';
 import type { Loan } from '@/types/loans';
 import { STATUS } from '@/config/database-constants';
@@ -67,52 +68,36 @@ export function LoanCard({ loan, viewMode = 'grid' }: LoanCardProps) {
   }
 
   return (
-    <Link href={`${ENTITY_REGISTRY['loan'].publicBasePath}/${loan.id}`}>
-      <Card className="oc-card-link h-full">
-        <CardHeader className="pb-3">
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2">
-              <div className="oc-icon-tile h-8 w-8 flex-shrink-0">
-                <DollarSign className="w-4 h-4 text-fg-primary" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <CardTitle className="text-base truncate">{loan.title}</CardTitle>
-                <CardDescription className="text-xs">
-                  Listed {formatRelativeTime(loan.created_at)}
-                </CardDescription>
-              </div>
-            </div>
-            <Badge
-              variant={loan.status === STATUS.LOANS.ACTIVE ? 'default' : 'secondary'}
-              className="capitalize text-xs"
-            >
-              {loan.status}
-            </Badge>
+    <EntityCard
+      id={loan.id}
+      title={loan.title}
+      description={loan.description}
+      href={`${ENTITY_REGISTRY['loan'].publicBasePath}/${loan.id}`}
+      headerSlot={
+        <Badge
+          variant={loan.status === STATUS.LOANS.ACTIVE ? 'default' : 'secondary'}
+          className="text-xs capitalize"
+        >
+          {loan.status}
+        </Badge>
+      }
+      progressSlot={
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-fg-secondary">Remaining</span>
+            <span className="font-semibold text-fg-primary">
+              {formatAmount(loan.remaining_balance, loan.currency)}
+            </span>
           </div>
-        </CardHeader>
-
-        <CardContent className="space-y-3">
-          {/* Description */}
-          {loan.description && (
-            <p className="text-sm text-fg-secondary line-clamp-2">{loan.description}</p>
-          )}
-
-          {/* Financial Summary */}
-          <div className="space-y-2">
-            <div className="flex justify-between items-center">
-              <span className="text-sm text-fg-secondary">Remaining</span>
-              <span className="font-semibold text-fg-primary">
-                {formatAmount(loan.remaining_balance, loan.currency)}
-              </span>
-            </div>
-            <Progress value={progress} className="h-1.5" />
-            <div className="flex justify-between text-xs text-fg-secondary">
-              <span>{progress.toFixed(0)}% funded</span>
-              <span>{formatAmount(loan.original_amount, loan.currency)} total</span>
-            </div>
+          <Progress value={progress} className="h-1.5" />
+          <div className="flex justify-between text-xs text-fg-secondary">
+            <span>{progress.toFixed(0)}% funded</span>
+            <span>{formatAmount(loan.original_amount, loan.currency)} total</span>
           </div>
-
-          {/* Interest Rate & Monthly Payment */}
+        </div>
+      }
+      metricsSlot={
+        loan.interest_rate || loan.monthly_payment ? (
           <div className="flex items-center justify-between text-sm">
             {loan.interest_rate && (
               <div className="flex items-center gap-1">
@@ -127,17 +112,17 @@ export function LoanCard({ loan, viewMode = 'grid' }: LoanCardProps) {
               </div>
             )}
           </div>
-
-          {/* Lender Info */}
-          {loan.lender_name && (
-            <div className="flex items-center gap-2 text-xs text-fg-secondary">
-              <User className="h-3 w-3" />
-              <span className="truncate">Current lender: {loan.lender_name}</span>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </Link>
+        ) : null
+      }
+      footerSlot={
+        loan.lender_name ? (
+          <div className="flex items-center gap-2 text-xs text-fg-secondary">
+            <User className="h-3 w-3" />
+            <span className="truncate">Current lender: {loan.lender_name}</span>
+          </div>
+        ) : null
+      }
+    />
   );
 }
 


### PR DESCRIPTION
The Discover grid rendered **4 incompatible card structures** side-by-side (the audit's #1 inconsistency). Now loan/investment/generic grid tiles render through the shared `EntityCard` like `ProjectCard` already does — same image-top structure, gradient placeholder for imageless entities, same clamp policy, entity-specific bits mapped onto `headerSlot`/`progressSlot`/`metricsSlot`/`footerSlot`.

- **GenericPublicCard** (groups, wishlists, causes, research…) → status header + category.
- **LoanCard** → status, remaining/total progress, APR/monthly, lender footer.
- **InvestmentCard** → type, raised/target progress, return/risk, term footer.

List-view layouts unchanged. ProfileCard stays distinct (avatar-first, not an image-top listing). tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)