### PR TITLE
feat(cat): right entity type + a required 'why' — decision rubric, loan pathway, prefill dedupe, Zürich language fix

### DIFF
--- a/__tests__/unit/cat/entity-type-rubric.test.ts
+++ b/__tests__/unit/cat/entity-type-rubric.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Locks the deterministic pieces of the Cat's entity-type selection quality:
+ *
+ * 1. The system prompt carries the decision rubric (service vs product vs
+ *    project/cause vs loan vs event vs group) and REQUIRES a one-line
+ *    "why this type" with every proposal.
+ * 2. A money NEED reaches the tool pass (loan drafting) and counts as a
+ *    create intent, never a platform search.
+ * 3. The prefill tool result instructs the model to explain the type choice.
+ *
+ * The founder-reported failures these guard: a service proposed as a
+ * product/project, no explanation given, and loans never suggested.
+ */
+
+import { buildCatSystemPrompt } from '@/services/cat/system-prompt';
+import {
+  hasMoneyNeedIntent,
+  hasCreateIntent,
+  messageMightNeedTools,
+} from '@/services/cat/tool-use-detection';
+
+describe('system prompt — entity-type decision rubric', () => {
+  const prompt = buildCatSystemPrompt();
+
+  it('contains the decision rubric section', () => {
+    expect(prompt).toContain('Choosing the Entity Type (decision rubric');
+  });
+
+  it('pins the founder failure case: priced labor is a service, not a product', () => {
+    expect(prompt).toContain('A price attached to work does NOT make it a product');
+  });
+
+  it('maps a repayable money need to loan — never product or cause', () => {
+    expect(prompt).toContain('NEEDS money and intends to REPAY');
+    expect(prompt).toContain('**loan** — never a product, never a cause');
+  });
+
+  it('requires a one-line "why this type" with every proposal', () => {
+    expect(prompt).toContain('Always say WHY (required)');
+    expect(prompt).toContain('Never present a proposal without its why');
+  });
+
+  it('softens the interview posture: thin input gets ONE focused question, not a blind draft', () => {
+    expect(prompt).toContain('When input is THIN, ask');
+    expect(prompt).toContain('ONE focused question');
+  });
+
+  it('routes money NEEDS to lending/funding in the pathway map', () => {
+    expect(prompt).toContain('**Needs money NOW**');
+  });
+});
+
+describe('money-need intent detection', () => {
+  it.each([
+    'I need 500 CHF to fix my bike so I can deliver food',
+    'need 1200 EUR for a new laptop',
+    'can I borrow money here?',
+    'I want to take out a loan',
+    'I need some cash for materials',
+  ])('detects "%s" as a money need', msg => {
+    expect(hasMoneyNeedIntent(msg)).toBe(true);
+    expect(messageMightNeedTools(msg)).toBe(true);
+    // A money need drafts the user's OWN loan — create intent, not a search.
+    expect(hasCreateIntent(msg)).toBe(true);
+  });
+
+  it.each([
+    'I need help with my profile',
+    'do you need anything from me?',
+    'I need to think about it',
+  ])('does not fire on a non-monetary "need" ("%s")', msg => {
+    expect(hasMoneyNeedIntent(msg)).toBe(false);
+  });
+});

--- a/__tests__/unit/cat/reply-language.test.ts
+++ b/__tests__/unit/cat/reply-language.test.ts
@@ -20,6 +20,13 @@ describe('detectReplyLanguage', () => {
     expect(detectReplyLanguage('Größe')).toBe('de');
   });
 
