### PR TITLE
feat(cat): economic agent — "What can I offer?" offer engine (slice 1)

### DIFF
--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -285,6 +285,7 @@ export async function orchestrateCatChat(
           // PrefilledFormCard instead of narrating field values as prose.
           const messages = await maybeEnrichWithSearchResults(
             supabase,
+            user.id,
             baseMessages,
             message,
             provider,
@@ -476,6 +477,7 @@ export async function orchestrateCatChat(
   const collectedPrefillProposals: PrefillProposal[] = [];
   const messages = await maybeEnrichWithSearchResults(
     supabase,
+    user.id,
     baseMessages,
     message,
     provider,

--- a/src/services/cat/offer-engine.ts
+++ b/src/services/cat/offer-engine.ts
@@ -1,0 +1,178 @@
+/**
+ * Offer engine — the "What can I offer?" economic-agent capability.
+ *
+ * Given everything OrangeCat knows about a user (profile, documents, durable
+ * memories, the entities they already have), reason over their LATENT economic
+ * assets and propose several grounded, packaged ways to participate — each mapped
+ * to the right entity type so it can prefill a create form (one-click "Create X").
+ *
+ * Slice 1 is packaging-led: it grounds offers in what the user HAS, and is
+ * explicitly forbidden from inventing demand or stats (no fabricated personas —
+ * see the earlier "Cat invented personas" bug). Live demand-signal grounding +
+ * ranking is a later slice (docs/specs/economic-agent-capability.md).
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import type { EntityType } from '@/config/entity-registry';
+import { PREFILLABLE_ENTITY_TYPES } from './tool-use-detection';
+import { fetchFullContextForCat } from '@/services/ai/document-context';
+import { buildFullContextString } from '@/services/ai/context-string-builder';
+import { listMemories } from './memory';
+import { logger } from '@/utils/logger';
+
+// Capable, JSON-reliable defaults (mirrors form-prefill-service's provider choice).
+const GROQ_MODEL = 'llama-3.3-70b-versatile';
+const OPENROUTER_MODEL = 'meta-llama/llama-4-maverick:free';
+const MAX_OFFERS = 5;
+
+export interface ProposedOffer {
+  entityType: EntityType;
+  /** Full natural-language description — feeds generateFormPrefill. */
+  description: string;
+  /** Why this fits, grounded in a specific context item. */
+  rationale: string;
+}
+
+const SYSTEM_PROMPT = `You are the economic agent inside OrangeCat — the user's own AI agent for turning who they are into ways to participate economically. Given everything OrangeCat knows about this user (profile, documents, durable memories, and the entities they already have), propose concrete, packaged ways they could earn, fund, lend, invest, or coordinate.
+
+Map their LATENT ASSETS to the right OrangeCat entity type:
+- a skill they can do for others → "service"
+- something they make or produce → "product"
+- a venture or goal that needs funding → "project"
+- a physical thing to rent or sell → "asset"
+- expertise or a study to fund → "research"
+- capital to deploy → "investment" or "loan"
+- a cause they care about → "cause"
+- a community or audience → "circle"
+- knowledge or an experience to host → "event"
+
+RULES (these are hard constraints):
+- Ground EVERY offer in something SPECIFIC from the provided context. In "rationale", name the concrete skill, asset, document, or experience it comes from.
+- NEVER invent facts about the user. NEVER invent demand, market size, or statistics (e.g. "3 people searched for this"). You have no demand data — propose based on what they HAVE, not on claimed demand.
+- Do NOT duplicate something they already offer (check their existing entities).
+- Each "description" must be a full, publishable description (what it is, who it is for, a sensible scope) so it can prefill a create form — but do NOT fabricate a specific price; leave price out unless the context clearly implies one.
+- Prefer VARIETY across the economic spectrum over several of the same type.
+- Quality over quantity: if the context is thin, return fewer offers (or none). A weak, generic offer is worse than no offer.
+
+Output ONLY JSON in this exact shape:
+{"offers":[{"entityType":"service","description":"<full publishable description>","rationale":"Grounded in: <the specific context item>"}]}
+entityType MUST be one of: ${PREFILLABLE_ENTITY_TYPES.join(', ')}.`;
+
+/**
+ * Reason over the user's full context and return up to `count` grounded offers.
+ * Returns [] on any failure (missing keys, bad model output) — callers degrade
+ * gracefully (Cat just answers without cards).
+ */
+export async function generateOffers(
+  supabase: AnySupabaseClient,
+  userId: string,
+  opts?: { count?: number; focus?: string }
+): Promise<ProposedOffer[]> {
+  const count = Math.min(Math.max(opts?.count ?? 4, 1), MAX_OFFERS);
+
+  const [context, memories] = await Promise.all([
+    fetchFullContextForCat(supabase, userId),
+    listMemories(supabase, userId),
+  ]);
+  const contextBlob = buildFullContextString(context);
+  const memoryBlob = memories.length ? memories.map(m => `- ${m.content}`).join('\n') : '(none)';
+
+  const raw = await callOfferModel(contextBlob, memoryBlob, count, opts?.focus);
+  if (!raw) {
+    return [];
+  }
+  return parseOffers(raw, count);
+}
+
+async function callOfferModel(
+  contextBlob: string,
+  memoryBlob: string,
+  count: number,
+  focus?: string
+): Promise<string | null> {
+  const groqKey = process.env.GROQ_API_KEY;
+  const openRouterKey = process.env.OPENROUTER_API_KEY;
+  const useGroq = !!groqKey;
+  const apiKey = useGroq ? groqKey : openRouterKey;
+  if (!apiKey) {
+    logger.warn('offer-engine: no platform AI key configured', {}, 'OfferEngine');
+    return null;
+  }
+
+  const url = useGroq
+    ? 'https://api.groq.com/openai/v1/chat/completions'
+    : 'https://openrouter.ai/api/v1/chat/completions';
+  const model = useGroq ? GROQ_MODEL : OPENROUTER_MODEL;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+  };
+  if (!useGroq) {
+    headers['HTTP-Referer'] = process.env.NEXT_PUBLIC_APP_URL || 'https://orangecat.ch';
+  }
+
+  const userPrompt = `Everything OrangeCat knows about this user:
+
+${contextBlob}
+
+DURABLE MEMORIES:
+${memoryBlob}
+${focus ? `\nFocus the suggestions around: ${focus}\n` : ''}
+Propose up to ${count} grounded offers as JSON.`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: userPrompt },
+        ],
+        temperature: 0.5,
+        max_tokens: 1600,
+        response_format: { type: 'json_object' },
+      }),
+    });
+    if (!response.ok) {
+      logger.warn('offer-engine: model call failed', { status: response.status }, 'OfferEngine');
+      return null;
+    }
+    const json = (await response.json()) as {
+      choices?: { message?: { content?: string } }[];
+    };
+    return json.choices?.[0]?.message?.content ?? null;
+  } catch (err) {
+    logger.warn('offer-engine: model call threw', { err: String(err) }, 'OfferEngine');
+    return null;
+  }
+}
+
+function parseOffers(raw: string, count: number): ProposedOffer[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    const arr: unknown[] = Array.isArray(parsed)
+      ? parsed
+      : ((parsed as { offers?: unknown[] })?.offers ?? []);
+    const prefillable = PREFILLABLE_ENTITY_TYPES as readonly string[];
+    return arr
+      .filter(
+        (o): o is { entityType: string; description: string; rationale?: string } =>
+          !!o &&
+          typeof (o as { entityType?: unknown }).entityType === 'string' &&
+          typeof (o as { description?: unknown }).description === 'string' &&
+          (o as { description: string }).description.trim().length >= 10
+      )
+      .filter(o => prefillable.includes(o.entityType))
+      .slice(0, count)
+      .map(o => ({
+        entityType: o.entityType as EntityType,
+        description: o.description.trim(),
+        rationale: String(o.rationale ?? '').trim(),
+      }));
+  } catch {
+    logger.warn('offer-engine: could not parse model output as JSON', {}, 'OfferEngine');
+    return [];
+  }
+}

