### PR TITLE
fix(mobile): top findings from the mobile-first audit

### DIFF
--- a/src/app/(authenticated)/settings/page.tsx
+++ b/src/app/(authenticated)/settings/page.tsx
@@ -78,7 +78,7 @@ export default function SettingsPage() {
         description="Manage your email, password, and security"
       >
         <div className="bg-surface-base rounded-lg border border-subtle overflow-hidden">
-          <div className="flex items-center gap-4 border-b border-subtle px-8 py-6">
+          <div className="flex items-center gap-4 border-b border-subtle px-4 py-5 sm:px-8 sm:py-6">
             <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-surface-raised text-fg-secondary">
               <Lock className="h-5 w-5" />
             </div>
@@ -92,7 +92,7 @@ export default function SettingsPage() {
             </div>
           </div>
 
-          <div className="p-8 space-y-10">
+          <div className="space-y-10 p-4 sm:p-8">
             <SettingsEmailSection
               email={formData.email}
               isSubmitting={isSubmittingEmail}

--- a/src/components/ai-chat/ModernChatPanel/components/ConversationRail.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/ConversationRail.tsx
@@ -66,7 +66,7 @@ function RailBody({ conversations, activeId, onSelect, onNew, onDelete }: Conver
                 <button
                   type="button"
                   onClick={() => onDelete(c.id)}
-                  className="flex-shrink-0 rounded p-1 text-fg-tertiary opacity-0 transition-opacity hover:text-status-negative group-hover:opacity-100"
+                  className="flex-shrink-0 rounded p-2 text-fg-tertiary opacity-100 transition-opacity hover:text-status-negative md:opacity-0 md:group-hover:opacity-100"
                   aria-label={`Delete ${railTitle(c)}`}
                   title="Delete conversation"
                 >

--- a/src/components/entity/EntityCardActions.tsx
+++ b/src/components/entity/EntityCardActions.tsx
@@ -101,7 +101,7 @@ export function EntityCardActions({
           <button
             type="button"
             onClick={e => e.stopPropagation()}
-            className="h-8 w-8 flex items-center justify-center rounded-md hover:bg-surface-raised opacity-0 group-hover:opacity-100 transition-opacity"
+            className="flex h-9 w-9 items-center justify-center rounded-md opacity-100 transition-opacity hover:bg-surface-raised sm:opacity-0 sm:group-hover:opacity-100"
             aria-label="Actions"
           >
             <MoreHorizontal className="h-4 w-4 text-fg-secondary" />

--- a/src/components/entity/EntityDetailPage.tsx
+++ b/src/components/entity/EntityDetailPage.tsx
@@ -230,7 +230,7 @@ export default async function EntityDetailPage<T extends BaseEntity>({
       left={
         <div className="space-y-4">
           {(fields.left ?? []).length > 0 ? (
-            <div className="grid grid-cols-2 gap-3 text-sm">
+            <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
               {(fields.left ?? []).map((field, idx) => (
                 <div key={idx}>
                   <div className="text-fg-secondary">{field.label}</div>

--- a/src/components/messaging/MessageView/MessageHeader.tsx
+++ b/src/components/messaging/MessageView/MessageHeader.tsx
@@ -108,7 +108,7 @@ export default function MessageHeader({ conversation, currentUserId, onBack }: M
           </div>
         ) : null}
 
-        <div>
+        <div className="min-w-0 flex-1">
           {primaryParticipant && !conversation.is_group ? (
             <Link
               href={
@@ -120,12 +120,12 @@ export default function MessageHeader({ conversation, currentUserId, onBack }: M
               }
               className="hover:underline"
             >
-              <h2 className="font-semibold text-fg-primary">{displayName}</h2>
+              <h2 className="truncate font-semibold text-fg-primary">{displayName}</h2>
             </Link>
           ) : (
-            <h2 className="font-semibold text-fg-primary">{displayName}</h2>
+            <h2 className="truncate font-semibold text-fg-primary">{displayName}</h2>
           )}
-          <p className="text-sm text-fg-secondary">{subtitle}</p>
+          <p className="truncate text-sm text-fg-secondary">{subtitle}</p>
         </div>
       </div>
     </div>

--- a/src/components/profile/ProfileLayout.tsx
+++ b/src/components/profile/ProfileLayout.tsx
@@ -190,10 +190,10 @@ export default function ProfileLayout({
 
         <div className="mt-12 sm:mt-16 md:mt-20">
           <div className="oc-surface mb-4 p-4 sm:mb-6 sm:p-6">
-            <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-fg-primary mb-1 sm:mb-2">
+            <h1 className="mb-1 break-words text-xl font-bold text-fg-primary sm:mb-2 sm:text-2xl md:text-3xl">
               {profile.name || profile.username || 'User'}
             </h1>
-            <p className="text-sm sm:text-base md:text-lg text-fg-secondary font-medium mb-3 sm:mb-4">
+            <p className="mb-3 break-all text-sm font-medium text-fg-secondary sm:mb-4 sm:text-base md:text-lg">
               @{profile.username}
             </p>
             {profile.bio && (

--- a/src/components/profile/ProfileWizard/components/WizardFooter.tsx
+++ b/src/components/profile/ProfileWizard/components/WizardFooter.tsx
@@ -44,7 +44,7 @@ export function WizardFooter({
         </div>
       </div>
 
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <Button
           type="button"
           variant="outline"
@@ -80,7 +80,7 @@ export function WizardFooter({
             onClick={onNext}
             disabled={!canProceed || isSaving}
             variant="accent"
-            className="px-8 py-2 min-w-[140px]"
+            className="px-5 py-2 sm:min-w-[140px] sm:px-8"
           >
             {isSaving ? (
               <>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid max-h-[90vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       {...props}

--- a/src/config/timeline.ts
+++ b/src/config/timeline.ts
@@ -77,7 +77,7 @@ export const TIMELINE_SURFACE = {
   buttonPrimary:
     'rounded-md bg-fg-primary px-5 py-2 text-sm font-semibold text-fg-inverted transition-colors hover:bg-fg-primary/90 disabled:bg-surface-raised disabled:text-fg-secondary',
   iconButton:
-    'flex min-h-10 min-w-10 items-center justify-center rounded-md text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary disabled:cursor-not-allowed disabled:opacity-50',
+    'flex min-h-11 min-w-11 items-center justify-center rounded-md text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary disabled:cursor-not-allowed disabled:opacity-50',
   chip: 'inline-flex items-center gap-1.5 rounded-md border border-subtle bg-surface-page px-2.5 py-1 text-xs font-medium text-fg-secondary transition-colors hover:border-default hover:text-fg-primary',
   chipActive:
     'border-fg-primary bg-fg-primary text-fg-inverted hover:border-fg-primary hover:text-fg-inverted',


### PR DESCRIPTION
App is mobile-mature; fixed the top of each finding cluster:

**Functional (hover-only invisible on touch):** EntityCardActions card ⋯ menu + ConversationRail delete → visible by default on mobile, hover-reveal on sm+.
**Shared dialog (1 edit, 18 modals):** base `DialogContent` got `max-h-[90vh] overflow-y-auto` — tall modals no longer push submit off-screen.
**Overflow/touch:** ProfileLayout `break-words`; MessageHeader `min-w-0`+`truncate`; settings responsive padding; timeline iconButton `min-h-11`; EntityDetailPage `grid-cols-1 sm:grid-cols-2`; WizardFooter `flex-wrap`.

tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)