### PR TITLE
fix(search): committed search → discover dropped the query (q vs search mismatch)

### DIFF
--- a/src/app/discover/useDiscoverState.ts
+++ b/src/app/discover/useDiscoverState.ts
@@ -20,7 +20,9 @@ export function useDiscoverState() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const initialSearchTerm = searchParams?.get('search') || '';
+  // Standardize on `q` (matches the global search handoff + the SEO sitelinks template);
+  // fall back to the legacy `search` param so old links/bookmarks still work.
+  const initialSearchTerm = searchParams?.get('q') || searchParams?.get('search') || '';
   const initialCategories = (searchParams?.get('category') || '')
     .split(',')
     .map(s => s.trim())

--- a/src/app/discover/useDiscoverUrlSync.ts
+++ b/src/app/discover/useDiscoverUrlSync.ts
@@ -38,10 +38,11 @@ export function useDiscoverUrlSync({
       p.delete('type');
     }
     if (searchTerm) {
-      p.set('search', searchTerm);
+      p.set('q', searchTerm);
     } else {
-      p.delete('search');
+      p.delete('q');
     }
+    p.delete('search'); // legacy param — standardized on `q`
     if (selectedCategories.length > 0) {
       p.set('category', selectedCategories.join(','));
     } else {


### PR DESCRIPTION
Global search's "Search Discover for X" (Enter) → `/discover?q=X` (SEO template uses `?q=` too), but discover read `?search=` → query silently dropped, landing on the full unfiltered catalog with an empty box.

Standardize discover on `q` (web standard + global-search + SEO), with a `search` fallback for old links; URL-sync writes `q` and cleans up legacy `search`. Bug reproduced live ("bitcoin" → 53 unfiltered results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)