### PR TITLE
fix(migration): make user_economic_profile policies idempotent (unblock deploy)

### DIFF
--- a/supabase/migrations/20260630000000_create_user_economic_profile.sql
+++ b/supabase/migrations/20260630000000_create_user_economic_profile.sql
@@ -40,11 +40,17 @@ CREATE INDEX IF NOT EXISTS idx_user_economic_profile_skills
 
 ALTER TABLE user_economic_profile ENABLE ROW LEVEL SECURITY;
 
+-- DROP+CREATE so the migration is idempotent: Postgres has no
+-- CREATE POLICY IF NOT EXISTS, and the deploy pipeline re-applies migrations.
+DROP POLICY IF EXISTS "user_economic_profile_select" ON user_economic_profile;
 CREATE POLICY "user_economic_profile_select" ON user_economic_profile
   FOR SELECT USING (auth.uid() = user_id);
+DROP POLICY IF EXISTS "user_economic_profile_insert" ON user_economic_profile;
 CREATE POLICY "user_economic_profile_insert" ON user_economic_profile
   FOR INSERT WITH CHECK (auth.uid() = user_id);
+DROP POLICY IF EXISTS "user_economic_profile_update" ON user_economic_profile;
 CREATE POLICY "user_economic_profile_update" ON user_economic_profile
   FOR UPDATE USING (auth.uid() = user_id);
+DROP POLICY IF EXISTS "user_economic_profile_delete" ON user_economic_profile;
 CREATE POLICY "user_economic_profile_delete" ON user_economic_profile
   FOR DELETE USING (auth.uid() = user_id);


### PR DESCRIPTION
CD auto-applies migrations and re-ran 20260630000000; CREATE POLICY (no IF NOT EXISTS) errored once policies existed → deploy aborted (live release untouched). Wrapped each policy in DROP IF EXISTS + CREATE so it re-applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)