### PR TITLE
feat(cat): growth nudge maps each skill to the right entity type

### DIFF
--- a/__tests__/unit/cat/economic-profile.test.ts
+++ b/__tests__/unit/cat/economic-profile.test.ts
@@ -7,6 +7,7 @@ import {
   economicCompleteness,
   economicProfileGaps,
   isEconomicProfileEmpty,
+  suggestedEntityForSkill,
   type EconomicProfile,
 } from '@/services/cat/economic-profile';
 
@@ -76,5 +77,19 @@ describe('isEconomicProfileEmpty', () => {
   it('matches a 0% score', () => {
     expect(isEconomicProfileEmpty(empty)).toBe(true);
     expect(isEconomicProfileEmpty(full)).toBe(false);
+  });
+});
+
+describe('suggestedEntityForSkill', () => {
+  it('maps sellable artifacts to product', () => {
+    expect(suggestedEntityForSkill('ebook writing')).toBe('product');
+    expect(suggestedEntityForSkill('Lightroom presets')).toBe('product');
+    expect(suggestedEntityForSkill('online course')).toBe('product');
+  });
+
+  it('defaults skills to service (time/expertise for hire)', () => {
+    expect(suggestedEntityForSkill('photography')).toBe('service');
+    expect(suggestedEntityForSkill('translation')).toBe('service');
+    expect(suggestedEntityForSkill('coaching')).toBe('service');
   });
 });

--- a/src/services/cat/economic-profile.ts
+++ b/src/services/cat/economic-profile.ts
@@ -111,6 +111,44 @@ export function economicCompleteness(p: EconomicProfile | null): number {
   return Math.round((filled / ECONOMIC_DIMENSIONS.length) * 100);
 }
 
+// Skill phrases that describe a sellable ARTIFACT (a thing you make once and sell
+// many times) rather than time-for-hire. Everything else defaults to a service.
+const PRODUCT_SKILL_HINTS = [
+  'ebook',
+  'e-book',
+  'template',
+  'preset',
+  'course',
+  'guide',
+  'pattern',
+  'sample pack',
+  'print',
+  'poster',
+  'sticker',
+  'kit',
+  'plugin',
+  'font',
+  'stock photo',
+  'recipe',
+  'beat',
+  'album',
+  'artwork',
+  'worksheet',
+  'planner',
+  'mockup',
+  'lut',
+];
+
+/**
+ * The entity type a skill most naturally becomes: a sellable artifact → product,
+ * otherwise a service (time/expertise for hire — the common case). Deterministic;
+ * lets the growth nudge open the RIGHT prefilled form instead of always a service.
+ */
+export function suggestedEntityForSkill(skill: string): 'service' | 'product' {
+  const s = skill.toLowerCase();
+  return PRODUCT_SKILL_HINTS.some(h => s.includes(h)) ? 'product' : 'service';
+}
+
 export async function getEconomicProfile(
   supabase: AnySupabaseClient,
   userId: string

--- a/src/services/cat/nudges.ts
+++ b/src/services/cat/nudges.ts
@@ -21,7 +21,11 @@ import { ROUTES } from '@/config/routes';
 import { DEFAULT_FREE_MODEL_ID } from '@/config/ai-models';
 import { createOpenRouterService } from '@/services/ai';
 import { searchPlatform } from './platform-search';
-import { getEconomicProfile, type EconomicProfile } from './economic-profile';
+import {
+  getEconomicProfile,
+  suggestedEntityForSkill,
+  type EconomicProfile,
+} from './economic-profile';
 import { logger } from '@/utils/logger';
 
 export interface Nudge {
@@ -261,14 +265,19 @@ async function growthNudges(
   const skill = uncoveredSkills.find(wanted) ?? uncoveredSkills[0];
   if (skill) {
     const isWanted = wanted(skill);
+    const et = suggestedEntityForSkill(skill);
+    const meta = ENTITY_REGISTRY[et];
+    const noun = meta.name.toLowerCase();
     out.push({
       nudge_type: 'growth',
-      title: `Turn "${skill}" into a service`,
+      title: `Turn "${skill}" into a ${noun}`,
       body: isWanted
-        ? `People on OrangeCat are already asking for ${skill} — and you can do it, but it isn't listed yet. Drafting it takes one tap.`
-        : `You can do ${skill}, but it isn't listed yet — people here can only hire you for what they can see. Drafting it takes one tap.`,
-      cta_label: `Draft a ${skill} service`,
-      cta_url: `${ENTITY_REGISTRY.service.createPath}?title=${encodeURIComponent(skill)}`,
+        ? `People on OrangeCat are already asking for ${skill} — and you have it, but it isn't listed yet. Drafting it takes one tap.`
+        : et === 'product'
+          ? `You make ${skill}, but it isn't listed yet — people here can only buy what they can see. Drafting it takes one tap.`
+          : `You can do ${skill}, but it isn't listed yet — people here can only hire you for what they can see. Drafting it takes one tap.`,
+      cta_label: `Draft a ${skill} ${noun}`,
+      cta_url: `${meta.createPath}?title=${encodeURIComponent(skill)}`,
       dedupe_key: `growth:skill:${skill.toLowerCase()}`,
       score: isWanted ? 0.88 : 0.82,
     });


### PR DESCRIPTION
Not everything is a service. A sellable-artifact skill (ebook, presets, course, prints…) → product; everything else → service. The growth nudge's one-tap CTA now opens the RIGHT prefilled form with matching copy.

- `suggestedEntityForSkill()` (deterministic, reusable) + growthNudges uses it; 2 unit tests.

tsc 0; lint clean; tests 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)