### PR TITLE
feat(search): attach result count to the search log on the proven ⌘K path

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { SlidersHorizontal } from 'lucide-react';
 import Button from '@/components/ui/Button';
@@ -12,7 +11,6 @@ import DiscoverEmptyState from '@/components/discover/DiscoverEmptyState';
 import { DiscoverLoadingState } from '@/components/discover/DiscoverLoadingState';
 import DiscoverResults from '@/components/discover/DiscoverResults';
 import { GRADIENTS } from '@/config/gradients';
-import { API_ROUTES } from '@/config/api-routes';
 import { useDiscoverState } from './useDiscoverState';
 
 export default function DiscoverPage() {
@@ -100,43 +98,6 @@ export default function DiscoverPage() {
     wishlists.length +
     research.length +
     aiAssistants.length;
-
-  // Log each committed search as an aggregate demand signal WITH its true result
-  // count — zero/low-result searches are the sharpest unmet-demand signal. This is
-  // the single logging point (every committed search lands here, from ⌘K, a direct
-  // link, or the in-page box). No PII; deduped per query. We fire ~1.5s after the
-  // query stabilizes (via a ref to the latest count) rather than gating on the
-  // page's loading flags — those can stay "loading" if a load cycle isn't observed,
-  // which would silently suppress the log. sendBeacon survives navigation.
-  const resultsFoundRef = useRef(0);
-  resultsFoundRef.current = resultsFound;
-  const loggedSearchRef = useRef<string | null>(null);
-  useEffect(() => {
-    const q = searchTerm.trim().toLowerCase();
-    if (!q || searchError || loggedSearchRef.current === q) {
-      return;
-    }
-    const timer = setTimeout(() => {
-      loggedSearchRef.current = q;
-      try {
-        const payload = JSON.stringify({ query: q, resultCount: resultsFoundRef.current });
-        const beacon = navigator.sendBeacon?.bind(navigator);
-        if (beacon) {
-          beacon(API_ROUTES.SEARCH.LOG, new Blob([payload], { type: 'application/json' }));
-        } else {
-          void fetch(API_ROUTES.SEARCH.LOG, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: payload,
-            keepalive: true,
-          }).catch(() => {});
-        }
-      } catch {
-        /* logging must never disrupt discovery */
-      }
-    }, 1500);
-    return () => clearTimeout(timer);
-  }, [searchTerm, searchError]);
 
   // Shared filter props to avoid duplication between desktop and mobile
   const filterProps = {

--- a/src/components/search/CommandPalette.tsx
+++ b/src/components/search/CommandPalette.tsx
@@ -47,6 +47,7 @@ import {
   Wallet,
 } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
+import { API_ROUTES } from '@/config/api-routes';
 import { useGlobalSearch } from '@/hooks/useGlobalSearch';
 import { cn } from '@/lib/utils';
 import type { GlobalSearchHit } from '@/services/search';
@@ -129,12 +130,29 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       if (!trimmed) {
         return;
       }
-      // The demand log fires from the discover page (the single point every
-      // committed search lands on), where the true result count is known.
+      // Log the committed search as an aggregate demand signal, with the instant
+      // cross-entity result count — 0 means nothing matched (the sharpest unmet-demand
+      // signal). No PII; sendBeacon survives the navigation that follows.
+      try {
+        const payload = JSON.stringify({ query: trimmed, resultCount: hits.length });
+        const beacon = navigator.sendBeacon?.bind(navigator);
+        if (beacon) {
+          beacon(API_ROUTES.SEARCH.LOG, new Blob([payload], { type: 'application/json' }));
+        } else {
+          void fetch(API_ROUTES.SEARCH.LOG, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: payload,
+            keepalive: true,
+          }).catch(() => {});
+        }
+      } catch {
+        /* logging must never disrupt search */
+      }
       close();
       router.push(`${ROUTES.DISCOVER}?q=${encodeURIComponent(trimmed)}`);
     },
-    [close, router]
+    [close, router, hits]
   );
 
   const quickActions: PaletteItem[] = useMemo(


### PR DESCRIPTION
The discover-page logging effect wouldn't fire reliably (timer torn down by render/Suspense timing), so move count enrichment back to CommandPalette (verified to log). Attach the instant cross-entity count from useGlobalSearch — 0 = nothing matched (sharpest unmet-demand signal); capped at the fetch limit, so 'none vs some' not an exact total.

- `CommandPalette.submitFullSearch`: {query, resultCount: hits.length} via sendBeacon.
- `discover/page.tsx`: dropped the non-firing effect; kept the DRY `resultsFound` for the UI.

tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)