### PR TITLE
feat(public): richer product detail + drop spurious pay section on ai_assistant

### DIFF
--- a/src/app/ai-assistants/[id]/page.tsx
+++ b/src/app/ai-assistants/[id]/page.tsx
@@ -38,6 +38,12 @@ const config: EntityDetailConfig = {
   ownerLabel: 'Created by',
   descriptionTitle: 'About this AI Assistant',
   metadataSelect: 'title, description, avatar_url',
+  // No pay-the-seller-direct section: you don't pay an assistant up front — you
+  // chat, and it charges per its pricing model (free / per-message via Cat
+  // Credits) inside the chat widget. This also suppresses the default mobile
+  // sticky CTA, which would otherwise anchor "Chat" to a #pay section that
+  // shouldn't exist here. The chat widget is the primary action.
+  showPaymentSection: false,
   getViewRoute: id => ROUTES.AI_ASSISTANTS.VIEW(id),
   renderHeaderIcon: entity =>
     entity.avatar_url ? (

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -25,6 +25,7 @@ const config: EntityDetailConfig = {
   entityType: 'product',
   ownerLabel: 'Seller',
   createdLabel: 'Listed',
+  descriptionTitle: 'About this product',
   getViewRoute: id => ROUTES.PRODUCTS.VIEW(id),
   getCoverImages: entity => {
     const images = Array.isArray(entity.images) ? (entity.images as string[]) : [];
@@ -42,16 +43,54 @@ const config: EntityDetailConfig = {
   },
   renderDetails: entity => {
     const { amount, currency } = getPrice(entity);
-    return amount > 0 ? (
+    const hasPrice = Number.isFinite(amount) && amount > 0;
+    const productType = entity.product_type as string | undefined;
+    const inventory = entity.inventory_count as number | null | undefined;
+    return (
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg">Price</CardTitle>
+          <CardTitle className="text-lg">Details</CardTitle>
         </CardHeader>
-        <CardContent>
-          <PriceDisplay amount={amount} currency={currency} />
+        <CardContent className="space-y-4">
+          {hasPrice && (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-fg-secondary">Price</span>
+              <PriceDisplay
+                amount={amount}
+                currency={currency}
+                className="text-right text-xl font-bold text-fg-primary"
+              />
+            </div>
+          )}
+          {productType && (
+            <div className="flex items-center justify-between">
+              <span className="text-fg-secondary">Type</span>
+              <span className="font-medium capitalize">{productType}</span>
+            </div>
+          )}
+          <div className="flex items-center justify-between">
+            <span className="text-fg-secondary">Availability</span>
+            <span className="font-medium">
+              {inventory === null || inventory === undefined
+                ? 'In stock'
+                : inventory > 0
+                  ? `${inventory} available`
+                  : 'Sold out'}
+            </span>
+          </div>
+          {hasPrice && (
+            // Anchors to the payment section (#pay) — the buyer's "Buy" is paying
+            // the seller direct in Bitcoin. Mirrors the service page's Book CTA.
+            <a
+              href="#pay"
+              className="mt-1 flex w-full items-center justify-center rounded-md bg-accent-warm px-4 py-2.5 font-medium text-white transition-colors hover:bg-accent-warm/90"
+            >
+              Buy now
+            </a>
+          )}
         </CardContent>
       </Card>
-    ) : null;
+    );
   },
 };
 


### PR DESCRIPTION
Brings product + ai_assistant public pages up to the service page's quality.

- **Product**: `descriptionTitle` "About this product"; bare Price card → real **Details** card (Price + Type + Availability) with a **Buy now** CTA anchoring to the pay-direct section (mirrors the service Book CTA).
- **AI assistant**: `showPaymentSection: false` — it was rendering a wrong pay-the-seller-direct section (you chat & it charges per pricing model, not pay up front); also suppresses the misdirected mobile "Chat"→#pay sticky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)