### PR TITLE
feat(cat): economic-profile completeness score

### DIFF
--- a/__tests__/unit/cat/economic-profile.test.ts
+++ b/__tests__/unit/cat/economic-profile.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Economic-profile derived signals — completeness score and gap list.
+ * Both derive from one SSOT dimension list, so this guards that they stay consistent
+ * and that the score is deterministic and even-weighted.
+ */
+import {
+  economicCompleteness,
+  economicProfileGaps,
+  isEconomicProfileEmpty,
+  type EconomicProfile,
+} from '@/services/cat/economic-profile';
+
+const empty: EconomicProfile = {
+  skills: [],
+  assets: [],
+  goals: [],
+  constraints: [],
+  askedFor: [],
+  motivation: null,
+  stage: null,
+};
+
+const full: EconomicProfile = {
+  skills: [{ name: 'translation' }],
+  assets: [{ name: 'drone' }],
+  goals: [{ text: 'earn on the side', kind: 'earn' }],
+  constraints: ['only weekends'],
+  askedFor: ['clear emails'],
+  motivation: 'earn',
+  stage: 'exploring',
+};
+
+const TOTAL_DIMENSIONS = 6;
+
+describe('economicCompleteness', () => {
+  it('is 0 for null or an empty profile', () => {
+    expect(economicCompleteness(null)).toBe(0);
+    expect(economicCompleteness(empty)).toBe(0);
+  });
+
+  it('is 100 when every dimension is filled', () => {
+    expect(economicCompleteness(full)).toBe(100);
+  });
+
+  it('is even-weighted across dimensions', () => {
+    // 3 of 6 dimensions filled → 50%
+    const half: EconomicProfile = {
+      ...empty,
+      skills: [{ name: 'x' }],
+      assets: [{ name: 'y' }],
+      goals: [{ text: 'z' }],
+    };
+    expect(economicCompleteness(half)).toBe(50);
+  });
+});
+
+describe('economicProfileGaps', () => {
+  it('lists every dimension for null/empty, none for full', () => {
+    expect(economicProfileGaps(null)).toHaveLength(TOTAL_DIMENSIONS);
+    expect(economicProfileGaps(empty)).toHaveLength(TOTAL_DIMENSIONS);
+    expect(economicProfileGaps(full)).toEqual([]);
+  });
+
+  it('probes the richest signal first', () => {
+    expect(economicProfileGaps(empty)[0]).toBe('what people come to them for');
+  });
+
+  it('stays consistent with the completeness score', () => {
+    const partial: EconomicProfile = { ...empty, skills: [{ name: 'x' }], motivation: 'community' };
+    const filled = TOTAL_DIMENSIONS - economicProfileGaps(partial).length;
+    expect(economicCompleteness(partial)).toBe(Math.round((filled / TOTAL_DIMENSIONS) * 100));
+  });
+});
+
+describe('isEconomicProfileEmpty', () => {
+  it('matches a 0% score', () => {
+    expect(isEconomicProfileEmpty(empty)).toBe(true);
+    expect(isEconomicProfileEmpty(full)).toBe(false);
+  });
+});

--- a/src/services/ai/context-sections.ts
+++ b/src/services/ai/context-sections.ts
@@ -7,7 +7,7 @@
  */
 import type { DocumentContext, EntitySummary, FullUserContext } from './document-context-types';
 import { ENTITY_STATUS } from '@/config/database-constants';
-import { economicProfileGaps } from '@/services/cat/economic-profile';
+import { economicProfileGaps, economicCompleteness } from '@/services/cat/economic-profile';
 
 const DOCUMENT_TYPE_LABELS: Record<string, string> = {
   goals: 'Goals & Aspirations',
@@ -193,12 +193,17 @@ export function renderEconomicProfile(ep: FullUserContext['economicProfile']): s
   }
 
   // What's still unknown drives the interview: tell Cat exactly what to draw out.
