### PR TITLE
fix(search): log from CommandPalette (the real ⌘K palette), via sendBeacon

### DIFF
--- a/src/components/search/CommandPalette.tsx
+++ b/src/components/search/CommandPalette.tsx
@@ -47,6 +47,7 @@ import {
   Wallet,
 } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
+import { API_ROUTES } from '@/config/api-routes';
 import { useGlobalSearch } from '@/hooks/useGlobalSearch';
 import { cn } from '@/lib/utils';
 import type { GlobalSearchHit } from '@/services/search';
@@ -128,6 +129,24 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       const trimmed = term.trim();
       if (!trimmed) {
         return;
+      }
+      // Log the committed search as an aggregate demand signal — no PII. sendBeacon
+      // survives the navigation that follows (a plain fetch would be canceled).
+      try {
+        const beacon = navigator.sendBeacon?.bind(navigator);
+        const payload = JSON.stringify({ query: trimmed });
+        if (beacon) {
+          beacon(API_ROUTES.SEARCH.LOG, new Blob([payload], { type: 'application/json' }));
+        } else {
+          void fetch(API_ROUTES.SEARCH.LOG, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: payload,
+            keepalive: true,
+          }).catch(() => {});
+        }
+      } catch {
+        /* logging must never disrupt search */
       }
       close();
       router.push(`${ROUTES.DISCOVER}?q=${encodeURIComponent(trimmed)}`);


### PR DESCRIPTION
Root cause: logging was in `useEnhancedSearch` (EnhancedSearchBar), but the header ⌘K palette is `CommandPalette.tsx` — a different component. The log code was never on the path that runs (confirmed: the palette's live chunk had neither the beacon nor `discover?q=`). Added the sendBeacon demand log to `CommandPalette.submitFullSearch`. tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)