### PR TITLE
fix(forms): full-width form fields + context-aware Cat quick-starts

### DIFF
--- a/__tests__/unit/cat/suggestions.test.ts
+++ b/__tests__/unit/cat/suggestions.test.ts
@@ -8,6 +8,7 @@ import {
   hasRichContext,
   DEFAULT_SUGGESTIONS,
 } from '@/services/ai/suggestions';
+import { CAT_QUICKSTARTS, selectQuickstarts } from '@/config/cat-quickstarts';
 import type { FullUserContext } from '@/services/ai/document-context';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -120,7 +121,9 @@ describe('hasRichContext', () => {
   });
 
   it('returns false when profile exists but is blank', () => {
-    const ctx = makeContext({ profile: { username: 'alice', name: null, bio: null, background: null } });
+    const ctx = makeContext({
+      profile: { username: 'alice', name: null, bio: null, background: null },
+    });
     expect(hasRichContext(ctx)).toBe(false);
   });
 
@@ -165,7 +168,13 @@ describe('generateSuggestionsFromContext', () => {
       documents: [makeDocument('2026 Goals')],
       tasks: [makeTask()],
       wallets: [makeWallet()],
-      stats: { ...EMPTY_STATS, totalProducts: 1, totalServices: 1, totalProjects: 1, totalCauses: 1 },
+      stats: {
+        ...EMPTY_STATS,
+        totalProducts: 1,
+        totalServices: 1,
+        totalProjects: 1,
+        totalCauses: 1,
+      },
     });
     expect(generateSuggestionsFromContext(ctx).length).toBeLessThanOrEqual(4);
   });
@@ -206,22 +215,25 @@ describe('generateSuggestionsFromContext', () => {
     expect(suggestions.some(s => s.includes('Ocean Clean-Up'))).toBe(true);
   });
 