--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -624,12 +624,13 @@ These are *mentions*, not actions. You are surfacing awareness, not doing anythi
 If the user opens with a clear request, skip the proactive mentions and respond to their request. Don't interrupt a focused user with status updates they didn't ask for.
 
 ## Tools You Can Call
-You have access to two tools that run BEFORE you write your response. Use them when relevant; don't pretend you used them — the platform will surface tool calls to the user visually as chips/cards.
+You have access to tools that run BEFORE you write your response. Use them when relevant; don't pretend you used them — the platform will surface tool calls to the user visually as chips/cards.
 
 - **search_platform(query, type)**: Search for people, projects, products, services, events, or causes on OrangeCat. Use when the user wants to find or connect with someone, or needs platform examples.
 - **prefill_entity_form(entityType, description)**: Draft a full entity (product / service / project / cause / event / asset / loan / investment / research / wishlist) from a natural-language description. Use this INSTEAD of a create_X exec_action block when the user has described what they want to create with enough detail (a name or strong title hint + at least one specific attribute like price, location, category, audience, duration). The user will see a structured card and can review fields before opening the form. NEVER call this for vague requests — first ask the user discovery questions to nail down a specific draft. Quote prices in the user's display currency (see "Current Session"); the prefill service handles conversion.
+- **suggest_offers(focus?, count?)**: The economic agent. Call this when the user asks what THEY could offer, sell, or create, how they could make money or participate economically, or wants ideas grounded in who they are ("what can I offer?", "help me make money", "any ideas for me?"). It reads everything you know about them (profile, documents, memories, existing entities) and proposes several ready-to-publish offers across the economic spectrum, each as a draft card — you do not pass the message, just an optional focus area.
 
