### PR TITLE
fix(ui): breadcrumb 44px-box centering + stray chat 0

### DIFF
--- a/docs/business/executive/master-plan-2026-07.md
+++ b/docs/business/executive/master-plan-2026-07.md
@@ -202,6 +202,14 @@ The bridge spec (`fleetcrown/docs/architecture/cross-product-identity-bridge.md`
 correct and its build order stands — except step 1 is already half-done (OC's OIDC
 provider is live). Remaining work is mostly FC-side:
 
+> **Status update 2026-07-02 (from the FleetCrown tab):** 1.1, 1.3, and 1.4
+> SHIPPED same day this plan was written (FC PR #55, commits `6e96bce` +
+> `b879625`; token-auth-method fix `7bdf0c9`). 1.2 is effectively satisfied via
+> per-user OIDC bearer tokens with refresh rotation (`orangecat-identity.ts`)
+> instead of `ock_` keys. 1.6 done. Still open: 1.5 (FC-side wallet/funding
+> read surface), plus FC-side backfill job and settings-connect (tracked in
+> `fleetcrown/docs/master-plan-2026-07.md`, the FC counterpart to this plan).
+
 | #   | Item                                                                                                                                                                                                           | Where   |
 | --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | 1.1 | "Login with OrangeCat" in FleetCrown: custom Auth.js OIDC provider against orangecat.ch, `users.orangecatActorId` column, account-linking UI; surface the button on FC's sign-in                               | FC      |

--- a/src/components/ai-chat/AIChatMessage.tsx
+++ b/src/components/ai-chat/AIChatMessage.tsx
@@ -65,14 +65,15 @@ export function AIChatMessage({
             {isUser ? userName : assistantName}
           </span>
           <span className="text-xs text-fg-tertiary">{formatShortTime(message.created_at)}</span>
-          {!isUser && message.tokens_used && message.tokens_used > 0 && (
+          {/* Numeric guards must yield booleans — `value && …` renders a literal "0" when the value is 0. */}
+          {!isUser && (message.tokens_used ?? 0) > 0 && (
             <span className="text-xs text-fg-tertiary">({message.tokens_used} tokens)</span>
           )}
         </div>
         <div className="prose prose-sm max-w-none text-fg-primary whitespace-pre-wrap break-words">
           {message.content}
         </div>
-        {!isUser && message.cost_btc && message.cost_btc > 0 && (
+        {!isUser && (message.cost_btc ?? 0) > 0 && (
           <div className="mt-2 text-xs text-fg-tertiary">
             Cost: {formatAmountBtc(message.cost_btc)}
           </div>

--- a/src/components/ai-chat/AIChatMessage.tsx
+++ b/src/components/ai-chat/AIChatMessage.tsx
@@ -75,7 +75,7 @@ export function AIChatMessage({
         </div>
         {!isUser && (message.cost_btc ?? 0) > 0 && (
           <div className="mt-2 text-xs text-fg-tertiary">
-            Cost: {formatAmountBtc(message.cost_btc)}
+            Cost: {formatAmountBtc(message.cost_btc ?? 0)}
           </div>
         )}
       </div>

--- a/src/components/ui/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb.tsx
@@ -42,12 +42,21 @@ export function Breadcrumb({ items, className = '' }: BreadcrumbProps) {
       {items.map((item, i) => (
         <Fragment key={i}>
           <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+          {/* inline-flex items-center: globals.css forces a{min-height:44px} (touch
+              targets), and a plain block link top-aligns its text inside that box
+              while the Home link centers — THE breadcrumb misalignment. Center all
+              links the same way inside the forced box. */}
           {item.href ? (
-            <Link href={item.href} className="hover:text-foreground transition-colors">
+            <Link
+              href={item.href}
+              className="inline-flex items-center hover:text-foreground transition-colors"
+            >
               {item.label}
             </Link>
           ) : (
-            <span className="text-foreground font-medium">{item.label}</span>
+            <span className="inline-flex items-center text-foreground font-medium">
+              {item.label}
+            </span>
           )}
         </Fragment>
       ))}


### PR DESCRIPTION
Two prod-verified fixes:

1. **Actual breadcrumb misalignment root cause** (computed-styles verified in prod): `globals.css` forces `a { min-height: 44px }` for touch targets; a plain block link top-aligns its text inside that box while the Home link (inline-flex items-center) centers — labels floated ~15px above the row on every entity page. All crumbs now center inside the forced box.
2. **Stray literal '0' under assistant replies** — numeric `&&` guards render 0 when tokens/cost are 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)