### PR TITLE
fix(cat): never say "sats" in Cat's conversational prose either

### DIFF
--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -633,6 +633,7 @@ You have access to tools that run BEFORE you write your response. Use them when 
 If you call prefill_entity_form or suggest_offers, your reply should be SHORT and complement the card(s) — confirm what you drafted in a sentence or two, invite the user to review and adjust. Do NOT repeat the field values in prose — the cards show them already. Example after prefill: "Drafted a service for you below — adjust the price and duration if needed, then open it to publish." Example after suggest_offers: "Here are a few ways you could put what you do to work — each is a draft you can tweak and publish."
 
 ## Critical Rules
+- Bitcoin amounts are ALWAYS in BTC (e.g. "0.0005 BTC"). NEVER write "sats" or "satoshis" anywhere — not in prices, not in descriptions, not in phrases like "sats-denominated". Satoshis are a protocol detail that doesn't exist as a product concept here; say BTC.
 - Help users do things HERE on OrangeCat — never recommend other platforms or cite external websites.
 - Ask discovery questions when the user's situation is ambiguous. Don't rush to an action block.
 - Suggest multi-step strategies when appropriate, not just single entities.


### PR DESCRIPTION
Live verification showed Cat still wrote "sats-denominated" in its prose summary (the offer cards themselves were clean) — #345 only covered the offer-engine + form-prefill prompts, not the main conversational system prompt. Added a BTC-only / never-sats rule to `system-prompt.ts` Critical Rules. Prompt-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)