### PR TITLE
feat(cat): proactive interview — Cat draws out latent value when the profile is thin

### DIFF
--- a/src/services/ai/context-sections.ts
+++ b/src/services/ai/context-sections.ts
@@ -7,7 +7,7 @@
  */
 import type { DocumentContext, EntitySummary, FullUserContext } from './document-context-types';
 import { ENTITY_STATUS } from '@/config/database-constants';
-import { isEconomicProfileEmpty } from '@/services/cat/economic-profile';
+import { economicProfileGaps } from '@/services/cat/economic-profile';
 
 const DOCUMENT_TYPE_LABELS: Record<string, string> = {
   goals: 'Goals & Aspirations',
@@ -153,39 +153,55 @@ export function renderProfile(p: FullUserContext['profile']): string | null {
 }
 
 /**
- * The structured economic profile — what this person can offer. Returns null when
- * empty so it's invisible (and snapshot-neutral) until the user is interviewed.
+ * The structured economic profile — what this person can offer, plus what's still
+ * unknown (which drives the proactive interview). Returns null only when the field
+ * was never provided (e.g. non-chat contexts / snapshot), so it's snapshot-neutral;
+ * for a real user it always renders — either what we know, an invitation to draw
+ * out what we don't, or both.
  */
 export function renderEconomicProfile(ep: FullUserContext['economicProfile']): string | null {
-  if (!ep || isEconomicProfileEmpty(ep)) {
+  if (ep === undefined) {
     return null;
   }
   const parts: string[] = [];
-  if (ep.skills.length) {
+  if (ep) {
+    if (ep.skills.length) {
+      parts.push(
+        `**Skills**: ${ep.skills.map(s => (s.level ? `${s.name} (${s.level})` : s.name)).join(', ')}`
+      );
+    }
+    if (ep.askedFor.length) {
+      parts.push(`**People come to them for**: ${ep.askedFor.join('; ')}`);
+    }
+    if (ep.assets.length) {
+      parts.push(`**Assets**: ${ep.assets.map(a => a.name).join(', ')}`);
+    }
+    if (ep.goals.length) {
+      parts.push(
+        `**Goals**: ${ep.goals.map(g => (g.kind ? `${g.text} [${g.kind}]` : g.text)).join('; ')}`
+      );
+    }
+    if (ep.constraints.length) {
+      parts.push(`**Constraints**: ${ep.constraints.join('; ')}`);
+    }
+    if (ep.motivation) {
+      parts.push(`**Here for**: ${ep.motivation}`);
+    }
+    if (ep.stage) {
+      parts.push(`**Stage**: ${ep.stage}`);
+    }
+  }
+
+  // What's still unknown drives the interview: tell Cat exactly what to draw out.
+  const gaps = economicProfileGaps(ep ?? null);
+  if (gaps.length) {
     parts.push(
-      `**Skills**: ${ep.skills.map(s => (s.level ? `${s.name} (${s.level})` : s.name)).join(', ')}`
+      parts.length
+        ? `_Still unknown: ${gaps.join(', ')}. When it fits, draw these out ONE at a time (see "Drawing out what they can offer")._`
+        : `_Nothing captured yet. When it fits naturally, surface their latent value with ONE story-based question (see "Drawing out what they can offer") — start with what people come to them for._`
     );
   }
-  if (ep.askedFor.length) {
-    parts.push(`**People come to them for**: ${ep.askedFor.join('; ')}`);
-  }
-  if (ep.assets.length) {
-    parts.push(`**Assets**: ${ep.assets.map(a => a.name).join(', ')}`);
-  }
-  if (ep.goals.length) {
-    parts.push(
-      `**Goals**: ${ep.goals.map(g => (g.kind ? `${g.text} [${g.kind}]` : g.text)).join('; ')}`
-    );
-  }
-  if (ep.constraints.length) {
-    parts.push(`**Constraints**: ${ep.constraints.join('; ')}`);
-  }
-  if (ep.motivation) {
-    parts.push(`**Here for**: ${ep.motivation}`);
-  }
-  if (ep.stage) {
-    parts.push(`**Stage**: ${ep.stage}`);
-  }
+
   if (parts.length === 0) {
     return null;
   }

--- a/src/services/cat/economic-profile.ts
+++ b/src/services/cat/economic-profile.ts
@@ -73,6 +73,34 @@ export function isEconomicProfileEmpty(p: EconomicProfile | null): boolean {
   );
 }
 
+/**
+ * The economic dimensions still unknown, in the order Cat should probe them —
+ * "what people ask them for" first (the richest signal), motivation last.
+ * Drives the proactive interview: the context tells Cat exactly what to draw out.
+ */
+export function economicProfileGaps(p: EconomicProfile | null): string[] {
+  const gaps: string[] = [];
+  if (!p || p.askedFor.length === 0) {
+    gaps.push('what people come to them for');
+  }
+  if (!p || p.skills.length === 0) {
+    gaps.push('skills');
+  }
+  if (!p || p.assets.length === 0) {
+    gaps.push('assets they own that could earn');
+  }
+  if (!p || p.goals.length === 0) {
+    gaps.push('goals');
+  }
+  if (!p || p.constraints.length === 0) {
+    gaps.push('constraints (time, capital)');
+  }
+  if (!p || !p.motivation) {
+    gaps.push('what they want from being here');
+  }
+  return gaps;
+}
+
 export async function getEconomicProfile(
   supabase: AnySupabaseClient,
   userId: string

--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -102,6 +102,14 @@ The goal is to help in as few words and as few questions as possible. NEVER open
 
 Questions you MAY draw from (pick at most one, only when it changes your suggestion): income vs. community; just them or a group; first time or done before. Skip questions entirely when intent is already clear ("I want to sell my paintings") — go straight to a concrete next step.
 
+## Drawing out what they can offer (when their Economic Profile is thin)
+The **Economic Profile** context tells you what you already know about this person economically — and lists what's still unknown. When it's thin or empty, make your ONE optional question work to surface their latent value; that's the most useful thing you can learn about them. How to ask:
+- **Ask for a story, not a self-assessment.** Not "what are you good at?" (people freeze or go modest) but "what do people keep coming to you for?", "tell me about the last time someone thanked you", "what do you lose track of time doing?". They answer with an episode; you extract the value from it.
+- **Treat "that's nothing" as gold.** If they wave something off — "it's just a hobby", "anyone could do that" — that's usually their most sellable skill. Reflect it back: "that's exactly the kind of thing people pay for here."
+- **One dimension at a time, and target what's MISSING.** The context lists the gaps in priority order (what people ask them for → skills → assets → goals → constraints). Probe the first unknown; never re-ask what's already captured.
+- **Still ONE question, still optional, still after you've led with value.** Never a list, never an interrogation. Build on whatever they say — what they reveal is saved automatically, so you never ask twice.
+- **Ask before monetizing, and honor "just for me."** "Want me to explore ways this could earn — or keep it just for you?" Not everyone is here for income; some want connection or meaning. Meet them there.
+
 ## Orienting a New Person (first reply)
 On the very first exchange, after leading with their concrete options, briefly let them know how this works so they understand what's happening: you're their Cat, you can set any of these up for them, and they can tell you as much or as little as they want — you'll fill in the rest. Keep it to one short, warm sentence; don't lecture.
 


### PR DESCRIPTION
Instead of only capturing volunteered info, Cat now gently surfaces latent economic value when little is known. No new tool (free model can't be trusted to emit one) — a context signal + prompt guidance; the live passive extractor captures the answers.

- `economicProfileGaps()` — unknown dimensions in probe order.
- `renderEconomicProfile` now renders known + an explicit "still unknown: …" line guiding what to draw out; null only when undefined → **snapshot byte-identical (green)**.
- Anti-interrogation carve-out: when thin, the ONE optional question becomes a story-based value probe (stories not self-assessment, "that's nothing"=gold, one missing dimension, ask before monetizing, honor "just for me").

tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)