### PR TITLE
fix(product): treat inventory_count -1 as unlimited (In stock)

### DIFF
--- a/src/components/public/detail-configs/product.tsx
+++ b/src/components/public/detail-configs/product.tsx
@@ -66,7 +66,8 @@ export const productDetailConfig: EntityDetailConfig = {
           <div className="flex items-center justify-between">
             <span className="text-fg-secondary">Availability</span>
             <span className="font-medium">
-              {inventory === null || inventory === undefined
+              {/* inventory_count -1 (or null) = unlimited, e.g. digital goods. */}
+              {inventory === null || inventory === undefined || inventory < 0
                 ? 'In stock'
                 : inventory > 0
                   ? `${inventory} available`


### PR DESCRIPTION
Owner-view Details card showed 'Sold out' for unlimited digital products (inventory_count -1 read as 0). -1/null = unlimited → 'In stock'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)