### PR TITLE
feat(credits): Phase 2 — frontier metering, BTC-only units, honest pricing

### DIFF
--- a/__tests__/unit/api/entities.schema.smoke.test.ts
+++ b/__tests__/unit/api/entities.schema.smoke.test.ts
@@ -21,7 +21,7 @@ describe('Entity schema smoke validation', () => {
       min_funding_sats: 1000,
       funding_type: 'all_or_nothing',
       deadline: new Date(Date.now() + 86400000).toISOString(),
-      currency: 'SATS',
+      currency: 'BTC',
       transparency_mode: 'public',
       status: 'draft',
     });
@@ -35,7 +35,7 @@ describe('Entity schema smoke validation', () => {
       description: 'desc',
       category: 'test',
       price: 1500,
-      currency: 'SATS',
+      currency: 'BTC',
       product_type: 'physical',
       images: [],
     });
@@ -49,7 +49,7 @@ describe('Entity schema smoke validation', () => {
       description: 'desc',
       category: 'consulting',
       fixed_price: 5000,
-      currency: 'SATS',
+      currency: 'BTC',
       service_location_type: 'remote',
     });
 
@@ -62,7 +62,7 @@ describe('Entity schema smoke validation', () => {
       description: 'desc',
       cause_category: 'Healthcare',
       goal_amount: 20000,
-      currency: 'SATS',
+      currency: 'BTC',
       lightning_address: '',
       beneficiaries: [],
     });
@@ -76,7 +76,7 @@ describe('Entity schema smoke validation', () => {
       type: 'real_estate',
       description: 'Asset description',
       estimated_value: 1000000,
-      currency: 'SATS',
+      currency: 'BTC',
       documents: [],
     });
 
@@ -108,7 +108,7 @@ describe('Entity schema smoke validation', () => {
       is_online: true,
       online_url: 'https://example.com/meet',
       ticket_price: 1000,
-      currency: 'SATS',
+      currency: 'BTC',
       lightning_address: '',
     });
 

--- a/__tests__/unit/cat/credit-metering.test.ts
+++ b/__tests__/unit/cat/credit-metering.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Cat Credit usage metering — money path.
+ *
+ * The unit is BTC everywhere: this suite pins the 2026-07-02 fix where
+ * calculateCostBtc returned satoshis despite its name (a 1e8 drift that would
+ * have drained balances). It also pins the metering rules: only paid registry
+ * models bill, the debit is cost × markup rounded up to 1e-8, and a failed
+ * ledger append never throws at the user.
+ */
+
+import {
+  meterCreditUsage,
+  checkFrontierAccess,
+  isPlatformMeteredModel,
+  CREDIT_USAGE_MARKUP,
+  MIN_FRONTIER_BALANCE_BTC,
+} from '@/services/cat/credit-metering';
+import { calculateCostBtc, getFreeModels, getAvailableModels } from '@/config/ai-models';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+// Live-rate lookup is best-effort; pin it for determinism.
+jest.mock('@/services/currency/rates', () => ({
+  convertFromBTC: jest.fn().mockResolvedValue(100000), // 1 BTC = 100k USD
+}));
+
+const appendCreditEntry = jest.fn();
+const getCreditBalance = jest.fn();
+jest.mock('@/services/cat/credits', () => ({
+  appendCreditEntry: (...a: unknown[]) => appendCreditEntry(...a),
+  getCreditBalance: (...a: unknown[]) => getCreditBalance(...a),
+}));
+
+const admin = {} as never;
+const PAID_MODEL = getAvailableModels().find(m => m.tier !== 'free')?.id as string;
+const FREE_MODEL = getFreeModels()[0]?.id as string;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('calculateCostBtc returns BTC, not satoshis', () => {
+  it('a ~$0.01 completion costs ~1e-7 BTC (would be ~10 BTC under the sats bug)', () => {
+    // Any paid model: cost scales linearly, so assert the magnitude bound.
+    const cost = calculateCostBtc(PAID_MODEL, 1000, 1000, 100000);
+    expect(cost).toBeGreaterThan(0);
+    expect(cost).toBeLessThan(0.001); // sats-bug values were >= 1 whole unit
+  });
+
+  it('rounds up to ledger precision instead of billing 0', () => {
+    const cost = calculateCostBtc(PAID_MODEL, 1, 1, 100000);
+    expect(cost).toBeGreaterThanOrEqual(0.00000001);
+  });
+
+  it('unknown models cost 0', () => {
+    expect(calculateCostBtc('no-such-model', 1000, 1000)).toBe(0);
+  });
+});
+
+describe('isPlatformMeteredModel', () => {
+  it('true for paid registry models only', () => {
+    expect(isPlatformMeteredModel(PAID_MODEL)).toBe(true);
+    expect(isPlatformMeteredModel(FREE_MODEL)).toBe(false);
+    expect(isPlatformMeteredModel('not-in-registry')).toBe(false);
+    expect(isPlatformMeteredModel(undefined)).toBe(false);
+  });
+});
+
+describe('checkFrontierAccess', () => {
+  it('allows at or above the minimum balance', async () => {
+    getCreditBalance.mockResolvedValue(MIN_FRONTIER_BALANCE_BTC);
+    await expect(checkFrontierAccess(admin, 'u1')).resolves.toEqual({
+      allowed: true,
+      balanceBtc: MIN_FRONTIER_BALANCE_BTC,
+    });
+  });
+
+  it('denies below it', async () => {
+    getCreditBalance.mockResolvedValue(0);
+    await expect(checkFrontierAccess(admin, 'u1')).resolves.toMatchObject({ allowed: false });
+  });
+});
+
+describe('meterCreditUsage', () => {
+  it('debits cost × markup as a negative usage entry with the request ref', async () => {
+    appendCreditEntry.mockResolvedValue(0.001);
+    const charged = await meterCreditUsage(admin, 'u1', {
+      model: PAID_MODEL,
+      inputTokens: 100000,
+      outputTokens: 100000,
+      ref: 'cat_chat_abc',
+    });
+
+    expect(charged).toBeGreaterThan(0);
+    expect(appendCreditEntry).toHaveBeenCalledTimes(1);
+    const [, userId, entry] = appendCreditEntry.mock.calls[0] as [unknown, string, any];
+    expect(userId).toBe('u1');
+    expect(entry.kind).toBe('usage');
+    expect(entry.ref).toBe('cat_chat_abc');
+    expect(entry.amountBtc).toBeCloseTo(-charged, 10);
+
+    // Charge covers the raw cost plus the platform margin.
+    const raw = calculateCostBtc(PAID_MODEL, 100000, 100000, 100000);
+    expect(charged).toBeGreaterThanOrEqual(raw * CREDIT_USAGE_MARKUP - 1e-8);
+    expect(charged).toBeLessThan(raw * CREDIT_USAGE_MARKUP + 1e-7);
+  });
+
+  it('never bills free or unknown models', async () => {
+    await meterCreditUsage(admin, 'u1', {
+      model: FREE_MODEL,
+      inputTokens: 5000,
+      outputTokens: 5000,
+      ref: 'r1',
+    });
+    await meterCreditUsage(admin, 'u1', {
+      model: 'no-such-model',
+      inputTokens: 5000,
+      outputTokens: 5000,
+      ref: 'r2',
+    });
+    expect(appendCreditEntry).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 (never throws) when the ledger append fails', async () => {
+    appendCreditEntry.mockResolvedValue(null);
+    await expect(
+      meterCreditUsage(admin, 'u1', {
+        model: PAID_MODEL,
+        inputTokens: 100000,
+        outputTokens: 100000,
+        ref: 'r3',
+      })
+    ).resolves.toBe(0);
+  });
+});

