### PR TITLE
fix(search): fire the demand log on a settle-timer, not the page's loading flags

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -104,32 +104,39 @@ export default function DiscoverPage() {
   // Log each committed search as an aggregate demand signal WITH its true result
   // count — zero/low-result searches are the sharpest unmet-demand signal. This is
   // the single logging point (every committed search lands here, from ⌘K, a direct
-  // link, or the in-page box). No PII; deduped per query; only once results settle;
-  // sendBeacon survives navigation.
+  // link, or the in-page box). No PII; deduped per query. We fire ~1.5s after the
+  // query stabilizes (via a ref to the latest count) rather than gating on the
+  // page's loading flags — those can stay "loading" if a load cycle isn't observed,
+  // which would silently suppress the log. sendBeacon survives navigation.
+  const resultsFoundRef = useRef(0);
+  resultsFoundRef.current = resultsFound;
   const loggedSearchRef = useRef<string | null>(null);
   useEffect(() => {
     const q = searchTerm.trim().toLowerCase();
-    if (!q || showInitialLoading || searchError || loggedSearchRef.current === q) {
+    if (!q || searchError || loggedSearchRef.current === q) {
       return;
     }
-    loggedSearchRef.current = q;
-    try {
-      const payload = JSON.stringify({ query: q, resultCount: resultsFound });
-      const beacon = navigator.sendBeacon?.bind(navigator);
-      if (beacon) {
-        beacon(API_ROUTES.SEARCH.LOG, new Blob([payload], { type: 'application/json' }));
-      } else {
-        void fetch(API_ROUTES.SEARCH.LOG, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: payload,
-          keepalive: true,
-        }).catch(() => {});
+    const timer = setTimeout(() => {
+      loggedSearchRef.current = q;
+      try {
+        const payload = JSON.stringify({ query: q, resultCount: resultsFoundRef.current });
+        const beacon = navigator.sendBeacon?.bind(navigator);
+        if (beacon) {
+          beacon(API_ROUTES.SEARCH.LOG, new Blob([payload], { type: 'application/json' }));
+        } else {
+          void fetch(API_ROUTES.SEARCH.LOG, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: payload,
+            keepalive: true,
+          }).catch(() => {});
+        }
+      } catch {
+        /* logging must never disrupt discovery */
       }
-    } catch {
-      /* logging must never disrupt discovery */
-    }
-  }, [searchTerm, showInitialLoading, searchError, resultsFound]);
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [searchTerm, searchError]);
 
   // Shared filter props to avoid duplication between desktop and mobile
   const filterProps = {


### PR DESCRIPTION
The log was gated on showInitialLoading/hasCompletedFirstLoad, which can stay 'loading' when a load cycle isn't observed → log never fired (verified: route+beacon work, effect didn't). Replace with a ~1.5s settle-timer + latest-count ref. Deduped, no PII, sendBeacon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)