### PR TITLE
fix(mobile): mop up the long-tail audit findings

### DIFF
--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -234,7 +234,7 @@ function FaqAccordionItem({
       </button>
       {isOpen && (
         <div className="px-5 pb-5 pt-1 bg-surface-base border-t border-subtle">
-          <div className="text-fg-secondary leading-relaxed text-[15px]">{item.answer}</div>
+          <div className="text-base leading-relaxed text-fg-secondary">{item.answer}</div>
         </div>
       )}
     </div>

--- a/src/components/ai-chat/ModernChatPanel/components/ChatInput.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/ChatInput.tsx
@@ -102,7 +102,7 @@ export function ChatInput({
                 <button
                   type="button"
                   onClick={onClearChat}
-                  className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary"
+                  className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary"
                   aria-label="Clear chat"
                   title="Clear chat"
                 >
@@ -122,7 +122,7 @@ export function ChatInput({
                 <button
                   type="button"
                   onClick={onStop}
-                  className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-fg-primary text-fg-inverted transition-opacity hover:opacity-90"
+                  className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-fg-primary text-fg-inverted transition-opacity hover:opacity-90"
                   aria-label="Stop generating"
                 >
                   <Square className="h-3.5 w-3.5 fill-current" />
@@ -133,7 +133,7 @@ export function ChatInput({
                   onClick={onSend}
                   disabled={!canSend}
                   className={cn(
-                    'flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg transition-colors',
+                    'flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg transition-colors',
                     canSend
                       ? 'bg-fg-primary text-fg-inverted hover:opacity-90'
                       : 'cursor-not-allowed text-fg-secondary'

--- a/src/components/ai-chat/ModernChatPanel/components/MessageBubble.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/MessageBubble.tsx
@@ -271,7 +271,7 @@ export function MessageBubble({
             </span>
             <button
               onClick={handleCopy}
-              className="text-fg-tertiary hover:text-fg-primary transition-colors p-0.5"
+              className="rounded p-2 text-fg-tertiary transition-colors hover:text-fg-primary"
               title="Copy response"
             >
               {copied ? (

--- a/src/components/ai-chat/ModernChatPanel/components/ModelSelector.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/ModelSelector.tsx
@@ -83,7 +83,7 @@ export function ModelSelector({
       {isOpen && (
         <div
           className={cn(
-            'absolute left-0 z-50 max-h-80 w-72 overflow-y-auto rounded-md border border-subtle bg-surface-modal py-2 shadow-sm',
+            'absolute left-0 z-50 max-h-80 w-72 max-w-[calc(100vw-1.5rem)] overflow-y-auto rounded-md border border-subtle bg-surface-modal py-2 shadow-sm',
             openUp ? 'bottom-full mb-2' : 'top-full mt-2'
           )}
         >

--- a/src/components/ai/AIKeyAddForm.tsx
+++ b/src/components/ai/AIKeyAddForm.tsx
@@ -146,7 +146,7 @@ export function AIKeyAddForm({ onAdd, onCancel, onFieldFocus }: AIKeyAddFormProp
         <div>
           <label className="block text-sm font-medium text-fg-primary mb-2">Provider</label>
           <div
-            className="grid grid-cols-2 gap-2"
+            className="grid grid-cols-1 gap-2 sm:grid-cols-2"
             onFocus={() => onFieldFocus?.('provider')}
             onBlur={() => onFieldFocus?.(null)}
           >

--- a/src/components/ai/AIOnboarding/components/ConfigureStep.tsx
+++ b/src/components/ai/AIOnboarding/components/ConfigureStep.tsx
@@ -80,7 +80,7 @@ export function ConfigureStep({
             </span>
           )}
         </label>
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {MODEL_TIERS.map(tier => {
             const config = TIER_CONFIG[tier];
             const tierInfo = tierDescriptions[tier];

--- a/src/components/create/WizardProgressBar.tsx
+++ b/src/components/create/WizardProgressBar.tsx
@@ -65,7 +65,7 @@ export function WizardProgressBar({
                 {isCompleted ? <Check className="w-4 h-4" /> : index + 1}
               </div>
               <span
-                className={`text-xs font-medium max-w-[80px] text-center leading-tight ${
+                className={`max-w-[64px] text-center text-[10px] font-medium leading-tight sm:max-w-[80px] sm:text-xs ${
                   isCurrent ? 'text-fg-primary' : 'text-fg-secondary'
                 }`}
               >

--- a/src/components/create/collateral/CollateralSelector.tsx
+++ b/src/components/create/collateral/CollateralSelector.tsx
@@ -158,10 +158,10 @@ export function CollateralSelector({
                 key={`${item.type}-${item.id}`}
                 className="flex items-center justify-between p-3 bg-surface-raised/50 rounded-lg border border-default"
               >
-                <div className="flex items-center gap-3">
+                <div className="flex min-w-0 items-center gap-3">
                   <div
                     className={cn(
-                      'h-8 w-8 rounded-full flex items-center justify-center',
+                      'h-8 w-8 flex-shrink-0 rounded-full flex items-center justify-center',
                       item.type === 'asset' ? BADGE_COLORS.info : BADGE_COLORS.tiffany
                     )}
                   >
@@ -171,9 +171,11 @@ export function CollateralSelector({
                       <Wallet className="w-4 h-4" />
                     )}
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-fg-primary">{item.name}</span>
+                      <span className="truncate text-sm font-medium text-fg-primary">
+                        {item.name}
+                      </span>
                       <Badge variant="outline" className="text-xs">
                         {item.type === 'asset' ? 'Asset' : 'Wallet'}
                       </Badge>

--- a/src/components/public/PublicEntityHero.tsx
+++ b/src/components/public/PublicEntityHero.tsx
@@ -35,7 +35,7 @@ export default function PublicEntityHero({ images, title }: PublicEntityHeroProp
         <Image src={cover} alt={title} fill unoptimized className="object-cover" />
       </div>
       {extras.length > 0 && (
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
           {extras.map((src, i) => (
             <div
               key={`${src}-${i}`}

--- a/src/components/timeline/ComposerShared.tsx
+++ b/src/components/timeline/ComposerShared.tsx
@@ -18,7 +18,7 @@ export function TextFormatToolbar({
 }: TextFormatToolbarProps) {
   const baseClasses = cn(
     'flex items-center justify-center rounded-md transition-colors',
-    size === 'sm' ? 'h-9 w-9' : 'min-h-11 min-w-11 p-2'
+    size === 'sm' ? 'h-10 w-10' : 'min-h-11 min-w-11 p-2'
   );
 
   const colorClasses =
@@ -140,7 +140,7 @@ export function ProjectToggleButton({
       type="button"
       onClick={onToggle}
       className={cn(
-        'flex h-9 w-9 items-center justify-center rounded-md transition-colors touch-manipulation',
+        'flex h-10 w-10 items-center justify-center rounded-md transition-colors touch-manipulation',
         isActive
           ? variant === 'accent'
             ? 'bg-surface-raised text-fg-primary ring-1 ring-border-strong'


### PR DESCRIPTION
Lower-priority mobile-audit items: chat/composer/message-bubble touch targets (→40/36px), CollateralSelector `min-w-0`+truncate, ConfigureStep+AIKeyAddForm `grid-cols-1 sm:grid-cols-2`, WizardProgressBar mobile label sizing, PublicEntityHero `grid-cols-3 sm:grid-cols-4`, ModelSelector `max-w-[calc(100vw-1.5rem)]`, faq off-scale text. tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)