### PR TITLE
refactor(owner-view): converge circle onto public layout + enrich (SSOT)

### DIFF
--- a/src/app/(authenticated)/dashboard/circles/[id]/page.tsx
+++ b/src/app/(authenticated)/dashboard/circles/[id]/page.tsx
@@ -1,27 +1,18 @@
-import EntityDetailPage from '@/components/entity/EntityDetailPage';
-import { circleEntityConfig, type CircleListItem } from '@/config/entities/circles';
-import { capitalize } from '@/utils/string';
+import PublicEntityDetailPage from '@/components/public/PublicEntityDetailPage';
+import { circleDetailConfig } from '@/components/public/detail-configs/circle';
 
-interface CircleDetailPageProps {
+interface PageProps {
   params: Promise<{ id: string }>;
 }
 
-export default async function CircleDetailPage({ params }: CircleDetailPageProps) {
+/**
+ * Circle detail (owner / dashboard).
+ *
+ * Renders the SAME layout members see (PublicEntityDetailPage) plus the owner
+ * manage bar — no separate flat label→value grid. Config shared with the public
+ * route via circleDetailConfig (SSOT).
+ */
+export default async function CircleDetailPage({ params }: PageProps) {
   const { id } = await params;
-
-  return (
-    <EntityDetailPage<CircleListItem>
-      config={circleEntityConfig}
-      entityId={id}
-      requireAuth={false}
-      makeDetailFields={circle => ({
-        left: [
-          { label: 'Category', value: circle.category || '—' },
-          { label: 'Visibility', value: capitalize(circle.visibility || 'public') },
-          { label: 'Members', value: String(circle.member_count ?? 0) },
-        ],
-        right: [],
-      })}
-    />
-  );
+  return <PublicEntityDetailPage id={id} config={circleDetailConfig} />;
 }

--- a/src/app/circles/[id]/page.tsx
+++ b/src/app/circles/[id]/page.tsx
@@ -2,28 +2,12 @@ import { Metadata } from 'next';
 import { generateEntityMetadata } from '@/lib/seo/metadata';
 import PublicEntityDetailPage, {
   fetchEntityForMetadata,
-  type EntityDetailConfig,
 } from '@/components/public/PublicEntityDetailPage';
-import { Badge } from '@/components/ui/badge';
-import { ROUTES } from '@/config/routes';
+import { circleDetailConfig } from '@/components/public/detail-configs/circle';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
-
-const config: EntityDetailConfig = {
-  entityType: 'circle',
-  ownerLabel: 'Created by',
-  descriptionTitle: 'About this Circle',
-  metadataSelect: 'title, description',
-  getViewRoute: id => ROUTES.CIRCLES.VIEW(id),
-  renderHeaderExtra: entity =>
-    entity.category ? (
-      <Badge variant="outline" className="capitalize">
-        {entity.category as string}
-      </Badge>
-    ) : null,
-};
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
@@ -41,5 +25,5 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function PublicCirclePage({ params }: PageProps) {
   const { id } = await params;
-  return <PublicEntityDetailPage id={id} config={config} />;
+  return <PublicEntityDetailPage id={id} config={circleDetailConfig} />;
 }

--- a/src/components/public/detail-configs/circle.tsx
+++ b/src/components/public/detail-configs/circle.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/badge';
+import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailPage';
+import { ROUTES } from '@/config/routes';
+
+/**
+ * SSOT for the circle detail page — shared by the public route (/circles/[id])
+ * and the owner dashboard route (/dashboard/circles/[id]). Circles are a light
+ * community structure: no payment, the facts that matter are members / visibility
+ * / category. (Enriched from the previously bare public config, which showed only
+ * the description; the owner dashboard's flat grid surfaced these facts and they
+ * belong on the page itself.)
+ */
+export const circleDetailConfig: EntityDetailConfig = {
+  entityType: 'circle',
+  ownerLabel: 'Created by',
+  descriptionTitle: 'About this Circle',
+  metadataSelect: 'title, description',
+  showPaymentSection: false,
+  getViewRoute: id => ROUTES.CIRCLES.VIEW(id),
+  renderHeaderExtra: entity =>
+    entity.category ? (
+      <Badge variant="outline" className="capitalize">
+        {entity.category as string}
+      </Badge>
+    ) : null,
+  renderDetails: entity => {
+    const memberCount = entity.member_count as number | null | undefined;
+    const visibility = entity.visibility as string | undefined;
+    const category = entity.category as string | undefined;
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-fg-secondary">Members</span>
+            <span className="font-medium">{memberCount ?? 0}</span>
+          </div>
+          {visibility && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-fg-secondary">Visibility</span>
+              <span className="font-medium capitalize">{visibility}</span>
+            </div>
+          )}
+          {category && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-fg-secondary">Category</span>
+              <span className="font-medium capitalize">{category}</span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    );
+  },
+};

--- a/src/components/public/detail-configs/index.ts
+++ b/src/components/public/detail-configs/index.ts
@@ -17,6 +17,7 @@ import { aiAssistantDetailConfig } from './ai-assistant';
 import { loanDetailConfig } from './loan';
 import { investmentDetailConfig } from './investment';
 import { assetDetailConfig } from './asset';
+import { circleDetailConfig } from './circle';
 
 export {
   productDetailConfig,
@@ -28,6 +29,7 @@ export {
   loanDetailConfig,
   investmentDetailConfig,
   assetDetailConfig,
+  circleDetailConfig,
 };
 
 export const DETAIL_CONFIGS: Partial<Record<EntityType, EntityDetailConfig>> = {
@@ -40,4 +42,5 @@ export const DETAIL_CONFIGS: Partial<Record<EntityType, EntityDetailConfig>> = {
   loan: loanDetailConfig,
   investment: investmentDetailConfig,
   asset: assetDetailConfig,
+  circle: circleDetailConfig,
 };


### PR DESCRIPTION
Last dashboard route on the flat EntityDetailPage. Enriched circle's shared config with a Details card (members/visibility/category) so both public + owner show them; both routes now render PublicEntityDetailPage.

The other 3 candidates are deliberately NOT migrated — not buyer-listings, already right: **wishlist** (custom rich owner item-management + rich public), **group** (shared `GroupDetail` governance for both routes), **document** (private viewer, no public route). Forcing the listing layout would remove their proper UIs.

tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)