### PR TITLE
refactor(owner-view): owner detail = public layout + manage bar (products, slice 1)

### DIFF
--- a/src/app/(authenticated)/dashboard/store/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/store/[id]/page.tsx
@@ -1,66 +1,19 @@
-import EntityDetailPage from '@/components/entity/EntityDetailPage';
-import { productEntityConfig } from '@/config/entities/products';
-import type { UserProduct } from '@/types/database';
-import { convert, formatCurrency } from '@/services/currency';
-import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
-import type { Currency } from '@/types/settings';
+import PublicEntityDetailPage from '@/components/public/PublicEntityDetailPage';
+import { productDetailConfig } from '@/components/public/detail-configs/product';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
 /**
- * Product Detail Page
+ * Product detail (owner / dashboard).
  *
- * Unified detail page using EntityDetailPage component.
- *
- * Created: 2025-01-27
- * Last Modified: 2026-01-03
- * Last Modified Summary: Refactored to use unified EntityDetailPage component
+ * Renders the SAME layout buyers see (PublicEntityDetailPage) — the owner just
+ * additionally gets the manage bar (Edit + status). Replaces the old flat
+ * label→value grid: owners shouldn't be shown their listing as a database row.
+ * SSOT config shared with the public route via productDetailConfig.
  */
 export default async function ProductDetailPage({ params }: PageProps) {
   const { id } = await params;
-
-  return (
-    <EntityDetailPage<UserProduct>
-      config={productEntityConfig}
-      entityId={id}
-      requireAuth={true}
-      redirectPath="/auth?mode=login&from=/dashboard/store"
-      makeDetailFields={(product, userCurrency) => {
-        // Display price in user's preferred currency (or product's currency)
-        const displayCurrency = (userCurrency ||
-          product.currency ||
-          PLATFORM_DEFAULT_CURRENCY) as Currency;
-        const priceValue =
-          product.price && product.currency
-            ? (() => {
-                const price =
-                  product.currency === displayCurrency
-                    ? product.price
-                    : convert(product.price, product.currency as Currency, displayCurrency);
-                return formatCurrency(price, displayCurrency);
-              })()
-            : 'Not set';
-
-        const left = [
-          { label: 'Status', value: product.status || 'draft' },
-          { label: 'Price', value: priceValue },
-          { label: 'Type', value: product.product_type || '—' },
-          {
-            label: 'Inventory',
-            value:
-              product.inventory_count === -1 ? 'Unlimited' : String(product.inventory_count || 0),
-          },
-          { label: 'Fulfillment', value: product.fulfillment_type || '—' },
-        ];
-
-        if (product.tags && product.tags.length > 0) {
-          left.push({ label: 'Tags', value: product.tags.join(', ') });
-        }
-
-        return { left, right: [] };
-      }}
-    />
-  );
+  return <PublicEntityDetailPage id={id} config={productDetailConfig} />;
 }

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -2,97 +2,12 @@ import { Metadata } from 'next';
 import { generateEntityMetadata } from '@/lib/seo/metadata';
 import PublicEntityDetailPage, {
   fetchEntityForMetadata,
-  type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
-import PriceDisplay from '@/components/public/PriceDisplay';
-import { ROUTES } from '@/config/routes';
+import { productDetailConfig } from '@/components/public/detail-configs/product';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
-
-// user_products stores `price` in the entity's chosen `currency` (NOT price_btc —
-// that column doesn't exist). The old code read entity.price_btc, so the Price card
-// never rendered and products showed no price. Read price + currency and format in
-// that currency. See decision_currency_convention / 20260618000005.
-const getPrice = (entity: Record<string, unknown>) => ({
-  amount: typeof entity.price === 'number' ? entity.price : Number(entity.price ?? NaN),
-  currency: (entity.currency as string) || 'CHF',
-});
-
-const config: EntityDetailConfig = {
-  entityType: 'product',
-  ownerLabel: 'Seller',
-  createdLabel: 'Listed',
-  descriptionTitle: 'About this product',
-  getViewRoute: id => ROUTES.PRODUCTS.VIEW(id),
-  getCoverImages: entity => {
-    const images = Array.isArray(entity.images) ? (entity.images as string[]) : [];
-    return [...images, entity.thumbnail_url as string].filter(Boolean);
-  },
-  getPrice: entity => {
-    const { amount, currency } = getPrice(entity);
-    return Number.isFinite(amount) && amount > 0 ? { amount, currency } : null;
-  },
-  getJsonLdExtra: entity => {
-    const { amount, currency } = getPrice(entity);
-    return amount > 0
-      ? { offers: { '@type': 'Offer', priceCurrency: currency, price: amount } }
-      : {};
-  },
-  renderDetails: entity => {
-    const { amount, currency } = getPrice(entity);
-    const hasPrice = Number.isFinite(amount) && amount > 0;
-    const productType = entity.product_type as string | undefined;
-    const inventory = entity.inventory_count as number | null | undefined;
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Details</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {hasPrice && (
-            <div className="flex items-center justify-between gap-4">
-              <span className="text-fg-secondary">Price</span>
-              <PriceDisplay
-                amount={amount}
-                currency={currency}
-                className="text-right text-xl font-bold text-fg-primary"
-              />
-            </div>
-          )}
-          {productType && (
-            <div className="flex items-center justify-between">
-              <span className="text-fg-secondary">Type</span>
-              <span className="font-medium capitalize">{productType}</span>
-            </div>
-          )}
-          <div className="flex items-center justify-between">
-            <span className="text-fg-secondary">Availability</span>
-            <span className="font-medium">
-              {inventory === null || inventory === undefined
-                ? 'In stock'
-                : inventory > 0
-                  ? `${inventory} available`
-                  : 'Sold out'}
-            </span>
-          </div>
-          {hasPrice && (
-            // Anchors to the payment section (#pay) — the buyer's "Buy" is paying
-            // the seller direct in Bitcoin. Mirrors the service page's Book CTA.
-            <a
-              href="#pay"
-              className="mt-1 flex w-full items-center justify-center rounded-md bg-accent-warm px-4 py-2.5 font-medium text-white transition-colors hover:bg-accent-warm/90"
-            >
-              Buy now
-            </a>
-          )}
-        </CardContent>
-      </Card>
-    );
-  },
-};
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
@@ -113,5 +28,5 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function PublicProductPage({ params }: PageProps) {
   const { id } = await params;
-  return <PublicEntityDetailPage id={id} config={config} />;
+  return <PublicEntityDetailPage id={id} config={productDetailConfig} />;
 }

