### PR TITLE
fix(cat): fresh new-chat landing, lazy conversation creation, honest quota chip, friendly model names

### DIFF
--- a/__tests__/unit/cat/model-display-name.test.ts
+++ b/__tests__/unit/cat/model-display-name.test.ts
@@ -1,0 +1,50 @@
+/**
+ * getModelDisplayName — friendly names for reply provenance.
+ *
+ * Providers report resolved ids that can carry snapshot suffixes the registry
+ * doesn't key on; the UI must never print a raw slug under a reply.
+ */
+
+import { getModelDisplayName, AI_MODEL_REGISTRY } from '@/config/ai-models';
+
+describe('getModelDisplayName', () => {
+  it('returns the registry name for an exact id', () => {
+    expect(getModelDisplayName('openai/gpt-oss-120b:free')).toBe(
+      AI_MODEL_REGISTRY['openai/gpt-oss-120b:free'].name
+    );
+  });
+
+  it('resolves dated snapshot ids to the registered model name', () => {
+    // The founder-reported case: gemma snapshot id printed raw under replies.
+    expect(getModelDisplayName('google/gemma-4-31b-it-20260402:free')).toBe(
+      AI_MODEL_REGISTRY['google/gemma-4-31b-it:free'].name
+    );
+  });
+
+  it('matches only at segment boundaries (20b must not swallow 120b)', () => {
+    expect(getModelDisplayName('openai/gpt-oss-120b-0525:free')).toBe(
+      AI_MODEL_REGISTRY['openai/gpt-oss-120b:free'].name
+    );
+    expect(getModelDisplayName('openai/gpt-oss-20b-0525:free')).toBe(
+      AI_MODEL_REGISTRY['openai/gpt-oss-20b:free'].name
+    );
+  });
+
+  it('resolves a shorter reported id to the registered variant', () => {
+    // Server may strip a suffix relative to the registry key.
+    expect(getModelDisplayName('meta-llama/llama-3.3-70b-instruct')).toBe(
+      AI_MODEL_REGISTRY['meta-llama/llama-3.3-70b-instruct:free'].name
+    );
+  });
+
+  it('prettifies unknown slugs instead of echoing them raw', () => {
+    const name = getModelDisplayName('mistralai/devstral-small-2505:free');
+    expect(name).not.toContain('/');
+    expect(name).not.toContain(':free');
+    expect(name).toBe('Devstral Small 2505 (Free)');
+  });
+
+  it('uppercases parameter-size tokens in derived names', () => {
+    expect(getModelDisplayName('acme/foo-bar-32b')).toBe('Foo Bar 32B');
+  });
+});

