### PR TITLE
feat(discover): real anon counts, per-type filters, OAuth gate hardening, FleetCrown cross-sell

### DIFF
--- a/src/app/(authenticated)/dashboard/projects/page.tsx
+++ b/src/app/(authenticated)/dashboard/projects/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import EntityDashboardPage from '@/components/entity/EntityDashboardPage';
+import FleetCrownBuildCta from '@/components/integrations/FleetCrownBuildCta';
 import Button from '@/components/ui/Button';
 import { Target, Heart } from 'lucide-react';
 import { projectEntityConfig, type ProjectListItem } from '@/config/entities/projects';
@@ -14,6 +15,7 @@ export default function ProjectsDashboardPage() {
       title="My Projects"
       description="Manage your projects and track funding"
       createButtonLabel="Create Project"
+      headerContent={<FleetCrownBuildCta variant="banner" />}
       tabs={[
         { id: 'my-projects', label: 'My Projects', icon: Target },
         {

--- a/src/app/api/auth/oauth-providers/route.ts
+++ b/src/app/api/auth/oauth-providers/route.ts
@@ -1,0 +1,86 @@
+/**
+ * GET /api/auth/oauth-providers
+ *
+ * Returns the OAuth providers that are actually usable on this deployment.
+ *
+ * GoTrue's /auth/v1/settings only says whether a provider is *flagged* enabled
+ * (`GOTRUE_EXTERNAL_<P>_ENABLED=true`). A provider can be flagged on while its
+ * credentials are missing/broken — its /authorize then bounces straight back to
+ * the site URL instead of the identity provider, so the login button errors.
+ * (Observed live: twitter flagged enabled but redirecting to the site root,
+ * while google/github redirect to their real IdPs.)
+ *
+ * So this route is the login UI's SSOT: flagged enabled AND the authorize
+ * redirect actually leaves for an external IdP. Probes run server-side (the
+ * browser can't read cross-origin redirect targets) and are cached.
+ */
+import {
+  OAUTH_PROVIDER_IDS,
+  OAUTH_TO_SUPABASE,
+  type OAuthProvider,
+} from '@/app/auth/oauth-provider-map';
+import { apiSuccess } from '@/lib/api/standardResponse';
+import { logger } from '@/utils/logger';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // provider config changes rarely; keep probes cheap
+const CACHE_CONTROL = 's-maxage=300, stale-while-revalidate=1800';
+
+let cache: { at: number; providers: OAuthProvider[] } | null = null;
+
+/** A provider works iff its /authorize redirect leaves for an external IdP. */
+async function providerIsFunctional(gotrueKey: string): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `${SUPABASE_URL}/auth/v1/authorize?provider=${encodeURIComponent(gotrueKey)}`,
+      { headers: { apikey: ANON_KEY as string }, redirect: 'manual' }
+    );
+    if (res.status < 300 || res.status >= 400) {
+      return false;
+    }
+    const location = res.headers.get('location');
+    if (!location || location.includes('error=')) {
+      return false;
+    }
+    // Broken providers bounce back to GoTrue's own host / site URL ("/").
+    const target = new URL(location, SUPABASE_URL);
+    return target.host !== new URL(SUPABASE_URL as string).host;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveWorkingProviders(): Promise<OAuthProvider[]> {
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/settings`, {
+    headers: { apikey: ANON_KEY as string },
+  });
+  const settings = (await res.json()) as { external?: Record<string, boolean> };
+  const external = settings.external ?? {};
+
+  const flaggedOn = OAUTH_PROVIDER_IDS.filter(id => external[OAUTH_TO_SUPABASE[id]]);
+  const checks = await Promise.all(
+    flaggedOn.map(id => providerIsFunctional(OAUTH_TO_SUPABASE[id]))
+  );
+  return flaggedOn.filter((_, i) => checks[i]);
+}
+
+export async function GET() {
+  if (!SUPABASE_URL || !ANON_KEY) {
+    return apiSuccess({ providers: [] as OAuthProvider[] }, { cache: CACHE_CONTROL });
+  }
+
+  if (!cache || Date.now() - cache.at > CACHE_TTL_MS) {
+    try {
+      cache = { at: Date.now(), providers: await resolveWorkingProviders() };
+    } catch (error) {
+      logger.error('Failed to resolve OAuth providers', error, 'Auth');
+      // Fail closed: no broken buttons. Don't cache the failure for long.
+      cache = { at: Date.now() - CACHE_TTL_MS + 30_000, providers: [] };
+    }
+  }
+
+  return apiSuccess({ providers: cache.providers }, { cache: CACHE_CONTROL });
+}

--- a/src/app/api/discover/counts/route.ts
+++ b/src/app/api/discover/counts/route.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /api/discover/counts
+ *
+ * Public entity counts for the /discover hero + tab badges.
+ *
+ * These counts used to be queried straight from the browser client, which
+ * meant anonymous visitors (blocked from the tables by the DB grants/RLS)
+ * saw "0 Projects / 0 People / 0 Finance" while signed-in users saw the real
+ * numbers. Counting server-side (admin client, public-only filters — see
+ * fetchDiscoverCounts) returns the same real numbers to everyone.
+ */
+import { getAdminClient } from '@/lib/supabase/admin';
+import { fetchDiscoverCounts, type DiscoverCounts } from '@/services/search/discoverCounts';
+import { apiSuccess, apiError } from '@/lib/api/standardResponse';
+import { logger } from '@/utils/logger';
+
+export const dynamic = 'force-dynamic';
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_CONTROL = 's-maxage=300, stale-while-revalidate=1800';
+
+let cache: { at: number; counts: DiscoverCounts } | null = null;
+
+export async function GET() {
+  try {
+    if (!cache || Date.now() - cache.at > CACHE_TTL_MS) {
+      cache = { at: Date.now(), counts: await fetchDiscoverCounts(getAdminClient()) };
+    }
+    return apiSuccess(cache.counts, { cache: CACHE_CONTROL });
+  } catch (error) {
+    logger.error('Error fetching discover counts', error, 'Discover');
+    return apiError('Failed to fetch discover counts', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/src/app/auth/oauth-provider-map.ts
+++ b/src/app/auth/oauth-provider-map.ts
@@ -1,0 +1,23 @@
+/**
+ * App OAuth provider ids → Supabase/GoTrue provider keys.
+ *
+ * Server-safe SSOT (no 'use client') so both the login UI and the
+ * /api/auth/oauth-providers route derive providers from the same map.
+ * NOTE: "X" is still `twitter` upstream in GoTrue/supabase-js.
+ */
+export const OAUTH_TO_SUPABASE = {
+  google: 'google',
+  github: 'github',
+  facebook: 'facebook',
+  apple: 'apple',
+  x: 'twitter',
+} as const;
+
+/** App-level OAuth provider id — derived from the map (SSOT). */
+export type OAuthProvider = keyof typeof OAUTH_TO_SUPABASE;
+
+export const OAUTH_PROVIDER_IDS = Object.keys(OAUTH_TO_SUPABASE) as OAuthProvider[];
+
+export function isOAuthProvider(value: string): value is OAuthProvider {
+  return value in OAUTH_TO_SUPABASE;
+}

--- a/src/app/auth/oauthProviders.ts
+++ b/src/app/auth/oauthProviders.ts
@@ -1,31 +1,17 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import type { OAuthProvider } from './useAuthForm';
+import { isOAuthProvider, type OAuthProvider } from './oauth-provider-map';
 
 /**
- * App provider id → Supabase/GoTrue provider key.
- * NOTE: "X" is still `twitter` upstream in GoTrue/supabase-js.
- */
-export const OAUTH_TO_SUPABASE: Record<OAuthProvider, string> = {
-  google: 'google',
-  github: 'github',
-  facebook: 'facebook',
-  apple: 'apple',
-  x: 'twitter',
-};
-
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const ANON_KEY =
-  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-/**
- * Which OAuth providers the GoTrue server actually has enabled.
+ * Which OAuth providers actually work on this deployment.
  *
- * The login UI is driven from this (single source of truth) so we never render
- * a social button that can't work. Enabling a provider on the server
- * (`GOTRUE_EXTERNAL_<P>_ENABLED=true`) makes its button appear with zero code
- * change; disabling it removes the button.
+ * Driven by /api/auth/oauth-providers (single source of truth), which checks
+ * both that GoTrue flags the provider enabled AND that its authorize flow
+ * really redirects to the external IdP — a provider can be flagged on with
+ * broken credentials, which used to render a dead button. Enabling and
+ * configuring a provider on the server makes its button appear with zero
+ * code change; a disabled or broken provider never renders.
  */
 export function useEnabledOAuthProviders(): { enabled: Set<OAuthProvider>; loaded: boolean } {
   const [enabled, setEnabled] = useState<Set<OAuthProvider>>(new Set());
@@ -33,25 +19,13 @@ export function useEnabledOAuthProviders(): { enabled: Set<OAuthProvider>; loade
 
   useEffect(() => {
     let active = true;
-    if (!SUPABASE_URL || !ANON_KEY) {
-      setLoaded(true);
-      return;
-    }
     (async () => {
       try {
-        const res = await fetch(`${SUPABASE_URL}/auth/v1/settings`, {
-          headers: { apikey: ANON_KEY },
-        });
-        const data = await res.json();
-        const ext: Record<string, boolean> = data?.external ?? {};
-        const on = new Set<OAuthProvider>();
-        (Object.keys(OAUTH_TO_SUPABASE) as OAuthProvider[]).forEach(id => {
-          if (ext[OAUTH_TO_SUPABASE[id]]) {
-            on.add(id);
-          }
-        });
+        const res = await fetch('/api/auth/oauth-providers');
+        const body = (await res.json()) as { success?: boolean; data?: { providers?: string[] } };
+        const providers = (body.data?.providers ?? []).filter(isOAuthProvider);
         if (active) {
-          setEnabled(on);
+          setEnabled(new Set(providers));
         }
       } catch {
         // Network/parse failure → leave empty so no broken buttons are shown.

--- a/src/app/auth/useAuthForm.ts
+++ b/src/app/auth/useAuthForm.ts
@@ -6,9 +6,9 @@ import { signInAnonymously } from '@/services/supabase/auth';
 import { getReadableError } from '@/utils/getReadableError';
 import supabase from '@/lib/supabase/browser';
 import { useAuthSubmission } from './useAuthSubmission';
-import { OAUTH_TO_SUPABASE } from './oauthProviders';
+import { OAUTH_TO_SUPABASE, type OAuthProvider } from './oauth-provider-map';
 
-export type OAuthProvider = 'google' | 'github' | 'apple' | 'x' | 'facebook';
+export type { OAuthProvider };
 
 export type AuthMode = 'login' | 'register' | 'forgot';
 

--- a/src/app/discover/discoverConstants.ts
+++ b/src/app/discover/discoverConstants.ts
@@ -16,3 +16,26 @@ export const VALID_TAB_TYPES: DiscoverTabType[] = [
   'research',
   'ai_assistants',
 ];
+
+/** Which sidebar filter blocks apply per tab. */
+export interface DiscoverTabFilterConfig {
+  projectStatus: boolean;
+  projectCategories: boolean;
+}
+
+// The status chips (active/paused/completed/cancelled) and category chips feed
+// the project search only (useSearch); the per-entity tabs (loans, events,
+// ai_assistants, …) ignore them entirely — so showing them there was noise.
+const PROJECT_SEARCH_TABS = new Set<DiscoverTabType>(['all', 'projects']);
+
+/** Config map: which filter blocks the sidebar shows for each tab (SSOT). */
+export const DISCOVER_TAB_FILTERS: Record<DiscoverTabType, DiscoverTabFilterConfig> =
+  Object.fromEntries(
+    VALID_TAB_TYPES.map(tab => [
+      tab,
+      {
+        projectStatus: PROJECT_SEARCH_TABS.has(tab),
+        projectCategories: PROJECT_SEARCH_TABS.has(tab),
+      },
+    ])
+  ) as Record<DiscoverTabType, DiscoverTabFilterConfig>;

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -11,6 +11,7 @@ import DiscoverEmptyState from '@/components/discover/DiscoverEmptyState';
 import { DiscoverLoadingState } from '@/components/discover/DiscoverLoadingState';
 import DiscoverResults from '@/components/discover/DiscoverResults';
 import { GRADIENTS } from '@/config/gradients';
+import { DISCOVER_TAB_FILTERS } from './discoverConstants';
 import { useDiscoverState } from './useDiscoverState';
 
 export default function DiscoverPage() {
@@ -110,10 +111,10 @@ export default function DiscoverPage() {
     onViewModeChange: setViewMode,
     selectedStatuses,
     onToggleStatus: handleToggleStatus,
-    showStatusFilter: activeTab !== 'profiles',
+    showStatusFilter: DISCOVER_TAB_FILTERS[activeTab].projectStatus,
     selectedCategories,
     onToggleCategory: handleToggleCategory,
-    showCategoryFilter: activeTab !== 'profiles',
+    showCategoryFilter: DISCOVER_TAB_FILTERS[activeTab].projectCategories,
     country,
     onCountryChange: setCountry,
     city,

--- a/src/app/discover/useDiscoverCounts.ts
+++ b/src/app/discover/useDiscoverCounts.ts
@@ -2,48 +2,17 @@
 
 import { useEffect, useState } from 'react';
 import { logger } from '@/utils/logger';
-import supabase from '@/lib/supabase/browser';
-import { getTableName } from '@/config/entity-registry';
-import { DATABASE_TABLES } from '@/config/database-tables';
-import { STATUS, ENTITY_STATUS } from '@/config/database-constants';
+import { ZERO_DISCOVER_COUNTS, type DiscoverCounts } from '@/services/search/discoverCounts';
 
-const CACHE_KEY = 'discover_counts_v2';
+// v3: counts now come from /api/discover/counts (server-side, admin client) so
+// anonymous visitors see the real public numbers instead of RLS-blocked zeros.
+const CACHE_KEY = 'discover_counts_v3';
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 
-interface DiscoverCounts {
-  totalProjectsCount: number;
-  totalProfilesCount: number;
-  totalLoansCount: number;
-  totalInvestmentsCount: number;
-  totalAssetsCount: number;
-  totalCausesCount: number;
-  totalEventsCount: number;
-  totalProductsCount: number;
-  totalServicesCount: number;
-  totalGroupsCount: number;
-  totalWishlistsCount: number;
-  totalResearchCount: number;
-  totalAiAssistantsCount: number;
-}
-
-const ZERO: DiscoverCounts = {
-  totalProjectsCount: 0,
-  totalProfilesCount: 0,
-  totalLoansCount: 0,
-  totalInvestmentsCount: 0,
-  totalAssetsCount: 0,
-  totalCausesCount: 0,
-  totalEventsCount: 0,
-  totalProductsCount: 0,
-  totalServicesCount: 0,
-  totalGroupsCount: 0,
-  totalWishlistsCount: 0,
-  totalResearchCount: 0,
-  totalAiAssistantsCount: 0,
-};
+export type { DiscoverCounts };
 
 export function useDiscoverCounts(): DiscoverCounts {
-  const [counts, setCounts] = useState<DiscoverCounts>(ZERO);
+  const [counts, setCounts] = useState<DiscoverCounts>(ZERO_DISCOVER_COUNTS);
 
   useEffect(() => {
     const fetchCounts = async () => {
@@ -53,128 +22,17 @@ export function useDiscoverCounts(): DiscoverCounts {
           const parsed = JSON.parse(cached) as DiscoverCounts & { timestamp: number };
           if (Date.now() - parsed.timestamp < CACHE_DURATION) {
             const { timestamp: _t, ...rest } = parsed;
-            setCounts({ ...ZERO, ...rest });
+            setCounts({ ...ZERO_DISCOVER_COUNTS, ...rest });
             return;
           }
         }
 
-        // Filter shapes mirror discoverGenericFetcher.ts so badge totals match
-        // the entity-tab views.
-        const head = (q: ReturnType<ReturnType<typeof supabase.from>['select']>) =>
-          q as unknown as Promise<{ count: number | null }>;
-
-        const [
-          projectsRes,
-          profilesRes,
-          loansRes,
-          investmentsRes,
-          assetsRes,
-          causesRes,
-          eventsRes,
-          productsRes,
-          servicesRes,
-          groupsRes,
-          wishlistsRes,
-          researchRes,
-          aiAssistantsRes,
-        ] = await Promise.all([
-          head(
-            supabase
-              .from(getTableName('project'))
-              .select('*', { count: 'exact', head: true })
-              .eq('status', ENTITY_STATUS.ACTIVE)
-          ),
-          head(supabase.from(DATABASE_TABLES.PROFILES).select('*', { count: 'exact', head: true })),
-          head(
-            supabase
-              .from(getTableName('loan'))
-              .select('*', { count: 'exact', head: true })
-              .eq('is_public', true)
-              .eq('status', ENTITY_STATUS.ACTIVE)
-          ),
-          head(
-            supabase
-              .from(getTableName('investment'))
-              .select('*', { count: 'exact', head: true })
-              .eq('is_public', true)
-          ),
-          head(
-            supabase
-              .from(getTableName('asset'))
-              .select('*', { count: 'exact', head: true })
-              // Assets are public when active (status-driven, like products). The
-              // public_visibility flag is created false and never set, so gating on it
-              // hid every asset — see 20260618000006.
-              .eq('status', ENTITY_STATUS.ACTIVE)
-          ),
-          head(
-            supabase
-              .from(getTableName('cause'))
-              .select('*', { count: 'exact', head: true })
-              .eq('status', STATUS.CAUSES.ACTIVE)
-          ),
-          head(
-            supabase
-              .from(getTableName('event'))
-              .select('*', { count: 'exact', head: true })
-              .in('status', [STATUS.EVENTS.PUBLISHED, STATUS.EVENTS.OPEN, STATUS.EVENTS.ONGOING])
-          ),
-          head(
-            supabase
-              .from(getTableName('product'))
-              .select('*', { count: 'exact', head: true })
-              .eq('status', STATUS.PRODUCTS.ACTIVE)
-          ),
-          head(
-            supabase
-              .from(getTableName('service'))
-              .select('*', { count: 'exact', head: true })
-              .eq('status', STATUS.SERVICES.ACTIVE)
-          ),
-          head(
-            supabase
-              .from(getTableName('group'))
-              .select('*', { count: 'exact', head: true })
-              .eq('is_public', true)
-          ),
-          head(
-            supabase
-              .from(getTableName('wishlist'))
-              .select('*', { count: 'exact', head: true })
-              .eq('visibility', 'public')
-              .eq('is_active', true)
-          ),
-          head(
-            supabase
-              .from(getTableName('research'))
-              .select('*', { count: 'exact', head: true })
-              .eq('is_public', true)
-              .eq('status', ENTITY_STATUS.ACTIVE)
-          ),
-          head(
-            supabase
-              .from(getTableName('ai_assistant'))
-              .select('*', { count: 'exact', head: true })
-              .eq('is_public', true)
-              .eq('status', STATUS.AI_ASSISTANTS.ACTIVE)
-          ),
-        ]);
-
-        const next: DiscoverCounts = {
-          totalProjectsCount: projectsRes.count ?? 0,
-          totalProfilesCount: profilesRes.count ?? 0,
-          totalLoansCount: loansRes.count ?? 0,
-          totalInvestmentsCount: investmentsRes.count ?? 0,
-          totalAssetsCount: assetsRes.count ?? 0,
-          totalCausesCount: causesRes.count ?? 0,
-          totalEventsCount: eventsRes.count ?? 0,
-          totalProductsCount: productsRes.count ?? 0,
-          totalServicesCount: servicesRes.count ?? 0,
-          totalGroupsCount: groupsRes.count ?? 0,
-          totalWishlistsCount: wishlistsRes.count ?? 0,
-          totalResearchCount: researchRes.count ?? 0,
-          totalAiAssistantsCount: aiAssistantsRes.count ?? 0,
-        };
+        const res = await fetch('/api/discover/counts');
+        if (!res.ok) {
+          throw new Error(`Discover counts request failed: ${res.status}`);
+        }
+        const body = (await res.json()) as { success?: boolean; data?: Partial<DiscoverCounts> };
+        const next: DiscoverCounts = { ...ZERO_DISCOVER_COUNTS, ...(body.data ?? {}) };
 
         setCounts(next);
         localStorage.setItem(CACHE_KEY, JSON.stringify({ ...next, timestamp: Date.now() }));

--- a/src/components/integrations/FleetCrownBuildCta.tsx
+++ b/src/components/integrations/FleetCrownBuildCta.tsx
@@ -16,7 +16,10 @@ import { ORANGECAT_FLEETCROWN_INTEGRATION } from '@/config/entity-registry';
  * - `card`: compact block for the project detail sidebar rail.
  */
 
-const FLEETCROWN_BUILD_URL = `${ORANGECAT_FLEETCROWN_INTEGRATION.fleetCrown.site}/sign-in?callbackUrl=${encodeURIComponent('/projects')}`;
+// Deep link straight into FleetCrown's create-project dialog (?new=1 opens it,
+// params survive the sign-in redirect — FC PR #56). Unauthenticated users pass
+// through "Continue with OrangeCat" and land in the open dialog.
+const FLEETCROWN_BUILD_URL = `${ORANGECAT_FLEETCROWN_INTEGRATION.fleetCrown.site}/projects?new=1`;
 
 const COPY = {
   title: `Build it with ${ORANGECAT_FLEETCROWN_INTEGRATION.fleetCrown.title}`,

--- a/src/components/integrations/FleetCrownBuildCta.tsx
+++ b/src/components/integrations/FleetCrownBuildCta.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { ArrowUpRight, Bot } from 'lucide-react';
+import Button from '@/components/ui/Button';
+import { ORANGECAT_FLEETCROWN_INTEGRATION } from '@/config/entity-registry';
+
+/**
+ * FleetCrown cross-sell — "build this with an AI fleet".
+ *
+ * FleetCrown is the sibling execution product (OC = economic layer, FC =
+ * production layer; one shared login via "Login with OrangeCat"). This CTA is
+ * the single bridge component; the target URL derives from the integration
+ * SSOT in the entity registry.
+ *
+ * - `banner`: slim horizontal strip for the projects dashboard.
+ * - `card`: compact block for the project detail sidebar rail.
+ */
+
+const FLEETCROWN_BUILD_URL = `${ORANGECAT_FLEETCROWN_INTEGRATION.fleetCrown.site}/sign-in?callbackUrl=${encodeURIComponent('/projects')}`;
+
+const COPY = {
+  title: `Build it with ${ORANGECAT_FLEETCROWN_INTEGRATION.fleetCrown.title}`,
+  body: 'Run AI agents on this project. One login: your OrangeCat account.',
+  action: `Open ${ORANGECAT_FLEETCROWN_INTEGRATION.fleetCrown.title}`,
+} as const;
+
+interface FleetCrownBuildCtaProps {
+  variant: 'banner' | 'card';
+}
+
+export default function FleetCrownBuildCta({ variant }: FleetCrownBuildCtaProps) {
+  if (variant === 'banner') {
+    return (
+      <div className="mb-4 rounded-md border border-subtle bg-surface-raised/30 p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="rounded-md border border-subtle bg-surface-page p-2">
+              <Bot className="h-5 w-5 text-accent-warm" aria-hidden="true" />
+            </div>
+            <div>
+              <h3 className="font-medium text-fg-primary">{COPY.title}</h3>
+              <p className="mt-1 text-sm text-fg-secondary">{COPY.body}</p>
+            </div>
+          </div>
+          <Button href={FLEETCROWN_BUILD_URL} variant="outline" size="sm" className="shrink-0">
+            {COPY.action}
+            <ArrowUpRight className="ml-1.5 h-4 w-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-subtle bg-surface-base p-4">
+      <div className="flex items-start gap-3">
+        <div className="rounded-md border border-subtle bg-surface-page p-2">
+          <Bot className="h-5 w-5 text-accent-warm" aria-hidden="true" />
+        </div>
+        <div className="min-w-0">
+          <h3 className="text-sm font-medium text-fg-primary">{COPY.title}</h3>
+          <p className="mt-1 text-sm text-fg-secondary">{COPY.body}</p>
+        </div>
+      </div>
+      <Button href={FLEETCROWN_BUILD_URL} variant="outline" size="sm" className="mt-3 w-full">
+        {COPY.action}
+        <ArrowUpRight className="ml-1.5 h-4 w-4" aria-hidden="true" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/project/ProjectPageClient.tsx
+++ b/src/components/project/ProjectPageClient.tsx
@@ -19,6 +19,7 @@ const ProjectSummaryRail = dynamic(() => import('@/components/project/ProjectSum
 const ProjectHeader = dynamic(() => import('@/components/project/ProjectHeader'));
 const ProjectContent = dynamic(() => import('@/components/project/ProjectContent'));
 const ProjectTimeline = dynamic(() => import('@/components/project/ProjectTimeline'));
+const FleetCrownBuildCta = dynamic(() => import('@/components/integrations/FleetCrownBuildCta'));
 
 interface Project {
   id: string;
@@ -186,6 +187,10 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
               }}
               isOwner={isOwner}
             />
+
+            {/* Cross-sell: owners can run AI agents on this project in
+                FleetCrown (sibling product, shared OrangeCat login). */}
+            {isOwner && <FleetCrownBuildCta variant="card" />}
           </div>
         </div>
       </div>

--- a/src/services/search/discoverCounts.ts
+++ b/src/services/search/discoverCounts.ts
@@ -1,0 +1,160 @@
+/**
+ * Public entity counts for /discover (hero stats + tab badges).
+ *
+ * Filter shapes mirror discoverGenericFetcher.ts so badge totals match the
+ * entity-tab views. Runs on the server (admin client) so anonymous visitors
+ * see the same real, public-only-filtered numbers as signed-in users.
+ */
+import { getTableName } from '@/config/entity-registry';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { STATUS, ENTITY_STATUS } from '@/config/database-constants';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+
+export interface DiscoverCounts {
+  totalProjectsCount: number;
+  totalProfilesCount: number;
+  totalLoansCount: number;
+  totalInvestmentsCount: number;
+  totalAssetsCount: number;
+  totalCausesCount: number;
+  totalEventsCount: number;
+  totalProductsCount: number;
+  totalServicesCount: number;
+  totalGroupsCount: number;
+  totalWishlistsCount: number;
+  totalResearchCount: number;
+  totalAiAssistantsCount: number;
+}
+
+export const ZERO_DISCOVER_COUNTS: DiscoverCounts = {
+  totalProjectsCount: 0,
+  totalProfilesCount: 0,
+  totalLoansCount: 0,
+  totalInvestmentsCount: 0,
+  totalAssetsCount: 0,
+  totalCausesCount: 0,
+  totalEventsCount: 0,
+  totalProductsCount: 0,
+  totalServicesCount: 0,
+  totalGroupsCount: 0,
+  totalWishlistsCount: 0,
+  totalResearchCount: 0,
+  totalAiAssistantsCount: 0,
+};
+
+export async function fetchDiscoverCounts(supabase: AnySupabaseClient): Promise<DiscoverCounts> {
+  const head = (q: unknown) => q as Promise<{ count: number | null }>;
+
+  const [
+    projectsRes,
+    profilesRes,
+    loansRes,
+    investmentsRes,
+    assetsRes,
+    causesRes,
+    eventsRes,
+    productsRes,
+    servicesRes,
+    groupsRes,
+    wishlistsRes,
+    researchRes,
+    aiAssistantsRes,
+  ] = await Promise.all([
+    head(
+      supabase
+        .from(getTableName('project'))
+        .select('*', { count: 'exact', head: true })
+        .eq('status', ENTITY_STATUS.ACTIVE)
+    ),
+    head(supabase.from(DATABASE_TABLES.PROFILES).select('*', { count: 'exact', head: true })),
+    head(
+      supabase
+        .from(getTableName('loan'))
+        .select('*', { count: 'exact', head: true })
+        .eq('is_public', true)
+        .eq('status', ENTITY_STATUS.ACTIVE)
+    ),
+    head(
+      supabase
+        .from(getTableName('investment'))
+        .select('*', { count: 'exact', head: true })
+        .eq('is_public', true)
+    ),
+    head(
+      supabase
+        .from(getTableName('asset'))
+        .select('*', { count: 'exact', head: true })
+        // Assets are public when active (status-driven, like products). The
+        // public_visibility flag is created false and never set, so gating on it
+        // hid every asset — see 20260618000006.
+        .eq('status', ENTITY_STATUS.ACTIVE)
+    ),
+    head(
+      supabase
+        .from(getTableName('cause'))
+        .select('*', { count: 'exact', head: true })
+        .eq('status', STATUS.CAUSES.ACTIVE)
+    ),
+    head(
+      supabase
+        .from(getTableName('event'))
+        .select('*', { count: 'exact', head: true })
+        .in('status', [STATUS.EVENTS.PUBLISHED, STATUS.EVENTS.OPEN, STATUS.EVENTS.ONGOING])
+    ),
+    head(
+      supabase
+        .from(getTableName('product'))
+        .select('*', { count: 'exact', head: true })
+        .eq('status', STATUS.PRODUCTS.ACTIVE)
+    ),
+    head(
+      supabase
+        .from(getTableName('service'))
+        .select('*', { count: 'exact', head: true })
+        .eq('status', STATUS.SERVICES.ACTIVE)
+    ),
+    head(
+      supabase
+        .from(getTableName('group'))
+        .select('*', { count: 'exact', head: true })
+        .eq('is_public', true)
+    ),
+    head(
+      supabase
+        .from(getTableName('wishlist'))
+        .select('*', { count: 'exact', head: true })
+        .eq('visibility', 'public')
+        .eq('is_active', true)
+    ),
+    head(
+      supabase
+        .from(getTableName('research'))
+        .select('*', { count: 'exact', head: true })
+        .eq('is_public', true)
+        .eq('status', ENTITY_STATUS.ACTIVE)
+    ),
+    head(
+      supabase
+        .from(getTableName('ai_assistant'))
+        .select('*', { count: 'exact', head: true })
+        .eq('is_public', true)
+        .eq('status', STATUS.AI_ASSISTANTS.ACTIVE)
+    ),
+  ]);
+
+  return {
+    totalProjectsCount: projectsRes.count ?? 0,
+    totalProfilesCount: profilesRes.count ?? 0,
+    totalLoansCount: loansRes.count ?? 0,
+    totalInvestmentsCount: investmentsRes.count ?? 0,
+    totalAssetsCount: assetsRes.count ?? 0,
+    totalCausesCount: causesRes.count ?? 0,
+    totalEventsCount: eventsRes.count ?? 0,
+    totalProductsCount: productsRes.count ?? 0,
+    totalServicesCount: servicesRes.count ?? 0,
+    totalGroupsCount: groupsRes.count ?? 0,
+    totalWishlistsCount: wishlistsRes.count ?? 0,
+    totalResearchCount: researchRes.count ?? 0,
+    totalAiAssistantsCount: aiAssistantsRes.count ?? 0,
+  };
+}


### PR DESCRIPTION
Four discover/auth follow-ups.

## 1. Auth provider gating (hardened)

The settings-driven gate from e45ac7cb still works — the buttons reappeared because GoTrue now *flags* google/github/twitter enabled (`/auth/v1/settings .external`). Probing live showed the real state:

- **google / github**: `/authorize` 302s to the real IdP (working credentials)
- **twitter**: flagged enabled but `/authorize` bounces back to the site URL — a dead button

Fix: new `/api/auth/oauth-providers` route is the login UI's SSOT. A provider renders only if it's flagged enabled **and** its authorize redirect verifiably leaves for an external IdP (probed server-side — the browser can't read cross-origin redirect targets — cached 5 min, fail-closed). If none qualify, the "Or continue with" block disappears cleanly, as before. The app→GoTrue provider map moved to a server-safe module (`src/app/auth/oauth-provider-map.ts`) shared by UI and route.

## 2. Anon discover hero stats

`useDiscoverCounts` queried the tables from the browser client, so anonymous visitors (RLS/grant-blocked, verified live: `content-range: */0`) saw **0 / 0 / 0** while signed-in users saw 3 / 46 / 4. Counts now come from `/api/discover/counts` (admin client, identical public-only filter shapes, extracted to `src/services/search/discoverCounts.ts`, 5-min server + localStorage cache). Same real numbers for everyone; nothing hardcoded. Tab badges benefit too.

## 3. Per-type discover filters

Project Status + Categories chips only feed the project search (`useSearch`) but rendered on every tab. New `DISCOVER_TAB_FILTERS` config map in `discoverConstants.ts` drives the sidebar: the two blocks render only on `all`/`projects`, and are gone for `ai_assistants`, `loans`, etc. No per-type forks.

## 4. FleetCrown cross-sell

New shared `FleetCrownBuildCta` (URL derived from `ORANGECAT_FLEETCROWN_INTEGRATION` SSOT in the entity registry; monochrome surfaces + single warm-accent icon, semantic tokens only, no new deps), linking to `https://fleetcrown.orangecat.ch/sign-in?callbackUrl=%2Fprojects`:

- **banner** variant on `/dashboard/projects` via the existing `headerContent` slot
- **card** variant in the project detail sidebar rail, owner-only (`isOwner` was already in scope)

## Gates

- `npm run type-check`: 0 errors
- `npm run lint`: clean
- `npx jest __tests__/unit`: 54 suites / 576 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)