### PR TITLE
fix(cat): never write "sats" in offer-engine + prefill output (BTC only)

### DIFF
--- a/src/lib/ai/prompts/form-prefill.ts
+++ b/src/lib/ai/prompts/form-prefill.ts
@@ -21,7 +21,7 @@ Your task is to extract structured data from a user's natural language descripti
 
 IMPORTANT CONTEXT:
 - OrangeCat supports Bitcoin/Lightning and any fiat payment method (Twint, PayPal, Venmo, bank transfers, etc.)
-- Express Bitcoin prices in BTC (e.g., 0.001 BTC), not satoshis
+- Express Bitcoin amounts in BTC (e.g., 0.001 BTC) EVERYWHERE — in prices and in any title/description text. NEVER write "sats" or "satoshis"; rephrase to BTC even if the user's description used sats.
 - Keep fiat prices in their original currency (CHF, USD, EUR, etc.)
 - Price examples: "0.001 BTC", "CHF 50", "$25", "€100"
 

--- a/src/services/cat/offer-engine.ts
+++ b/src/services/cat/offer-engine.ts
@@ -51,6 +51,7 @@ RULES (these are hard constraints):
 - NEVER invent facts about the user. NEVER invent demand, market size, or statistics (e.g. "3 people searched for this"). You have no demand data — propose based on what they HAVE, not on claimed demand.
 - Do NOT duplicate something they already offer (check their existing entities).
 - Each "description" must be a full, publishable description (what it is, who it is for, a sensible scope) so it can prefill a create form — but do NOT fabricate a specific price; leave price out unless the context clearly implies one.
+- Money is always Bitcoin (BTC) or a fiat currency. NEVER write "sats" or "satoshis" — say "BTC" (e.g. "0.0005 BTC", never "50,000 sats").
 - Prefer VARIETY across the economic spectrum over several of the same type.
 - Quality over quantity: if the context is thin, return fewer offers (or none). A weak, generic offer is worse than no offer.
 


### PR DESCRIPTION
The offer engine produced "sats-denominated" in a draft description (breaks never-use-sats). Added a BTC-only rule to the offer-engine prompt and broadened the form-prefill prompt's price-only rule to all text fields. Prompt-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)