--- a/src/app/(authenticated)/dashboard/cat/page.tsx
+++ b/src/app/(authenticated)/dashboard/cat/page.tsx
@@ -28,9 +28,11 @@ export default function CatHubPage() {
   const {
     conversations,
     activeId,
+    isLoading: isLoadingConversations,
     refresh: refreshConversations,
     selectConversation,
     newConversation,
+    adoptConversation,
     deleteConversation,
   } = useConversations();
 
@@ -68,6 +70,7 @@ export default function CatHubPage() {
       <ConversationRail
         conversations={conversations}
         activeId={activeId}
+        isLoading={isLoadingConversations}
         onSelect={selectConversation}
         onNew={newConversation}
         onDelete={deleteConversation}
@@ -77,6 +80,7 @@ export default function CatHubPage() {
         <ModernChatPanel
           variant="focus"
           conversationId={activeId}
+          onConversationCreated={adoptConversation}
           onConversationStarted={refreshConversations}
           initialMessage={initialMessage}
           isNewUser={isNewUser}

--- a/src/components/ai-chat/ModernChatPanel/components/ConversationRail.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/ConversationRail.tsx
@@ -15,7 +15,10 @@ import type { ConversationSummary } from '../hooks/useConversations';
 
 interface ConversationRailProps {
   conversations: ConversationSummary[];
+  /** null = fresh new-chat draft (the default landing state). */
   activeId: string | null;
+  /** True while the initial conversation list is loading — show placeholders, not "empty". */
+  isLoading?: boolean;
   onSelect: (id: string) => void;
   onNew: () => void;
   onDelete: (id: string) => void;
@@ -25,14 +28,25 @@ function railTitle(c: ConversationSummary): string {
   return c.title?.trim() || 'New chat';
 }
 
-function RailBody({ conversations, activeId, onSelect, onNew, onDelete }: ConversationRailProps) {
+function RailBody({
+  conversations,
+  activeId,
+  isLoading,
+  onSelect,
+  onNew,
+  onDelete,
+}: ConversationRailProps) {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="p-2">
         <button
           type="button"
           onClick={onNew}
-          className="flex w-full items-center gap-2 rounded-lg border border-subtle bg-surface-base px-3 py-2 text-sm font-medium text-fg-primary transition-colors hover:bg-surface-raised"
+          className={cn(
+            'flex w-full items-center gap-2 rounded-lg border border-subtle px-3 py-2 text-sm font-medium text-fg-primary transition-colors hover:bg-surface-raised',
+            // Draft state (no active conversation) = "New chat" is where you are.
+            activeId === null ? 'bg-surface-raised' : 'bg-surface-base'
+          )}
         >
           <Plus className="h-4 w-4" />
           New chat
@@ -40,7 +54,14 @@ function RailBody({ conversations, activeId, onSelect, onNew, onDelete }: Conver
       </div>
 
       <nav className="min-h-0 flex-1 space-y-0.5 overflow-y-auto px-2 pb-2">
-        {conversations.length === 0 ? (
+        {isLoading ? (
+          // Skeleton rows while the list resolves — never flash "no conversations".
+          <div className="space-y-1.5 px-1 py-1" aria-hidden>
+            {[0, 1, 2].map(i => (
+              <div key={i} className="h-8 animate-pulse rounded-lg bg-surface-raised/60" />
+            ))}
+          </div>
+        ) : conversations.length === 0 ? (
           <p className="px-3 py-4 text-xs text-fg-tertiary">No conversations yet.</p>
         ) : (
           conversations.map(c => {

--- a/src/components/ai-chat/ModernChatPanel/components/MessageBubble.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/MessageBubble.tsx
@@ -6,7 +6,7 @@
 import { cn } from '@/lib/utils';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { Cat, User, Copy, Check, Clock, X } from 'lucide-react';
-import { AI_MODEL_REGISTRY } from '@/config/ai-models';
+import { getModelDisplayName } from '@/config/ai-models';
 import { getModelCapability } from '@/config/model-capability';
 import { renderChatMarkdown } from '@/utils/markdown';
 import { ActionButton } from './ActionButton';
@@ -253,7 +253,7 @@ export function MessageBubble({
                   <span aria-hidden> · </span>
                 </>
               )}
-              <span>{AI_MODEL_REGISTRY[message.modelUsed]?.name || message.modelUsed}</span>
+              <span title={message.modelUsed}>{getModelDisplayName(message.modelUsed)}</span>
               {(() => {
                 const cap = getModelCapability(message.modelUsed);
                 return (

--- a/src/components/ai-chat/ModernChatPanel/components/QuotaMeter.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/QuotaMeter.tsx
@@ -6,10 +6,13 @@
  *
  * Tier-aware states:
  *   - byok    → "Your key" badge; cap doesn't apply
- *   - pro     → "Pro · N / limit" chip; same near-cap / capped CTA logic as free
- *   - free    → "N / limit" chip, normal weight
- *   - warning → ≤2 remaining: chip + inline "Use your key →" link
+ *   - pro     → "Pro · N of limit … left" chip; same near-cap / capped CTA logic as free
+ *   - free    → "N of limit free messages left today" chip, normal weight
+ *   - warning → ≤2 remaining: chip + inline "Add your key →" link
  *   - capped  → 0 remaining: red chip + same link
+ *
+ * The chip must be self-explanatory (founder feedback): full sentence on ≥sm,
+ * compact "N of M left" on mobile, complete explanation in the tooltip + sr text.
  *
  * The CTA points at /settings/ai (BYOK setup) because that's the only
  * real escape today — once /pricing has a real Pro checkout we swap it
@@ -58,6 +61,13 @@ export function QuotaMeter({ quota, className }: QuotaMeterProps) {
   const isCapped = requestsRemaining <= 0;
   const isNearCap = !isCapped && requestsRemaining <= NEAR_CAP_THRESHOLD;
 
+  // Self-explanatory in full via tooltip + screen readers; the visible chip
+  // stays compact on small screens and spells itself out on ≥sm.
+  const noun = isPro ? 'Cat messages' : 'free messages';
+  const explanation = isCapped
+    ? `You've used all ${dailyLimit} ${noun} for today · Add your own API key for unlimited`
+    : `${requestsRemaining} of ${dailyLimit} ${noun} left today · Add your own API key for unlimited`;
+
   return (
     <span
       className={cn(
@@ -71,24 +81,31 @@ export function QuotaMeter({ quota, className }: QuotaMeterProps) {
         !isCapped && !isNearCap && !isPro && 'border-subtle bg-surface-raised text-fg-secondary',
         className
       )}
+      title={explanation}
     >
       {isPro && !isCapped && !isNearCap && (
         <Sparkles className="h-3 w-3 text-accent-warm" aria-hidden="true" />
       )}
       <span className="whitespace-nowrap" aria-live="polite">
-        {isCapped
-          ? 'Daily limit'
-          : isPro
-            ? `Pro · ${requestsRemaining} / ${dailyLimit}`
-            : `${requestsRemaining} / ${dailyLimit}`}
-        <span className="sr-only"> Cat messages remaining today</span>
+        {isCapped ? (
+          'Daily limit reached'
+        ) : (
+          <>
+            {isPro && 'Pro · '}
+            {requestsRemaining} of {dailyLimit}
+            <span className="hidden sm:inline"> {noun}</span> left
+            <span className="hidden sm:inline"> today</span>
+          </>
+        )}
+        <span className="sr-only"> {explanation}</span>
       </span>
       {(isCapped || isNearCap) && (
         <Link
           href={ROUTES.SETTINGS_AI}
           className="whitespace-nowrap font-medium underline decoration-dotted underline-offset-2 hover:no-underline"
+          title="Bring your own API key — unlimited messages, you pay your provider directly"
         >
-          Use your key →
+          Add your key →
         </Link>
       )}
     </span>

--- a/src/components/ai-chat/ModernChatPanel/hooks/useChatHistory.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useChatHistory.ts
@@ -4,28 +4,47 @@ import { logger } from '@/utils/logger';
 import type { Message } from '../types';
 
 /**
- * Loads chat history for the active conversation. When `conversationId` is given
- * it loads that conversation (and reloads on switch); otherwise the user's
- * default conversation. Clears the view immediately on switch so messages from
- * the previous conversation don't linger while the next loads.
+ * Loads chat history for the active conversation.
+ *
+ * - `conversationId` set → load that conversation (and reload on switch),
+ *   clearing the view immediately so the previous thread doesn't linger.
+ * - `conversationId` null → fresh new-chat draft: no fetch, no loading state.
+ *   (The old behaviour — loading the default conversation — is what made the
+ *   page flash "Loading conversation…" and then open an old thread.)
+ * - `justCreatedIdRef` guard: when the panel lazily creates a conversation on
+ *   first send and adopts it, the id flips null → new id while the live
+ *   stream is already in state. Fetching then would wipe the thread (the
+ *   server saves messages after the exchange), so that one transition is
+ *   skipped. The guard is consumed on match, so revisiting the conversation
+ *   later refetches normally.
  */
 export function useChatHistory(
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>,
-  conversationId?: string | null
+  conversationId?: string | null,
+  justCreatedIdRef?: React.MutableRefObject<string | null>
 ) {
-  const [isLoadingHistory, setIsLoadingHistory] = useState(true);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(!!conversationId);
 
   useEffect(() => {
+    if (!conversationId) {
+      // Fresh new chat: nothing to load.
+      setMessages([]);
+      setIsLoadingHistory(false);
+      return;
+    }
+
+    if (justCreatedIdRef?.current === conversationId) {
+      justCreatedIdRef.current = null;
+      setIsLoadingHistory(false);
+      return;
+    }
+
     let cancelled = false;
     setIsLoadingHistory(true);
     // Switching conversations: drop the old thread right away.
     setMessages([]);
 
-    const url = conversationId
-      ? API_ROUTES.CAT.CONVERSATION(conversationId)
-      : API_ROUTES.CAT.HISTORY;
-
-    fetch(url)
+    fetch(API_ROUTES.CAT.CONVERSATION(conversationId))
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         if (cancelled || !data?.data?.length) {
@@ -60,7 +79,7 @@ export function useChatHistory(
     return () => {
       cancelled = true;
     };
-  }, [setMessages, conversationId]);
+  }, [setMessages, conversationId, justCreatedIdRef]);
 
   return { isLoadingHistory };
 }

--- a/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
@@ -61,7 +61,7 @@ function readLocale(): string {
 
 interface UseChatMessagesOptions {
   selectedModel: string;
-  /** Active conversation. Omitted/null → the user's default conversation. */
+  /** Active conversation. Omitted/null → fresh draft; a conversation is created on first send. */
   conversationId?: string | null;
   onPendingResult?: () => void;
   /**
@@ -75,6 +75,26 @@ interface UseChatMessagesOptions {
    * rail can refresh (the conversation gets its auto-title server-side).
    */
   onConversationStarted?: () => void;
+  /**
+   * Fires when the first send of a fresh draft lazily created a conversation,
+   * so the owner can adopt it (highlight in the rail, route later sends to it).
+   */
+  onConversationCreated?: (id: string) => void;
+}
+
+/** Create a conversation row on the server; null on failure (send falls back to default). */
+async function createConversationOnServer(): Promise<string | null> {
+  try {
+    const res = await fetch(API_ROUTES.CAT.CONVERSATIONS, { method: 'POST' });
+    if (!res.ok) {
+      return null;
+    }
+    const data = await res.json();
+    return data?.data?.id ?? null;
+  } catch (err) {
+    logger.warn('Failed to create conversation', { err }, 'useChatMessages');
+    return null;
+  }
 }
 
 export function useChatMessages({
@@ -83,6 +103,7 @@ export function useChatMessages({
   onPendingResult,
   onMessageSent,
   onConversationStarted,
+  onConversationCreated,
 }: UseChatMessagesOptions) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -95,9 +116,28 @@ export function useChatMessages({
   onMessageSentRef.current = onMessageSent;
   const onConversationStartedRef = useRef(onConversationStarted);
   onConversationStartedRef.current = onConversationStarted;
+  const onConversationCreatedRef = useRef(onConversationCreated);
+  onConversationCreatedRef.current = onConversationCreated;
   const preferredCurrency = useUserCurrency();
 
-  const { isLoadingHistory } = useChatHistory(setMessages, conversationId);
+  // Conversation created lazily on the first send of a fresh draft. `pending`
+  // routes follow-up sends until the owner adopts the id into the prop;
+  // `justCreated` tells useChatHistory to skip the one refetch that adoption
+  // triggers (the live thread is already in state).
+  const pendingConversationIdRef = useRef<string | null>(null);
+  const justCreatedConversationIdRef = useRef<string | null>(null);
+
+  // Any change of the active conversation (including → null for "New chat")
+  // invalidates the pending draft id.
+  useEffect(() => {
+    pendingConversationIdRef.current = null;
+  }, [conversationId]);
+
+  const { isLoadingHistory } = useChatHistory(
+    setMessages,
+    conversationId,
+    justCreatedConversationIdRef
+  );
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -124,6 +164,20 @@ export function useChatMessages({
       setMessages(prev => [...prev, userMessage]);
       setIsLoading(true);
 
+      // Fresh draft: create the conversation now (first send), so every new
+      // chat is its own thread instead of piling into the default one. On
+      // failure we send without an id and the server falls back to default.
+      let activeConversationId = conversationId ?? pendingConversationIdRef.current;
+      if (!activeConversationId) {
+        const created = await createConversationOnServer();
+        if (created) {
+          pendingConversationIdRef.current = created;
+          justCreatedConversationIdRef.current = created;
+          activeConversationId = created;
+          onConversationCreatedRef.current?.(created);
+        }
+      }
+
       const assistantId = `assistant-${Date.now()}`;
       setMessages(prev => [
         ...prev,
@@ -145,7 +199,7 @@ export function useChatMessages({
             preferredCurrency,
             locale: readLocale(),
             lastVisitedPath: readLastVisitedPath(),
-            conversationId: conversationId ?? undefined,
+            conversationId: activeConversationId ?? undefined,
           }),
           signal: abortController.signal,
         });
@@ -312,9 +366,12 @@ export function useChatMessages({
   const clearChat = useCallback(() => {
     setMessages([]);
     setError(null);
-    const url = conversationId
-      ? `${API_ROUTES.CAT.HISTORY}?conversationId=${encodeURIComponent(conversationId)}`
-      : API_ROUTES.CAT.HISTORY;
+    // A fresh draft has no server-side thread yet — nothing to clear there.
+    const targetId = conversationId ?? pendingConversationIdRef.current;
+    if (!targetId) {
+      return;
+    }
+    const url = `${API_ROUTES.CAT.HISTORY}?conversationId=${encodeURIComponent(targetId)}`;
     fetch(url, { method: 'DELETE' }).catch((err: unknown) => {
       logger.warn('Failed to clear server history', { err }, 'useChatMessages');
     });

--- a/src/components/ai-chat/ModernChatPanel/hooks/useConversations.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useConversations.ts
@@ -11,9 +11,13 @@ export interface ConversationSummary {
 
 /**
  * Manages the user's Cat conversation list for the rail: load, switch, start a
- * new chat, and delete. The active id drives which conversation the chat panel
- * loads/sends to. On first load the most-recently-updated conversation is active
- * (null until we know — the panel falls back to the default conversation).
+ * new chat, and delete.
+ *
+ * `activeId === null` means "fresh new chat" — the draft state the page lands
+ * on and the state after "New chat". No conversation row exists yet; the chat
+ * panel creates one lazily on the first send (see useChatMessages) and adopts
+ * it via `adoptConversation`. This is deliberate: eagerly POSTing on load or on
+ * "New chat" litters the rail (and the DB) with empty untitled conversations.
  */
 export function useConversations() {
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
@@ -29,8 +33,6 @@ export function useConversations() {
       const data = await res.json();
       const list: ConversationSummary[] = data?.data?.conversations ?? [];
       setConversations(list);
-      // Adopt an active id on first load (most recent) if none is set yet.
-      setActiveId(prev => prev ?? list[0]?.id ?? null);
     } catch (err) {
       logger.warn('Failed to load conversations', { err }, 'useConversations');
     } finally {
@@ -46,35 +48,26 @@ export function useConversations() {
     setActiveId(id);
   }, []);
 
-  const newConversation = useCallback(async () => {
-    try {
-      const res = await fetch(API_ROUTES.CAT.CONVERSATIONS, { method: 'POST' });
-      if (!res.ok) {
-        return;
-      }
-      const data = await res.json();
-      const id: string | undefined = data?.data?.id;
-      if (id) {
-        setActiveId(id);
-        await refresh();
-      }
-    } catch (err) {
-      logger.warn('Failed to start new conversation', { err }, 'useConversations');
-    }
-  }, [refresh]);
+  /** "New chat": back to the draft state. The row is created on first send. */
+  const newConversation = useCallback(() => {
+    setActiveId(null);
+  }, []);
+
+  /** Adopt a conversation the chat panel just created on first send. */
+  const adoptConversation = useCallback(
+    (id: string) => {
+      setActiveId(id);
+      void refresh();
+    },
+    [refresh]
+  );
 
   const deleteConversation = useCallback(
     async (id: string) => {
-      // Optimistic: drop it from the list immediately.
+      // Optimistic: drop it from the list immediately; if it was active,
+      // fall back to a fresh new chat.
       setConversations(prev => prev.filter(c => c.id !== id));
-      setActiveId(prev => {
-        if (prev !== id) {
-          return prev;
-        }
-        // Was active → fall back to the next most-recent, or default (null).
-        const remaining = conversations.filter(c => c.id !== id);
-        return remaining[0]?.id ?? null;
-      });
+      setActiveId(prev => (prev === id ? null : prev));
       try {
         await fetch(API_ROUTES.CAT.CONVERSATION(id), { method: 'DELETE' });
       } catch (err) {
@@ -82,7 +75,7 @@ export function useConversations() {
       }
       await refresh();
     },
-    [conversations, refresh]
+    [refresh]
   );
 
   return {
@@ -92,6 +85,7 @@ export function useConversations() {
     refresh,
     selectConversation,
     newConversation,
+    adoptConversation,
     deleteConversation,
   };
 }

--- a/src/components/ai-chat/ModernChatPanel/index.tsx
+++ b/src/components/ai-chat/ModernChatPanel/index.tsx
@@ -36,10 +36,15 @@ interface ModernChatPanelProps {
    * page reload. Composed alongside the internal post-send wiring.
    */
   onMessageSent?: () => void;
-  /** Active conversation to load/send to. Omitted/null → default conversation. */
+  /**
+   * Active conversation to load/send to. Omitted/null → fresh new-chat draft:
+   * nothing is loaded and a conversation is created lazily on the first send.
+   */
   conversationId?: string | null;
   /** Fires after each send so the conversation rail can refresh title + order. */
   onConversationStarted?: () => void;
+  /** Fires when the first send of a fresh draft created a conversation — adopt it. */
+  onConversationCreated?: (id: string) => void;
   className?: string;
 }
 
@@ -53,6 +58,7 @@ export function ModernChatPanel({
   onMessageSent,
   conversationId,
   onConversationStarted,
+  onConversationCreated,
   className,
 }: ModernChatPanelProps = {}) {
   const router = useRouter();
@@ -106,6 +112,7 @@ export function ModernChatPanel({
       onMessageSent?.();
     },
     onConversationStarted,
+    onConversationCreated,
   });
 
   const { suggestions, hasContext, isLoadingSuggestions } = useSuggestions();

--- a/src/config/ai-models.ts
+++ b/src/config/ai-models.ts
@@ -374,6 +374,58 @@ export function getModelMetadata(modelId: string): AIModelMetadata | undefined {
 }
 
 /**
+ * Human-friendly display name for any model id — registered or not.
+ *
+ * Providers report *resolved* ids that can carry snapshot suffixes the
+ * registry doesn't key on (e.g. `google/gemma-4-31b-it-20260402:free` for the
+ * registered `google/gemma-4-31b-it:free`). Never surface a raw slug in UI:
+ *   1. exact registry hit → its display name
+ *   2. registry entry whose id is a boundary-safe prefix of the reported id
+ *      (or vice versa) → its display name (longest match wins)
+ *   3. otherwise derive a readable name from the slug itself
+ */
+export function getModelDisplayName(modelId: string): string {
+  const exact = AI_MODEL_REGISTRY[modelId];
+  if (exact) {
+    return exact.name;
+  }
+
+  const stripFree = (id: string) => id.replace(/:free$/, '');
+  const base = stripFree(modelId);
+  // "a" is a prefix of "b" ending at a segment boundary ("-", ".", ":" or end).
+  const boundaryPrefix = (a: string, b: string) =>
+    b.startsWith(a) && (b.length === a.length || ['-', '.', ':'].includes(b[a.length]));
+
+  let match: AIModelMetadata | undefined;
+  for (const model of Object.values(AI_MODEL_REGISTRY)) {
+    const registryBase = stripFree(model.id);
+    if (boundaryPrefix(registryBase, base) || boundaryPrefix(base, registryBase)) {
+      if (!match || registryBase.length > stripFree(match.id).length) {
+        match = model;
+      }
+    }
+  }
+  if (match) {
+    return match.name;
+  }
+
+  // Unknown model: prettify the slug ("mistralai/devstral-small-2505" → "Devstral Small 2505").
+  const isFree = modelId.endsWith(':free');
+  const slug = base.split('/').pop() ?? base;
+  const pretty = slug
+    .replace(/-\d{8}$/, '') // drop trailing date snapshot
+    .split('-')
+    .filter(Boolean)
+    .map(word =>
+      /^\d+(\.\d+)?[bm]$/i.test(word)
+        ? word.toUpperCase()
+        : word.charAt(0).toUpperCase() + word.slice(1)
+    )
+    .join(' ');
+  return isFree ? `${pretty} (Free)` : pretty;
+}
+
+/**
  * Get all models for a specific tier
  */
 export function getModelsByTier(tier: ModelTier): AIModelMetadata[] {


### PR DESCRIPTION
Four founder-verified bugs on `/dashboard/cat`, fixed at the x.ai bar.

## 1. Rail listed every conversation twice — root cause: duplicate DATA, not client merging

Investigated the suspected fetch-merging / realtime double-insert paths: there are none — `useConversations` does a single plain fetch-and-replace, no realtime channel, one rail instance. Ground truth from the live DB proved the rows were **genuinely duplicated**: two identical scripted eval batches (the 8 offer-engine scenarios) were run against prod ~30 min apart on 2026-07-03 (08:56–09:00 and 09:24–09:28), each creating its own conversation per prompt — same titles, different ids, different assistant replies. Plus 3 empty untitled rows from the eager "New chat" POST.

**Fixes:**
- Product flaw removed: "New chat" no longer POSTs a row eagerly. A conversation is created **lazily on first send**, so abandoned drafts can't litter the rail/DB anymore.
- Prod artifacts cleaned on the box (12 rows: 9 second-copy eval conversations + 3 stale empties), backed up first in `_backup_cat_conversations_20260703` / `_backup_cat_messages_20260703`. Rail now shows 11 unique conversations, zero duplicate titles.
- No Set band-aid: distinct conversations may legitimately share a title; hiding them would lie.

## 2. Landing flash → old conversation

The page auto-adopted the most-recently-updated conversation after the list resolved (`No conversations yet.` → `Loading conversation…` → old thread). Now:
- `activeId === null` is a first-class **fresh new-chat draft**: the page lands there, nothing is fetched, no loading flash — instant empty state with suggestions.
- History is one click away in the rail, which shows **skeleton rows** while the list loads instead of a false empty state; "New chat" is highlighted while in draft state.
- First send creates the conversation, adopts it into the rail, and a just-created guard stops the adoption from refetching over the live stream. Creation failure degrades gracefully to the server-side default conversation.

## 3. Quota chip is now self-explanatory

`2 / 10 — Use your key →` becomes `2 of 10 free messages left today` (compact `2 of 10 left` on mobile), full explanation in the tooltip + sr-only text, CTA reworded to `Add your key →` with its own explanatory tooltip. Visual restraint kept — same chip, same states.

## 4. Friendly model names under replies

Providers report resolved ids with snapshot suffixes (`google/gemma-4-31b-it-20260402:free`) that miss the registry's exact keys, so the raw slug fell through. New `getModelDisplayName()` in `src/config/ai-models.ts` (SSOT): exact registry hit → boundary-safe prefix match (longest wins, `…-20b` can't swallow `…-120b`) → prettified slug for unknowns. Raw id preserved in a `title` tooltip. Unit-tested (6 cases).

## Gates
- `npm run type-check` — 0 errors
- `npm run lint` — clean
- `npx jest __tests__/unit --silent` — 59 suites, 683 tests green (incl. new `model-display-name.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)