-If you call prefill_entity_form, your reply should be SHORT and complement the card — confirm what you drafted in one sentence, invite the user to review and adjust. Do NOT repeat the field values in prose — the card shows them already. Example reply after prefill: "Drafted a service for you below — adjust the price and duration if needed, then open it to publish."
+If you call prefill_entity_form or suggest_offers, your reply should be SHORT and complement the card(s) — confirm what you drafted in a sentence or two, invite the user to review and adjust. Do NOT repeat the field values in prose — the cards show them already. Example after prefill: "Drafted a service for you below — adjust the price and duration if needed, then open it to publish." Example after suggest_offers: "Here are a few ways you could put what you do to work — each is a draft you can tweak and publish."
 
 ## Critical Rules
 - Help users do things HERE on OrangeCat — never recommend other platforms or cite external websites.

--- a/src/services/cat/tool-executor.ts
+++ b/src/services/cat/tool-executor.ts
@@ -7,6 +7,7 @@
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { searchPlatform, type SearchType } from './platform-search';
 import { generateFormPrefill } from '@/lib/ai/form-prefill-service';
+import { generateOffers } from './offer-engine';
 import { getEntityConfig } from '@/config/entity-configs/get-config';
 import { isValidEntityType, type EntityType } from '@/config/entity-registry';
 import { PREFILLABLE_ENTITY_TYPES } from './tool-use-detection';
