### PR TITLE
feat(payments): trustless LNURL-verify (LUD-21) settlement + trust scrub

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"4b93e302-9d53-48a5-abd5-35ab7801f3d6","pid":1187686,"procStart":"15086894","acquiredAt":1781841532016}
+{"sessionId":"79875723-428d-44af-a7a4-e381fc204493","pid":54255,"procStart":"1405752","acquiredAt":1782997076285}

--- a/__tests__/unit/domain/payments/lnurlVerify.test.ts
+++ b/__tests__/unit/domain/payments/lnurlVerify.test.ts
@@ -1,0 +1,123 @@
+/**
+ * LNURL-verify (LUD-21) — trustless settlement for lightning_address payments.
+ *
+ * Money path: a payment must only flip to PAID on an explicit `settled: true`
+ * from the provider's verify endpoint. Provider errors, malformed bodies, and
+ * unsettled invoices must all read as "not paid yet".
+ */
+
+import { checkLnurlVerifyPaymentStatus } from '@/domain/payments/paymentStatusService';
+import { checkPaymentStatus } from '@/domain/payments/paymentFlowService';
+import { STATUS } from '@/config/database-constants';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/lib/email/send-seller-notification', () => ({
+  sendSellerPaymentNotification: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/services/notifications/dispatcher', () => ({
+  NotificationDispatcher: { dispatch: jest.fn().mockResolvedValue(undefined) },
+}));
+
+const VERIFY_URL = 'https://getalby.com/lnurlp/oc/verify/abc123';
+
+function mockFetchOnce(body: unknown, ok = true) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    json: () => Promise.resolve(body),
+  }) as unknown as typeof fetch;
+}
+
+describe('checkLnurlVerifyPaymentStatus', () => {
+  it('returns true only on explicit settled=true', async () => {
+    mockFetchOnce({ status: 'OK', settled: true, preimage: 'aa' });
+    await expect(
+      checkLnurlVerifyPaymentStatus({ id: 'pi-1', lnurl_verify_url: VERIFY_URL })
+    ).resolves.toBe(true);
+  });
+
+  it('returns false when not yet settled', async () => {
+    mockFetchOnce({ status: 'OK', settled: false, preimage: null });
+    await expect(
+      checkLnurlVerifyPaymentStatus({ id: 'pi-1', lnurl_verify_url: VERIFY_URL })
+    ).resolves.toBe(false);
+  });
+
+  it('returns false on provider error status', async () => {
+    mockFetchOnce({ status: 'ERROR', reason: 'not found' });
+    await expect(
+      checkLnurlVerifyPaymentStatus({ id: 'pi-1', lnurl_verify_url: VERIFY_URL })
+    ).resolves.toBe(false);
+  });
+
+  it('returns false on HTTP failure', async () => {
+    mockFetchOnce({}, false);
+    await expect(
+      checkLnurlVerifyPaymentStatus({ id: 'pi-1', lnurl_verify_url: VERIFY_URL })
+    ).resolves.toBe(false);
+  });
+
+  it('returns false (never throws) on network error', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('timeout')) as unknown as typeof fetch;
+    await expect(
+      checkLnurlVerifyPaymentStatus({ id: 'pi-1', lnurl_verify_url: VERIFY_URL })
+    ).resolves.toBe(false);
+  });
+
+  it('returns false when no verify URL is stored (pre-LUD-21 intents)', async () => {
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    await expect(
+      checkLnurlVerifyPaymentStatus({ id: 'pi-1', lnurl_verify_url: null })
+    ).resolves.toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkPaymentStatus — lightning_address + verify URL', () => {
+  const PI = {
+    id: 'pi-1',
+    buyer_id: 'buyer-1',
+    seller_id: 'seller-1',
+    entity_type: 'cause',
+    entity_id: 'ent-1',
+    amount_btc: 0.0001,
+    status: STATUS.PAYMENT_INTENTS.INVOICE_READY,
+    payment_method: 'lightning_address',
+    lnurl_verify_url: VERIFY_URL,
+    paid_at: null,
+    expires_at: null,
+    description: 'Cause: Test',
+  };
+
+  function makeSupabase(intent: Record<string, unknown>) {
+    const update = jest.fn();
+    const builder: Record<string, unknown> = {};
+    for (const m of ['select', 'update', 'eq', 'in']) {
+      builder[m] = jest.fn((...args: unknown[]) => {
+        if (m === 'update') update(...args);
+        return builder;
+      });
+    }
+    builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
+    builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve({ error: null }).then(resolve, reject);
+    return { client: { from: jest.fn(() => builder) } as never, update };
+  }
+
+  it('flips to PAID when the verify endpoint reports settled', async () => {
+    mockFetchOnce({ status: 'OK', settled: true });
+    const { client, update } = makeSupabase(PI);
+    const res = await checkPaymentStatus(client, PI.id, PI.buyer_id);
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({ status: 'paid' }));
+  });
+
+  it('stays invoice_ready when not settled', async () => {
+    mockFetchOnce({ status: 'OK', settled: false });
+    const { client, update } = makeSupabase(PI);
+    const res = await checkPaymentStatus(client, PI.id, PI.buyer_id);
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.INVOICE_READY);
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/content/blog/orangecat-2025-complete-platform.mdx
+++ b/content/blog/orangecat-2025-complete-platform.mdx
@@ -87,12 +87,12 @@ OrangeCat enables **true AI ownership** - you create AI assistants as software t
 - Works with any AI provider (OpenAI, Anthropic, etc.)
 - You control the intellectual property
 
-### Real AI Business Examples
-- **Customer Service AI**: Handles 1000+ support tickets daily for ₿0.5/month per customer
-- **Content Creation AI**: Generates blog posts and social media for ₿0.1 per article
-- **Code Review AI**: Automated code quality checks for ₿0.05 per review
+### Example AI Businesses
+- **Customer Service AI**: handling support tickets for ₿0.5/month per customer
+- **Content Creation AI**: generating blog posts and social media for ₿0.1 per article
+- **Code Review AI**: automated code quality checks for ₿0.05 per review
 
-**Economic Impact**: Creators earn **99% of revenue** (only 0.1% Bitcoin network fees) vs traditional platforms' 80-88%.
+**Economic Impact**: OrangeCat takes **0% platform fees** — creators keep 100% of revenue minus tiny Bitcoin network fees, vs the 80-88% they keep on traditional platforms.
 
 ---
 
@@ -142,7 +142,7 @@ OrangeCat enables **free flow of knowledge and value** through interconnected so
 - **AI-enhanced collective intelligence** synthesizes insights
 
 ### Economic Value Flows
-- **Direct Bitcoin payments** (0.1% fees vs 5-20% on platforms)
+- **Direct Bitcoin payments** (0% platform fees vs 5-20% on platforms)
 - **Transparent treasuries** for all entities
 - **Multi-signature security** for large transactions
 - **Automated revenue sharing** and payroll
@@ -195,7 +195,7 @@ OrangeCat operates under the **BitBaum corporate umbrella**, following the TikTo
 
 | Feature | Traditional Platforms | OrangeCat |
 |---------|----------------------|-----------|
-| **Fees** | 5-20% + payment processing | 0.1% (Bitcoin network) |
+| **Fees** | 5-20% + payment processing | 0% platform fee (only Bitcoin network fees) |
 | **Censorship** | Account bans possible | Bitcoin censorship-resistant |
 | **Transparency** | Opaque financials | Full on-chain visibility |
 | **Ownership** | Platform owns user data | Users own their creations |
@@ -204,7 +204,7 @@ OrangeCat operates under the **BitBaum corporate umbrella**, following the TikTo
 ### Real Economic Impact
 
 **For Creators:**
-- Keep 99% of earnings vs 80-88% on traditional platforms
+- Keep 100% of earnings (minus network fees) vs 80-88% on traditional platforms
 - Own their AI models and software
 - Build communities around their work
 

--- a/content/blog/orangecat-bitcoin-alternative.mdx
+++ b/content/blog/orangecat-bitcoin-alternative.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OrangeCat: The Bitcoin-Native Alternative to Patreon, Kickstarter, and Traditional Finance"
-excerpt: "OrangeCat eliminates platform fees, censorship, and opacity—giving creators 95% of earnings while building transparent, Bitcoin-powered communities that actually work."
+excerpt: "OrangeCat eliminates platform fees, censorship, and opacity—giving creators 100% of earnings (0% platform fees) while building transparent, Bitcoin-powered communities that actually work."
 date: "2025-12-25"
 tags: ["Bitcoin", "Creator Economy", "Platform Economics", "Future of Work", "Decentralized Finance"]
 featured: true
@@ -10,7 +10,7 @@ published: true
 
 # OrangeCat: The Bitcoin-Native Alternative to Patreon, Kickstarter, and Traditional Finance
 
-**OrangeCat is a Bitcoin-powered platform that makes creators keep 95% of their earnings while building transparent, community-owned economies.**
+**OrangeCat is a Bitcoin-powered platform that lets creators keep 100% of their earnings (0% platform fees) while building transparent, community-owned economies.**
 
 ---
 
@@ -30,7 +30,7 @@ Today, platforms extract massive rents from creators:
 
 ## OrangeCat: Bitcoin-Native, Creator-First
 
-OrangeCat flips this equation. **Creators keep 99% of their earnings** through Bitcoin's 0.1% network fees.
+OrangeCat flips this equation. **Creators keep 100% of their earnings** — OrangeCat charges 0% platform fees; only tiny Bitcoin network fees apply.
 
 ### What OrangeCat Actually Does
 
@@ -76,7 +76,7 @@ OrangeCat lets people create and transact with **9 types of entities**:
 
 | Feature | OrangeCat | Traditional Platforms |
 |---------|-----------|----------------------|
-| **Fees** | 0.1% (Bitcoin network) | 5-20% + payment processing |
+| **Fees** | 0% platform fee (only Bitcoin network fees) | 5-20% + payment processing |
 | **Censorship** | Bitcoin = uncensorable | Accounts can be banned |
 | **Transparency** | Full on-chain visibility | Opaque financials |
 | **Interoperability** | Bitcoin works everywhere | Funds locked to platform |

--- a/docs/business/executive/master-plan-2026-07.md
+++ b/docs/business/executive/master-plan-2026-07.md
@@ -1,0 +1,304 @@
+# OrangeCat × FleetCrown — Master Plan (July 2026)
+
+**Status:** Proposed — supersedes `strategic-plan.md` (Dec 2025) where they conflict
+**Basis:** Full-codebase inspection (OC + FC repos), docs/blog audit, live-site outsider audit, and production DB ground truth, all conducted 2026-07-02.
+
+---
+
+## 1. Ground Truth (2026-07-02)
+
+### Usage (production DB, supabase.orangecat.ch)
+
+| Metric                           | Value                                                                          |
+| -------------------------------- | ------------------------------------------------------------------------------ |
+| Registered users                 | 44 (12 signed up last 30d, 13 active last 30d)                                 |
+| Entities (all 15 types combined) | ~50 (6 products, 11 services, 6 projects, 4 causes, 6 groups, 5 assistants, …) |
+| **Completed payments, ever**     | **0** (1 expired intent, 1 stuck at `invoice_ready`, both a single April test) |
+| Cat conversations / messages     | 12 / 36                                                                        |
+| DMs                              | 176 across 110 conversations                                                   |
+| OAuth clients                    | 1 (FleetCrown)                                                                 |
+| Stakeholder edges                | 1 (FleetCrown = customer)                                                      |
+
+### Technology (what actually works)
+
+The plumbing is unusually far along. Working end-to-end **in code**:
+create+view for all 15 entity types (registry-driven generic CRUD), a production-grade
+**OIDC identity provider** (PKCE, refresh rotation, JWKS, hashed secrets — live, FleetCrown
+registered), a real payment orchestration (`paymentFlowService`: NWC and on-chain
+auto-verify; LNURL falls back to buyer-confirm), governance that tallies votes and
+**auto-executes** passed proposals, full messaging/timeline/notifications, and a Cat with
+29 implemented actions, tool use, pgvector memory, offer engine, and demand signals.
+
+Loops that are ~80% wired but **do not close**:
+
+1. **Cat Credits** — ledger + Lightning top-up built; the chat path **never spends credits**
+   (`'usage'` ledger kind defined, never written). Top-up itself gated on unset
+   `PLATFORM_NWC_URI`.
+2. **Identity bridge** — OC side (OIDC provider) shipped; **FleetCrown side unbuilt**
+   (no OrangeCat provider in FC's Auth.js, no `orangecatActorId` column). FC docs still
+   call the whole thing "not yet built" — stale.
+3. **Publish bus** — OC ingest endpoint (`POST /api/v1/timeline/publish`, idempotent,
+   scoped) is live; the **FleetCrown emit half is unbuilt**. Today's only live integration
+   is a one-way subscription→service mirror over a single shared service key.
+4. **Edit UX** — only 3 of 15 entity types have a human edit form.
+5. **Payments in production** — code paths exist; nothing has ever settled.
+
+Debt: money/security paths under-tested (0 dedicated tests for OIDC flows and
+governance execution; 5 for payments); newest tables (`oauth_*`, `cat_credit_*`,
+`stakeholder_relationships`) untyped via `AnySupabaseClient` casts; repeated corrective
+schema-drift migrations; dead `MockPaymentProvider` stack; all settlement is polling;
+box disk at 91%.
+
+### Business (what the docs actually say)
+
+- **Revenue model is undefined and self-contradictory.** `strategic-plan.md` claims
+  "percentage-based fees on Bitcoin transactions"; `legal-compliance-overview.md` rests
+  the entire low-regulatory-risk posture on the platform **never touching funds**; the
+  live landing page advertises **"0% fees / 100% to creator"**; a Dec 2025 blog post says
+  95%. All four cannot be true.
+- No pricing, no tiers defined (a `user_plans` table exists with no documented plans),
+  no financials, no CAC/funnel.
+- ICP is split-brained: Dec 2025 personas (doctors, lawyers, artists — fictional,
+  AI-generated) vs the June 2026 blog thesis (AI-assisted solo builders). Never reconciled.
+- BitBaum AG is claimed publicly as owner but listed internally as an unstarted TODO.
+- FleetCrown's business is conventional and coherent: tiered SaaS (Stripe today),
+  ICP = builders running agent fleets, raising money.
+
+### Outside view (live sites)
+
+Message is clear and credible; the social-proof layer says "pre-launch": ~16 public
+items on Discover, two of three flagship projects are OrangeCat and FleetCrown
+themselves, "Test Organization" debris in public listings, Discover ships zero HTML
+(client-rendered → invisible to search engines and AI crawlers), FleetCrown shows no
+pricing and doesn't surface "Login with OrangeCat".
+
+---
+
+## 2. Diagnosis
+
+Three problems, in causal order:
+
+1. **No loop has ever closed.** The platform's thesis is economic participation, and
+   zero economic events have completed on it. Everything else is downstream of this.
+   The constraint is not missing features — it is that the existing 80%-wired loops
+   (payment, credits, identity bridge, publish bus) were each stopped one step short.
+
+2. **The business model contradicts itself.** You cannot simultaneously be non-custodial
+   ("we never touch funds"), advertise 0% fees, and plan to earn % of transactions.
+   One of these must be dropped — and the codebase has already voted: the only
+   monetization actually built is **Cat Credits** (prepaid, Bitcoin-paid AI) and the
+   **95/5 paid-assistant split** — both are "selling intelligence", not "taxing rails".
+
+3. **No distribution, and the marketplace cold-start is being fought head-on.**
+   44 users cannot make a marketplace liquid. But OrangeCat doesn't need liquidity to
+   be useful: a profile + wallet + Cat + published offers is valuable to **one person
+   alone**. The distribution engine that exists and is being ignored is FleetCrown —
+   its audience is exactly OC's ICP, and the founder's own build-in-public loop is the
+   demo. "FC emits, OC distributes" is the right thesis; it just isn't wired.
+
+---
+
+## 3. Strategy
+
+### 3.1 What OrangeCat is (positioning, sharpened)
+
+**Single-player first, marketplace second.** OrangeCat is your public economic
+homepage plus an AI agent that runs it: a page, a wallet, and a Cat that interviews
+you, packages what you can offer, publishes it, and handles the money — pseudonymously,
+in Bitcoin or anything else, with 0% platform fees. Network effects (discovery,
+matchmaking, funding) compound later; the product must be worth signing up for at N=1.
+
+### 3.2 The division of labor with FleetCrown
+
+- **FleetCrown = the revenue engine.** Conventional SaaS, clear ICP, Stripe now,
+  per-seat later. It pays the bills and acquires the users.
+- **OrangeCat = the moat and the upside.** It is what makes FleetCrown different from
+  every other agent-orchestration tool (your fleet's output gets a public face, a
+  wallet, funding, and customers), and it owns the long-term "economic layer for
+  AI-assisted individuals" position.
+- **The integration is the product.** Neither is compelling enough alone at current
+  scale; the closed loop (build in FC → publish to OC → get funded/paid on OC → fund
+  more building) is the story no competitor tells.
+
+Consequence: **do not burden OrangeCat with near-term revenue targets.** Burden it
+with _closed loops and activation_. FleetCrown carries revenue; OrangeCat carries proof.
+
+### 3.3 The business model (resolves the contradiction)
+
+Adopt "**sell intelligence, not rails**" as the codified model:
+
+1. **Peer-to-peer payments: 0% forever, non-custodial.** This stays the marketing
+   wedge and keeps the legal posture coherent (platform never processes funds;
+   NWC/LNURL/on-chain settle wallet-to-wallet).
+2. **Cat Credits (built, needs wiring):** prepaid Lightning top-ups spent on
+   frontier-model Cat usage. Platform margin lives in the credit price. This is
+   selling _your own service_, not payment processing — legally clean.
+3. **Supporter plan** (use the existing `user_plans` table): flat CHF 10/month or
+   10k sats — monthly frontier-Cat allowance, priority support, supporter badge.
+   Keep it to exactly two tiers: Free and Supporter.
+4. **Paid AI assistants:** 95/5 creator split (already built) — the only take-rate,
+   and it's on platform-mediated AI services, not P2P money.
+5. **FleetCrown as first customer:** its value is _proof and distribution_, not
+   revenue. Long-term: FC settles its own billing over OC rails ("Lightning rails,
+   no Stripe in the path") — that's the roadmap demonstration, not a 2026 revenue line.
+
+**Kill** the "% of Bitcoin transactions" line from `strategic-plan.md`. **Reconcile**
+public copy to one claim: 0% platform fees on payments; we make money when you use
+frontier AI.
+
+### 3.4 ICP and go-to-market
+
+**ICP (narrowed):** AI-assisted solo builders and micro-studios — people already
+shipping with agents who need a public economic presence without a company, a Stripe
+account, or a real name. Secondary: Swiss Bitcoin community (local, reachable,
+values-aligned). **Drop** the doctors/lawyers persona set.
+
+Channels, in order of leverage:
+
+1. **The founder's own machine as the demo.** Every FC-built project auto-publishes
+   to OC; weekly build-in-public posts; the OC timeline becomes living proof. This is
+   free and differentiated — do it before any paid channel.
+2. **FleetCrown cross-sell** (per the bridge spec's detect-and-suggest): after FC
+   onboarding → "Claim your public profile + wallet on OrangeCat" — one click via the
+   identity bridge.
+3. **Seed real supply from the real portfolio.** The founder's orbit (RevampIT and
+   the ~15 projects in ~/dev) contains genuinely sellable products/services. 20–30
+   real entities with real wallets makes Discover look alive because it _is_ alive.
+4. **Zurich/Swiss Bitcoin community**: meetups, Bitcoin Association Switzerland,
+   hand-onboard the first 10 external users personally.
+5. **SEO/AI-discoverability**: SSR Discover + entity pages. Every public entity is a
+   landing page; today crawlers see nothing.
+
+**The activation moment** (the north-star flow, spec'd in
+`cat-economic-interviewer.md` + `economic-agent-capability.md`): sign up → Cat
+interviews you ("what do people ask you for help with?") → proposes 3 grounded offers →
+one click publishes → wallet attached → shareable page. Target: **median
+signup→first-published-offer under 15 minutes**, and the second metric that matters:
+**time to first sat received**.
+
+---
+
+## 4. The Plan
+
+Sequencing rule: **one loop closed end-to-end beats ten features at 80%.** Phases are
+ordered by dependency; each ends with a public, verifiable proof.
+
+### Phase 0 — Close the money loop (days) 🔴
+
+The whole thesis is unproven until one payment settles.
+
+| #   | Item                                                                                                                                                                                | Owner   |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| 0.1 | **Provision `PLATFORM_NWC_URI`** (Alby Hub or NWC-capable wallet for the platform) — the single blocker named in every audit; unblocks Cat Credit top-ups and paid assistants       | Founder |
+| 0.2 | Execute one real payment end-to-end in production for each pattern: fixed-price product (NWC), contribution (on-chain or LNURL). Fix whatever breaks. **Payments-ever goes 0 → ≥2** | Agent   |
+| 0.3 | Trust scrub: hide/delete "Test Organization" groups from public listings; reconcile 0%-vs-95% copy; fix "Loading blog posts…" artifact                                              | Agent   |
+| 0.4 | Box hygiene: disk at 91% — clean; verify off-site backup path (B2) for the supabase-db container dump                                                                               | Agent   |
+
+**Proof:** a real invoice paid on orangecat.ch, screenshotted, blogged.
+
+### Phase 1 — Wire the machine: FC ⇄ OC (2–3 weeks) 🟠
+
+The bridge spec (`fleetcrown/docs/architecture/cross-product-identity-bridge.md`) is
+correct and its build order stands — except step 1 is already half-done (OC's OIDC
+provider is live). Remaining work is mostly FC-side:
+
+| #   | Item                                                                                                                                                                                                           | Where   |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| 1.1 | "Login with OrangeCat" in FleetCrown: custom Auth.js OIDC provider against orangecat.ch, `users.orangecatActorId` column, account-linking UI; surface the button on FC's sign-in                               | FC      |
+| 1.2 | One-consent capability grant: authorize flow mints actor-bound `ock_` key, replacing the shared service-account key                                                                                            | FC + OC |
+| 1.3 | "Publish to OrangeCat" per FC project → creates/links OC project entity (`user_projects.orangecatProjectId`)                                                                                                   | FC      |
+| 1.4 | FC emit half of the publish bus: config-driven promote step → `POST /api/v1/timeline/publish` (OC ingest already live; async, idempotent `dedupe_key`)                                                         | FC      |
+| 1.5 | Surface both directions: OC timeline/home feed shows FC build events; FC project page shows OC wallet/funding state (read via API — defer iframe embeds until pain is real, per PLATFORM_AND_COLLABORATION.md) | Both    |
+| 1.6 | Update FC's stale integration docs to reflect OC OIDC reality                                                                                                                                                  | FC      |
+
+**Proof:** the FleetCrown project page on orangecat.ch shows a live stream of real
+build events, and a FleetCrown user signs in with OrangeCat.
+
+### Phase 2 — Monetization coherence (2 weeks) 🟠
+
+| #   | Item                                                                                                                                                                                                                                    |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.1 | Wire Cat Credit **`'usage'` metering** into `chat-orchestrator.ts`: frontier-tier requests debit the ledger; free tier stays on platform quota. The pay-Bitcoin-for-AI loop closes                                                      |
+| 2.2 | First live top-up test (founder, real sats) — Cat Credits Phase 2 exit criterion                                                                                                                                                        |
+| 2.3 | Define Free/Supporter in `user_plans` + pricing page on orangecat.ch; FleetCrown publishes its pricing page (currently none — a trust gap)                                                                                              |
+| 2.4 | Rewrite `strategic-plan.md` §Business Model to this document's §3.3; delete the transaction-fee claim; align legal doc (credits = prepaid service, not payment processing)                                                              |
+| 2.5 | Founder decision: engage a Swiss attorney on (a) credits/prepaid model, (b) the **loans** feature vs Consumer Credit Act — consider unlisting P2P loans publicly until reviewed, (c) BitBaum AG — register it or scrub the public claim |
+
+**Proof:** first franc/sat of platform revenue in the credit ledger.
+
+### Phase 3 — Activation + supply (4–6 weeks) 🟡
+
+| #   | Item                                                                                                                                                                  |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.1 | **Cat economic interviewer** (spec exists; remove the system-prompt prohibition): the signup→interview→3 offers→publish flow. This is the product's magic moment      |
+| 3.2 | **Registry-driven generic edit form** — one component, all 15 entity types (the architecture begs for it; closes the create-but-can't-edit gap)                       |
+| 3.3 | SSR `/discover` + entity detail pages (SEO/AI-crawler visibility); implement `entity-detail-redesign.md` (founder already flagged detail pages as "useless and ugly") |
+| 3.4 | Search across **all** entity types (today: effectively profiles/projects/loans despite embeddings existing)                                                           |
+| 3.5 | LNURL-verify (LUD-21) where the receiving wallet supports it — trustless lightning-address settlement instead of "I've paid"                                          |
+| 3.6 | Seed 20–30 real entities from the founder's real portfolio with real wallets; hand-onboard first 10 external users (Zurich Bitcoin community)                         |
+| 3.7 | Weekly build-in-public cadence: FC events on OC timeline + a blog post; the two-layer format of `your-most-valuable-skill.mdx` is the template                        |
+
+**Proof:** 10 external users each with a published offer; ≥1 stranger-to-stranger payment.
+
+### Phase 4 — Hardening (ongoing, parallel) 🟢
+
+| #   | Item                                                                                                                                                                                                |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4.1 | Tests on money/security paths first: payment E2E (all 3 methods), OIDC flows (code replay, PKCE, rotation), governance auto-execution. Target: no untested path that moves money or grants identity |
+| 4.2 | Regenerate DB types; eliminate `AnySupabaseClient` casts on `oauth_*`, `cat_credit_*`, `stakeholder_relationships`                                                                                  |
+| 4.3 | Delete the dead `MockPaymentProvider`/`getPaymentProvider()` stack                                                                                                                                  |
+| 4.4 | Migration auto-apply on deploy (root cause of the repeated drift-remediation migrations; sovereign-infra P0)                                                                                        |
+| 4.5 | Fix the ~27 tables missing from `DATABASE_TABLES` SSOT; split the 7 >500-LOC service files as touched                                                                                               |
+| 4.6 | Later, at scale: webhook/event settlement instead of polling; iframe embed routes when FC actually needs them                                                                                       |
+
+---
+
+## 5. What "working perfectly" means (success metrics, 90 days)
+
+| Metric                                | Now   | Day 90 target                       |
+| ------------------------------------- | ----- | ----------------------------------- |
+| Completed payments (cumulative)       | 0     | ≥ 50                                |
+| External users with a published offer | ~0    | ≥ 10                                |
+| Median signup → first published offer | n/a   | < 15 min                            |
+| Users who received ≥1 sat             | 0     | ≥ 10                                |
+| FC public projects publishing to OC   | 0     | 100%                                |
+| Cat Credit revenue                    | 0     | > 0, ≥ 5 paying users               |
+| Money-path test coverage              | ~thin | payment/OIDC/governance all covered |
+| Public copy contradictions            | 3+    | 0                                   |
+
+Technology "perfect" = every advertised loop closes and is tested; deploys apply
+migrations automatically; no drift; no dead payment code. Business "perfect" = one
+coherent, legal, built model (0% rails, paid intelligence) with public pricing and a
+narrowed ICP, distributed through FleetCrown and the founder's own loop.
+
+---
+
+## 6. Risks & honest constraints
+
+- **Marketplace cold start** — mitigated by single-player-first positioning; do not
+  measure OC on liquidity in 2026, measure it on activation.
+- **Solo founder bandwidth** — the phases are strictly sequential for a reason; agents
+  can execute nearly all engineering items, but 0.1 (NWC), 2.2 (real-sats test), 2.5
+  (legal/AG), and 3.6 (community onboarding) are founder-only.
+- **Regulatory** — the loans feature is the sharpest edge (Swiss Consumer Credit Act);
+  credits model is defensible but should be attorney-reviewed before scale.
+- **Free-tier AI cost** — platform quota + rate-limit fallback chain already bound it;
+  wire usage metering (2.1) before promoting frontier features.
+- **Aspirational public claims** (DAO multisig/quadratic voting, "wired in production",
+  BitBaum AG) — either build, or soften the copy. Credibility is the scarcest asset at
+  44 users. The blog's honesty norm (label what's roadmap) should apply retroactively.
+- **Any-currency promise** — keep the claim, don't build Twint/PayPal yet (YAGNI);
+  Lightning first-class is the wedge.
+
+---
+
+## 7. Decisions needed from the founder
+
+1. **Provision the platform NWC wallet** (Phase 0.1) — everything paid is behind it.
+2. **Sign off the business model** (§3.3): 0% rails + paid intelligence; kill the
+   transaction-fee model.
+3. **Pricing numbers** for Supporter (proposal: CHF 10/mo or 10k sats).
+4. **ICP narrowing**: retire the Dec 2025 personas.
+5. **Legal**: attorney engagement scope; loans feature exposure; BitBaum AG register-or-scrub.
+6. **Green-light Phase 1** (FC-side identity bridge) — it's the highest-leverage
+   engineering block and it's ready to build today.

--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { getPublishedPosts, getFeaturedPost, getAllTags } from '@/lib/blog';
 import BlogClientWrapper from '@/components/blog/BlogClientWrapper';
@@ -25,9 +24,7 @@ export default function BlogPage() {
           </p>
         </div>
 
-        <Suspense fallback={<div>Loading blog posts...</div>}>
-          <BlogClientWrapper posts={allPosts} featuredPost={featuredPost} tags={allTags} />
-        </Suspense>
+        <BlogClientWrapper posts={allPosts} featuredPost={featuredPost} tags={allTags} />
       </div>
     </div>
   );

--- a/src/domain/payments/invoiceGenerationService.ts
+++ b/src/domain/payments/invoiceGenerationService.ts
@@ -19,6 +19,8 @@ interface GeneratedInvoice {
   payment_hash: string | null;
   /** On-chain BTC address */
   onchain_address: string | null;
+  /** LUD-21 verify URL (lightning_address only, when the provider supports it) */
+  lnurl_verify_url: string | null;
   /** QR code data (bolt11 uppercased, or bitcoin: URI) */
   qr_data: string;
   /** When the invoice expires (ISO string) */
@@ -76,6 +78,7 @@ async function generateNWCInvoice(
       bolt11: invoice.invoice,
       payment_hash: invoice.payment_hash,
       onchain_address: null,
+      lnurl_verify_url: null,
       qr_data: invoice.invoice.toUpperCase(), // Uppercase for QR efficiency
       expires_at: expiresAt,
     };
@@ -145,10 +148,19 @@ async function generateLightningAddressInvoice(
     throw new Error('LNURL callback did not return a payment request');
   }
 
+  // LUD-21: providers like Alby and Coinos return a `verify` URL alongside the
+  // invoice. Polling it lets us detect settlement trustlessly — without it the
+  // flow degrades to buyer-confirmed ("I've paid").
+  const verifyUrl =
+    typeof invoiceData.verify === 'string' && invoiceData.verify.startsWith('https://')
+      ? invoiceData.verify
+      : null;
+
   return {
     bolt11: invoiceData.pr,
     payment_hash: null, // LNURL-pay doesn't always return payment_hash directly
     onchain_address: null,
+    lnurl_verify_url: verifyUrl,
     qr_data: invoiceData.pr.toUpperCase(),
     expires_at: new Date(Date.now() + LIGHTNING_INVOICE_EXPIRY_SECS * 1000).toISOString(),
   };
@@ -175,6 +187,7 @@ async function generateOnchainInvoice(
     bolt11: null,
     payment_hash: null,
     onchain_address: address,
+    lnurl_verify_url: null,
     qr_data: bip21Uri,
     // On-chain payments don't expire — address is valid forever
     expires_at: null,

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -19,7 +19,11 @@ import { convertToBTC } from '@/services/currency/rates';
 import type { CurrencyCode } from '@/config/currencies';
 import { resolveSellerWallet, getSellerUserId } from './walletResolutionService';
 import { generateInvoice } from './invoiceGenerationService';
-import { checkNWCPaymentStatus, checkOnchainPaymentStatus } from './paymentStatusService';
+import {
+  checkNWCPaymentStatus,
+  checkOnchainPaymentStatus,
+  checkLnurlVerifyPaymentStatus,
+} from './paymentStatusService';
 import type {
   InitiatePaymentInput,
   InitiatePaymentResult,
@@ -87,6 +91,7 @@ export async function initiatePayment(
       bolt11: invoice.bolt11,
       payment_hash: invoice.payment_hash,
       onchain_address: invoice.onchain_address,
+      lnurl_verify_url: invoice.lnurl_verify_url,
       status:
         invoice.bolt11 || invoice.onchain_address
           ? STATUS.PAYMENT_INTENTS.INVOICE_READY
@@ -211,6 +216,15 @@ export async function checkPaymentStatus(
   // For NWC, actively check via relay
   if (pi.payment_method === 'nwc' && pi.payment_hash) {
     const paid = await checkNWCPaymentStatus(supabase, pi);
+    if (paid) {
+      await handlePaymentConfirmed(supabase, pi);
+      return { status: STATUS.PAYMENT_INTENTS.PAID, paid_at: new Date().toISOString() };
+    }
+  }
+
+  // For lightning_address with LUD-21 support, actively check the verify URL
+  if (pi.payment_method === 'lightning_address' && pi.lnurl_verify_url) {
+    const paid = await checkLnurlVerifyPaymentStatus(pi);
     if (paid) {
       await handlePaymentConfirmed(supabase, pi);
       return { status: STATUS.PAYMENT_INTENTS.PAID, paid_at: new Date().toISOString() };

--- a/src/domain/payments/paymentStatusService.ts
+++ b/src/domain/payments/paymentStatusService.ts
@@ -3,7 +3,8 @@
  *
  * Checks payment status using the appropriate method:
  * - NWC: lookup_invoice via Nostr relay
- * - Lightning Address: buyer-confirmed (no server-side verification)
+ * - Lightning Address: LNURL-verify (LUD-21) when the provider supports it,
+ *   otherwise buyer-confirmed (no server-side verification)
  * - On-chain: Mempool.space API polling
  */
 
@@ -68,6 +69,39 @@ export async function checkNWCPaymentStatus(
     return false;
   } finally {
     client.disconnect();
+  }
+}
+
+/**
+ * Check if a lightning_address payment has settled via its LUD-21 verify URL.
+ *
+ * The verify endpoint returns `{ status: "OK", settled: boolean, ... }`.
+ * Returns true only on an explicit `settled: true`. Never throws — network or
+ * provider errors are logged and treated as "not settled yet".
+ */
+export async function checkLnurlVerifyPaymentStatus(
+  paymentIntent: Pick<PaymentIntent, 'id' | 'lnurl_verify_url'>
+): Promise<boolean> {
+  if (!paymentIntent.lnurl_verify_url) {
+    return false;
+  }
+
+  try {
+    const response = await fetch(paymentIntent.lnurl_verify_url, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) {
+      return false;
+    }
+
+    const data = (await response.json()) as { status?: string; settled?: boolean };
+    return data.status === 'OK' && data.settled === true;
+  } catch (error) {
+    logger.warn('LNURL-verify check failed', {
+      paymentIntentId: paymentIntent.id,
+      error,
+    });
+    return false;
   }
 }
 

--- a/src/domain/payments/types.ts
+++ b/src/domain/payments/types.ts
@@ -31,6 +31,8 @@ export interface PaymentIntent {
   bolt11: string | null;
   payment_hash: string | null;
   onchain_address: string | null;
+  /** LUD-21 verify URL — enables trustless settlement detection for lightning_address */
+  lnurl_verify_url: string | null;
   status: PaymentIntentStatus;
   description: string | null;
   expires_at: string | null;

--- a/supabase/migrations/20260702000000_payment_intents_lnurl_verify.sql
+++ b/supabase/migrations/20260702000000_payment_intents_lnurl_verify.sql
@@ -1,0 +1,8 @@
+-- LNURL-verify (LUD-21) support: lightning-address invoices can carry a verify URL
+-- returned by the LNURL-pay callback. Polling it lets us settle lightning_address
+-- payments trustlessly instead of falling back to buyer "I've paid" confirmation.
+ALTER TABLE payment_intents
+  ADD COLUMN IF NOT EXISTS lnurl_verify_url text;
+
+COMMENT ON COLUMN payment_intents.lnurl_verify_url IS
+  'LUD-21 verify URL from the LNURL-pay callback; polled to auto-detect settlement for lightning_address payments.';


### PR DESCRIPTION
Phase 0 of the master plan (docs/business/executive/master-plan-2026-07.md).

## Payments
- Capture the LUD-21 `verify` URL from LNURL-pay callbacks, persist on `payment_intents` (migration `20260702000000`, **already applied to prod**), and poll it in `checkPaymentStatus` — lightning-address payments now settle trustlessly instead of via buyer 'I've paid'. Verified live: coinos.io (the wallet from the only real payment attempt) returns verify URLs.
- 8 new tests covering the money path.

## Trust scrub
- Blog fee claims reconciled to the canonical **0% platform fee** positioning (was 95%/99%/0.1% across two Dec-2025 posts).
- Removed the Suspense fallback that shipped 'Loading blog posts…' in served HTML.

Also includes the master plan document.

Prod-side actions already done (not in this diff): test orgs hidden from public listings, backup stub-dump bug fixed on the box, FC OAuth secret rotated + installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)