--- a/src/components/public/PublicEntityDetailPage.tsx
+++ b/src/components/public/PublicEntityDetailPage.tsx
@@ -7,9 +7,11 @@
  * Each entity page becomes a thin wrapper that passes entityType + optional custom sections.
  */
 
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { Tag } from 'lucide-react';
+import { Pencil, Tag } from 'lucide-react';
 import { createServerClient } from '@/lib/supabase/server';
+import Button from '@/components/ui/Button';
 import { getTableName, getEntityMetadata, type EntityType } from '@/config/entity-registry';
 import { STATUS } from '@/config/database-constants';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
@@ -152,6 +154,10 @@ export default async function PublicEntityDetailPage({
   const visibilityCol = config.visibilityFilter?.column ?? 'status';
   const visibilityVal = config.visibilityFilter?.value ?? STATUS.PRODUCTS.ACTIVE;
 
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
   const { data: publicData } = await supabase
     .from(table)
     .select('*')
@@ -165,18 +171,13 @@ export default async function PublicEntityDetailPage({
   // Not publicly visible (e.g. a draft). Let the OWNER preview it — the dashboard
   // "View public page" link would otherwise hit a bare 404 for unpublished
   // entities. Verify ownership before showing; never leak a draft to anyone else.
-  if (!entity) {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (user) {
-      const { data: ownData } = await supabase.from(table).select('*').eq('id', id).single();
-      const candidate = ownData as EntityData | null;
-      const candidateOwner = candidate ? await fetchEntityOwner(supabase, candidate) : null;
-      if (candidate && candidateOwner?.user_id && candidateOwner.user_id === user.id) {
-        entity = candidate;
-        isOwnerPreview = true;
-      }
+  if (!entity && user) {
+    const { data: ownData } = await supabase.from(table).select('*').eq('id', id).single();
+    const candidate = ownData as EntityData | null;
+    const candidateOwner = candidate ? await fetchEntityOwner(supabase, candidate) : null;
+    if (candidate && candidateOwner?.user_id === user.id) {
+      entity = candidate;
+      isOwnerPreview = true;
     }
   }
 
@@ -185,6 +186,11 @@ export default async function PublicEntityDetailPage({
   }
 
   const owner = await fetchEntityOwner(supabase, entity);
+  // The viewer owns this entity (published or draft) → show a manage bar. This is
+  // also the owner's dashboard detail view: one layout, buyers see the listing,
+  // the owner sees it + Edit (no separate flat-grid dashboard page).
+  const isOwner = !!user && !!owner?.user_id && owner.user_id === user.id;
+  const editHref = `${meta.basePath}/${id}/edit`;
 
   // Resolve the seller's public receiving info + BTC amount server-side so a
   // logged-out visitor can pay direct (permissionless) — no account, no gate.
@@ -217,11 +223,27 @@ export default async function PublicEntityDetailPage({
     <>
       <JsonLdScript data={jsonLd} />
       <div className={`min-h-screen oc-mobile-action-stack-padding ${pageSurface}`}>
-        {isOwnerPreview && (
-          <div className="border-b border-accent-warm/30 bg-accent-warm/10 px-4 py-2.5 text-center text-sm text-fg-primary">
-            Preview — this {meta.name.toLowerCase()} is{' '}
-            <span className="font-medium capitalize">{entity.status}</span> and only visible to you.
-            Publish it to make this page public.
+        {isOwner && (
+          <div className="border-b border-default bg-surface-raised">
+            <div className="mx-auto flex max-w-4xl flex-wrap items-center justify-between gap-2 px-4 py-2.5 sm:px-6 lg:px-8">
+              <span className="text-sm text-fg-secondary">
+                {isOwnerPreview ? (
+                  <>
+                    Preview — this {meta.name.toLowerCase()} is{' '}
+                    <span className="font-medium capitalize text-fg-primary">{entity.status}</span>{' '}
+                    and only visible to you. Publish it to go live.
+                  </>
+                ) : (
+                  <>This is your live {meta.name.toLowerCase()} as buyers see it.</>
+                )}
+              </span>
+              <Link href={editHref}>
+                <Button variant="outline" size="sm" className="gap-1.5">
+                  <Pencil className="h-3.5 w-3.5" />
+                  Edit
+                </Button>
+              </Link>
+            </div>
           </div>
         )}
         <div className="bg-surface-base border-b border-default">

--- a/src/components/public/detail-configs/product.tsx
+++ b/src/components/public/detail-configs/product.tsx
@@ -1,0 +1,90 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import PriceDisplay from '@/components/public/PriceDisplay';
+import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailPage';
+import { ROUTES } from '@/config/routes';
+
+// user_products stores `price` in the entity's chosen `currency` (NOT price_btc —
+// that column doesn't exist). Read price + currency and format in that currency.
+// See decision_currency_convention / 20260618000005.
+const getPrice = (entity: Record<string, unknown>) => ({
+  amount: typeof entity.price === 'number' ? entity.price : Number(entity.price ?? NaN),
+  currency: (entity.currency as string) || 'CHF',
+});
+
+/**
+ * SSOT for the product detail page. Used by BOTH the public route
+ * (/products/[id]) and the owner dashboard route (/dashboard/store/[id]) — one
+ * layout, buyers see the listing, the owner sees it plus the manage bar.
+ */
+export const productDetailConfig: EntityDetailConfig = {
+  entityType: 'product',
+  ownerLabel: 'Seller',
+  createdLabel: 'Listed',
+  descriptionTitle: 'About this product',
+  getViewRoute: id => ROUTES.PRODUCTS.VIEW(id),
+  getCoverImages: entity => {
+    const images = Array.isArray(entity.images) ? (entity.images as string[]) : [];
+    return [...images, entity.thumbnail_url as string].filter(Boolean);
+  },
+  getPrice: entity => {
+    const { amount, currency } = getPrice(entity);
+    return Number.isFinite(amount) && amount > 0 ? { amount, currency } : null;
+  },
+  getJsonLdExtra: entity => {
+    const { amount, currency } = getPrice(entity);
+    return amount > 0
+      ? { offers: { '@type': 'Offer', priceCurrency: currency, price: amount } }
+      : {};
+  },
+  renderDetails: entity => {
+    const { amount, currency } = getPrice(entity);
+    const hasPrice = Number.isFinite(amount) && amount > 0;
+    const productType = entity.product_type as string | undefined;
+    const inventory = entity.inventory_count as number | null | undefined;
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {hasPrice && (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-fg-secondary">Price</span>
+              <PriceDisplay
+                amount={amount}
+                currency={currency}
+                className="text-right text-xl font-bold text-fg-primary"
+              />
+            </div>
+          )}
+          {productType && (
+            <div className="flex items-center justify-between">
+              <span className="text-fg-secondary">Type</span>
+              <span className="font-medium capitalize">{productType}</span>
+            </div>
+          )}
+          <div className="flex items-center justify-between">
+            <span className="text-fg-secondary">Availability</span>
+            <span className="font-medium">
+              {inventory === null || inventory === undefined
+                ? 'In stock'
+                : inventory > 0
+                  ? `${inventory} available`
+                  : 'Sold out'}
+            </span>
+          </div>
+          {hasPrice && (
+            // Anchors to the payment section (#pay) — the buyer's "Buy" is paying
+            // the seller direct in Bitcoin. Mirrors the service page's Book CTA.
+            <a
+              href="#pay"
+              className="mt-1 flex w-full items-center justify-center rounded-md bg-accent-warm px-4 py-2.5 font-medium text-white transition-colors hover:bg-accent-warm/90"
+            >
+              Buy now
+            </a>
+          )}
+        </CardContent>
+      </Card>
+    );
+  },
+};


### PR DESCRIPTION
Owner dashboard detail was a flat label→value grid. Now the owner sees the SAME layout buyers see + a manage bar.

- `PublicEntityDetailPage` is owner-aware: detects ownership (published or draft), renders a manage bar (status + Edit); the draft-only preview banner folds in. Buyers see no bar.
- Extracted `productDetailConfig` (SSOT) shared by `/products/[id]` and `/dashboard/store/[id]`.
- Dashboard product route now renders `PublicEntityDetailPage` — flat grid gone.

Slice 1 of N (products). Other types follow the same pattern. tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)