@@ -24,11 +25,81 @@ import type {
  */
 export async function executeToolCall(
   supabase: AnySupabaseClient,
+  userId: string,
   toolCall: RawToolCall,
   onToolCall?: OnToolCall,
   onPrefillProposal?: OnPrefillProposal
 ): Promise<ToolResultMessage> {
   const toolName = toolCall.function?.name;
+
+  // ── suggest_offers (economic agent) ────────────────────────────────────────
+  // Reads the user's full context, reasons over latent assets, and emits each
+  // grounded offer as a prefill card (the UI already renders N cards per turn).
+  if (toolName === 'suggest_offers') {
+    const parsedArgs = (() => {
+      try {
+        return JSON.parse(toolCall.function.arguments ?? '{}') as {
+          focus?: string;
+          count?: number;
+        };
+      } catch {
+        return {} as { focus?: string; count?: number };
+      }
+    })();
+
+    const offers = await generateOffers(supabase, userId, {
+      count: parsedArgs.count,
+      focus: parsedArgs.focus,
+    });
+
+    let emitted = 0;
+    await Promise.all(
+      offers.map(async offer => {
+        const entityConfig = getEntityConfig(offer.entityType);
+        if (!entityConfig) {
+          return;
+        }
+        try {
+          const prefill = await generateFormPrefill(
+            offer.entityType,
+            offer.description,
+            entityConfig
+          );
+          if (!prefill.success) {
+            return;
+          }
+          emitted += 1;
+          onPrefillProposal?.({
+            entityType: offer.entityType,
+            sourceDescription: offer.rationale
+              ? `${offer.description}\n\nWhy: ${offer.rationale}`
+              : offer.description,
+            data: prefill.data as Record<string, unknown>,
+            confidence: prefill.confidence as Record<string, number>,
+          });
+        } catch {
+          // One offer failing to prefill shouldn't sink the rest.
+        }
+      })
+    );
+
+    onToolCall?.({
+      id: toolCall.id,
+      name: toolName,
+      status: 'completed',
+      resultCount: emitted,
+      results: [],
+    });
+
+    return {
+      role: 'tool',
+      tool_call_id: toolCall.id,
+      content:
+        emitted > 0
+          ? `Proposed ${emitted} grounded offer${emitted === 1 ? '' : 's'} as draft cards the user can review and publish. Introduce them in one or two warm sentences — do NOT list the field values; the cards show those.`
+          : `Couldn't draft grounded offers from the user's current context. Invite them to add a little more about themselves (a quick document or a few profile details) so you can tailor real ideas — do not invent offers.`,
+    };
+  }
 
   // ── search_platform ──────────────────────────────────────────────────────
   if (toolName === 'search_platform') {

--- a/src/services/cat/tool-use-detection.ts
+++ b/src/services/cat/tool-use-detection.ts
@@ -51,6 +51,21 @@ const TOOL_TRIGGER_KEYWORDS = [
   'i organize',
   'i need to raise',
   'fundraise',
+  // economic-agent / suggest_offers ("what can I offer?")
+  'what can i offer',
+  'what can i sell',
+  'what could i offer',
+  'what should i create',
+  'what should i sell',
+  'make money',
+  'earn money',
+  'monetize',
+  'monetise',
+  'ways to earn',
+  'help me make money',
+  'what can i do to earn',
+  'ideas for me',
+  'how can i participate',
 ];
 
 /**
@@ -134,6 +149,28 @@ export const PLATFORM_TOOL_DEFINITION = [
           },
         },
         required: ['entityType', 'description'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'suggest_offers',
+      description:
+        'The economic agent. Call this when the user asks what they could offer, sell, or create, how they could make money, or wants ideas grounded in who they are. It reads everything OrangeCat knows about them (profile, documents, memories, existing entities) and proposes several concrete, ready-to-publish offers across the economic spectrum, each as a draft card. Takes no required arguments — it reads their stored context, not the message.',
+      parameters: {
+        type: 'object',
+        properties: {
+          focus: {
+            type: 'string',
+            description:
+              'Optional area to focus suggestions on (e.g. "design", "teaching", "renting out gear"). Omit for a broad spread.',
+          },
+          count: {
+            type: 'number',
+            description: 'How many offers to propose (1-5). Default 4.',
+          },
+        },
       },
     },
   },

--- a/src/services/cat/tool-use.ts
+++ b/src/services/cat/tool-use.ts
@@ -57,6 +57,7 @@ const MAX_TOOL_STEPS = 3;
  */
 export async function maybeEnrichWithSearchResults(
   supabase: AnySupabaseClient,
+  userId: string,
   messages: ToolAugmentedMessage[],
   userMessage: string,
   provider: string,
@@ -103,6 +104,7 @@ export async function maybeEnrichWithSearchResults(
         'You gather what an OrangeCat chat request needs by calling platform tools. Call ONE tool at a time; after you see its result you may call another tool to refine or follow up, or stop when you have enough.\n' +
         '- prefill_entity_form: when the user describes something THEY want to create / sell / offer / launch / fundraise (e.g. "I make mugs and want to sell them", "I want to start a project"). This is about THEIR own new thing.\n' +
         '- search_platform: ONLY when the user wants to FIND, discover, or connect with things that already exist on the platform and belong to OTHERS (e.g. "find a designer", "who else is building X"). You may search again with a refined query if the first results are weak.\n' +
+        '- suggest_offers: when the user asks what THEY could offer/sell/create, how they could make money or participate, or wants ideas grounded in who they are (e.g. "what can I offer?", "help me make money", "any ideas for me?"). It reads their stored profile/documents/memories — pass no message text, just an optional focus.\n' +
         'NEVER call search_platform for a create/sell/offer intent — describing your own thing to list is prefill_entity_form, not a search. If neither clearly applies, call no tool. Only decide and call tools — do not write a chat reply.',
     },
     { role: 'user' as const, content: userMessage },
@@ -164,6 +166,7 @@ export async function maybeEnrichWithSearchResults(
       for (const toolCall of toolCalls) {
         const resultMessage = await executeToolCall(
           supabase,
+          userId,
           toolCall,
           onToolCall,
           onPrefillProposal


### PR DESCRIPTION
First slice of the economic-agent capability. Cat reasons over your profile + documents + memories + existing entities and proposes several grounded, publishable offers across the economic spectrum — each a one-click "Create X" draft card.

- **`offer-engine.ts`** (new): `generateOffers` gathers context → capable model → N ranked offers. Guardrails in-prompt: ground in a specific context item, **never invent demand/stats/personas**, no duplicates, no fabricated prices, quality>quantity.
- Wired as a **`suggest_offers`** tool reusing the existing prefill-card pipe (each offer → `generateFormPrefill` → `onPrefillProposal`; N cards already render client-side). Threaded `userId`; added trigger keywords + schema + routing/system-prompt copy.

Degrades gracefully (no key/thin context → Cat just answers, invites adding context, never invents). Demand grounding + proactive surfacing are later slices. tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)