### PR TITLE
refactor(owner-view): converge service/cause/research/event/ai_assistant onto public layout (SSOT)

### DIFF
--- a/src/app/(authenticated)/dashboard/ai-assistants/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/ai-assistants/[id]/page.tsx
@@ -1,62 +1,17 @@
-import EntityDetailPage from '@/components/entity/EntityDetailPage';
-import { aiAssistantEntityConfig } from '@/config/entities/ai-assistants';
-import type { AIAssistant } from '@/types/database';
-import { capitalize } from '@/utils/string';
+import PublicEntityDetailPage from '@/components/public/PublicEntityDetailPage';
+import { aiAssistantDetailConfig } from '@/components/public/detail-configs/ai-assistant';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
 /**
- * AI Assistant Detail Page
+ * AI-assistant detail (owner / dashboard).
  *
- * Unified detail page using EntityDetailPage component.
- *
- * Created: 2026-01-03
- * Last Modified: 2026-01-03
- * Last Modified Summary: Initial creation using unified EntityDetailPage component
+ * Renders the SAME layout visitors see (PublicEntityDetailPage) plus the owner
+ * manage bar. Config shared with the public route via aiAssistantDetailConfig (SSOT).
  */
 export default async function AIAssistantDetailPage({ params }: PageProps) {
   const { id } = await params;
-
-  return (
-    <EntityDetailPage<AIAssistant>
-      config={aiAssistantEntityConfig}
-      entityId={id}
-      requireAuth={true}
-      redirectPath="/auth?mode=login&from=/dashboard/ai-assistants"
-      makeDetailFields={assistant => {
-        const left = [
-          {
-            label: 'Status',
-            value: capitalize(assistant.status || 'draft'),
-          },
-          { label: 'Category', value: assistant.category || '—' },
-          { label: 'Model Preference', value: assistant.model_preference || 'Any' },
-        ];
-
-        if (assistant.tags && assistant.tags.length > 0) {
-          left.push({ label: 'Tags', value: assistant.tags.join(', ') });
-        }
-
-        const right: Array<{ label: string; value: string }> = [];
-
-        if (assistant.lightning_address) {
-          right.push({ label: 'Lightning Address', value: assistant.lightning_address });
-        }
-        if (assistant.bitcoin_address) {
-          right.push({ label: 'Bitcoin Address', value: assistant.bitcoin_address });
-        }
-
-        if (assistant.published_at) {
-          right.push({
-            label: 'Published',
-            value: new Date(assistant.published_at).toLocaleString(),
-          });
-        }
-
-        return { left, right };
-      }}
-    />
-  );
+  return <PublicEntityDetailPage id={id} config={aiAssistantDetailConfig} />;
 }

--- a/src/app/(authenticated)/dashboard/causes/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/causes/[id]/page.tsx
@@ -1,59 +1,17 @@
-import EntityDetailPage from '@/components/entity/EntityDetailPage';
-import { causeEntityConfig } from '@/config/entities/causes';
-import type { UserCause } from '@/types/database';
-import { capitalize } from '@/utils/string';
+import PublicEntityDetailPage from '@/components/public/PublicEntityDetailPage';
+import { causeDetailConfig } from '@/components/public/detail-configs/cause';
 
