### PR TITLE
feat(cat): save_economic_profile action — Cat populates the economic-profile store

### DIFF
--- a/src/config/cat-actions.ts
+++ b/src/config/cat-actions.ts
@@ -49,7 +49,7 @@ export type ActionRiskLevel = 'low' | 'medium' | 'high';
 
 interface ActionParameter {
   name: string;
-  type: 'string' | 'number' | 'boolean' | 'entity_id' | 'user_id' | 'btc';
+  type: 'string' | 'number' | 'boolean' | 'entity_id' | 'user_id' | 'btc' | 'array';
   required: boolean;
   description: string;
   default?: unknown;
@@ -874,6 +874,66 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
 
   // ---------- CONTEXT ACTIONS ----------
 
+  save_economic_profile: {
+    id: 'save_economic_profile',
+    name: 'Save Economic Profile',
+    description:
+      'Save latent economic value the user reveals — skills, things they own to rent/sell, goals, constraints, what people come to them for, motivation, or stage — into their structured economic profile so Cat can suggest better offers.',
+    category: 'context',
+    icon: TrendingUp,
+    riskLevel: 'low',
+    requiresConfirmation: false,
+    parameters: [
+      {
+        name: 'skills',
+        type: 'array',
+        required: false,
+        description: 'Skills — strings, or {name, level?, years?}',
+      },
+      {
+        name: 'assets',
+        type: 'array',
+        required: false,
+        description: 'Things they own that could be rented/sold — strings, or {name, type?}',
+      },
+      {
+        name: 'goals',
+        type: 'array',
+        required: false,
+        description: 'Goals — strings, or {text, kind: earn|fund|learn|connect|build}',
+      },
+      {
+        name: 'constraints',
+        type: 'array',
+        required: false,
+        description: 'Constraints, e.g. "only evenings", "no upfront capital"',
+      },
+      {
+        name: 'asked_for',
+        type: 'array',
+        required: false,
+        description: 'What people come to them for (the richest signal)',
+      },
+      {
+        name: 'motivation',
+        type: 'string',
+        required: false,
+        description: 'Why they are here: earn / community / meaning / learn / unsure',
+      },
+      {
+        name: 'stage',
+        type: 'string',
+        required: false,
+        description: 'exploring / has-offers / scaling',
+      },
+    ],
+    examples: [
+      "I'm a translator and I fix bikes on weekends",
+      'I have a spare workshop I could rent out',
+      'I want to earn from my design skills',
+    ],
+    enabled: true,
+  },
   add_context: {
     id: 'add_context',
     name: 'Add Context',

--- a/src/services/cat/action-descriptions.ts
+++ b/src/services/cat/action-descriptions.ts
@@ -66,6 +66,8 @@ export function generateActionDescription(
     }
     case 'add_context':
       return `Add context document: "${parameters.title}"`;
+    case 'save_economic_profile':
+      return 'Update your economic profile';
     case 'create_task': {
       const priority = parameters.priority ? ` [${parameters.priority}]` : '';
       const due = parameters.due_date ? ` due ${parameters.due_date}` : '';

--- a/src/services/cat/handlers/context.ts
+++ b/src/services/cat/handlers/context.ts
@@ -1,8 +1,82 @@
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { DATABASE_TABLES } from '@/config/database-tables';
+import {
+  saveEconomicProfile,
+  type EconomicProfile,
+  type EconomicSkill,
+  type EconomicAsset,
+  type EconomicGoal,
+} from '../economic-profile';
 import type { ActionHandler } from './types';
 
 export const contextHandlers: Record<string, ActionHandler> = {
+  // Persist latent economic value the user discloses (skills/assets/goals/etc.)
+  // into the structured economic-profile store — the keystone the offer engine
+  // and interview build on. Merge-upserts; safe to call repeatedly.
+  save_economic_profile: async (supabase, userId, _actorId, params) => {
+    const strArr = (v: unknown): string[] =>
+      Array.isArray(v)
+        ? v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
+        : [];
+    const skills: EconomicSkill[] = (Array.isArray(params.skills) ? params.skills : [])
+      .map((s: unknown) => (typeof s === 'string' ? { name: s } : (s as EconomicSkill)))
+      .filter(
+        (s): s is EconomicSkill => !!s && typeof s.name === 'string' && s.name.trim().length > 0
+      );
+    const assets: EconomicAsset[] = (Array.isArray(params.assets) ? params.assets : [])
+      .map((a: unknown) => (typeof a === 'string' ? { name: a } : (a as EconomicAsset)))
+      .filter(
+        (a): a is EconomicAsset => !!a && typeof a.name === 'string' && a.name.trim().length > 0
+      );
+    const goals: EconomicGoal[] = (Array.isArray(params.goals) ? params.goals : [])
+      .map((g: unknown) => (typeof g === 'string' ? { text: g } : (g as EconomicGoal)))
+      .filter(
+        (g): g is EconomicGoal => !!g && typeof g.text === 'string' && g.text.trim().length > 0
+      );
+
+    const patch: Partial<EconomicProfile> = {
+      skills,
+      assets,
+      goals,
+      constraints: strArr(params.constraints),
+      askedFor: strArr((params as Record<string, unknown>).asked_for ?? params.askedFor),
+      motivation: typeof params.motivation === 'string' ? params.motivation : undefined,
+      stage: typeof params.stage === 'string' ? params.stage : undefined,
+    };
+
+    const hasAny =
+      skills.length > 0 ||
+      assets.length > 0 ||
+      goals.length > 0 ||
+      (patch.constraints?.length ?? 0) > 0 ||
+      (patch.askedFor?.length ?? 0) > 0 ||
+      !!patch.motivation ||
+      !!patch.stage;
+    if (!hasAny) {
+      return {
+        success: false,
+        error:
+          'Nothing to save — provide at least one of: skills, assets, goals, constraints, asked_for, motivation, stage.',
+      };
+    }
+
+    const ok = await saveEconomicProfile(supabase, userId, patch);
+    if (!ok) {
+      return { success: false, error: 'Could not save the economic profile.' };
+    }
+    const summary = [
+      skills.length && `${skills.length} skill(s)`,
+      assets.length && `${assets.length} asset(s)`,
+      goals.length && `${goals.length} goal(s)`,
+    ]
+      .filter(Boolean)
+      .join(', ');
+    return {
+      success: true,
+      data: { displayMessage: `🧭 Updated your economic profile${summary ? ` (${summary})` : ''}` },
+    };
+  },
+
   add_context: async (supabase, _userId, actorId, params) => {
     const { data, error } = await supabase
       .from(ENTITY_REGISTRY.document.tableName)

--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -486,6 +486,28 @@ When the user wants you to remember something across sessions:
 - Executes immediately without confirmation — the saved content will appear in your context in all future conversations
 - After saving, confirm: "Got it — I'll remember that."
 
+### Capture the user's latent economic value (skills, assets, goals…)
+Whenever the user reveals something economically relevant — a skill, something they own that could be rented or sold, a goal, a constraint, what people come to them for, why they're here, or how far along they are — quietly save it so your offer suggestions get sharper over time:
+\`\`\`exec_action
+{
+  "type": "exec_action",
+  "actionId": "save_economic_profile",
+  "parameters": {
+    "skills": ["translation", "fixing bikes"],
+    "assets": ["spare workshop"],
+    "goals": [{ "text": "earn on the side", "kind": "earn" }],
+    "constraints": ["only evenings"],
+    "asked_for": ["help with German paperwork"],
+    "motivation": "earn",
+    "stage": "exploring"
+  }
+}
+\`\`\`
+- Provide ONLY the fields the user actually revealed; omit the rest. Arrays accept plain strings or objects.
+- Treat self-deprecation as signal: if they shrug something off ("it's nothing, I just…"), that's often a real skill — save it.
+- Executes silently without confirmation; it just makes you smarter. Don't announce it or read the values back — keep replying naturally.
+- This is how "what can I offer?" gets better: the more you capture here, the more grounded your offers.
+
 ### Create a savings goal or budget wallet
 When the user wants to save toward a target or set up a recurring budget:
 \`\`\`exec_action


### PR DESCRIPTION
Makes the keystone store (#350) functional. Cat now persists economic value the user reveals (skills/assets/goals/constraints/asked-for/motivation/stage) into `user_economic_profile`, which the read path already surfaces back into context — so normal chat silently builds the profile and offers get sharper.

- `save_economic_profile` handler (normalizes string|object arrays → merge-upsert).
- Action config + `'array'` added to the param-type union; description + system-prompt doc (capture silently, treat self-deprecation as a skill flag, no confirmation).

Proactive interview is next; this is the disclosure write path. tsc 0; lint clean. Migration already applied + verified on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)