-  it('includes gap suggestion when user has products but no project or cause', () => {
+  it('leads with the wallet chip when user has entities but no wallet', () => {
     const ctx = makeContext({
       entities: [makeEntity('product', 'Merch')],
       stats: { ...EMPTY_STATS, totalProducts: 1 },
     });
     const suggestions = generateSuggestionsFromContext(ctx);
-    expect(suggestions.some(s => s.toLowerCase().includes('project'))).toBe(true);
+    expect(suggestions[0]).toBe(CAT_QUICKSTARTS.entitiesNoWallet[0]);
+    expect(suggestions[0].toLowerCase()).toContain('wallet');
   });
 
-  it('includes gap suggestion when user has services but no products', () => {
+  it('uses the established tier when user has entities and a wallet', () => {
     const ctx = makeContext({
       entities: [makeEntity('service', 'Consulting')],
-      stats: { ...EMPTY_STATS, totalServices: 1 },
+      wallets: [makeWallet()],
+      stats: { ...EMPTY_STATS, totalServices: 1, totalWallets: 1 },
     });
     const suggestions = generateSuggestionsFromContext(ctx);
-    expect(suggestions.some(s => s.toLowerCase().includes('product'))).toBe(true);
+    expect(suggestions[0]).toBe(CAT_QUICKSTARTS.established[0]);
+    expect(suggestions.some(s => s.toLowerCase().includes('wallet'))).toBe(false);
   });
 
   it('includes task nudge when user has tasks', () => {
@@ -234,14 +246,14 @@ describe('generateSuggestionsFromContext', () => {
     expect(suggestions.some(s => s.toLowerCase().includes('task'))).toBe(true);
   });
 
-  it('includes wallet nudge when user has wallets', () => {
+  it('uses the noEntities tier for users with a wallet but nothing listed', () => {
     const ctx = makeContext({
       wallets: [makeWallet()],
       stats: { ...EMPTY_STATS, totalWallets: 1 },
       profile: { name: 'Alice', username: 'alice' },
     });
     const suggestions = generateSuggestionsFromContext(ctx);
-    expect(suggestions.some(s => s.toLowerCase().includes('saving') || s.toLowerCase().includes('goal'))).toBe(true);
+    expect(suggestions[0]).toBe(CAT_QUICKSTARTS.noEntities[0]);
   });
 
   it('returns document-based suggestions when only documents are present', () => {
@@ -266,6 +278,16 @@ describe('generateSuggestionsFromContext', () => {
     expect(unique.size).toBe(suggestions.length);
   });
 
+  it('keeps a named-entity chip alongside the tier chips', () => {
+    const ctx = makeContext({
+      entities: [makeEntity('product', 'Handmade Candles')],
+      wallets: [makeWallet()],
+      stats: { ...EMPTY_STATS, totalProducts: 1, totalWallets: 1 },
+    });
+    const suggestions = generateSuggestionsFromContext(ctx);
+    expect(suggestions.some(s => s.includes('Handmade Candles'))).toBe(true);
+  });
+
   it('falls back to generic suggestions when context exists but produces no specific matches', () => {
     // Profile with a name but no entities/tasks/wallets/docs
     const ctx = makeContext({
@@ -275,5 +297,41 @@ describe('generateSuggestionsFromContext', () => {
     // Should still return something (gap nudge or generic)
     expect(suggestions.length).toBeGreaterThan(0);
     expect(suggestions).not.toEqual(DEFAULT_SUGGESTIONS);
+  });
+});
+
+// ─── selectQuickstarts (tier rules SSOT) ──────────────────────────────────────
+
+describe('selectQuickstarts', () => {
+  it('returns the noEntities tier when the user has nothing listed', () => {
+    expect(selectQuickstarts({ entityCount: 0, hasWallet: false })).toEqual(
+      CAT_QUICKSTARTS.noEntities
+    );
+    expect(selectQuickstarts({ entityCount: 0, hasWallet: true })).toEqual(
+      CAT_QUICKSTARTS.noEntities
+    );
+  });
+
+  it('returns the entitiesNoWallet tier when listings exist but no wallet does', () => {
+    expect(selectQuickstarts({ entityCount: 2, hasWallet: false })).toEqual(
+      CAT_QUICKSTARTS.entitiesNoWallet
+    );
+  });
+
+  it('returns the established tier when entities and a wallet both exist', () => {
+    expect(selectQuickstarts({ entityCount: 1, hasWallet: true })).toEqual(
+      CAT_QUICKSTARTS.established
+    );
+  });
+
+  it('every tier stays within the 3-4 chip budget', () => {
+    for (const chips of Object.values(CAT_QUICKSTARTS)) {
+      expect(chips.length).toBeGreaterThanOrEqual(3);
+      expect(chips.length).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it('DEFAULT_SUGGESTIONS mirrors the noEntities tier', () => {
+    expect(DEFAULT_SUGGESTIONS).toEqual([...CAT_QUICKSTARTS.noEntities]);
   });
 });

--- a/src/components/create/EntityForm/index.tsx
+++ b/src/components/create/EntityForm/index.tsx
@@ -141,27 +141,95 @@ export function EntityForm<T extends Record<string, unknown>>({
   const Icon = config.icon;
   const theme = FORM_THEME[config.colorTheme];
 
-  return (
-    <div
-      className={
-        wizardMode || embedded
-          ? ''
-          : `min-h-screen ${theme.pageSurface} p-4 sm:p-6 lg:p-8 pb-24 md:pb-8`
-      }
-    >
-      {!wizardMode && !embedded && (
-        <FormHeader
-          icon={Icon}
-          colorTheme={config.colorTheme}
-          name={config.name}
-          namePlural={config.namePlural}
-          pageDescription={config.pageDescription}
-          backUrl={config.backUrl}
-          mode={mode}
-        />
+  /**
+   * FORM WIDTH SSOT
+   *
+   * Two layout modes, one rule: the form fields always get the full width of
+   * a single comfortable content column — never a fraction of one.
+   *
+   * - Hosted (wizard step / embedded dialog): the host already provides the
+   *   card + width. Render the bare form so fields span the host's content
+   *   width. (Previously this branch kept a `lg:grid-cols-3` + `col-span-2`
+   *   grid whose third column — the GuidancePanel — is never rendered in
+   *   wizard mode, cramping every input to ~2/3 of an already-nested card.)
+   * - Full page (create without wizard / edit): a max-w-6xl shell where the
+   *   form card takes 2/3 (~3xl of fields) and the GuidancePanel 1/3.
+   */
+  const formElement = (
+    <form onSubmit={handleSubmit} className="space-y-8">
+      {/* Cat-powered prefill on EVERY form — create and edit alike — so
+                    users can describe what they want (or the change they want)
+                    and have the fields filled instead of typing each one. On edit
+                    the bar refines the existing values (it receives existingData). */}
+      <AIPrefillBar
+        entityType={config.type}
+        onPrefill={handleAIPrefill}
+        disabled={formState.isSubmitting}
+        existingData={formState.data}
+        mode={mode}
+      />
+
+      <FormFieldGroups
+        visibleFieldGroups={visibleFieldGroups}
+        isGroupVisible={isGroupVisible}
+        isFieldVisible={isFieldVisible}
+        formState={formState}
+        handleFieldChange={handleFieldChange}
+        handleFieldFocus={handleFieldFocus}
+        handleFieldBlur={handleFieldBlur}
+        aiGeneratedFields={aiGeneratedFields}
+      />
+
+      {config.infoBanner && <FormInfoBanner banner={config.infoBanner} />}
+
+      {formState.errors.general && (
+        <div className="oc-error-surface">
+          <p className="text-sm">{formState.errors.general}</p>
+        </div>
       )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      {config.templates && config.templates.length > 0 && mode === 'create' && !wizardMode && (
+        <div className="mt-8 pt-8 border-t border-default">
+          <TemplatePicker
+            label={config.namePlural}
+            templates={config.templates as EntityTemplate<T>[]}
+            onSelectTemplate={handleTemplateSelect}
+          />
+        </div>
+      )}
+
+      <FormActions
+        isSubmitting={formState.isSubmitting}
+        mode={mode}
+        entityName={config.name}
+        backUrl={config.backUrl}
+        theme={theme}
+        wizardMode={wizardMode}
+        lastSavedAt={lastSavedAt}
+        formatRelativeTime={formatRelativeTime}
+      />
+    </form>
+  );
+
+  // Hosted mode: wizard step card or dialog owns the chrome — bare form,
+  // full width of the host's content column.
+  if (wizardMode || embedded) {
+    return formElement;
+  }
+
+  return (
+    <div className={`min-h-screen ${theme.pageSurface} p-4 sm:p-6 lg:p-8 pb-24 md:pb-8`}>
+      <FormHeader
+        icon={Icon}
+        colorTheme={config.colorTheme}
+        name={config.name}
+        namePlural={config.namePlural}
+        pageDescription={config.pageDescription}
+        backUrl={config.backUrl}
+        mode={mode}
+      />
+
+      <div className="max-w-6xl grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
           <Card>
             <CardHeader>
@@ -172,76 +240,17 @@ export function EntityForm<T extends Record<string, unknown>>({
                   : `Update your ${config.name.toLowerCase()} details.`}
               </CardDescription>
             </CardHeader>
-            <CardContent>
-              <form onSubmit={handleSubmit} className="space-y-8">
-                {/* Cat-powered prefill on EVERY form — create and edit alike — so
-                    users can describe what they want (or the change they want)
-                    and have the fields filled instead of typing each one. On edit
-                    the bar refines the existing values (it receives existingData). */}
-                <AIPrefillBar
-                  entityType={config.type}
-                  onPrefill={handleAIPrefill}
-                  disabled={formState.isSubmitting}
-                  existingData={formState.data}
-                  mode={mode}
-                />
-
-                <FormFieldGroups
-                  visibleFieldGroups={visibleFieldGroups}
-                  isGroupVisible={isGroupVisible}
-                  isFieldVisible={isFieldVisible}
-                  formState={formState}
-                  handleFieldChange={handleFieldChange}
-                  handleFieldFocus={handleFieldFocus}
-                  handleFieldBlur={handleFieldBlur}
-                  aiGeneratedFields={aiGeneratedFields}
-                />
-
-                {config.infoBanner && <FormInfoBanner banner={config.infoBanner} />}
-
-                {formState.errors.general && (
-                  <div className="oc-error-surface">
-                    <p className="text-sm">{formState.errors.general}</p>
-                  </div>
-                )}
-
-                {config.templates &&
-                  config.templates.length > 0 &&
-                  mode === 'create' &&
-                  !wizardMode && (
-                    <div className="mt-8 pt-8 border-t border-default">
-                      <TemplatePicker
-                        label={config.namePlural}
-                        templates={config.templates as EntityTemplate<T>[]}
-                        onSelectTemplate={handleTemplateSelect}
-                      />
-                    </div>
-                  )}
-
-                <FormActions
-                  isSubmitting={formState.isSubmitting}
-                  mode={mode}
-                  entityName={config.name}
-                  backUrl={config.backUrl}
-                  theme={theme}
-                  wizardMode={wizardMode}
-                  lastSavedAt={lastSavedAt}
-                  formatRelativeTime={formatRelativeTime}
-                />
-              </form>
-            </CardContent>
+            <CardContent>{formElement}</CardContent>
           </Card>
         </div>
 
-        {!wizardMode && (
-          <div className="lg:col-span-1">
-            <GuidancePanel
-              activeField={formState.activeField}
-              guidanceContent={config.guidanceContent}
-              defaultGuidance={config.defaultGuidance}
-            />
-          </div>
-        )}
+        <div className="lg:col-span-1">
+          <GuidancePanel
+            activeField={formState.activeField}
+            guidanceContent={config.guidanceContent}
+            defaultGuidance={config.defaultGuidance}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/config/cat-quickstarts.ts
+++ b/src/config/cat-quickstarts.ts
@@ -1,0 +1,63 @@
+/**
+ * CAT QUICK-STARTS — SSOT for the opening suggestion chips in My Cat chat.
+ *
+ * The chips a user sees before their first message are the Cat's pitch: they
+ * must point at the next economically useful step, not generic filler. The
+ * rules are deliberately cheap — they read only data the suggestions API
+ * already loads (entity count, wallets), no extra queries, no LLM call.
+ *
+ * Context rules (evaluated in order):
+ *
+ * 1. `noEntities` — user has nothing listed yet (0 entities).
+ *    Goal: get their world into the platform with minimal typing. Lead with
+ *    "give me a link / tell me what you do" so the Cat can do the setup work.
+ *    Also the fallback for anonymous visitors and fetch errors
+ *    (DEFAULT_SUGGESTIONS in src/services/ai/suggestions.ts).
+ *
+ * 2. `entitiesNoWallet` — has at least one entity but no wallet row.
+ *    Goal: unblock getting paid. Everything they list is unmonetizable until
+ *    a wallet exists, so the wallet chip leads.
+ *
+ * 3. `established` — has entities AND at least one wallet.
+ *    Goal: grow. Lean on the offer engine ("What can I offer next?") and
+ *    demand matching.
+ *
+ * Personalisation (named-entity chips, document/task nudges) is layered on
+ * top by generateSuggestionsFromContext — this file only owns the tier chips.
+ */
+
+export interface QuickstartContext {
+  /** Total entities the user owns (any type). */
+  entityCount: number;
+  /** True when the user has at least one wallet row (any kind — a way to get paid). */
+  hasWallet: boolean;
+}
+
+export const CAT_QUICKSTARTS = {
+  noEntities: [
+    "Paste a link to your website or LinkedIn and I'll set you up",
+    "Tell me what you do and I'll suggest what to offer",
+    'What could I earn Bitcoin doing today?',
+  ],
+  entitiesNoWallet: [
+    'Connect a wallet so you can get paid',
+    'What can I offer next?',
+    'Find people who need what I offer',
+  ],
+  established: [
+    'What can I offer next?',
+    'Find people who need what I offer',
+    "How can I grow what I've already listed?",
+  ],
+} as const;
+
+/** Pick the quick-start tier for a user's economic state. */
+export function selectQuickstarts(ctx: QuickstartContext): readonly string[] {
+  if (ctx.entityCount === 0) {
+    return CAT_QUICKSTARTS.noEntities;
+  }
+  if (!ctx.hasWallet) {
+    return CAT_QUICKSTARTS.entitiesNoWallet;
+  }
+  return CAT_QUICKSTARTS.established;
+}

--- a/src/services/ai/suggestions.ts
+++ b/src/services/ai/suggestions.ts
@@ -2,6 +2,7 @@
  * My Cat suggestion generation — pure functions, no DB dependencies.
  */
 
+import { CAT_QUICKSTARTS, selectQuickstarts } from '@/config/cat-quickstarts';
 import type { DocumentContext, FullUserContext } from './document-context';
 
 function truncate(str: string, maxLen: number): string {
@@ -56,17 +57,10 @@ const DOCUMENT_TYPE_SUGGESTIONS: Record<string, (doc: DocumentContext) => string
   other: _doc => [`Give me advice based on my context`, `What opportunities should I consider?`],
 };
 
-// Shown to brand-new users with no context yet.
-// Lead with the magic moment — "Draft a product" lands a PrefilledFormCard
-// the user can publish in one click. That's Cat's superpower the rest of the
-// suggestions don't expose. Other entries cover the rest of the surface
-// (value-finding, profile setup, Bitcoin onboarding) without being filler.
-export const DEFAULT_SUGGESTIONS = [
-  'Draft a product I could sell on OrangeCat',
-  'What can I earn Bitcoin doing today?',
-  'Help me write a clear profile bio',
-  'How do Lightning payments work here?',
-];
+// Shown to anonymous visitors, on fetch errors, and to signed-in users with
+// zero context — all of whom have 0 entities, so the noEntities quick-start
+// tier is exactly right. SSOT: src/config/cat-quickstarts.ts.
+export const DEFAULT_SUGGESTIONS: string[] = [...CAT_QUICKSTARTS.noEntities];
 
 const CONTEXT_AWARE_GENERIC = [
   'What should I create next based on my context?',
@@ -108,7 +102,17 @@ export function generateSuggestionsFromContext(context: FullUserContext): string
     }
   }
 
-  // 1. Named-entity suggestions — most specific and valuable
+  // 1. Quick-start tier — the economically useful next step for this user's
+  //    state (no entities → get set up; entities w/o wallet → get paid;
+  //    both → grow). SSOT + rules: src/config/cat-quickstarts.ts.
+  for (const s of selectQuickstarts({
+    entityCount: context.entities.length,
+    hasWallet: context.wallets.length > 0,
+  })) {
+    add(s);
+  }
+
+  // 2. One named-entity suggestion — the most personal chip we can offer
   const firstProduct = context.entities.find(e => e.type === 'product');
   const firstService = context.entities.find(e => e.type === 'service');
   const firstProject = context.entities.find(e => e.type === 'project');
@@ -116,44 +120,17 @@ export function generateSuggestionsFromContext(context: FullUserContext): string
 
   if (firstProduct) {
     add(`Help me write a better description for "${truncate(firstProduct.title, 35)}"`);
-  }
-  if (firstService) {
+  } else if (firstService) {
     add(`How can I attract more clients for "${truncate(firstService.title, 35)}"?`);
-  }
-  if (firstProject) {
+  } else if (firstProject) {
     add(`What should the next milestone be for "${truncate(firstProject.title, 35)}"?`);
-  }
-  if (firstCause) {
+  } else if (firstCause) {
     add(`How do I grow support for "${truncate(firstCause.title, 35)}"?`);
   }
 
-  // 2. Gap suggestions — based on what the user has vs. what's missing
-  const hasProducts = context.stats.totalProducts > 0;
-  const hasServices = context.stats.totalServices > 0;
-  const hasProjects = context.stats.totalProjects > 0;
-  const hasCauses = context.stats.totalCauses > 0;
-  const hasWallets = context.wallets.length > 0;
-  const hasTasks = context.tasks.length > 0;
-
-  if (hasProducts && !hasProjects && !hasCauses) {
-    add('I have products — should I also create a project to fund a bigger vision?');
-  }
-  if (hasServices && !hasProducts) {
-    add('What digital products could I create alongside my services?');
-  }
-  if (!hasProducts && !hasServices && !hasProjects && !hasCauses) {
-    // Has profile/tasks/wallets but no entities — new user nudge
-    const name = context.profile?.name;
-    if (name) {
-      add(`What's the best first thing to list for someone like me?`);
-    } else {
-      add('What should I create first on OrangeCat?');
-    }
-  }
-  if (hasWallets) {
-    add('How do I reach my savings goal faster?');
-  }
-  if (hasTasks) {
+  // 2b. Light nudges from non-entity context (mostly reachable for users
+  //     without entities, where the tier leaves a free slot)
+  if (context.tasks.length > 0) {
     add('Help me prioritize my current tasks');
   }
 


### PR DESCRIPTION
## Founder complaints addressed

### 1. Narrow form fields on web (root cause found)

`EntityForm` kept its full-page `lg:grid-cols-3` + `col-span-2` grid **even in wizard mode**, where the third column (the GuidancePanel) is never rendered. Every input in the entity create flow was cramped to ~2/3 of the max-w-4xl wizard card — inside a *second* nested Card — leaving **~500px fields** on desktop.

**Fix at the layout SSOT** (`src/components/create/EntityForm/index.tsx`), no page-by-page patches:
- **Hosted modes** (wizard step / embedded dialog): render the bare form spanning the host's full content column — fields go from ~500px to **~850px** (the wizard card's max-w-4xl content width). Also removes the redundant nested Card + duplicate title inside wizard steps.
- **Full-page mode** (edit / non-wizard create): keeps the form + GuidancePanel grid, now capped at `max-w-6xl` so the field column sits at a comfortable ~3xl (~736px) measure instead of stretching unbounded on wide monitors.

Every entity create/edit form (all 15 registry types) benefits automatically.

### 2. Cat opening quick-starts: generic → economically useful

New SSOT config **`src/config/cat-quickstarts.ts`** with documented context rules, derived from data the suggestions API already loads (zero extra queries, no LLM call):

| User state | Chips |
|---|---|
| 0 entities | "Paste a link to your website or LinkedIn and I'll set you up" · "Tell me what you do and I'll suggest what to offer" · "What could I earn Bitcoin doing today?" |
| entities, no wallet | "Connect a wallet so you can get paid" (leads) · "What can I offer next?" · "Find people who need what I offer" |
| entities + wallet | "What can I offer next?" · "Find people who need what I offer" · "How can I grow what I've already listed?" |

One personalized named-entity chip stays layered on top (e.g. *Help me write a better description for "X"*); 3–4 chips max, plain language, no gamification. `DEFAULT_SUGGESTIONS` (anonymous / fetch-error fallback) mirrors the noEntities tier — both are 0-entity users.

## Gates
- `npm run type-check` — 0 errors
- `npm run lint` — clean (one pre-existing warning in an untouched file)
- `npx jest __tests__/unit --silent` — 56 suites, 659 tests green (suggestions tests updated + new `selectQuickstarts` tier tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)