--- a/__tests__/unit/hooks/useDisplayCurrency.test.ts
+++ b/__tests__/unit/hooks/useDisplayCurrency.test.ts
@@ -44,25 +44,9 @@ describe('useDisplayCurrency', () => {
     const chf = renderHook(() => useDisplayCurrency());
     expect(chf.result.current.formatSats(0)).toBe('CHF 0.00');
 
-    mockCurrency = 'SATS';
-    const sats = renderHook(() => useDisplayCurrency());
-    expect(sats.result.current.formatSats(0)).toBe('0 sat');
-
     mockCurrency = 'BTC';
     const btc = renderHook(() => useDisplayCurrency());
     expect(btc.result.current.formatSats(0)).toBe('₿0');
-  });
-
-  it('respects forceSats regardless of preference', () => {
-    mockCurrency = 'CHF';
-    const { result } = renderHook(() => useDisplayCurrency());
-    expect(result.current.formatSats(100_000, { forceSats: true })).toBe('100,000 sat');
-  });
-
-  it('renders sats preference as raw sats', () => {
-    mockCurrency = 'SATS';
-    const { result } = renderHook(() => useDisplayCurrency());
-    expect(result.current.formatSats(100_000)).toBe('100,000 sat');
   });
 
   it('renders BTC preference with the ₿ symbol', () => {
@@ -81,11 +65,5 @@ describe('useDisplayCurrency', () => {
     expect(out).not.toMatch(/sat/i);
     expect(out).toMatch(/BTC|₿/);
     expect(result.current.isLoading).toBe(true);
-  });
-
-  it('shows both fiat and sats when requested', () => {
-    mockCurrency = 'CHF';
-    const { result } = renderHook(() => useDisplayCurrency());
-    expect(result.current.formatSats(100_000, { showBoth: true })).toBe('CHF 86.00 (100,000 sat)');
   });
 });

--- a/__tests__/unit/utils/currency-helpers.test.ts
+++ b/__tests__/unit/utils/currency-helpers.test.ts
@@ -10,8 +10,9 @@ describe('isBitcoinNativeCurrency', () => {
     expect(isBitcoinNativeCurrency('BTC')).toBe(true);
   });
 
