### PR TITLE
feat(search): enrich search log with true result count; log from one place

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { SlidersHorizontal } from 'lucide-react';
 import Button from '@/components/ui/Button';
@@ -11,6 +12,7 @@ import DiscoverEmptyState from '@/components/discover/DiscoverEmptyState';
 import { DiscoverLoadingState } from '@/components/discover/DiscoverLoadingState';
 import DiscoverResults from '@/components/discover/DiscoverResults';
 import { GRADIENTS } from '@/config/gradients';
+import { API_ROUTES } from '@/config/api-routes';
 import { useDiscoverState } from './useDiscoverState';
 
 export default function DiscoverPage() {
@@ -79,6 +81,55 @@ export default function DiscoverPage() {
     handleLoadMore,
     clearFilters,
   } = useDiscoverState();
+
+  // The total the page shows as "N results found" — single source for the UI and
+  // the demand log below. Mirrors the per-tab handling: useSearch only counts
+  // projects/profiles/all; entity tabs add their own loaded lengths.
+  const resultsFound =
+    (activeTab === 'all' || activeTab === 'projects' || activeTab === 'profiles'
+      ? totalResults
+      : 0) +
+    loans.length +
+    investments.length +
+    assets.length +
+    causes.length +
+    events.length +
+    products.length +
+    services.length +
+    groups.length +
+    wishlists.length +
+    research.length +
+    aiAssistants.length;
+
+  // Log each committed search as an aggregate demand signal WITH its true result
+  // count — zero/low-result searches are the sharpest unmet-demand signal. This is
+  // the single logging point (every committed search lands here, from ⌘K, a direct
+  // link, or the in-page box). No PII; deduped per query; only once results settle;
+  // sendBeacon survives navigation.
+  const loggedSearchRef = useRef<string | null>(null);
+  useEffect(() => {
+    const q = searchTerm.trim().toLowerCase();
+    if (!q || showInitialLoading || searchError || loggedSearchRef.current === q) {
+      return;
+    }
+    loggedSearchRef.current = q;
+    try {
+      const payload = JSON.stringify({ query: q, resultCount: resultsFound });
+      const beacon = navigator.sendBeacon?.bind(navigator);
+      if (beacon) {
+        beacon(API_ROUTES.SEARCH.LOG, new Blob([payload], { type: 'application/json' }));
+      } else {
+        void fetch(API_ROUTES.SEARCH.LOG, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: payload,
+          keepalive: true,
+        }).catch(() => {});
+      }
+    } catch {
+      /* logging must never disrupt discovery */
+    }
+  }, [searchTerm, showInitialLoading, searchError, resultsFound]);
 
   // Shared filter props to avoid duplication between desktop and mobile
   const filterProps = {
@@ -215,30 +266,7 @@ export default function DiscoverPage() {
                   wishlists={wishlists}
                   research={research}
                   aiAssistants={aiAssistants}
-                  totalResults={
-                    // useSearch (which feeds `totalResults`) only handles
-                    // projects + profiles + all. When the active tab is one
-                    // of the entity-specific tabs (loans, causes, …) it
-                    // still returns its initialType count — i.e., a
-                    // projects count that nothing on-screen reflects —
-                    // and adding it produces "6 results found" while
-                    // only 3 loans render. Skip that contribution unless
-                    // the tab is one useSearch actually targets.
-                    (activeTab === 'all' || activeTab === 'projects' || activeTab === 'profiles'
-                      ? totalResults
-                      : 0) +
-                    loans.length +
-                    investments.length +
-                    assets.length +
-                    causes.length +
-                    events.length +
-                    products.length +
-                    services.length +
-                    groups.length +
-                    wishlists.length +
-                    research.length +
-                    aiAssistants.length
-                  }
+                  totalResults={resultsFound}
                   loading={
                     loading || loansLoading || investmentsLoading || assetsLoading || genericLoading
                   }

--- a/src/components/search/CommandPalette.tsx
+++ b/src/components/search/CommandPalette.tsx
@@ -47,7 +47,6 @@ import {
   Wallet,
 } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
-import { API_ROUTES } from '@/config/api-routes';
 import { useGlobalSearch } from '@/hooks/useGlobalSearch';
 import { cn } from '@/lib/utils';
 import type { GlobalSearchHit } from '@/services/search';
@@ -130,24 +129,8 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       if (!trimmed) {
         return;
       }
-      // Log the committed search as an aggregate demand signal — no PII. sendBeacon
-      // survives the navigation that follows (a plain fetch would be canceled).
-      try {
-        const beacon = navigator.sendBeacon?.bind(navigator);
-        const payload = JSON.stringify({ query: trimmed });
-        if (beacon) {
-          beacon(API_ROUTES.SEARCH.LOG, new Blob([payload], { type: 'application/json' }));
-        } else {
-          void fetch(API_ROUTES.SEARCH.LOG, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: payload,
-            keepalive: true,
-          }).catch(() => {});
-        }
-      } catch {
-        /* logging must never disrupt search */
-      }
+      // The demand log fires from the discover page (the single point every
+      // committed search lands on), where the true result count is known.
       close();
       router.push(`${ROUTES.DISCOVER}?q=${encodeURIComponent(trimmed)}`);
     },

--- a/src/components/search/useEnhancedSearch.ts
+++ b/src/components/search/useEnhancedSearch.ts
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { useSearchSuggestions } from '@/hooks/useSearchSuggestions';
 import { useAuth } from '@/hooks/useAuth';
 import { ROUTES } from '@/config/routes';
-import { API_ROUTES } from '@/config/api-routes';
 import { useEnhancedSearchKeyboard } from './useEnhancedSearchKeyboard';
 
 export interface SearchItem {
@@ -96,26 +95,8 @@ export function useEnhancedSearch({ showQuickActions = true }: UseEnhancedSearch
         setSearchHistory(newHistory);
         localStorage.setItem(`search-history-${user.id}`, JSON.stringify(newHistory));
       }
-      // Log the committed search as an aggregate demand signal — no PII. Use
-      // sendBeacon: it's built to survive the navigation that follows on the next
-      // line (a plain fetch — even keepalive — gets canceled by router.push).
-      // Falls back to a keepalive fetch where sendBeacon is unavailable.
-      try {
-        const payload = JSON.stringify({ query: searchQuery });
-        const beacon = navigator.sendBeacon?.bind(navigator);
-        if (beacon) {
-          beacon(API_ROUTES.SEARCH.LOG, new Blob([payload], { type: 'application/json' }));
-        } else {
-          void fetch(API_ROUTES.SEARCH.LOG, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: payload,
-            keepalive: true,
-          }).catch(() => {});
-        }
-      } catch {
-        /* logging must never disrupt search */
-      }
+      // The demand log fires from the discover page (the single point every
+      // committed search lands on), where the true result count is known.
       router.push(`/discover?q=${encodeURIComponent(searchQuery)}`);
       setIsOpen(false);
       setQuery('');


### PR DESCRIPTION
Move demand logging to the discover page — the single point every committed search lands on — so it captures the true "N results found" count. Zero/low-result searches = sharpest unmet-demand signal.

- `discover/page.tsx`: extract displayed total to `resultsFound` (DRY), deduped settle-gated sendBeacon log of {query, resultCount}.
- Remove entry-point logs from CommandPalette + useEnhancedSearch → exactly one row per committed search, with count.

tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)