-interface CauseDetailPageProps {
+interface PageProps {
   params: Promise<{ id: string }>;
 }
 
 /**
- * Cause Detail Page
+ * Cause detail (owner / dashboard).
  *
- * Unified detail page using EntityDetailPage component.
- *
- * Created: 2025-01-27
- * Last Modified: 2026-01-03
- * Last Modified Summary: Refactored to use unified EntityDetailPage component
+ * Renders the SAME layout supporters see (PublicEntityDetailPage) plus the owner
+ * manage bar. Config shared with the public route via causeDetailConfig (SSOT).
  */
-export default async function CauseDetailPage({ params }: CauseDetailPageProps) {
+export default async function CauseDetailPage({ params }: PageProps) {
   const { id } = await params;
-
-  return (
-    <EntityDetailPage<UserCause>
-      config={causeEntityConfig}
-      entityId={id}
-      requireAuth={false}
-      makeDetailFields={cause => {
-        const left = [
-          { label: 'Category', value: cause.cause_category || '—' },
-          {
-            label: 'Status',
-            value: capitalize(cause.status || 'draft'),
-          },
-          {
-            label: 'Goal Amount',
-            value: cause.target_amount
-              ? `${cause.target_amount.toLocaleString()} ${cause.currency || 'CHF'}`
-              : 'Open-ended',
-          },
-          {
-            label: 'Current Amount',
-            value: `${(cause.current_amount || 0).toLocaleString()} ${cause.currency || 'CHF'}`,
-          },
-        ];
-
-        const right: Array<{ label: string; value: string }> = [];
-
-        if (cause.bitcoin_address) {
-          right.push({ label: 'Bitcoin Address', value: cause.bitcoin_address });
-        }
-        if (cause.lightning_address) {
-          right.push({ label: 'Lightning Address', value: cause.lightning_address });
-        }
-
-        return { left, right };
-      }}
-    />
-  );
+  return <PublicEntityDetailPage id={id} config={causeDetailConfig} />;
 }

--- a/src/app/(authenticated)/dashboard/events/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/events/[id]/page.tsx
@@ -1,82 +1,17 @@
-import EntityDetailPage from '@/components/entity/EntityDetailPage';
-import { eventEntityConfig, type Event } from '@/config/entities/events';
-import { capitalize } from '@/utils/string';
+import PublicEntityDetailPage from '@/components/public/PublicEntityDetailPage';
+import { eventDetailConfig } from '@/components/public/detail-configs/event';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
+/**
+ * Event detail (owner / dashboard).
+ *
+ * Renders the SAME layout attendees see (PublicEntityDetailPage) plus the owner
+ * manage bar. Config shared with the public route via eventDetailConfig (SSOT).
+ */
 export default async function EventDetailPage({ params }: PageProps) {
   const { id } = await params;
-
-  return (
-    <EntityDetailPage<Event>
-      config={eventEntityConfig}
-      entityId={id}
-      requireAuth={true}
-      redirectPath="/auth?mode=login&from=/dashboard/events"
-      makeDetailFields={event => {
-        const left = [
-          { label: 'Status', value: capitalize(event.status || 'draft') },
-          { label: 'Type', value: capitalize(event.event_type || '—') },
-          { label: 'Category', value: event.category || '—' },
-          {
-            label: 'Date',
-            value: event.start_date ? new Date(event.start_date).toLocaleString() : '—',
-          },
-        ];
-
-        if (event.end_date) {
-          left.push({
-            label: 'End Date',
-            value: new Date(event.end_date).toLocaleString(),
-          });
-        }
-
-        if (event.max_attendees) {
-          left.push({
-            label: 'Capacity',
-            value: `${event.current_attendees ?? 0} / ${event.max_attendees} attendees`,
-          });
-        }
-
-        const right = [];
-
-        if (event.is_online) {
-          right.push({ label: 'Format', value: 'Online' });
-          if (event.online_url) {
-            right.push({ label: 'URL', value: event.online_url });
-          }
-        } else {
-          const locationParts = [
-            event.venue_name,
-            event.venue_address,
-            event.venue_city,
-            event.venue_country,
-          ].filter(Boolean);
-          if (locationParts.length > 0) {
-            right.push({ label: 'Location', value: locationParts.join(', ') });
-          }
-        }
-
-        if (event.is_free) {
-          right.push({ label: 'Ticket Price', value: 'Free' });
-        } else if (event.ticket_price) {
-          right.push({
-            label: 'Ticket Price',
-            value: `${event.ticket_price} ${event.currency || 'CHF'}`,
-          });
-        }
-
-        if (event.bitcoin_address) {
-          right.push({ label: 'Bitcoin Address', value: event.bitcoin_address });
-        }
-        if (event.lightning_address) {
-          right.push({ label: 'Lightning Address', value: event.lightning_address });
-        }
-
-        return { left, right };
-      }}
-    />
-  );
+  return <PublicEntityDetailPage id={id} config={eventDetailConfig} />;
 }

--- a/src/app/(authenticated)/dashboard/research/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/research/[id]/page.tsx
@@ -1,75 +1,17 @@
-import EntityDetailPage from '@/components/entity/EntityDetailPage';
-import { researchEntityConfig } from '@/config/entities/research';
-import { ResearchEntity } from '@/types/research';
-import { capitalize } from '@/utils/string';
-import { displayBTC } from '@/services/currency/formatting';
+import PublicEntityDetailPage from '@/components/public/PublicEntityDetailPage';
+import { researchDetailConfig } from '@/components/public/detail-configs/research';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
+/**
+ * Research detail (owner / dashboard).
+ *
+ * Renders the SAME layout funders see (PublicEntityDetailPage) plus the owner
+ * manage bar. Config shared with the public route via researchDetailConfig (SSOT).
+ */
 export default async function ResearchDetailPage({ params }: PageProps) {
   const { id } = await params;
-
-  return (
-    <EntityDetailPage<ResearchEntity>
-      config={researchEntityConfig}
-      entityId={id}
-      requireAuth={true}
-      redirectPath="/auth?mode=login&from=/dashboard/research"
-      makeDetailFields={entity => {
-        const left = [
-          { label: 'Status', value: capitalize(String(entity.status || 'draft')) },
-          {
-            label: 'Field',
-            value: entity.field ? String(entity.field).replace(/_/g, ' ') : '—',
-          },
-          {
-            label: 'Methodology',
-            value: entity.methodology ? String(entity.methodology).replace(/_/g, ' ') : '—',
-          },
-          {
-            label: 'Timeline',
-            value: entity.timeline ? String(entity.timeline).replace(/_/g, ' ') : '—',
-          },
-          { label: 'Lead Researcher', value: entity.lead_researcher || '—' },
-        ];
-
-        const right = [];
-
-        if (entity.funding_goal) {
-          right.push({
-            label: 'Funding Goal',
-            value: `${Number(entity.funding_goal).toLocaleString()} ${entity.funding_goal_currency || 'CHF'}`,
-          });
-        }
-
-        right.push({
-          label: 'Funding Raised',
-          value: displayBTC(entity.funding_raised_btc ? Number(entity.funding_raised_btc) : 0),
-        });
-
-        right.push({
-          label: 'Contributors',
-          value: `${entity.total_contributors ?? 0}`,
-        });
-
-        if (entity.completion_percentage !== null && entity.completion_percentage !== undefined) {
-          right.push({
-            label: 'Completion',
-            value: `${Math.round(Number(entity.completion_percentage))}%`,
-          });
-        }
-
-        if (entity.next_deadline) {
-          right.push({
-            label: 'Next Deadline',
-            value: new Date(entity.next_deadline).toLocaleDateString(),
-          });
-        }
-
-        return { left, right };
-      }}
-    />
-  );
+  return <PublicEntityDetailPage id={id} config={researchDetailConfig} />;
 }

--- a/src/app/(authenticated)/dashboard/services/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/services/[id]/page.tsx
@@ -1,75 +1,18 @@
-import EntityDetailPage from '@/components/entity/EntityDetailPage';
-import { serviceEntityConfig } from '@/config/entities/services';
-import type { UserService } from '@/types/database';
-import { convert, formatCurrency } from '@/services/currency';
-import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
-import type { Currency } from '@/types/settings';
+import PublicEntityDetailPage from '@/components/public/PublicEntityDetailPage';
+import { serviceDetailConfig } from '@/components/public/detail-configs/service';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
 /**
- * Service Detail Page
+ * Service detail (owner / dashboard).
  *
- * Unified detail page using EntityDetailPage component.
- *
- * Created: 2025-01-27
- * Last Modified: 2026-01-03
- * Last Modified Summary: Refactored to use unified EntityDetailPage component
+ * Renders the SAME layout buyers see (PublicEntityDetailPage) plus the owner
+ * manage bar — no separate flat label→value grid. Config shared with the public
+ * route via serviceDetailConfig (SSOT).
  */
 export default async function ServiceDetailPage({ params }: PageProps) {
   const { id } = await params;
-
-  return (
-    <EntityDetailPage<UserService>
-      config={serviceEntityConfig}
-      entityId={id}
-      requireAuth={true}
-      redirectPath="/auth?mode=login&from=/dashboard/services"
-      makeDetailFields={(service, userCurrency) => {
-        // Display prices in user's preferred currency (or service's currency)
-        const displayCurrency = (userCurrency ||
-          service.currency ||
-          PLATFORM_DEFAULT_CURRENCY) as Currency;
-        const priceParts: string[] = [];
-        if (service.hourly_rate && service.currency) {
-          const hourlyRate =
-            service.currency === displayCurrency
-              ? service.hourly_rate
-              : convert(service.hourly_rate, service.currency as Currency, displayCurrency);
-          priceParts.push(`${formatCurrency(hourlyRate, displayCurrency)}/hour`);
-        }
-        if (service.fixed_price && service.currency) {
-          const fixedPrice =
-            service.currency === displayCurrency
-              ? service.fixed_price
-              : convert(service.fixed_price, service.currency as Currency, displayCurrency);
-          priceParts.push(formatCurrency(fixedPrice, displayCurrency));
-        }
-        const priceLabel = priceParts.length > 0 ? priceParts.join(' or ') : 'Contact for pricing';
-
-        const left = [
-          { label: 'Status', value: service.status || 'draft' },
-          { label: 'Category', value: service.category || '—' },
-          { label: 'Pricing', value: priceLabel },
-          {
-            label: 'Location',
-            value:
-              service.service_location_type === 'remote'
-                ? 'Remote'
-                : service.service_location_type === 'onsite'
-                  ? 'On-site'
-                  : service.service_location_type || '—',
-          },
-        ];
-
-        if (service.duration_minutes) {
-          left.push({ label: 'Duration', value: `${service.duration_minutes} minutes` });
-        }
-
-        return { left, right: [] };
-      }}
-    />
-  );
+  return <PublicEntityDetailPage id={id} config={serviceDetailConfig} />;
 }

--- a/src/app/ai-assistants/[id]/page.tsx
+++ b/src/app/ai-assistants/[id]/page.tsx
@@ -1,152 +1,13 @@
 import { Metadata } from 'next';
-import Image from 'next/image';
 import { generateEntityMetadata } from '@/lib/seo/metadata';
 import PublicEntityDetailPage, {
   fetchEntityForMetadata,
-  type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
-import { Badge } from '@/components/ui/badge';
-import PriceDisplay from '@/components/public/PriceDisplay';
-import AiAssistantChat from '@/components/ai-assistants/AiAssistantChat';
-import { ROUTES } from '@/config/routes';
+import { aiAssistantDetailConfig } from '@/components/public/detail-configs/ai-assistant';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
-
-// ai_assistants price by pricing_model, stored in BTC (no currency column;
-// the sats→BTC migration dropped the _sats suffix and converted values).
-const AI_PRICE_BY_MODEL: Record<string, { column: string; suffix: string }> = {
-  per_message: { column: 'price_per_message', suffix: ' / message' },
-  per_token: { column: 'price_per_1k_tokens', suffix: ' / 1k tokens' },
-  subscription: { column: 'subscription_price', suffix: ' / month' },
-};
-
-const getAiPricing = (entity: Record<string, unknown>) => {
-  const model = (entity.pricing_model as string) || 'free';
-  if (model === 'free') {
-    return { isFree: true, amount: 0, suffix: '' };
-  }
-  const spec = AI_PRICE_BY_MODEL[model];
-  const amount = spec ? Number(entity[spec.column] ?? 0) : 0;
-  return { isFree: false, amount, suffix: spec?.suffix ?? '' };
-};
-
-const config: EntityDetailConfig = {
-  entityType: 'ai_assistant',
-  ownerLabel: 'Created by',
-  descriptionTitle: 'About this AI Assistant',
-  metadataSelect: 'title, description, avatar_url',
-  // No pay-the-seller-direct section: you don't pay an assistant up front — you
-  // chat, and it charges per its pricing model (free / per-message via Cat
-  // Credits) inside the chat widget. This also suppresses the default mobile
-  // sticky CTA, which would otherwise anchor "Chat" to a #pay section that
-  // shouldn't exist here. The chat widget is the primary action.
-  showPaymentSection: false,
-  getViewRoute: id => ROUTES.AI_ASSISTANTS.VIEW(id),
-  renderHeaderIcon: entity =>
-    entity.avatar_url ? (
-      <Image
-        src={entity.avatar_url as string}
-        alt={(entity.title as string) || 'AI assistant'}
-        width={64}
-        height={64}
-        className="w-16 h-16 rounded-lg object-cover flex-shrink-0"
-        unoptimized
-      />
-    ) : undefined,
-  renderHeaderExtra: entity => {
-    if (!entity.category) {
-      return null;
-    }
-    return (
-      <Badge variant="outline" className="capitalize">
-        {entity.category}
-      </Badge>
-    );
-  },
-  renderDetails: entity => {
-    const tags: string[] = Array.isArray(entity.tags) ? entity.tags : [];
-    const traits: string[] = Array.isArray(entity.personality_traits)
-      ? entity.personality_traits
-      : [];
-    const welcome = entity.welcome_message as string | null | undefined;
-    const pricing = getAiPricing(entity);
-
-    return (
-      <>
-        <AiAssistantChat
-          assistantId={entity.id as string}
-          assistantName={(entity.title as string) || 'this assistant'}
-          assistantAvatar={entity.avatar_url as string | null | undefined}
-          welcomeMessage={welcome}
-          pricing={pricing}
-        />
-
-        {(pricing.isFree || pricing.amount > 0) && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Pricing</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {pricing.isFree ? (
-                <p className="text-2xl font-bold text-fg-primary">Free</p>
-              ) : (
-                <PriceDisplay amount={pricing.amount} currency="BTC" suffix={pricing.suffix} />
-              )}
-            </CardContent>
-          </Card>
-        )}
-
-        {welcome && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Welcome Message</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-fg-primary italic whitespace-pre-wrap">{welcome}</p>
-            </CardContent>
-          </Card>
-        )}
-
-        {(tags.length > 0 || traits.length > 0) && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Details</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {tags.length > 0 && (
-                <div>
-                  <p className="text-sm text-fg-secondary mb-2">Tags</p>
-                  <div className="flex flex-wrap gap-2">
-                    {tags.map(tag => (
-                      <Badge key={tag} variant="secondary">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {traits.length > 0 && (
-                <div>
-                  <p className="text-sm text-fg-secondary mb-2">Personality</p>
-                  <div className="flex flex-wrap gap-2">
-                    {traits.map(trait => (
-                      <Badge key={trait} variant="outline">
-                        {trait}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        )}
-      </>
-    );
-  },
-};
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
@@ -165,5 +26,5 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function PublicAIAssistantPage({ params }: PageProps) {
   const { id } = await params;
-  return <PublicEntityDetailPage id={id} config={config} />;
+  return <PublicEntityDetailPage id={id} config={aiAssistantDetailConfig} />;
 }

--- a/src/app/causes/[id]/page.tsx
+++ b/src/app/causes/[id]/page.tsx
@@ -2,50 +2,12 @@ import { Metadata } from 'next';
 import { generateEntityMetadata } from '@/lib/seo/metadata';
 import PublicEntityDetailPage, {
   fetchEntityForMetadata,
-  type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
-import FundingProgress from '@/components/public/FundingProgress';
-import { ROUTES } from '@/config/routes';
+import { causeDetailConfig } from '@/components/public/detail-configs/cause';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
-
-// user_causes stores goal_amount in its chosen `currency` (causes can be BTC OR CHF),
-// and the raised total is column `total_raised` — NOT `raised_amount` (that column
-// doesn't exist, so "raised" was always blank). The old code also rendered the goal
-// with displayBTC(), showing a CHF goal as BTC. Read total_raised + currency, format
-// with formatCurrency. See decision_currency_convention.
-const causeFunding = (entity: Record<string, unknown>) => ({
-  goal: Number(entity.goal_amount ?? 0),
-  raised: Number(entity.total_raised ?? 0),
-  currency: (entity.currency as string) || 'BTC',
-});
-
-const config: EntityDetailConfig = {
-  entityType: 'cause',
-  ownerLabel: 'Organized By',
-  descriptionTitle: 'About this Cause',
-  metadataSelect: 'title, description',
-  getViewRoute: id => ROUTES.CAUSES.VIEW(id),
-  getJsonLdExtra: entity => {
-    const { goal, currency } = causeFunding(entity);
-    return goal > 0
-      ? {
-          funding: {
-            '@type': 'MonetaryGrant',
-            amount: { '@type': 'MonetaryAmount', value: goal, currency },
-          },
-        }
-      : {};
-  },
-  renderDetails: entity => {
-    const { goal, raised, currency } = causeFunding(entity);
-    // Always render — a cause with no goal set must still show an inviting
-    // funding state, never a blank page. FundingProgress owns that decision.
-    return <FundingProgress raised={raised} goal={goal} currency={currency} />;
-  },
-};
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
@@ -66,5 +28,5 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function PublicCausePage({ params }: PageProps) {
   const { id } = await params;
-  return <PublicEntityDetailPage id={id} config={config} />;
+  return <PublicEntityDetailPage id={id} config={causeDetailConfig} />;
 }

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -2,88 +2,13 @@ import { Metadata } from 'next';
 import { generateEntityMetadata } from '@/lib/seo/metadata';
 import PublicEntityDetailPage, {
   fetchEntityForMetadata,
-  type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
-import { ROUTES } from '@/config/routes';
+import { eventDetailConfig } from '@/components/public/detail-configs/event';
 import { format } from 'date-fns';
-import { Calendar as CalendarIcon, MapPin, Users } from 'lucide-react';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
-
-const config: EntityDetailConfig = {
-  entityType: 'event',
-  ownerLabel: 'Organizer',
-  descriptionTitle: 'About this Event',
-  backText: 'Back to Events',
-  backHref: '/events',
-  metadataSelect: 'title, description, start_date, location',
-  getViewRoute: id => ROUTES.EVENTS.VIEW(id),
-  getCoverImages: entity => {
-    const images = Array.isArray(entity.images) ? (entity.images as string[]) : [];
-    return [entity.banner_url as string, entity.thumbnail_url as string, ...images].filter(Boolean);
-  },
-  getJsonLdExtra: entity => ({
-    ...(entity.start_date && { startDate: entity.start_date }),
-    ...(entity.end_date && { endDate: entity.end_date }),
-    ...(entity.location && { location: { '@type': 'Place', name: entity.location } }),
-    ...(entity.max_attendees && { maximumAttendeeCapacity: entity.max_attendees }),
-    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
-  }),
-  renderHeaderExtra: entity =>
-    entity.start_date ? (
-      <span className="text-fg-secondary text-sm">
-        {format(new Date(entity.start_date as string), 'EEEE, MMMM d, yyyy')}
-      </span>
-    ) : null,
-  renderDetails: entity => (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-lg">Event Details</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {entity.start_date && (
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-surface-raised/40 rounded-lg flex items-center justify-center">
-              <CalendarIcon className="w-5 h-5 text-fg-primary" />
-            </div>
-            <div>
-              <div className="font-medium">
-                {format(new Date(entity.start_date as string), 'EEEE, MMMM d, yyyy')}
-              </div>
-              <div className="text-sm text-fg-secondary">
-                {format(new Date(entity.start_date as string), 'h:mm a')}
-                {entity.end_date && ` - ${format(new Date(entity.end_date as string), 'h:mm a')}`}
-              </div>
-            </div>
-          </div>
-        )}
-        {entity.location && (
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-surface-raised/40 rounded-lg flex items-center justify-center">
-              <MapPin className="w-5 h-5 text-fg-primary" />
-            </div>
-            <div>
-              <div className="font-medium">{entity.location as string}</div>
-            </div>
-          </div>
-        )}
-        {entity.max_attendees && (
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-surface-raised/40 rounded-lg flex items-center justify-center">
-              <Users className="w-5 h-5 text-fg-primary" />
-            </div>
-            <div>
-              <div className="font-medium">Max {entity.max_attendees as number} attendees</div>
-            </div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  ),
-};
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
@@ -110,5 +35,5 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function PublicEventPage({ params }: PageProps) {
   const { id } = await params;
-  return <PublicEntityDetailPage id={id} config={config} />;
+  return <PublicEntityDetailPage id={id} config={eventDetailConfig} />;
 }

--- a/src/app/research/[id]/page.tsx
+++ b/src/app/research/[id]/page.tsx
@@ -2,86 +2,12 @@ import { Metadata } from 'next';
 import { generateEntityMetadata } from '@/lib/seo/metadata';
 import PublicEntityDetailPage, {
   fetchEntityForMetadata,
-  type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
-import { Badge } from '@/components/ui/badge';
-import FundingProgress from '@/components/public/FundingProgress';
-import { ROUTES } from '@/config/routes';
-import { RESEARCH_FIELDS, METHODOLOGIES, TIMELINES } from '@/config/research';
+import { researchDetailConfig } from '@/components/public/detail-configs/research';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
-
-const FIELD_LABELS = Object.fromEntries(RESEARCH_FIELDS.map(f => [f.value, f.label]));
-const METHODOLOGY_LABELS = Object.fromEntries(METHODOLOGIES.map(m => [m.value, m.label]));
-const TIMELINE_LABELS = Object.fromEntries(TIMELINES.map(t => [t.value, t.label]));
-
-const config: EntityDetailConfig = {
-  entityType: 'research',
-  ownerLabel: 'Lead Researcher',
-  descriptionTitle: 'About this Research',
-  metadataSelect: 'title, description',
-  getViewRoute: id => ROUTES.RESEARCH.VIEW(id),
-  renderHeaderExtra: entity => {
-    if (!entity.field) {
-      return null;
-    }
-    return (
-      <Badge variant="outline" className="capitalize">
-        {FIELD_LABELS[entity.field] || entity.field}
-      </Badge>
-    );
-  },
-  renderDetails: entity => {
-    const fundingGoal = Number(entity.funding_goal_btc ?? entity.funding_goal ?? 0);
-    const fundingRaised = Number(entity.funding_raised_btc ?? 0);
-
-    return (
-      <>
-        <FundingProgress raised={fundingRaised} goal={fundingGoal} currency="BTC" />
-
-        {/* Research Details */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Research Details</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {entity.methodology && (
-              <div className="flex justify-between text-sm">
-                <span className="text-fg-secondary">Methodology</span>
-                <span className="font-medium">
-                  {METHODOLOGY_LABELS[entity.methodology] || entity.methodology}
-                </span>
-              </div>
-            )}
-            {entity.timeline && (
-              <div className="flex justify-between text-sm">
-                <span className="text-fg-secondary">Timeline</span>
-                <span className="font-medium">
-                  {TIMELINE_LABELS[entity.timeline] || entity.timeline}
-                </span>
-              </div>
-            )}
-            {entity.lead_researcher && (
-              <div className="flex justify-between text-sm">
-                <span className="text-fg-secondary">Lead Researcher</span>
-                <span className="font-medium">{entity.lead_researcher}</span>
-              </div>
-            )}
-            {entity.expected_outcome && (
-              <div className="pt-2 border-t border-subtle">
-                <p className="text-sm text-fg-secondary mb-1">Expected Outcome</p>
-                <p className="text-sm text-fg-primary">{entity.expected_outcome}</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </>
-    );
-  },
-};
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
@@ -99,5 +25,5 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function PublicResearchPage({ params }: PageProps) {
   const { id } = await params;
-  return <PublicEntityDetailPage id={id} config={config} />;
+  return <PublicEntityDetailPage id={id} config={researchDetailConfig} />;
 }

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -2,108 +2,12 @@ import { Metadata } from 'next';
 import { generateEntityMetadata } from '@/lib/seo/metadata';
 import PublicEntityDetailPage, {
   fetchEntityForMetadata,
-  type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
-import PriceDisplay from '@/components/public/PriceDisplay';
-import { ROUTES } from '@/config/routes';
-import { BookEntityButton } from '@/components/bookings/BookEntityButton';
-import { hasAvailability, formatAvailabilityLines } from '@/lib/availability';
+import { serviceDetailConfig } from '@/components/public/detail-configs/service';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
-
-// user_services stores its price in `fixed_price` (or `hourly_rate`) in the entity's
-// chosen `currency` — NOT price_btc (no such column) and NOT in BTC. The old code read
-// price_btc ?? fixed_price and rendered it with displayBTC(), so a 50 CHF service showed
-// as "50 BTC". Read the real column + currency and format in that currency.
-// See decision_currency_convention.
-const getServicePrice = (entity: Record<string, unknown>) => {
-  const fixed = entity.fixed_price;
-  const hourly = entity.hourly_rate;
-  const raw = typeof fixed === 'number' && fixed > 0 ? fixed : hourly;
-  const amount = typeof raw === 'number' ? raw : Number(raw ?? NaN);
-  return {
-    amount: Number.isFinite(amount) ? amount : 0,
-    currency: (entity.currency as string) || 'CHF',
-    perHour: !(typeof fixed === 'number' && fixed > 0) && typeof hourly === 'number' && hourly > 0,
-  };
-};
-
-const config: EntityDetailConfig = {
-  entityType: 'service',
-  ownerLabel: 'Provider',
-  createdLabel: 'Listed',
-  descriptionTitle: 'About this Service',
-  getViewRoute: id => ROUTES.SERVICES.VIEW(id),
-  getCoverImages: entity =>
-    (Array.isArray(entity.images) ? (entity.images as string[]) : []).filter(Boolean),
-  getPrice: entity => {
-    const { amount, currency } = getServicePrice(entity);
-    return amount > 0 ? { amount, currency } : null;
-  },
-  getJsonLdExtra: entity => {
-    const { amount, currency } = getServicePrice(entity);
-    return {
-      ...(amount > 0 && {
-        offers: { '@type': 'Offer', priceCurrency: currency, price: amount },
-      }),
-      ...(entity.duration_minutes && { duration: `PT${entity.duration_minutes}M` }),
-    };
-  },
-  renderDetails: entity => {
-    const { amount, currency, perHour } = getServicePrice(entity);
-    const durationMinutes = (entity as { duration_minutes?: number }).duration_minutes;
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Details</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {amount > 0 && (
-            <div className="flex items-center justify-between gap-4">
-              <span className="text-fg-secondary">Price</span>
-              <PriceDisplay
-                amount={amount}
-                currency={currency}
-                className="text-xl font-bold text-fg-primary text-right"
-                suffix={perHour ? ' / hr' : undefined}
-              />
-            </div>
-          )}
-          {durationMinutes && (
-            <div className="flex items-center justify-between">
-              <span className="text-fg-secondary">Duration</span>
-              <span className="font-medium">{durationMinutes} minutes</span>
-            </div>
-          )}
-          {hasAvailability(entity.availability_schedule) && (
-            <div className="flex items-start justify-between gap-4">
-              <span className="text-fg-secondary">Availability</span>
-              <div className="text-right">
-                {formatAvailabilityLines(entity.availability_schedule).map(line => (
-                  <div key={line} className="font-medium text-fg-primary">
-                    {line}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-          <BookEntityButton
-            className="w-full"
-            bookableType="service"
-            bookableId={entity.id as string}
-            bookableTitle={(entity.title as string) || 'this service'}
-            priceBtc={amount > 0 ? amount : undefined}
-            priceCurrency={currency}
-            durationMinutes={durationMinutes}
-          />
-        </CardContent>
-      </Card>
-    );
-  },
-};
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
@@ -124,5 +28,5 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function PublicServicePage({ params }: PageProps) {
   const { id } = await params;
-  return <PublicEntityDetailPage id={id} config={config} />;
+  return <PublicEntityDetailPage id={id} config={serviceDetailConfig} />;
 }

--- a/src/components/public/detail-configs/ai-assistant.tsx
+++ b/src/components/public/detail-configs/ai-assistant.tsx
@@ -1,0 +1,141 @@
+import Image from 'next/image';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/badge';
+import PriceDisplay from '@/components/public/PriceDisplay';
+import AiAssistantChat from '@/components/ai-assistants/AiAssistantChat';
+import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailPage';
+import { ROUTES } from '@/config/routes';
+
+// ai_assistants price by pricing_model, stored in BTC (no currency column;
+// the sats→BTC migration dropped the _sats suffix and converted values).
+const AI_PRICE_BY_MODEL: Record<string, { column: string; suffix: string }> = {
+  per_message: { column: 'price_per_message', suffix: ' / message' },
+  per_token: { column: 'price_per_1k_tokens', suffix: ' / 1k tokens' },
+  subscription: { column: 'subscription_price', suffix: ' / month' },
+};
+
+const getAiPricing = (entity: Record<string, unknown>) => {
+  const model = (entity.pricing_model as string) || 'free';
+  if (model === 'free') {
+    return { isFree: true, amount: 0, suffix: '' };
+  }
+  const spec = AI_PRICE_BY_MODEL[model];
+  const amount = spec ? Number(entity[spec.column] ?? 0) : 0;
+  return { isFree: false, amount, suffix: spec?.suffix ?? '' };
+};
+
+/** SSOT for the AI-assistant detail page — shared by the public + owner dashboard routes. */
+export const aiAssistantDetailConfig: EntityDetailConfig = {
+  entityType: 'ai_assistant',
+  ownerLabel: 'Created by',
+  descriptionTitle: 'About this AI Assistant',
+  metadataSelect: 'title, description, avatar_url',
+  // No pay-the-seller-direct section: you don't pay an assistant up front — you
+  // chat, and it charges per its pricing model (free / per-message via Cat
+  // Credits) inside the chat widget. This also suppresses the default mobile
+  // sticky CTA, which would otherwise anchor "Chat" to a #pay section that
+  // shouldn't exist here. The chat widget is the primary action.
+  showPaymentSection: false,
+  getViewRoute: id => ROUTES.AI_ASSISTANTS.VIEW(id),
+  renderHeaderIcon: entity =>
+    entity.avatar_url ? (
+      <Image
+        src={entity.avatar_url as string}
+        alt={(entity.title as string) || 'AI assistant'}
+        width={64}
+        height={64}
+        className="w-16 h-16 rounded-lg object-cover flex-shrink-0"
+        unoptimized
+      />
+    ) : undefined,
+  renderHeaderExtra: entity => {
+    if (!entity.category) {
+      return null;
+    }
+    return (
+      <Badge variant="outline" className="capitalize">
+        {entity.category}
+      </Badge>
+    );
+  },
+  renderDetails: entity => {
+    const tags: string[] = Array.isArray(entity.tags) ? entity.tags : [];
+    const traits: string[] = Array.isArray(entity.personality_traits)
+      ? entity.personality_traits
+      : [];
+    const welcome = entity.welcome_message as string | null | undefined;
+    const pricing = getAiPricing(entity);
+
+    return (
+      <>
+        <AiAssistantChat
+          assistantId={entity.id as string}
+          assistantName={(entity.title as string) || 'this assistant'}
+          assistantAvatar={entity.avatar_url as string | null | undefined}
+          welcomeMessage={welcome}
+          pricing={pricing}
+        />
+
+        {(pricing.isFree || pricing.amount > 0) && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Pricing</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {pricing.isFree ? (
+                <p className="text-2xl font-bold text-fg-primary">Free</p>
+              ) : (
+                <PriceDisplay amount={pricing.amount} currency="BTC" suffix={pricing.suffix} />
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {welcome && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Welcome Message</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-fg-primary italic whitespace-pre-wrap">{welcome}</p>
+            </CardContent>
+          </Card>
+        )}
+
+        {(tags.length > 0 || traits.length > 0) && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {tags.length > 0 && (
+                <div>
+                  <p className="text-sm text-fg-secondary mb-2">Tags</p>
+                  <div className="flex flex-wrap gap-2">
+                    {tags.map(tag => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {traits.length > 0 && (
+                <div>
+                  <p className="text-sm text-fg-secondary mb-2">Personality</p>
+                  <div className="flex flex-wrap gap-2">
+                    {traits.map(trait => (
+                      <Badge key={trait} variant="outline">
+                        {trait}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </>
+    );
+  },
+};

--- a/src/components/public/detail-configs/cause.tsx
+++ b/src/components/public/detail-configs/cause.tsx
@@ -1,0 +1,38 @@
+import FundingProgress from '@/components/public/FundingProgress';
+import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailPage';
+import { ROUTES } from '@/config/routes';
+
+// user_causes stores goal_amount in its chosen `currency` (causes can be BTC OR CHF),
+// and the raised total is column `total_raised` — NOT `raised_amount`. Read
+// total_raised + currency, format with formatCurrency. See decision_currency_convention.
+const causeFunding = (entity: Record<string, unknown>) => ({
+  goal: Number(entity.goal_amount ?? 0),
+  raised: Number(entity.total_raised ?? 0),
+  currency: (entity.currency as string) || 'BTC',
+});
+
+/** SSOT for the cause detail page — shared by the public + owner dashboard routes. */
+export const causeDetailConfig: EntityDetailConfig = {
+  entityType: 'cause',
+  ownerLabel: 'Organized By',
+  descriptionTitle: 'About this Cause',
+  metadataSelect: 'title, description',
+  getViewRoute: id => ROUTES.CAUSES.VIEW(id),
+  getJsonLdExtra: entity => {
+    const { goal, currency } = causeFunding(entity);
+    return goal > 0
+      ? {
+          funding: {
+            '@type': 'MonetaryGrant',
+            amount: { '@type': 'MonetaryAmount', value: goal, currency },
+          },
+        }
+      : {};
+  },
+  renderDetails: entity => {
+    const { goal, raised, currency } = causeFunding(entity);
+    // Always render — a cause with no goal set must still show an inviting
+    // funding state, never a blank page. FundingProgress owns that decision.
+    return <FundingProgress raised={raised} goal={goal} currency={currency} />;
+  },
+};

--- a/src/components/public/detail-configs/event.tsx
+++ b/src/components/public/detail-configs/event.tsx
@@ -1,0 +1,78 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailPage';
+import { ROUTES } from '@/config/routes';
+import { format } from 'date-fns';
+import { Calendar as CalendarIcon, MapPin, Users } from 'lucide-react';
+
+/** SSOT for the event detail page — shared by the public + owner dashboard routes. */
+export const eventDetailConfig: EntityDetailConfig = {
+  entityType: 'event',
+  ownerLabel: 'Organizer',
+  descriptionTitle: 'About this Event',
+  backText: 'Back to Events',
+  backHref: '/events',
+  metadataSelect: 'title, description, start_date, location',
+  getViewRoute: id => ROUTES.EVENTS.VIEW(id),
+  getCoverImages: entity => {
+    const images = Array.isArray(entity.images) ? (entity.images as string[]) : [];
+    return [entity.banner_url as string, entity.thumbnail_url as string, ...images].filter(Boolean);
+  },
+  getJsonLdExtra: entity => ({
+    ...(entity.start_date && { startDate: entity.start_date }),
+    ...(entity.end_date && { endDate: entity.end_date }),
+    ...(entity.location && { location: { '@type': 'Place', name: entity.location } }),
+    ...(entity.max_attendees && { maximumAttendeeCapacity: entity.max_attendees }),
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+  }),
+  renderHeaderExtra: entity =>
+    entity.start_date ? (
+      <span className="text-fg-secondary text-sm">
+        {format(new Date(entity.start_date as string), 'EEEE, MMMM d, yyyy')}
+      </span>
+    ) : null,
+  renderDetails: entity => (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Event Details</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {entity.start_date && (
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-surface-raised/40 rounded-lg flex items-center justify-center">
+              <CalendarIcon className="w-5 h-5 text-fg-primary" />
+            </div>
+            <div>
+              <div className="font-medium">
+                {format(new Date(entity.start_date as string), 'EEEE, MMMM d, yyyy')}
+              </div>
+              <div className="text-sm text-fg-secondary">
+                {format(new Date(entity.start_date as string), 'h:mm a')}
+                {entity.end_date && ` - ${format(new Date(entity.end_date as string), 'h:mm a')}`}
+              </div>
+            </div>
+          </div>
+        )}
+        {entity.location && (
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-surface-raised/40 rounded-lg flex items-center justify-center">
+              <MapPin className="w-5 h-5 text-fg-primary" />
+            </div>
+            <div>
+              <div className="font-medium">{entity.location as string}</div>
+            </div>
+          </div>
+        )}
+        {entity.max_attendees && (
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-surface-raised/40 rounded-lg flex items-center justify-center">
+              <Users className="w-5 h-5 text-fg-primary" />
+            </div>
+            <div>
+              <div className="font-medium">Max {entity.max_attendees as number} attendees</div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  ),
+};

--- a/src/components/public/detail-configs/index.ts
+++ b/src/components/public/detail-configs/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Entity detail-page configs (SSOT).
+ *
+ * Each entity's PublicEntityDetailPage config is defined ONCE here and imported by
+ * both its public route (/{type}/[id]) and its owner dashboard route
+ * (/dashboard/{base}/[id]) — same layout for buyers and owners, owner additionally
+ * gets the manage bar. DETAIL_CONFIGS maps entityType → config for generic lookups.
+ */
+import type { EntityType } from '@/config/entity-registry';
+import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailPage';
+import { productDetailConfig } from './product';
+import { serviceDetailConfig } from './service';
+import { causeDetailConfig } from './cause';
+import { researchDetailConfig } from './research';
+import { eventDetailConfig } from './event';
+import { aiAssistantDetailConfig } from './ai-assistant';
+
+export {
+  productDetailConfig,
+  serviceDetailConfig,
+  causeDetailConfig,
+  researchDetailConfig,
+  eventDetailConfig,
+  aiAssistantDetailConfig,
+};
+
+export const DETAIL_CONFIGS: Partial<Record<EntityType, EntityDetailConfig>> = {
+  product: productDetailConfig,
+  service: serviceDetailConfig,
+  cause: causeDetailConfig,
+  research: researchDetailConfig,
+  event: eventDetailConfig,
+  ai_assistant: aiAssistantDetailConfig,
+};

--- a/src/components/public/detail-configs/research.tsx
+++ b/src/components/public/detail-configs/research.tsx
@@ -1,0 +1,76 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/badge';
+import FundingProgress from '@/components/public/FundingProgress';
+import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailPage';
+import { ROUTES } from '@/config/routes';
+import { RESEARCH_FIELDS, METHODOLOGIES, TIMELINES } from '@/config/research';
+
+const FIELD_LABELS = Object.fromEntries(RESEARCH_FIELDS.map(f => [f.value, f.label]));
+const METHODOLOGY_LABELS = Object.fromEntries(METHODOLOGIES.map(m => [m.value, m.label]));
+const TIMELINE_LABELS = Object.fromEntries(TIMELINES.map(t => [t.value, t.label]));
+
+/** SSOT for the research detail page — shared by the public + owner dashboard routes. */
+export const researchDetailConfig: EntityDetailConfig = {
+  entityType: 'research',
+  ownerLabel: 'Lead Researcher',
+  descriptionTitle: 'About this Research',
+  metadataSelect: 'title, description',
+  getViewRoute: id => ROUTES.RESEARCH.VIEW(id),
+  renderHeaderExtra: entity => {
+    if (!entity.field) {
+      return null;
+    }
+    return (
+      <Badge variant="outline" className="capitalize">
+        {FIELD_LABELS[entity.field] || entity.field}
+      </Badge>
+    );
+  },
+  renderDetails: entity => {
+    const fundingGoal = Number(entity.funding_goal_btc ?? entity.funding_goal ?? 0);
+    const fundingRaised = Number(entity.funding_raised_btc ?? 0);
+
+    return (
+      <>
+        <FundingProgress raised={fundingRaised} goal={fundingGoal} currency="BTC" />
+
+        {/* Research Details */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Research Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {entity.methodology && (
+              <div className="flex justify-between text-sm">
+                <span className="text-fg-secondary">Methodology</span>
+                <span className="font-medium">
+                  {METHODOLOGY_LABELS[entity.methodology] || entity.methodology}
+                </span>
+              </div>
+            )}
+            {entity.timeline && (
+              <div className="flex justify-between text-sm">
+                <span className="text-fg-secondary">Timeline</span>
+                <span className="font-medium">
+                  {TIMELINE_LABELS[entity.timeline] || entity.timeline}
+                </span>
+              </div>
+            )}
+            {entity.lead_researcher && (
+              <div className="flex justify-between text-sm">
+                <span className="text-fg-secondary">Lead Researcher</span>
+                <span className="font-medium">{entity.lead_researcher}</span>
+              </div>
+            )}
+            {entity.expected_outcome && (
+              <div className="pt-2 border-t border-subtle">
+                <p className="text-sm text-fg-secondary mb-1">Expected Outcome</p>
+                <p className="text-sm text-fg-primary">{entity.expected_outcome}</p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </>
+    );
+  },
+};

--- a/src/components/public/detail-configs/service.tsx
+++ b/src/components/public/detail-configs/service.tsx
@@ -1,0 +1,96 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import PriceDisplay from '@/components/public/PriceDisplay';
+import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailPage';
+import { ROUTES } from '@/config/routes';
+import { BookEntityButton } from '@/components/bookings/BookEntityButton';
+import { hasAvailability, formatAvailabilityLines } from '@/lib/availability';
+
+// user_services stores its price in `fixed_price` (or `hourly_rate`) in the entity's
+// chosen `currency` — NOT price_btc (no such column) and NOT in BTC. Read the real
+// column + currency and format in that currency. See decision_currency_convention.
+const getServicePrice = (entity: Record<string, unknown>) => {
+  const fixed = entity.fixed_price;
+  const hourly = entity.hourly_rate;
+  const raw = typeof fixed === 'number' && fixed > 0 ? fixed : hourly;
+  const amount = typeof raw === 'number' ? raw : Number(raw ?? NaN);
+  return {
+    amount: Number.isFinite(amount) ? amount : 0,
+    currency: (entity.currency as string) || 'CHF',
+    perHour: !(typeof fixed === 'number' && fixed > 0) && typeof hourly === 'number' && hourly > 0,
+  };
+};
+
+/** SSOT for the service detail page — shared by the public + owner dashboard routes. */
+export const serviceDetailConfig: EntityDetailConfig = {
+  entityType: 'service',
+  ownerLabel: 'Provider',
+  createdLabel: 'Listed',
+  descriptionTitle: 'About this Service',
+  getViewRoute: id => ROUTES.SERVICES.VIEW(id),
+  getCoverImages: entity =>
+    (Array.isArray(entity.images) ? (entity.images as string[]) : []).filter(Boolean),
+  getPrice: entity => {
+    const { amount, currency } = getServicePrice(entity);
+    return amount > 0 ? { amount, currency } : null;
+  },
+  getJsonLdExtra: entity => {
+    const { amount, currency } = getServicePrice(entity);
+    return {
+      ...(amount > 0 && {
+        offers: { '@type': 'Offer', priceCurrency: currency, price: amount },
+      }),
+      ...(entity.duration_minutes && { duration: `PT${entity.duration_minutes}M` }),
+    };
+  },
+  renderDetails: entity => {
+    const { amount, currency, perHour } = getServicePrice(entity);
+    const durationMinutes = (entity as { duration_minutes?: number }).duration_minutes;
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {amount > 0 && (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-fg-secondary">Price</span>
+              <PriceDisplay
+                amount={amount}
+                currency={currency}
+                className="text-xl font-bold text-fg-primary text-right"
+                suffix={perHour ? ' / hr' : undefined}
+              />
+            </div>
+          )}
+          {durationMinutes && (
+            <div className="flex items-center justify-between">
+              <span className="text-fg-secondary">Duration</span>
+              <span className="font-medium">{durationMinutes} minutes</span>
+            </div>
+          )}
+          {hasAvailability(entity.availability_schedule) && (
+            <div className="flex items-start justify-between gap-4">
+              <span className="text-fg-secondary">Availability</span>
+              <div className="text-right">
+                {formatAvailabilityLines(entity.availability_schedule).map(line => (
+                  <div key={line} className="font-medium text-fg-primary">
+                    {line}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          <BookEntityButton
+            className="w-full"
+            bookableType="service"
+            bookableId={entity.id as string}
+            bookableTitle={(entity.title as string) || 'this service'}
+            priceBtc={amount > 0 ? amount : undefined}
+            priceCurrency={currency}
+            durationMinutes={durationMinutes}
+          />
+        </CardContent>
+      </Card>
+    );
+  },
+};


### PR DESCRIPTION
Slice 2, following the product template (#339). Every type with a rich public detail page now renders that SAME layout for its owner too + the manage bar — flat grid gone.

- New `detail-configs/{service,cause,research,event,ai-assistant}.tsx` (configs moved verbatim, zero behavior change) + `index.ts` barrel & `DETAIL_CONFIGS` registry (entityType→config).
- Public routes slimmed to import their config; dashboard routes render `PublicEntityDetailPage` with the shared config (SSOT — one definition, two importers).

Flat types (assets/investments/loans/circles/groups/wishlists/documents) need their own configs — next chunk. tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)