-  it('returns true for SATS', () => {
-    expect(isBitcoinNativeCurrency('SATS')).toBe(true);
+  it('returns false for SATS — satoshis are not a product currency', () => {
+    // @ts-expect-error SATS was removed from CurrencyCode (2026-07-02)
+    expect(isBitcoinNativeCurrency('SATS')).toBe(false);
   });
 
   it('returns false for CHF', () => {
@@ -52,13 +53,13 @@ describe('isFiatCurrency', () => {
     expect(isFiatCurrency('BTC')).toBe(false);
   });
 
-  it('returns false for SATS', () => {
-    expect(isFiatCurrency('SATS')).toBe(false);
+  it('returns false for BTC-only edge', () => {
+    expect(isFiatCurrency('BTC')).toBe(false);
   });
 });
 
 describe('getGoalExplanation', () => {
-  const currencies: Currency[] = ['BTC', 'SATS', 'CHF', 'USD', 'EUR', 'GBP'];
+  const currencies: Currency[] = ['BTC', 'CHF', 'USD', 'EUR', 'GBP'];
 
   // Verify no thrown errors and always returns a non-empty string
   for (const currency of currencies) {

--- a/docs/business/executive/strategic-plan.md
+++ b/docs/business/executive/strategic-plan.md
@@ -59,12 +59,29 @@ OrangeCat is building the infrastructure for personal economies and voluntary so
 
 ## 💰 Business Model
 
-### Revenue Streams
+> Updated 2026-07-02 per `master-plan-2026-07.md` §3.3 — "sell intelligence,
+> not rails". The previous transaction-fee model contradicted both the
+> non-custodial legal posture (the platform never processes or holds funds)
+> and the public 0%-fee positioning, and is retired.
 
-1. **Platform Fees:** Percentage-based fees on successful Bitcoin transactions
-2. **Premium AI Features:** Enhanced AI capabilities, custom integrations, priority support
-3. **Professional Services:** AI consulting and custom implementations for enterprises
-4. **Data & Insights:** Aggregated market intelligence and analytics (future)
+### The model: 0% rails, paid intelligence
+
+1. **Peer-to-peer payments: 0% platform fees, forever, non-custodial.**
+   Payments settle wallet-to-wallet (NWC / Lightning address / on-chain);
+   OrangeCat never touches the funds. This is the marketing wedge AND the
+   legal posture — never reintroduce a transaction take-rate.
+2. **Cat Credits (built, primary revenue):** prepaid Lightning top-ups spent
+   on platform-served frontier AI, billed at provider cost + 20% margin
+   (SSOT: `src/services/cat/credit-metering.ts`). Selling our own service —
+   prepaid credits — not payment processing.
+3. **Paid AI assistants (built):** creators charge per message; the platform
+   keeps 5% of the AI-service price (95% creator share). The only take-rate,
+   and it is on platform-mediated AI services, not P2P money.
+4. **Supporter subscription (future):** a flat CHF/month plan (proposal:
+   CHF 10) with a monthly frontier allowance. Deliberately NOT advertised
+   until it can actually be purchased.
+5. **Professional services / data insights:** long-horizon options, not
+   planned revenue.
 
 ### Cost Structure
 
@@ -87,16 +104,22 @@ OrangeCat is building the infrastructure for personal economies and voluntary so
 - **Channels:** Bitcoin communities, tech forums, professional networks
 - **Goals:** Establish user base, validate AI assistant value proposition
 
-### Phase 2: Professional Adoption
+### Phase 2: AI-assisted builders (primary ICP — updated 2026-07-02)
 
-- **Target:** High-value professionals (lawyers, doctors, consultants)
-- **Channels:** Industry associations, professional networks, content marketing
-- **Goals:** Build reputation in professional segments, establish revenue
+- **Target:** Solo builders and micro-studios shipping with AI agents —
+  FleetCrown's exact audience; people who need a public economic presence
+  without a company, a Stripe account, or a real name
+- **Channels:** FleetCrown cross-sell (identity bridge, live since
+  2026-07-02), founder's build-in-public loop, Swiss Bitcoin community
+- **Goals:** Closed loops — published offers, completed payments, credit
+  spend. (The earlier lawyers/doctors persona set is retired; it was
+  AI-generated fiction never validated against a real user.)
 
 ### Phase 3: Market Expansion
 
-- **Target:** Broader professional and creative communities
-- **Channels:** Partnerships, referrals, content-driven growth
+- **Target:** Broader creative and pseudonymous-builder communities
+- **Channels:** Partnerships, referrals, content-driven growth, SEO from
+  server-rendered public entity pages
 - **Goals:** Scale adoption, refine AI capabilities based on user feedback
 
 ## 🎯 Product Roadmap
@@ -207,6 +230,3 @@ OrangeCat is building the infrastructure for personal economies and voluntary so
 - [Future updates will be tracked here]
 
 **Approval:** Founder & CEO
-
-
-

--- a/docs/business/legal/legal-compliance-overview.md
+++ b/docs/business/legal/legal-compliance-overview.md
@@ -161,7 +161,14 @@ Based on codebase analysis, OrangeCat:
 
 ### Tax Implications
 
-- **Platform Fees:** OrangeCat's revenue from transaction fees may be subject to VAT/sales tax
+- **Platform Revenue:** OrangeCat charges NO transaction fees (updated
+  2026-07-02 — consistent with the pure-facilitation posture above). Revenue
+  comes from selling the platform's own AI service: prepaid Cat Credits
+  (Bitcoin top-ups spent on managed frontier-model usage, cost + margin) and
+  a 5% platform share on paid AI-assistant messages. As a prepaid service
+  sold by the platform, this is ordinary service revenue — likely subject to
+  Swiss VAT once over the registration threshold; confirm treatment of
+  Bitcoin-denominated prepaid balances with a Swiss tax advisor.
 - **User Transactions:** Not taxable by platform (peer-to-peer)
 - **No Withholding:** No tax withholding obligations for Bitcoin transactions
 
@@ -364,6 +371,3 @@ Based on codebase analysis:
 **KEY TAKEAWAY:** OrangeCat's peer-to-peer model significantly reduces regulatory complexity compared to traditional fintech platforms. However, professional legal counsel is still essential for proper compliance implementation.
 
 **This document is for informational purposes only and does not constitute legal advice. OrangeCat must obtain professional legal counsel before proceeding with any platform development or launch activities.\*\***
-
-
-

--- a/src/app/api/cat/credits/route.ts
+++ b/src/app/api/cat/credits/route.ts
@@ -1,7 +1,7 @@
 /**
  * Cat Credits API
  *
- * GET /api/cat/credits - Your sats credit balance + ledger history
+ * GET /api/cat/credits - Your Cat Credit balance (BTC) + ledger history
  *
  * Read-only. Balance is derived from the cat_credit_entries ledger (SSOT).
  * Top-up (Lightning) and usage metering post entries server-side via

--- a/src/components/ai/TopUpDialog.tsx
+++ b/src/components/ai/TopUpDialog.tsx
@@ -17,7 +17,7 @@ import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { logger } from '@/utils/logger';
 import { API_ROUTES } from '@/config/api-routes';
 
-/** Preset amounts in BTC (1-sat precision): 10k / 50k / 100k sats. */
+/** Preset top-up amounts in BTC. */
 const PRESETS_BTC = [0.0001, 0.0005, 0.001];
 const POLL_MS = 3000;
 

--- a/src/components/create/DynamicSidebar.tsx
+++ b/src/components/create/DynamicSidebar.tsx
@@ -27,7 +27,7 @@ interface DynamicSidebarProps<T extends string = string> {
   guidanceContent: Record<NonNullable<T>, FieldGuidanceContent>;
   defaultContent: DefaultContent;
   goalAmount?: number;
-  goalCurrency?: 'CHF' | 'USD' | 'EUR' | 'BTC' | 'SATS';
+  goalCurrency?: 'CHF' | 'USD' | 'EUR' | 'BTC';
   className?: string;
 }
 

--- a/src/components/project/ProjectContent.tsx
+++ b/src/components/project/ProjectContent.tsx
@@ -118,7 +118,6 @@ export default function ProjectContent({ project }: ProjectContentProps) {
                           | 'USD'
                           | 'EUR'
                           | 'BTC'
-                          | 'SATS'
                       }
                     />
                   </div>
@@ -132,7 +131,6 @@ export default function ProjectContent({ project }: ProjectContentProps) {
                           | 'USD'
                           | 'EUR'
                           | 'BTC'
-                          | 'SATS'
                       }
                     />
                   </div>

--- a/src/components/ui/BTCAmountDisplay.tsx
+++ b/src/components/ui/BTCAmountDisplay.tsx
@@ -27,8 +27,8 @@ export default function BTCAmountDisplay({
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    // Skip conversion if already in BTC/SATS
-    if (currency === 'BTC' || currency === 'SATS') {
+    // Skip conversion if already in BTC
+    if (currency === 'BTC') {
       setIsLoading(false);
       return;
     }
@@ -70,14 +70,12 @@ export default function BTCAmountDisplay({
     };
   }, [amount, currency]);
 
-  // If already in BTC/SATS, just show the amount
-  if (currency === 'BTC' || currency === 'SATS') {
+  // If already in BTC, just show the amount
+  if (currency === 'BTC') {
     return (
       <span className={`inline-flex items-center gap-1 ${className}`}>
         {showIcon && <Bitcoin className="w-3 h-3 text-bitcoinOrange" />}
-        <span>
-          {currencyConverter.formatBTC(currency === 'BTC' ? amount : amount / 100_000_000)}
-        </span>
+        <span>{currencyConverter.formatBTC(amount)}</span>
       </span>
     );
   }

--- a/src/components/ui/CurrencyDisplay.tsx
+++ b/src/components/ui/CurrencyDisplay.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/lib/utils';
 
 interface CurrencyDisplayProps {
   amount: number | string;
-  currency: 'BTC' | 'USD' | 'CHF' | 'EUR' | 'SATS' | string;
+  currency: 'BTC' | 'USD' | 'CHF' | 'EUR' | string;
   size?: 'sm' | 'md' | 'lg' | 'xl';
   className?: string;
   showSymbol?: boolean;
@@ -50,11 +50,6 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
         // BTC: up to 8 decimal places, remove trailing zeros
         const btcFormatted = numAmount.toFixed(8).replace(/\.?0+$/, '');
         return showSymbol ? `${btcFormatted} BTC` : btcFormatted;
-      case 'SATS':
-        // SATS: no decimals, with thousand separators
-        return showSymbol
-          ? `${Math.round(numAmount).toLocaleString('en-US')} sat`
-          : Math.round(numAmount).toLocaleString('en-US');
       case 'USD':
         // Fiat currencies: 2 decimal places
         const usdFormatted = numAmount.toLocaleString('en-US', {

--- a/src/components/ui/CurrencyInput.tsx
+++ b/src/components/ui/CurrencyInput.tsx
@@ -3,9 +3,9 @@
 import { ArrowLeftRight, Bitcoin, Info } from 'lucide-react';
 import { Input } from '@/components/ui/Input';
 import { Currency, ALL_CURRENCIES } from '@/types/settings';
-import { formatCurrency, bitcoinToSats } from '@/services/currency';
+import { formatCurrency } from '@/services/currency';
 import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
-import { getGoalExplanation, isBitcoinNativeCurrency } from '@/utils/currency-helpers';
+import { getGoalExplanation } from '@/utils/currency-helpers';
 import { useCurrencyInput } from './useCurrencyInput';
 
 interface CurrencyInputProps {
@@ -86,7 +86,7 @@ export function CurrencyInput({
             onChange={handleInputChange}
             onFocus={onFocus}
             onBlur={() => handleBlur(onBlur)}
-            placeholder={placeholder || (inputCurrency === 'SATS' ? '0' : '0.00')}
+            placeholder={placeholder || '0.00'}
             disabled={disabled}
             className={`rounded-r-none ${error ? 'border-destructive' : ''}`}
           />
@@ -146,17 +146,8 @@ export function CurrencyInput({
               </div>
             )}
 
-            {inputCurrency !== 'SATS' && (
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground">SATS</span>
-                <span className="font-mono font-medium text-foreground">
-                  {bitcoinToSats(breakdown.btc).toLocaleString('en-US')}
-                </span>
-              </div>
-            )}
-
             {Object.entries(breakdown.other)
-              .slice(0, inputCurrency === 'BTC' || inputCurrency === 'SATS' ? 3 : 2)
+              .slice(0, inputCurrency === 'BTC' ? 3 : 2)
               .map(([curr, amount]) => (
                 <div key={curr} className="flex justify-between items-center">
                   <span className="text-muted-foreground">{curr}</span>
@@ -172,8 +163,6 @@ export function CurrencyInput({
             <p className="text-xs text-muted-foreground">
               All transactions settle in Bitcoin. Amounts shown are estimates based on current
               exchange rates.
-              {isBitcoinNativeCurrency(inputCurrency) &&
-                ' SATS shown for Bitcoin-native convenience.'}
             </p>
           </div>
         </div>

--- a/src/components/ui/useCurrencyInput.ts
+++ b/src/components/ui/useCurrencyInput.ts
@@ -47,8 +47,6 @@ export function useCurrencyInput(
       let formatted: string;
       if (inputCurrency === 'BTC') {
         formatted = numValue.toFixed(8).replace(/\.?0+$/, '');
-      } else if (inputCurrency === 'SATS') {
-        formatted = Math.round(numValue).toLocaleString('en-US', { maximumFractionDigits: 0 });
       } else {
         formatted = numValue.toFixed(2);
       }

--- a/src/components/wallets/WalletManager/components/WalletForm.tsx
+++ b/src/components/wallets/WalletManager/components/WalletForm.tsx
@@ -206,7 +206,6 @@ export function WalletForm({
             <option value="USD">USD</option>
             <option value="EUR">EUR</option>
             <option value="BTC">BTC</option>
-            <option value="SATS">SATS</option>
           </select>
         </div>
       </div>

--- a/src/config/ai-models.ts
+++ b/src/config/ai-models.ts
@@ -388,13 +388,18 @@ export function getAvailableModels(): AIModelMetadata[] {
 }
 
 /**
- * Calculate cost in satoshis for a given model and token usage
+ * Calculate inference cost in BTC (the canonical unit) for a model + token usage.
+ *
+ * Rounds UP to 1e-8 (the ledger/DB precision) so tiny completions never bill
+ * as zero. Historical bug fixed 2026-07-02: this returned SATOSHIS despite the
+ * name, which would have drifted every BTC-denominated column it fed
+ * (ai_messages.api_cost_btc / cost_btc) by 1e8.
  *
  * @param modelId - The model ID
  * @param inputTokens - Number of input tokens
  * @param outputTokens - Number of output tokens
  * @param btcPriceUsd - Current BTC price in USD (default: 100000)
- * @returns Cost in satoshis
+ * @returns Cost in BTC
  */
 export function calculateCostBtc(
   modelId: string,
@@ -411,9 +416,7 @@ export function calculateCostBtc(
   const outputCostUsd = (outputTokens / 1_000_000) * model.outputCostPer1M;
   const totalCostUsd = inputCostUsd + outputCostUsd;
 
-  // Convert USD to sats (1 BTC = 100M sats)
-  const satsPerUsd = 100_000_000 / btcPriceUsd;
-  return Math.ceil(totalCostUsd * satsPerUsd);
+  return Math.ceil((totalCostUsd / btcPriceUsd) * 1e8) / 1e8;
 }
 
 // ==================== CONSTANTS ====================

--- a/src/config/cat-plans.ts
+++ b/src/config/cat-plans.ts
@@ -1,14 +1,17 @@
 /**
  * Cat plans — SSOT for the pricing page and any in-product upgrade CTA.
  *
- * Three plans, honest about what's shipped:
- *   - free → what every user gets today (10 msgs/day on free models)
- *   - byok → already implemented; zero platform cost; recommended for power users
- *   - pro  → managed frontier AI, not live yet. OrangeCat has no fiat rails
- *            yet (can't bill francs or pay inference providers in fiat), so the
- *            franc price is a future anchor and the CTA routes to /support:
- *            back OrangeCat in Bitcoin as a founding supporter (a donation, NOT
- *            redeemable inference) + use BYOK to get frontier models today.
+ * Three plans, honest about what's shipped ("sell intelligence, not rails" —
+ * P2P payments stay 0% forever; the platform earns on Cat Credits):
+ *   - free    → what every user gets today (10 msgs/day on free models)
+ *   - byok    → already implemented; zero platform cost; for power users
+ *   - credits → pay-as-you-go frontier AI, billed in Bitcoin against a
+ *               prepaid Cat Credit balance (ledger + metering are live in
+ *               code; Lightning top-up activates with the platform wallet —
+ *               flip CAT_CREDITS_LIVE when PLATFORM_NWC_URI is provisioned).
+ *
+ * A flat Supporter subscription (CHF/month) may come later; it is deliberately
+ * NOT a card until it can actually be bought.
  *
  * The /pricing page and QuotaMeter both read from this file. If the daily
  * limit changes, update CAT_FREE_DAILY_LIMIT here and api-key-service.ts in
@@ -17,7 +20,17 @@
 
 import { ROUTES } from '@/config/routes';
 
-export type CatPlanId = 'free' | 'byok' | 'pro';
+export type CatPlanId = 'free' | 'byok' | 'credits';
+
+/**
+ * Flip to true the moment the platform Lightning wallet (PLATFORM_NWC_URI)
+ * is provisioned and one live top-up has been verified — the credits card
+ * then switches from "activating" to a live top-up CTA.
+ */
+export const CAT_CREDITS_LIVE = false;
+
+/** Platform margin on frontier inference billed to Cat Credits (SSOT: credit-metering.ts). */
+export const CAT_CREDITS_MARKUP_LABEL = 'provider cost + 20%';
 
 export interface CatPlan {
   id: CatPlanId;
@@ -100,19 +113,20 @@ export const CAT_PLANS: CatPlan[] = [
     badge: 'Available now',
   },
   {
-    id: 'pro',
-    name: 'Pro',
-    tagline: 'Managed frontier AI — zero setup',
-    // Franc price as the future anchor; the card makes clear it's not live yet.
-    priceCopy: 'CHF 19 / mo · founding access',
+    id: 'credits',
+    name: 'Cat Credits',
+    tagline: 'Pay as you go — managed frontier AI, billed in Bitcoin',
+    priceCopy: `Top up over Lightning · ${CAT_CREDITS_MARKUP_LABEL}`,
     bullets: [
       `Frontier models (${CAT_FRONTIER_MODELS_LIST}) managed by OrangeCat — no keys, no setup`,
-      'Higher limits, smarter defaults, full agentic Cat (discovery, matchmaking, multi-step)',
-      'Fiat billing is coming — until then, back us in Bitcoin as a founding supporter',
-      'Founding supporters get recognition and first access the day Pro goes live',
+      'No subscription: you pay only for what the Cat actually computes',
+      'Prepaid balance, transparent per-message ledger, top up from 0.00001 BTC',
+      'Full agentic Cat: discovery, matchmaking, multi-step tasks',
     ],
-    cta: { label: 'Become a founding supporter', href: ROUTES.SUPPORT, variant: 'outline' },
-    status: 'coming-soon',
-    badge: 'Founding access',
+    cta: CAT_CREDITS_LIVE
+      ? { label: 'Top up credits', href: ROUTES.SETTINGS_AI, variant: 'accent' }
+      : { label: 'Back us as a founding supporter', href: ROUTES.SUPPORT, variant: 'outline' },
+    status: CAT_CREDITS_LIVE ? 'available' : 'coming-soon',
+    badge: CAT_CREDITS_LIVE ? 'Live' : 'Activating',
   },
 ];

--- a/src/config/currencies.ts
+++ b/src/config/currencies.ts
@@ -5,7 +5,8 @@
  * All database constraints, validation schemas, and UI components MUST use these values.
  *
  * IMPORTANT:
- * - All transactions are stored and settled in BTC (satoshis)
+ * - Bitcoin amounts are stored and settled in BTC — the canonical unit.
+ *   Satoshis are a Lightning protocol detail and are NOT a currency here.
  * - Currency is ONLY for display and input purposes
  * - Users can set their preferred currency in settings (stored in profiles.currency)
  * - Default currency is CHF (Swiss-focused platform)
@@ -14,11 +15,11 @@
  * Database migrations MUST reference these values - do NOT hardcode currency lists.
  *
  * Created: 2025-01-03
- * Last Modified: 2026-01-05
- * Last Modified Summary: Established as SSOT with clear documentation about BTC-only transactions
+ * Last Modified: 2026-07-02
+ * Last Modified Summary: Removed SATS as a currency code — BTC is the only Bitcoin unit (prod had zero SATS rows).
  */
 
-export const CURRENCY_CODES = ['USD', 'EUR', 'CHF', 'GBP', 'BTC', 'SATS'] as const;
+export const CURRENCY_CODES = ['USD', 'EUR', 'CHF', 'GBP', 'BTC'] as const;
 export type CurrencyCode = (typeof CURRENCY_CODES)[number];
 
 /**
@@ -37,13 +38,9 @@ export const CURRENCY_METADATA: Record<
   CHF: { label: 'CHF (Swiss Franc)', symbol: 'CHF', precision: 2 },
   GBP: { label: 'GBP (British Pound)', symbol: '£', precision: 2 },
   BTC: { label: 'BTC (Bitcoin)', symbol: '₿', precision: 8 },
-  SATS: { label: 'Satoshis', symbol: 'sat', precision: 0 },
 };
 
-// SATS stays a valid code for internal/Lightning-protocol use, but is never
-// offered as a user-facing DISPLAY currency — the platform never shows amounts
-// in sats (always a fiat currency or BTC).
-export const currencySelectOptions = CURRENCY_CODES.filter(code => code !== 'SATS').map(code => ({
+export const currencySelectOptions = CURRENCY_CODES.map(code => ({
   value: code,
   label: CURRENCY_METADATA[code].label,
 }));

--- a/src/config/entity-configs/event-config.ts
+++ b/src/config/entity-configs/event-config.ts
@@ -236,7 +236,7 @@ const fieldGroups: FieldGroup[] = [
         type: 'currency',
         placeholder: '50.00',
         min: 1,
-        hint: 'Price per ticket. Enter in your preferred currency. All transactions settle in Bitcoin. Tip: Use BTC or SATS for Bitcoin-native pricing (no price conversion).',
+        hint: 'Price per ticket. Enter in your preferred currency. All transactions settle in Bitcoin. Tip: price in BTC for Bitcoin-native pricing (no conversion).',
         showWhen: {
           field: 'is_free',
           value: false,

--- a/src/config/entity-configs/research-config.ts
+++ b/src/config/entity-configs/research-config.ts
@@ -366,7 +366,7 @@ export const researchConfig: EntityConfig<ResearchEntity> = {
       {
         field: 'funding_goal_btc',
         rule: (value: unknown) => typeof value === 'number' && value >= 0.00001,
-        message: 'Funding goal must be at least 0.00001 BTC (~1,000 sats)',
+        message: 'Funding goal must be at least 0.00001 BTC',
       },
       {
         field: 'team_members',

--- a/src/domain/commerce/service.ts
+++ b/src/domain/commerce/service.ts
@@ -108,7 +108,7 @@ interface CreateProductInput {
   title: string;
   description?: string | null;
   price: number;
-  currency?: 'SATS' | 'BTC' | 'USD' | 'EUR' | 'CHF';
+  currency?: 'BTC' | 'USD' | 'EUR' | 'CHF';
   product_type?: 'physical' | 'digital' | 'service';
   images?: string[];
   thumbnail_url?: string | null;
@@ -132,7 +132,7 @@ interface CreateServiceInput {
   category: string;
   hourly_rate?: number | null;
   fixed_price?: number | null;
-  currency?: 'SATS' | 'BTC' | 'USD' | 'EUR' | 'CHF';
+  currency?: 'BTC' | 'USD' | 'EUR' | 'CHF';
   duration_minutes?: number | null;
   availability_schedule?: AvailabilitySchedule;
   service_location_type?: 'remote' | 'onsite' | 'both';
@@ -224,7 +224,7 @@ interface CreateCauseInput {
   description?: string | null;
   cause_category: string;
   goal_amount?: number | null;
-  currency?: 'SATS' | 'BTC' | 'USD' | 'EUR' | 'CHF';
+  currency?: 'BTC' | 'USD' | 'EUR' | 'CHF';
   bitcoin_address?: string | null;
   lightning_address?: string | null;
   distribution_rules?: DistributionRules;

--- a/src/hooks/useCurrencyConversion.ts
+++ b/src/hooks/useCurrencyConversion.ts
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { currencyConverter, satsToBitcoin, bitcoinToSats } from '@/services/currency';
+import { currencyConverter } from '@/services/currency';
 import { type CurrencyCode } from '@/config/currencies';
 
 export function useCurrencyConversion() {
@@ -38,12 +38,9 @@ export function useCurrencyConversion() {
 
     const currency = fromCurrency.toUpperCase() as CurrencyCode;
 
-    // For BTC/SATS, no API call needed
+    // For BTC, no API call needed
     if (currency === 'BTC') {
       return amount;
-    }
-    if (currency === 'SATS') {
-      return satsToBitcoin(amount);
     }
 
     // Use last cached rates (synchronous)
@@ -83,9 +80,6 @@ export function useCurrencyConversion() {
 
     if (currency === 'BTC') {
       return amountBTC;
-    }
-    if (currency === 'SATS') {
-      return bitcoinToSats(amountBTC);
     }
 
     try {

--- a/src/hooks/useDisplayCurrency.ts
+++ b/src/hooks/useDisplayCurrency.ts
@@ -18,12 +18,7 @@ import { useCallback } from 'react';
 import { useUserCurrency } from './useUserCurrency';
 import { isFiatCurrency } from '@/utils/currency-helpers';
 import { useCurrencyConversion } from './useCurrencyConversion';
-import {
-  formatCurrency,
-  formatSats as formatRawSats,
-  satsToBitcoin,
-  bitcoinToSats,
-} from '@/services/currency';
+import { formatCurrency, satsToBitcoin, bitcoinToSats } from '@/services/currency';
 import type { CurrencyCode } from '@/config/currencies';
 
 interface DisplayCurrencyOptions {
@@ -31,10 +26,6 @@ interface DisplayCurrencyOptions {
   showSymbol?: boolean;
   /** Compact format for large numbers (default: false) */
   compact?: boolean;
-  /** Always show in sats regardless of user preference */
-  forceSats?: boolean;
-  /** Show both fiat and sats (e.g., "CHF 86.00 (100,000 sats)") */
-  showBoth?: boolean;
 }
 
 interface UseDisplayCurrencyReturn {
@@ -79,22 +70,14 @@ export function useDisplayCurrency(): UseDisplayCurrencyReturn {
 
   const formatSats = useCallback(
     (sats: number, options: DisplayCurrencyOptions = {}): string => {
-      const { showSymbol = true, compact = false, forceSats = false, showBoth = false } = options;
+      const { showSymbol = true, compact = false } = options;
 
       // Handle zero/invalid amounts
       if (!sats || sats === 0) {
-        if (forceSats || displayCurrency === 'SATS') {
-          return '0 sat';
-        }
         if (displayCurrency === 'BTC') {
           return showSymbol ? '₿0' : '0';
         }
         return formatCurrency(0, displayCurrency, { showSymbol, compact });
-      }
-
-      // If user prefers sats or forceSats is true
-      if (forceSats || displayCurrency === 'SATS') {
-        return formatRawSats(sats);
       }
 
       // If user prefers BTC
@@ -114,14 +97,7 @@ export function useDisplayCurrency(): UseDisplayCurrencyReturn {
         return formatCurrency(btc, 'BTC', { showSymbol, compact });
       }
 
-      const fiatFormatted = formatCurrency(fiatAmount, displayCurrency, { showSymbol, compact });
-
-      // Show both fiat and sats if requested
-      if (showBoth) {
-        return `${fiatFormatted} (${formatRawSats(sats)})`;
-      }
-
-      return fiatFormatted;
+      return formatCurrency(fiatAmount, displayCurrency, { showSymbol, compact });
     },
     [displayCurrency, convertFromBTC, isLoading]
   );

--- a/src/lib/validation/wishlist.ts
+++ b/src/lib/validation/wishlist.ts
@@ -49,11 +49,14 @@ export const wishlistItemSchema = z.object({
   external_source: z.string().max(100).optional().nullable(),
 
   // Funding
+  // BTC is the canonical unit — fractional amounts down to 1e-8. The old
+  // .int('whole satoshis') gate was a sats-era leftover that rejected every
+  // normal BTC value (0.001 etc.).
   target_amount_btc: z
     .number()
-    .int('Amount must be whole satoshis')
-    .positive('Target amount must be positive'),
-  currency: z.enum(CURRENCY_CODES).optional().default('SATS'),
+    .positive('Target amount must be positive')
+    .multipleOf(0.00000001, 'Amount has a maximum precision of 8 decimal places'),
+  currency: z.enum(CURRENCY_CODES).optional().default('BTC'),
   original_amount: z.number().positive().optional().nullable(),
 
   // Wallet routing

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -26,6 +26,8 @@ import {
   saveMessages,
 } from '@/services/cat/conversation-history';
 import { resolveProvider, type FallbackProvider } from '@/services/cat/provider-resolver';
+import { meterCreditUsage } from '@/services/cat/credit-metering';
+import { getAdminClient } from '@/lib/supabase/admin';
 import { recallMemories, extractAndStoreMemories } from '@/services/cat/memory';
 import { extractAndStoreEconomicProfile } from '@/services/cat/economic-profile';
 import {
@@ -202,8 +204,13 @@ export async function orchestrateCatChat(
     platformUsage,
     keyService,
     userGroqKey,
+    metered,
     fallbacks,
   } = resolved;
+
+  // One stable id per request — the ledger idempotency ref for a metered
+  // (credit-paid frontier) exchange.
+  const meterRef = metered ? `cat_chat_${crypto.randomUUID()}` : null;
 
   // Resolve actor ID for exec_action execution
   const actorId = await getUserActorId(supabase, user.id);
@@ -425,7 +432,18 @@ export async function orchestrateCatChat(
               activeModel
             );
           }
-          if (!hasByok && usage?.totalTokens) {
+          if (metered && meterRef && usage?.totalTokens && activeModel === modelToUse) {
+            // Credit-paid frontier exchange: debit the ledger for the model
+            // that actually served. If a rate-limit fallback answered instead
+            // (activeModel changed), the user is NOT billed.
+            await meterCreditUsage(getAdminClient() as never, user.id, {
+              model: activeModel,
+              inputTokens: usage.inputTokens ?? 0,
+              outputTokens: usage.outputTokens ?? 0,
+              ref: meterRef,
+              conversationId,
+            });
+          } else if (!hasByok && usage?.totalTokens) {
             await keyService.incrementPlatformUsage(user.id, 1, usage.totalTokens);
           }
         } catch (err) {
@@ -542,7 +560,17 @@ export async function orchestrateCatChat(
     throw lastErr ?? new Error('Cat chat: no AI provider produced a response');
   }
 
-  if (!hasByok) {
+  if (metered && meterRef && !fellBackTo) {
+    // Credit-paid frontier exchange (non-streaming): debit only when the
+    // metered primary served — a fallback answer is a free-tier answer.
+    await meterCreditUsage(getAdminClient() as never, user.id, {
+      model: result.model,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      ref: meterRef,
+      conversationId,
+    });
+  } else if (!hasByok) {
     await keyService.incrementPlatformUsage(user.id, 1, result.totalTokens);
   }
 

--- a/src/services/cat/credit-metering.ts
+++ b/src/services/cat/credit-metering.ts
@@ -1,0 +1,131 @@
+/**
+ * Cat Credit usage metering — the spend half of Cat Credits.
+ *
+ * "Sell intelligence, not rails": platform P2P payments are 0% forever; the
+ * platform's revenue is the margin on prepaid Cat Credits spent on
+ * platform-served paid ("frontier") models. This module closes that loop:
+ *
+ *   top-up (credit-topup.ts) → balance (credits.ts) → SPEND (this file)
+ *
+ * Free-tier models stay on the daily platform quota and never touch the
+ * ledger. BYOK usage is the user's own key and is never metered. Only
+ * platform-served, non-free registry models are metered here.
+ *
+ * All amounts are BTC — the canonical unit platform-wide. Satoshis are a
+ * Lightning protocol detail and never appear in this API.
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { calculateCostBtc, getModelMetadata, isModelFree } from '@/config/ai-models';
+import { appendCreditEntry, getCreditBalance } from '@/services/cat/credits';
+import { convertFromBTC } from '@/services/currency/rates';
+import { logger } from '@/utils/logger';
+
+/**
+ * Platform margin on raw provider cost. The user's ledger is debited
+ * cost × markup; the spread is the platform's revenue on intelligence.
+ */
+export const CREDIT_USAGE_MARKUP = 1.2;
+
+/**
+ * Minimum balance (BTC) required to unlock platform-served frontier models —
+ * roughly one substantial exchange on a premium model, so a request never
+ * starts that the balance can't plausibly cover.
+ */
+export const MIN_FRONTIER_BALANCE_BTC = 0.000001;
+
+/** Round UP to the ledger precision (numeric(18,8)) so usage never bills 0. */
+const ceilBtc = (n: number): number => Math.ceil(n * 1e8) / 1e8;
+
+/**
+ * True when serving `modelId` through PLATFORM keys must be metered against
+ * Cat Credits: it's a known registry model and not free-tier.
+ */
+export function isPlatformMeteredModel(modelId: string | undefined): boolean {
+  if (!modelId) {
+    return false;
+  }
+  return Boolean(getModelMetadata(modelId)) && !isModelFree(modelId);
+}
+
+/**
+ * Can this user start a platform-served frontier request?
+ * Never throws; a balance-read failure reads as "no credits".
+ */
+export async function checkFrontierAccess(
+  admin: AnySupabaseClient,
+  userId: string
+): Promise<{ allowed: boolean; balanceBtc: number }> {
+  const balanceBtc = await getCreditBalance(admin, userId);
+  return { allowed: balanceBtc >= MIN_FRONTIER_BALANCE_BTC, balanceBtc };
+}
+
+/**
+ * Debit one completed frontier exchange against the user's Cat Credits.
+ *
+ * Charge = raw provider cost (live BTC/USD rate) × CREDIT_USAGE_MARKUP,
+ * rounded up to 1e-8. Fire-and-log: the response has already been served, so
+ * a failed debit is logged loudly for reconciliation, never thrown at the
+ * user. Idempotent per `ref` at the ledger layer.
+ *
+ * @returns the debited amount in BTC (0 when nothing was billed).
+ */
+export async function meterCreditUsage(
+  admin: AnySupabaseClient,
+  userId: string,
+  args: {
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    /** Stable per-request id — the ledger idempotency ref. */
+    ref: string;
+    conversationId?: string | null;
+  }
+): Promise<number> {
+  const { model, inputTokens, outputTokens, ref, conversationId } = args;
+  if (!isPlatformMeteredModel(model)) {
+    return 0;
+  }
+
+  let btcPriceUsd = 100000;
+  try {
+    const usdPerBtc = await convertFromBTC(1, 'USD');
+    if (Number.isFinite(usdPerBtc) && usdPerBtc > 0) {
+      btcPriceUsd = usdPerBtc;
+    }
+  } catch {
+    /* keep conservative default */
+  }
+
+  const rawCostBtc = calculateCostBtc(model, inputTokens, outputTokens, btcPriceUsd);
+  if (rawCostBtc <= 0) {
+    return 0;
+  }
+  const chargeBtc = ceilBtc(rawCostBtc * CREDIT_USAGE_MARKUP);
+
+  const newBalance = await appendCreditEntry(admin, userId, {
+    kind: 'usage',
+    amountBtc: -chargeBtc,
+    ref,
+    metadata: {
+      source: 'cat_chat',
+      model,
+      inputTokens,
+      outputTokens,
+      rawCostBtc,
+      markup: CREDIT_USAGE_MARKUP,
+      conversationId: conversationId ?? null,
+    },
+  });
+
+  if (newBalance === null) {
+    // Served but not billed (race/duplicate/transient). Reconcilable from logs.
+    logger.warn(
+      'Cat frontier usage debit failed — response served, ledger not debited',
+      { userId, model, chargeBtc, ref },
+      'CatCredits'
+    );
+    return 0;
+  }
+  return chargeBtc;
+}

--- a/src/services/cat/credits.ts
+++ b/src/services/cat/credits.ts
@@ -1,7 +1,7 @@
 /**
  * Cat Credits Service
  *
- * Bitcoin-paid access to frontier models. Users top up a sats balance over
+ * Bitcoin-paid access to frontier models. Users top up a BTC balance over
  * Lightning; frontier inference is metered against it. See
  * docs/architecture/CAT_CREDITS.md.
  *

--- a/src/services/cat/provider-resolver.ts
+++ b/src/services/cat/provider-resolver.ts
@@ -8,12 +8,15 @@
 
 import { createApiKeyService } from '@/services/ai/api-key-service';
 import {
+  createOpenRouterService,
   createOpenRouterServiceWithByok,
   createGroqServiceWithByok,
   createOpenAICompatibleServiceWithByok,
   isGroqAvailable,
   DEFAULT_GROQ_MODEL,
 } from '@/services/ai';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { isPlatformMeteredModel, checkFrontierAccess } from '@/services/cat/credit-metering';
 import { getModelMetadata, DEFAULT_FREE_MODEL_ID } from '@/config/ai-models';
 import { getProviderRuntime, isOpenAICompatibleProvider } from '@/config/ai-provider-runtime';
 import { createAutoRouter } from '@/services/ai/auto-router';
@@ -68,6 +71,12 @@ interface ResolvedProvider {
   platformUsage: { daily_limit: number; requests_remaining: number } | null;
   keyService: ReturnType<typeof createApiKeyService>;
   userGroqKey: string | null;
+  /**
+   * True when this request is a platform-served PAID model billed against the
+   * user's Cat Credits (frontier access). Metered requests bypass the free
+   * daily quota and must be debited after completion via meterCreditUsage.
+   */
+  metered: boolean;
   /**
    * Ordered chain of fallback providers to try on rate-limit. Built from
    * the platform chain (Groq + OpenRouter + Together + Ollama, whichever
@@ -247,7 +256,43 @@ export async function resolveProvider(
     );
   }
 
-  const primary = chain[0];
+  let primary = chain[0];
+
+  // ── Frontier access (Cat Credits) ───────────────────────────────────────
+  // A PAID registry model requested by a user whose chain would serve it from
+  // the platform is metered against Cat Credits: gate on balance up front,
+  // serve via the platform OpenRouter key, debit after completion. BYOK
+  // primaries are untouched — the user's own key, their own bill.
+  let metered = false;
+  if (
+    !primary.hasByok &&
+    isPlatformMeteredModel(requestedModel) &&
+    process.env.OPENROUTER_API_KEY
+  ) {
+    const access = await checkFrontierAccess(getAdminClient() as AnySupabaseClient, userId);
+    if (!access.allowed) {
+      return Response.json(
+        {
+          success: false,
+          error: 'Not enough Cat Credits for this model',
+          code: 'INSUFFICIENT_CREDITS',
+          message:
+            'This is a paid frontier model. Top up Cat Credits in Settings → AI, or pick a free model.',
+          balanceBtc: access.balanceBtc,
+          helpUrl: ROUTES.SETTINGS_AI,
+        },
+        { status: 402 }
+      );
+    }
+    primary = {
+      provider: 'openrouter',
+      modelToUse: requestedModel!,
+      aiService: createOpenRouterService(),
+      hasByok: false,
+    };
+    metered = true;
+  }
+
   const provider = primary.provider;
   const hasByok = primary.hasByok;
   const modelToUse = primary.modelToUse;
@@ -256,9 +301,10 @@ export async function resolveProvider(
   // Platform usage limit applies only when the platform default is the
   // primary (it will actually serve and increment usage). This matches the
   // chat route, which increments platform usage on `!hasByok`, and keeps the
-  // no-keys path identical to before.
+  // no-keys path identical to before. Metered (credit-paid) requests are
+  // exempt — they are paid, not free-quota, usage.
   let platformUsage: { daily_limit: number; requests_remaining: number } | null = null;
-  if (!hasByok) {
+  if (!hasByok && !metered) {
     const usage = await keyService.checkPlatformUsage(userId);
     if (!usage.can_use_platform) {
       return Response.json(
@@ -282,7 +328,11 @@ export async function resolveProvider(
 
   // Everything after the primary becomes the fallback chain, tried in order
   // on rate-limit/error. The Cat keeps chatting as long as one link is alive.
-  const fallbacks: FallbackProvider[] = chain.slice(1).map(s => ({
+  // A metered frontier primary sits ABOVE the regular chain, so the whole
+  // chain backs it up (falling back to a free model is safe — the debit only
+  // fires for completions actually served by the metered model).
+  const fallbackSteps = metered ? chain : chain.slice(1);
+  const fallbacks: FallbackProvider[] = fallbackSteps.map(s => ({
     provider: s.provider,
     modelToUse: s.modelToUse,
     aiService: s.aiService,
@@ -297,6 +347,7 @@ export async function resolveProvider(
     platformUsage,
     keyService,
     userGroqKey,
+    metered,
     fallbacks,
   };
 }

--- a/src/services/currency/formatting.ts
+++ b/src/services/currency/formatting.ts
@@ -5,7 +5,6 @@
  */
 
 import { CURRENCY_METADATA } from '@/config/currencies';
-import { bitcoinToSats } from './conversion';
 
 // ==================== GENERAL FORMATTING ====================
 
@@ -23,14 +22,6 @@ export function formatCurrency(
 
   if (!metadata) {
     return amount.toLocaleString(locale);
-  }
-
-  if (currency === 'SATS') {
-    const formatted =
-      compact && amount >= 1000000
-        ? `${(amount / 1000000).toFixed(1)}M`
-        : amount.toLocaleString(locale, { maximumFractionDigits: 0 });
-    return showSymbol ? `${formatted} sat` : formatted;
   }
 
   if (currency === 'BTC') {
@@ -64,19 +55,15 @@ export function formatCurrency(
 
 // ==================== BITCOIN DISPLAY ====================
 
-export function formatBitcoinDisplay(amount: number, unit: 'BTC' | 'sats' = 'BTC'): string {
-  if (unit === 'sats') {
-    return `${amount.toLocaleString('en-US')} sat`;
-  }
-
+export function formatBitcoinDisplay(amount: number): string {
+  // BTC is the only user-facing Bitcoin unit — small amounts get more
+  // precision, never a satoshi rendering.
   if (amount >= 1) {
     return `${amount.toFixed(4)} BTC`;
   } else if (amount >= 0.001) {
     return `${amount.toFixed(6)} BTC`;
-  } else {
-    const sats = bitcoinToSats(amount);
-    return `${sats.toLocaleString('en-US')} sat`;
   }
+  return `${amount.toFixed(8).replace(/0+$/, '')} BTC`;
 }
 
 export function formatBTC(amount: number): string {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -7,9 +7,9 @@
 import type { CurrencyCode } from '@/config/currencies';
 
 export type Currency = CurrencyCode;
-type FiatCurrency = Exclude<Currency, 'BTC' | 'SATS'>;
-type CryptoCurrency = Extract<Currency, 'BTC' | 'SATS'>;
+type FiatCurrency = Exclude<Currency, 'BTC'>;
+type CryptoCurrency = Extract<Currency, 'BTC'>;
 
 export const FIAT_CURRENCIES: FiatCurrency[] = ['CHF', 'EUR', 'USD', 'GBP'];
-const CRYPTO_CURRENCIES: CryptoCurrency[] = ['BTC', 'SATS'];
+const CRYPTO_CURRENCIES: CryptoCurrency[] = ['BTC'];
 export const ALL_CURRENCIES: Currency[] = [...FIAT_CURRENCIES, ...CRYPTO_CURRENCIES];

--- a/src/utils/currency-helpers.ts
+++ b/src/utils/currency-helpers.ts
@@ -17,10 +17,10 @@ import { Currency } from '@/types/settings';
  * Bitcoin-native currencies work differently:
  * - Goals can ONLY be reached by contributions (not price appreciation)
  * - No conversion needed for comparison (direct BTC comparison)
- * - Used by Bitcoin-native users who think in BTC/sats
+ * - Used by Bitcoin-native users who think in BTC
  */
 export function isBitcoinNativeCurrency(currency: Currency): boolean {
-  return currency === 'BTC' || currency === 'SATS';
+  return currency === 'BTC';
 }
 
 /**


### PR DESCRIPTION
Phase 2 of the master plan: the pay-Bitcoin-for-AI loop now closes in code, and satoshis are fully removed as a product concept.

## Cat Credit metering
- `credit-metering.ts`: platform-served **paid** registry models debit the credit ledger (`usage` kind) at **provider cost × 1.2** (live BTC/USD rate, rounded up to 1e-8), idempotent per-request ref, never throws at the user.
- `provider-resolver`: requesting a paid model without BYOK gates on balance (**402 INSUFFICIENT_CREDITS** with a top-up pointer), serves via platform OpenRouter, is exempt from the free daily quota, and keeps the free chain as fallback — **fallback answers are never billed**.
- Orchestrator settles both streaming and non-streaming paths.

## BTC is the unit (founder: "why do we still talk about sats?")
Two real bugs found and fixed:
- **`calculateCostBtc` returned satoshis** despite its name — a 1e8 drift into every BTC-denominated cost column had a paid model ever been used (prod verified clean: all historical costs are 0).
- **Wishlist validation required whole-satoshi integers in a BTC column** — every normal value like 0.001 BTC was rejected.

Plus the full sweep: `SATS` removed from `CURRENCY_CODES` and every branch/type/option/copy string it fed (currency input/display, wallet form, commerce types, `forceSats`/`showBoth`, sat-rendering in `formatBitcoinDisplay`). Prod verified: zero SATS rows, zero SATS preferences.

## Pricing / business coherence
- `cat-plans.ts`: aspirational Pro card → the **built** Cat Credits pay-as-you-go card (`CAT_CREDITS_LIVE` flag flips the CTA when `PLATFORM_NWC_URI` lands).
- `strategic-plan.md`: transaction-fee model retired for **0% rails + paid intelligence**; ICP updated to AI-assisted builders.
- `legal-compliance-overview.md`: revenue = prepaid service revenue, not payment processing.

9 new metering tests · 576 unit tests green · tsc + lint clean. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)