+  it('does not let a Swiss place-name umlaut flip an English message to German (regression)', () => {
+    // "Zürich" carries an umlaut but the sentence is English — the umlaut bump
+    // must not outvote actual English vocabulary.
+    expect(detectReplyLanguage('I offer haircuts at home in Zürich, 40 CHF')).toBe('en');
+    expect(detectReplyLanguage('my shop is in Zürich and I want to sell mugs')).toBe('en');
+  });
+
   it('returns unknown when there is no signal either way', () => {
     expect(detectReplyLanguage('DJ 2026')).toBe('unknown');
     expect(detectReplyLanguage('🎧🎶')).toBe('unknown');

--- a/__tests__/unit/cat/tool-use-prefill-dedupe.test.ts
+++ b/__tests__/unit/cat/tool-use-prefill-dedupe.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Cross-step prefill dedupe in the Cat tool loop.
+ *
+ * Prod bug: weak routing models re-called prefill_entity_form for the SAME
+ * entity type after seeing its result, so the user got two identical draft
+ * cards ("Haircuts at home in Zürich" twice). A repeat of an already-drafted
+ * type in a later step must be dropped; distinct types (and same-step
+ * multiples, used by the website flow) stay allowed.
+ */
+import { maybeEnrichWithSearchResults } from '@/services/cat/tool-use';
+import { executeToolCall } from '@/services/cat/tool-executor';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import type { RawToolCall } from '@/services/cat/tool-use-types';
+
+jest.mock('@/services/cat/tool-executor', () => ({
+  executeToolCall: jest.fn(),
+}));
+
+const mockExecuteToolCall = executeToolCall as jest.MockedFunction<typeof executeToolCall>;
+
+const supabase = {} as AnySupabaseClient;
+const USER_ID = 'user-1';
+// Message with create intent so the tool pass runs ("i offer" trigger).
+const MESSAGE = 'I offer haircuts at home in Zürich, 40 CHF';
+
+function prefillCall(id: string, entityType: string): RawToolCall {
+  return {
+    id,
+    type: 'function',
+    function: {
+      name: 'prefill_entity_form',
+      arguments: JSON.stringify({ entityType, description: `a ${entityType} the user described` }),
+    },
+  };
+}
+
+function toolCallsResponse(calls: RawToolCall[]) {
+  return {
+    ok: true,
+    json: async () => ({
+      choices: [
+        {
+          finish_reason: 'tool_calls',
+          message: { role: 'assistant', content: null, tool_calls: calls },
+        },
+      ],
+    }),
+  } as unknown as Response;
+}
+
+function stopResponse() {
+  return {
+    ok: true,
+    json: async () => ({
+      choices: [{ finish_reason: 'stop', message: { role: 'assistant', content: '' } }],
+    }),
+  } as unknown as Response;
+}
+
+function enrich() {
+  return maybeEnrichWithSearchResults(
+    supabase,
+    USER_ID,
+    [
+      { role: 'system', content: 'system prompt' },
+      { role: 'user', content: MESSAGE },
+    ],
+    MESSAGE,
+    'groq',
+    'test-groq-key',
+    'test-model'
+  );
+}
+
+describe('tool loop — cross-step prefill dedupe', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExecuteToolCall.mockImplementation(async (_sb, _uid, toolCall) => ({
+      role: 'tool',
+      tool_call_id: toolCall.id,
+      content: 'Drafted.',
+    }));
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('drops a later-step prefill for an entity type already drafted', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(toolCallsResponse([prefillCall('call_1', 'service')]))
+      .mockResolvedValueOnce(toolCallsResponse([prefillCall('call_2', 'service')]))
+      .mockResolvedValue(stopResponse()) as unknown as typeof fetch;
+
+    await enrich();
+
+    expect(mockExecuteToolCall).toHaveBeenCalledTimes(1);
+    expect(mockExecuteToolCall.mock.calls[0][2].id).toBe('call_1');
+  });
+
+  it('still allows a DIFFERENT entity type in a later step', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(toolCallsResponse([prefillCall('call_1', 'service')]))
+      .mockResolvedValueOnce(toolCallsResponse([prefillCall('call_2', 'product')]))
+      .mockResolvedValue(stopResponse()) as unknown as typeof fetch;
+
+    await enrich();
+
+    expect(mockExecuteToolCall).toHaveBeenCalledTimes(2);
+    const executedTypes = mockExecuteToolCall.mock.calls.map(
+      c => (JSON.parse(c[2].function.arguments) as { entityType: string }).entityType
+    );
+    expect(executedTypes).toEqual(['service', 'product']);
+  });
+
+  it('keeps same-step multiples (the website flow chains several in one message)', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        toolCallsResponse([prefillCall('call_1', 'service'), prefillCall('call_2', 'product')])
+      )
+      .mockResolvedValue(stopResponse()) as unknown as typeof fetch;
+
+    await enrich();
+
+    expect(mockExecuteToolCall).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/cat/few-shot-examples.ts
+++ b/src/services/cat/few-shot-examples.ts
@@ -65,7 +65,7 @@ Want me to start a draft for one? Tell me what you make and roughly what you'd c
 **Step 2**: Sell your best photos as Products — passive income.
 **Step 3**: Launch a Project to fund a photo book or exhibition once you have an audience.
 
-Let's start with Step 1:
+Let's start with Step 1 — a **Service** fits here because you're selling your time behind the camera, not an item:
 
 \`\`\`action
 {

--- a/src/services/cat/reply-language.ts
+++ b/src/services/cat/reply-language.ts
@@ -122,7 +122,13 @@ export function detectReplyLanguage(message: string): ReplyLanguage {
     }
   }
 
-  if (hasGermanChars) {
+  // Umlauts / ß are a strong German signal — but ONLY when the words around
+  // them don't clearly say otherwise. Swiss place names ("Zürich", "Männedorf")
+  // appear constantly inside English sentences ("I offer haircuts in Zürich"),
+  // and the old unconditional +2 made one umlaut outvote the actual English
+  // words, so English messages got German answers. Count the umlaut bump only
+  // when there's corroborating German vocabulary or no English signal at all.
+  if (hasGermanChars && (de > 0 || en === 0)) {
     de += 2;
   }
 

--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -5,8 +5,9 @@
  * Separated from the API route so the prompt can be tested and iterated independently.
  *
  * Created: 2026-02-09
- * Last Modified: 2026-02-19
- * Last Modified Summary: Expanded for diverse use cases, added wallet awareness
+ * Last Modified: 2026-07-03
+ * Last Modified Summary: Entity-type decision rubric + required "why this type" line,
+ *   money-need → loan pathway, thin-input single-question posture
  */
 
 import { CAT_CREATABLE_ENTITY_TYPES } from '@/types/cat';
@@ -80,6 +81,7 @@ Before suggesting anything, understand the person — not just their economic si
 4. **What STAGE are they at?** Starting from zero, earning but unstructured, established, lost something and rebuilding, or just looking for community
 
 Then map to the right pathway:
+- **Needs money NOW** → Loan request when they intend to repay ("I need CHF 500 to fix my bike so I can work" → Loan, repaid from earnings). Project when backers fund an outcome, Cause when it's support with no strings. Don't answer a money NEED with only "sell something" — name the borrowing/funding option too.
 - **Immediate income** → Service (sell time/expertise) or Product (sell goods)
 - **Recurring income** → Service retainers, Product catalog, Asset rentals
 - **Scaling beyond time** → Products from knowledge (ebooks, courses, templates, tools)
@@ -95,6 +97,8 @@ The goal is to help in as few words and as few questions as possible. NEVER open
 **Lead with what they can DO here.** From whatever they told you — even one phrase — name 2-3 concrete, specific things OrangeCat lets them do, mapped to THEIR exact words. A DJ → "list DJ sets as a bookable **Service**, sell your mixes as **Products**, run a ticketed **Event**." A baker → "sell loaves as **Products**, take pre-orders, host a weekend pop-up **Event**." Use their real noun — a DJ stays a DJ; do NOT generalize them into "musician" and ask what instrument they play. Showing the value first proves you understood them.
 
 **Then at most ONE question, and make it optional.** Ask a single question only if the answer changes what you'd suggest first — and immediately give a way past it: "…or just tell me which sounds good and we'll set it up." The person must always be able to move forward without answering.
+
+**When input is THIN, ask — don't blind-draft.** If someone names only what they are ("we're a bakery") without anything sellable-specific, still lead with the 2-3 mapped options, but then ask ONE focused question about THEM that unlocks a concrete draft ("What do you bake that people keep coming back for?"). One question, about their thing, never a list — and don't drift into unrelated scenarios they never mentioned. Draft an entity only once you have at least one specific detail from them.
 
 **Never re-ask what they already told you.** Carry every detail across turns (what they do, that they play weekends, that it's just them, that it's at home for now). If they just answered, BUILD on it — don't reset and ask fresh discovery questions. Re-asking reads as not listening and is the fastest way to lose someone.
 
@@ -146,6 +150,19 @@ Every person contains multiple possibilities. The categories in this prompt — 
 Hold possibilities open. Ask questions that reveal what someone wants right now, and what they might want later. Don't decide who someone is from one message. Every conversation can go in a direction you didn't predict.
 
 When you suggest something, offer it as an invitation, not a conclusion. "This might be worth considering if X" leaves room for the person to say "no, actually it's more like Y." That's the conversation doing its job.
+
+## Choosing the Entity Type (decision rubric — apply before EVERY proposal)
+Pick the type from what the thing IS, not from surface words:
+- Selling your time, skill, or labor to others — even at a fixed price ("haircuts at home, 40 CHF") → **service**. A price attached to work does NOT make it a product.
+- A tangible or digital ITEM that changes hands (mugs, bread, ebooks, software) → **product**
+- Raising money for a defined outcome, where milestones/accountability make sense → **project**
+- Open-ended, no-strings support for ongoing work or need → **cause**
+- The user NEEDS money and intends to REPAY it → **loan** — never a product, never a cause
+- A time-bound gathering with a date and place → **event**
+- People organizing together (a community, club, collective) → **group** (or the informal **circle**)
+- Something they OWN that others could rent or use → **asset**
+
+**Always say WHY (required).** Every entity you propose — via a card, an action block, or in prose — must come with ONE plain-language line explaining why that type fits, tied to the user's own words (e.g. "A Service fits because you're selling your time, not an item."). Never present a proposal without its why.
 
 ## Economic Building Blocks
 
@@ -253,7 +270,7 @@ Only include relevant prefill fields for the entity type:
 - **product**: price_btc, category
 - **service**: hourly_rate (BTC, for hourly) or fixed_price (BTC, for fixed-price), category
 - **project/cause**: goal_amount (BTC), category
-- **event**: location, start_date (ISO date string)
+- **event**: location, start_date (a real ISO date like "2026-08-15" — resolve relative phrases such as "next month" against the "Current Date & Time" in context; never output the phrase itself)
 - **asset**: asset_type, location
 - **loan**: original_amount (BTC amount requested), interest_rate (percentage, optional), loan_type ("new_request" or "existing_refinance")
 - **investment**: target_amount (BTC), investment_type ("revenue_share"|"equity"|"debt"|"convertible_note"), minimum_investment (BTC)

--- a/src/services/cat/tool-executor.ts
+++ b/src/services/cat/tool-executor.ts
@@ -312,7 +312,7 @@ INSTRUCTIONS (hard constraints):
       return {
         role: 'tool',
         tool_call_id: toolCall.id,
-        content: `Drafted a ${entityType} with ${fieldCount} fields. The user will see a card to review and open in the form. Do not repeat the field values in your response — just briefly confirm what you drafted and invite them to review.`,
+        content: `Drafted a ${entityType} with ${fieldCount} fields. The user will see a card to review and open in the form. Do not repeat the field values in your response — briefly confirm what you drafted, include ONE short line on why a ${entityType} is the right type for it (tied to the user's own words), and invite them to review. Do NOT call prefill_entity_form again for this same ${entityType} — it is already drafted.`,
       };
     } catch (err) {
       onToolCall?.({

--- a/src/services/cat/tool-use-detection.ts
+++ b/src/services/cat/tool-use-detection.ts
@@ -76,9 +76,31 @@ const TOOL_TRIGGER_KEYWORDS = [
  * weaker model toward upgrading, using the SAME signal that gates tool use
  * (one source of truth for "this wants more than chat").
  */
+/**
+ * A money NEED ("I need 500 CHF to fix my bike", "can I borrow money here?")
+ * is a lending/funding intent — it should reach the tool pass so Cat can draft
+ * a loan (or project/cause) instead of only suggesting things to sell.
+ * Deliberately narrow: "need" alone never triggers; it must pair with an
+ * amount+currency or an explicit borrow/loan word.
+ */
+const MONEY_NEED_PATTERNS = [
+  /\bborrow\b/i,
+  /\b(a|get|request|take)\s+(out\s+)?a?\s*loan\b/i,
+  /\bneed\s+(some\s+)?(money|cash|funds|capital)\b/i,
+  /\bneed\s+[\d'.,]+\s*(chf|eur|usd|btc|francs?|dollars?|euros?)\b/i,
+];
+
+export function hasMoneyNeedIntent(message: string): boolean {
+  return MONEY_NEED_PATTERNS.some(re => re.test(message));
+}
+
 export function messageMightNeedTools(message: string): boolean {
   const lower = message.toLowerCase();
-  return TOOL_TRIGGER_KEYWORDS.some(kw => lower.includes(kw)) || hasWebsiteAnalysisIntent(message);
+  return (
+    TOOL_TRIGGER_KEYWORDS.some(kw => lower.includes(kw)) ||
+    hasMoneyNeedIntent(message) ||
+    hasWebsiteAnalysisIntent(message)
+  );
 }
 
 /**
@@ -155,7 +177,9 @@ const CREATE_INTENT_PATTERNS = [
 ];
 
 export function hasCreateIntent(message: string): boolean {
-  return CREATE_INTENT_PATTERNS.some(re => re.test(message));
+  // A money need drafts the user's OWN loan/project — a create intent, never a
+  // platform search.
+  return CREATE_INTENT_PATTERNS.some(re => re.test(message)) || hasMoneyNeedIntent(message);
 }
 
 /** Entity types Cat can DRAFT via the prefill tool. Derived from the creatable SSOT so the

--- a/src/services/cat/tool-use.ts
+++ b/src/services/cat/tool-use.ts
@@ -188,6 +188,16 @@ export async function maybeEnrichWithSearchResults(
   }
 }
 
+/** The entityType a prefill_entity_form call targets ('' when unparseable). */
+function prefillType(toolCall: RawToolCall): string {
+  try {
+    const args = JSON.parse(toolCall.function?.arguments ?? '{}') as { entityType?: string };
+    return args.entityType ?? '';
+  } catch {
+    return '';
+  }
+}
+
 /**
  * The bounded agentic loop: the model can call a tool, see the result, and
  * decide its next move — up to MAX_TOOL_STEPS round-trips. May throw or run
@@ -228,7 +238,7 @@ async function runToolLoop(args: {
       role: 'system' as const,
       content:
         'You gather what an OrangeCat chat request needs by calling platform tools. Call ONE tool at a time; after you see its result you may call another tool to refine or follow up, or stop when you have enough.\n' +
-        '- prefill_entity_form: when the user describes something THEY want to create / sell / offer / launch / fundraise (e.g. "I make mugs and want to sell them", "I want to start a project"). This is about THEIR own new thing.\n' +
+        '- prefill_entity_form: when the user describes something THEY want to create / sell / offer / launch / fundraise (e.g. "I make mugs and want to sell them", "I want to start a project"). This is about THEIR own new thing. Pick entityType by what the thing IS: selling time/skill/labor (even at a fixed price, "haircuts, 40 CHF") = service; a tangible/digital item = product; fundraising a defined outcome = project; open-ended no-strings support = cause; the user NEEDS money and will repay = loan; a dated gathering = event; renting out something owned = asset; a community organizing itself = circle. Call it ONCE per distinct entity — never twice for the same thing.\n' +
         '- search_platform: ONLY when the user wants to FIND, discover, or connect with things that already exist on the platform and belong to OTHERS (e.g. "find a designer", "who else is building X"). You may search again with a refined query if the first results are weak.\n' +
         '- suggest_offers: when the user asks what THEY could offer/sell/create, how they could make money or participate, or wants ideas grounded in who they are (e.g. "what can I offer?", "help me make money", "any ideas for me?"). It reads their stored profile/documents/memories — pass no message text, just an optional focus.\n' +
         '- analyze_website: when the user pastes a website URL or bare domain and wants it read, analyzed, or used to set them up (e.g. "here\'s my site: https://… — set me up on OrangeCat", or a message that is nothing but a domain). Pass the EXACT URL from their message. After you see the extracted site text, follow its instructions: chain prefill_entity_form calls (at most 3, all in one message) for entities the site directly evidences — never for anything the site does not say.\n' +
@@ -242,6 +252,13 @@ async function runToolLoop(args: {
   // call sees.
   const loopMessages: ToolAugmentedMessage[] = [...detectionMessages];
   const enriched: ToolAugmentedMessage[] = [...messages];
+
+  // Entity types already drafted in an EARLIER step. Weak routing models keep
+  // re-calling prefill_entity_form for the same thing after seeing its result,
+  // which showed the user two identical draft cards. Same-step multiples stay
+  // allowed (the website flow legitimately chains several in one message);
+  // a repeat of an already-drafted type in a LATER step is always the dup bug.
+  const prefilledTypes = new Set<string>();
 
   // A message that is ONLY a URL/domain has exactly one plausible meaning —
   // "read this site and set me up" — so run analyze_website programmatically
@@ -317,6 +334,11 @@ async function runToolLoop(args: {
         toolCalls = kept;
       }
     }
+    // Cross-step dedupe: drop prefill calls re-drafting an entity type that an
+    // earlier step already drafted (see prefilledTypes above).
+    toolCalls = toolCalls.filter(
+      tc => tc.function?.name !== 'prefill_entity_form' || !prefilledTypes.has(prefillType(tc))
+    );
     if (toolCalls.length === 0) {
       break;
     }
@@ -336,6 +358,9 @@ async function runToolLoop(args: {
       );
       loopMessages.push(resultMessage);
       enriched.push(resultMessage);
+      if (toolCall.function?.name === 'prefill_entity_form') {
+        prefilledTypes.add(prefillType(toolCall));
+      }
     }
     // Loop continues — the model now sees these results and may call another
     // tool (e.g. refine a search) or stop.


### PR DESCRIPTION
## Mission

The Cat must propose the **right entity type** from arbitrary input, **explain why**, and prefill forms so users review-and-post. Founder failure cases to prevent: a service proposed as product/project, ungrounded suggestions, no explanation.

## Method — dogfooded via the real API

8 probes against the live chat pipeline (`POST /api/cat/chat`, non-streaming, fresh conversation per probe, test user Lena, free-tier models) — before and after. Harness signs in via GoTrue REST and forges the `@supabase/ssr` auth cookie.

## Before → After

| Probe | Expected | Before | After |
|---|---|---|---|
| a) "I offer haircuts at home in Zürich, 40 CHF" | service | service ✓ but **replied in German** to English input, **2 identical cards**, no why | service, English, **1 card**, "*A Service fits because you're selling your time and skill rather than a physical product*" |
| b) "I hand-make ceramic mugs and want to sell them" | product | product ✓ ×2 duplicate cards, weak why | product, 1 draft, "*Why a Product? Because you're selling a tangible item rather than your time*" |
| c) tree-planting fundraiser | cause/project | project ✓ with why | project ✓, explicit "*Why a Project?*" (this run attached no draft card — model variance, see Known gaps) |
| d) "I need 500 CHF to fix my bike so I can deliver food" | loan | loan ✓ | loan ✓ + repay-from-earnings framing, plus earn-to-repay alternative |
| e) LinkedIn-style engineer bio | service (+ask) | service ✓, no follow-up | service ✓, "*Why a Service?*" + **offers profile update** |
| f) "Bitcoin meetup next month in Basel" | event | event ✓ but `start_date: "next month"` (not ISO) | event ✓ with why; asks ONE date question with tappable dates + "Just start draft" escape |
| g) "we're a bakery" (thin input) | interview | rambled into proxy-mode assumptions, **no focused question** | 3 mapped options each with its why + ONE focused question ("what's your signature item people keep coming back for?") |
| h) Philosopher's-Stone community text | group/circle + project | 2 project drafts, group only as a question | **Group** proposed first with a formalize→fund strategy |

**Scores**: right type 7/8 → **8/8** · explanation present 4/8 → **8/8** · duplicate cards 2 probes → **0** · wrong-language replies 1 → **0** · thin-input focused question ✗ → ✓

## What changed

- **`system-prompt.ts`** — compact entity-type decision rubric (priced labor = service, item = product, milestone fundraising = project, no-strings = cause, repayable money need = loan — never a product/cause, dated gathering = event, community = group/circle, owned thing to rent = asset) + **required one-line "why this type"** with every proposal; money-NEED pathway so a need is never answered with only "sell something"; thin-input posture: ONE focused question that unlocks a draft (softens the interview ban in `docs/specs/cat-economic-interviewer.md` exactly as specced); event `start_date` must resolve to a real ISO date.
- **`tool-use.ts`** — same rubric compressed into the routing prompt so the prefill tool picks the right `entityType`; **cross-step prefill dedupe** (a later-step `prefill_entity_form` for an already-drafted type is dropped — was: two identical draft cards; same-step multiples stay allowed for the website flow).
- **`tool-use-detection.ts`** — `hasMoneyNeedIntent` ("I need 500 CHF to…", borrow/loan) triggers the tool pass and counts as create intent, never a platform search. Deliberately narrow: bare "need" never fires.
- **`tool-executor.ts`** — prefill result instructs the model to state why the type fits and never re-draft the same type.
- **`reply-language.ts`** — umlaut bump no longer lets a Swiss place name ("Zürich") flip an English message to a German reply; bump now requires corroborating German vocabulary or zero English signal.
- **`few-shot-examples.ts`** — photography example models the why-line.

## Tests

- `entity-type-rubric.test.ts` (new): rubric + why-requirement + thin-input posture present in the prompt; money-need detection positives/negatives.
- `tool-use-prefill-dedupe.test.ts` (new): later-step same-type prefill dropped; different type allowed; same-step multiples kept.
- `reply-language.test.ts`: Zürich regression cases.

**Gates**: type-check 0 · lint clean · `npx jest __tests__/unit` → 58 suites, 671 tests green (verified in an isolated worktree of this branch).

## Known gaps (follow-ups, not in this PR)

- Free-model variance: occasionally narrates "here's a draft" without attaching the card (probe c this run), or drafts a generic product on thin input alongside its focused question (probe g).
- Prod `POST /api/cat/chat` with `stream:false` returned 500 after ~38s on tool-heavy messages while streaming worked — suspected proxy/route timeout on the box, worth a separate look (the app UI uses streaming, so users are unaffected).
- Probe runs write real memories for the test user; later probes see earlier probes' facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)