### PR TITLE
feat(cat): demand-signal grounding for the offer engine (slice 2)

### DIFF
--- a/src/services/cat/demand-signals.ts
+++ b/src/services/cat/demand-signals.ts
@@ -1,0 +1,74 @@
+/**
+ * Demand signals — real platform supply/demand context for the offer engine.
+ *
+ * There is no search-query log yet (the spec's one genuinely-missing dependency),
+ * so we ground on what DOES exist: a live snapshot of the active listings already
+ * on OrangeCat per type + their categories. This is real data — never fabricated —
+ * and lets the offer engine price realistically, judge viability, and spot gaps
+ * ("no translation services exist yet") vs saturation ("lots of design services").
+ *
+ * Cold-start honest: on an early platform the snapshot is thin, and the engine is
+ * told to lean on packaging value and say so rather than invent demand.
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { getEntityMetadata, type EntityType } from '@/config/entity-registry';
+import { logger } from '@/utils/logger';
+
+// Listing types whose public visibility gate is status='active' and which carry a
+// category-like column. (loan/wishlist use different gates — omitted for now.)
+const DEMAND_TYPES: { type: EntityType; categoryCol: string }[] = [
+  { type: 'service', categoryCol: 'category' },
+  { type: 'product', categoryCol: 'category' },
+  { type: 'project', categoryCol: 'category' },
+  { type: 'cause', categoryCol: 'category' },
+  { type: 'event', categoryCol: 'category' },
+  { type: 'research', categoryCol: 'field' },
+];
+
+const MAX_ROWS = 300;
+const MAX_CATEGORIES = 4;
+
+function summarizeCategories(rows: Record<string, unknown>[], col: string): string {
+  const counts = new Map<string, number>();
+  for (const r of rows) {
+    const c = r[col];
+    if (typeof c === 'string' && c.trim()) {
+      counts.set(c, (counts.get(c) ?? 0) + 1);
+    }
+  }
+  const top = [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MAX_CATEGORIES)
+    .map(([c, n]) => `${c} ×${n}`);
+  return top.join(', ');
+}
+
+/**
+ * A compact, human-readable snapshot of what's already active on OrangeCat,
+ * for grounding offer suggestions. Returns '' if nothing could be read.
+ */
+export async function getDemandSignals(supabase: AnySupabaseClient): Promise<string> {
+  const lines = await Promise.all(
+    DEMAND_TYPES.map(async ({ type, categoryCol }) => {
+      try {
+        const meta = getEntityMetadata(type);
+        const { data, error } = await supabase
+          .from(meta.tableName)
+          .select(categoryCol)
+          .eq('status', 'active')
+          .limit(MAX_ROWS);
+        if (error || !data) {
+          return null;
+        }
+        const rows = data as unknown as Record<string, unknown>[];
+        const cats = summarizeCategories(rows, categoryCol);
+        return `- ${rows.length} active ${meta.namePlural.toLowerCase()}${cats ? ` (${cats})` : ''}`;
+      } catch (err) {
+        logger.warn('demand-signals: query failed', { type, err: String(err) }, 'DemandSignals');
+        return null;
+      }
+    })
+  );
+  return lines.filter((l): l is string => !!l).join('\n');
+}

--- a/src/services/cat/offer-engine.ts
+++ b/src/services/cat/offer-engine.ts
@@ -18,6 +18,7 @@ import { PREFILLABLE_ENTITY_TYPES } from './tool-use-detection';
 import { fetchFullContextForCat } from '@/services/ai/document-context';
 import { buildFullContextString } from '@/services/ai/context-string-builder';
 import { listMemories } from './memory';
+import { getDemandSignals } from './demand-signals';
 import { logger } from '@/utils/logger';
 
 // Capable, JSON-reliable defaults (mirrors form-prefill-service's provider choice).
@@ -48,7 +49,8 @@ Map their LATENT ASSETS to the right OrangeCat entity type:
 
 RULES (these are hard constraints):
 - Ground EVERY offer in something SPECIFIC from the provided context. In "rationale", name the concrete skill, asset, document, or experience it comes from.
-- NEVER invent facts about the user. NEVER invent demand, market size, or statistics (e.g. "3 people searched for this"). You have no demand data — propose based on what they HAVE, not on claimed demand.
+- NEVER invent facts about the user. NEVER invent demand, market size, or statistics (e.g. "3 people searched for this"). The "PLATFORM LANDSCAPE" section is the ONLY demand/supply data you have — do not invent searches, trends, or numbers beyond it.
+- Use the PLATFORM LANDSCAPE to make offers sharper: price in line with comparable active listings, prefer viable types, point out a GAP the user could fill ("no translation services exist on OrangeCat yet"), or differentiate where a niche is already crowded. When a landscape signal informs an offer, reference it in the rationale.
 - Do NOT duplicate something they already offer (check their existing entities).
 - Each "description" must be a full, publishable description (what it is, who it is for, a sensible scope) so it can prefill a create form — but do NOT fabricate a specific price; leave price out unless the context clearly implies one.
 - Money is always Bitcoin (BTC) or a fiat currency. NEVER write "sats" or "satoshis" — say "BTC" (e.g. "0.0005 BTC", never "50,000 sats").
@@ -71,14 +73,15 @@ export async function generateOffers(
 ): Promise<ProposedOffer[]> {
   const count = Math.min(Math.max(opts?.count ?? 4, 1), MAX_OFFERS);
 
-  const [context, memories] = await Promise.all([
+  const [context, memories, demandBlob] = await Promise.all([
     fetchFullContextForCat(supabase, userId),
     listMemories(supabase, userId),
+    getDemandSignals(supabase),
   ]);
   const contextBlob = buildFullContextString(context);
   const memoryBlob = memories.length ? memories.map(m => `- ${m.content}`).join('\n') : '(none)';
 
-  const raw = await callOfferModel(contextBlob, memoryBlob, count, opts?.focus);
+  const raw = await callOfferModel(contextBlob, memoryBlob, demandBlob, count, opts?.focus);
   if (!raw) {
     return [];
   }
@@ -88,6 +91,7 @@ export async function generateOffers(
 async function callOfferModel(
   contextBlob: string,
   memoryBlob: string,
+  demandBlob: string,
   count: number,
   focus?: string
 ): Promise<string | null> {
@@ -118,6 +122,9 @@ ${contextBlob}
 
 DURABLE MEMORIES:
 ${memoryBlob}
+
+PLATFORM LANDSCAPE — what's already active on OrangeCat right now (real, the only demand/supply data you have):
+${demandBlob || '(the platform is very early — few or no listings yet)'}
 ${focus ? `\nFocus the suggestions around: ${focus}\n` : ''}
 Propose up to ${count} grounded offers as JSON.`;
 


### PR DESCRIPTION
The offer engine was packaging-led (no demand/supply data). No search-query log exists yet (the spec's missing dependency), so we ground on the real available signal: a live snapshot of active listings.

- **`demand-signals.ts`** (new): `getDemandSignals` → active count + top categories per listing type (registry-driven, real data, graceful failure).
- **`offer-engine.ts`**: injects a "PLATFORM LANDSCAPE" section; new prompt rules — price vs comparables, prefer viable types, spot GAPS, differentiate in crowded niches, cite the signal; the landscape is the ONLY demand data (no inventing beyond it). Cold-start honest.

tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)