+  const pct = economicCompleteness(ep ?? null);
   const gaps = economicProfileGaps(ep ?? null);
   if (gaps.length) {
     parts.push(
       parts.length
-        ? `_Still unknown: ${gaps.join(', ')}. When it fits, draw these out ONE at a time (see "Drawing out what they can offer")._`
-        : `_Nothing captured yet. When it fits naturally, surface their latent value with ONE story-based question (see "Drawing out what they can offer") — start with what people come to them for._`
+        ? `_Economic picture ~${pct}% complete — still unknown: ${gaps.join(', ')}. When it fits, draw these out ONE at a time (see "Drawing out what they can offer"). You can frame it for them: "you're most of the way to a full picture."_`
+        : `_Economic picture 0% — nothing captured yet. When it fits naturally, surface their latent value with ONE story-based question (see "Drawing out what they can offer") — start with what people come to them for._`
+    );
+  } else {
+    parts.push(
+      `_Economic picture ~${pct}% complete — you have a full picture; focus on turning it into offers and next steps, not more discovery questions._`
     );
   }
 

--- a/src/services/cat/economic-profile.ts
+++ b/src/services/cat/economic-profile.ts
@@ -74,31 +74,41 @@ export function isEconomicProfileEmpty(p: EconomicProfile | null): boolean {
 }
 
 /**
- * The economic dimensions still unknown, in the order Cat should probe them —
- * "what people ask them for" first (the richest signal), motivation last.
- * Drives the proactive interview: the context tells Cat exactly what to draw out.
+ * SSOT for the economic dimensions, in the order Cat should probe them — "what
+ * people ask them for" first (the richest signal), motivation last. Both the gap
+ * list and the completeness score derive from this, so they can never drift.
  */
+const ECONOMIC_DIMENSIONS: ReadonlyArray<{
+  label: string;
+  filled: (p: EconomicProfile) => boolean;
+}> = [
+  { label: 'what people come to them for', filled: p => p.askedFor.length > 0 },
+  { label: 'skills', filled: p => p.skills.length > 0 },
+  { label: 'assets they own that could earn', filled: p => p.assets.length > 0 },
+  { label: 'goals', filled: p => p.goals.length > 0 },
+  { label: 'constraints (time, capital)', filled: p => p.constraints.length > 0 },
+  { label: 'what they want from being here', filled: p => !!p.motivation },
+];
+
+/** The dimensions still unknown — drives the proactive interview. */
 export function economicProfileGaps(p: EconomicProfile | null): string[] {
-  const gaps: string[] = [];
-  if (!p || p.askedFor.length === 0) {
-    gaps.push('what people come to them for');
+  if (!p) {
+    return ECONOMIC_DIMENSIONS.map(d => d.label);
   }
-  if (!p || p.skills.length === 0) {
-    gaps.push('skills');
+  return ECONOMIC_DIMENSIONS.filter(d => !d.filled(p)).map(d => d.label);
+}
+
+/**
+ * How complete the economic picture is, 0–100 (deterministic, even-weighted across
+ * the dimensions). Tells Cat how hard to lean into discovery and lets it frame
+ * progress for the user ("you're X% of the way to a full picture").
+ */
+export function economicCompleteness(p: EconomicProfile | null): number {
+  if (!p) {
+    return 0;
   }
-  if (!p || p.assets.length === 0) {
-    gaps.push('assets they own that could earn');
-  }
-  if (!p || p.goals.length === 0) {
-    gaps.push('goals');
-  }
-  if (!p || p.constraints.length === 0) {
-    gaps.push('constraints (time, capital)');
-  }
-  if (!p || !p.motivation) {
-    gaps.push('what they want from being here');
-  }
-  return gaps;
+  const filled = ECONOMIC_DIMENSIONS.filter(d => d.filled(p)).length;
+  return Math.round((filled / ECONOMIC_DIMENSIONS.length) * 100);
 }
 
 export async function getEconomicProfile(


### PR DESCRIPTION
A deterministic 0–100 score of how complete a user's economic picture is — tells Cat how hard to lean into discovery and lets it frame progress ("you're most of the way to a full picture"). Derives from one SSOT dimension list shared with the gap list (no drift).

- `ECONOMIC_DIMENSIONS` SSOT → `economicProfileGaps` refactored onto it + new `economicCompleteness()`.
- `renderEconomicProfile` shows "~N% complete"; when full, steers toward offers not questions. Snapshot byte-identical.
- 7 unit tests.

tsc 0; lint clean; tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)