### PR TITLE
feat(trust): entity-detail trust block, honest payment expectations, profile zero-suppression + /username shortlink

### DIFF
--- a/__tests__/unit/utils/dates.test.ts
+++ b/__tests__/unit/utils/dates.test.ts
@@ -1,4 +1,4 @@
-import { formatDate, formatTime, formatRelativeTime } from '@/utils/dates';
+import { formatDate, formatTime, formatRelativeTime, formatDurationMinutes } from '@/utils/dates';
 
 describe('formatDate', () => {
   it('formats a Date object to "MMM d, yyyy"', () => {
@@ -76,5 +76,28 @@ describe('formatRelativeTime', () => {
     const tenMinutesAgo = new Date(now.getTime() - 10 * 60 * 1000).toISOString();
     const result = formatRelativeTime(tenMinutesAgo);
     expect(result).toMatch(/10 minutes ago/i);
+  });
+});
+
+describe('formatDurationMinutes', () => {
+  it('formats sub-hour durations in minutes', () => {
+    expect(formatDurationMinutes(45)).toBe('45 min');
+  });
+
+  it('formats whole hours without a minute part', () => {
+    expect(formatDurationMinutes(180)).toBe('3 h');
+    expect(formatDurationMinutes(60)).toBe('1 h');
+  });
+
+  it('formats mixed hours and minutes', () => {
+    expect(formatDurationMinutes(90)).toBe('1 h 30 min');
+  });
+
+  it('returns empty string for missing or non-positive input', () => {
+    expect(formatDurationMinutes(0)).toBe('');
+    expect(formatDurationMinutes(-30)).toBe('');
+    expect(formatDurationMinutes(null)).toBe('');
+    expect(formatDurationMinutes(undefined)).toBe('');
+    expect(formatDurationMinutes(NaN)).toBe('');
   });
 });

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -1,0 +1,48 @@
+import { notFound, redirect } from 'next/navigation';
+import { createServerClient } from '@/lib/supabase/server';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { ROUTES } from '@/config/routes';
+
+/**
+ * Username shortlink: /<username> → /profiles/<username>.
+ *
+ * Profiles are the platform's identity primitive; a share-friendly
+ * orangecat.ch/anja must reach them. This page only resolves + redirects —
+ * /profiles/[username] stays the canonical URL (SSOT for rendering, SEO,
+ * OG cards).
+ *
+ * Shadowing safety: Next.js matches static segments before dynamic ones, so
+ * every existing top-level route (/about, /discover, /create, route-group
+ * pages, …) wins over this catch-all — this only receives single segments
+ * that would previously 404. A username that collides with a static route
+ * simply isn't reachable via the shortlink (its /profiles/<username> URL
+ * always works). Verified by `npm run audit:routes`.
+ */
+export default async function UsernameShortlinkPage({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+  // Usernames may contain URL-encoded characters (e.g. %40 for '@').
+  const decoded = decodeURIComponent(username);
+
+  // Mirror the /profiles/me convention at the top level.
+  if (decoded === 'me') {
+    redirect(ROUTES.PROFILES.ME);
+  }
+
+  const supabase = await createServerClient();
+  const { data } = await supabase
+    .from(DATABASE_TABLES.PROFILES)
+    .select('username')
+    .eq('username', decoded)
+    .maybeSingle();
+  const match = data as { username: string | null } | null;
+
+  if (!match?.username) {
+    notFound();
+  }
+
+  redirect(ROUTES.PROFILES.VIEW(encodeURIComponent(match.username)));
+}

--- a/src/app/profiles/[username]/page.tsx
+++ b/src/app/profiles/[username]/page.tsx
@@ -4,7 +4,7 @@ import { notFound, redirect } from 'next/navigation';
 import ProfilePageClient from '@/components/profile/ProfilePageClient';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { getTableName } from '@/config/entity-registry';
-import type { EntityType } from '@/config/entity-registry';
+import { fetchProfileListingCounts } from '@/services/profile/listingCounts';
 import { safeJsonLdString } from '@/lib/seo/structured-data';
 import type { ScalableProfile } from '@/services/profile/types';
 import { mapProjectRow } from '@/types/project';
@@ -226,32 +226,9 @@ export default async function PublicProfilePage({ params }: PageProps) {
   const receiveMethodCount =
     walletCount + (profile.bitcoin_address ? 1 : 0) + (profile.lightning_address ? 1 : 0);
 
-  // Fetch entity counts for profile tab badges in parallel.
-  // userField differs for asset (owner_id) vs. all others (user_id) — legacy schema.
-  const ENTITY_COUNT_CONFIG: Array<{ type: EntityType; userField: string }> = [
-    { type: 'product', userField: 'user_id' },
-    { type: 'service', userField: 'user_id' },
-    { type: 'cause', userField: 'user_id' },
-    { type: 'event', userField: 'user_id' },
-    { type: 'loan', userField: 'user_id' },
-    { type: 'asset', userField: 'owner_id' },
-    { type: 'ai_assistant', userField: 'user_id' },
-  ];
-
-  const entityCountResults = await Promise.all(
-    ENTITY_COUNT_CONFIG.map(({ type, userField }) =>
-      supabase
-        .from(getTableName(type))
-        .select('*', { count: 'exact', head: true })
-        .eq(userField, profile.id)
-        .neq('status', 'draft')
-        .neq('show_on_profile', false)
-    )
-  );
-
-  const entityCounts = Object.fromEntries(
-    ENTITY_COUNT_CONFIG.map(({ type }, i) => [type, entityCountResults[i].count || 0])
-  ) as Partial<Record<EntityType, number>>;
+  // Fetch entity counts for profile tab badges (shared SSOT with the
+  // entity-detail trust block — see listingCounts.ts).
+  const { counts: entityCounts } = await fetchProfileListingCounts(supabase, profile.id);
 
   // Calculate statistics
   const projectCount = projects?.length || 0;

--- a/src/components/payment/PaymentExpectationNote.tsx
+++ b/src/components/payment/PaymentExpectationNote.tsx
@@ -1,0 +1,14 @@
+import { APP_NAME } from '@/config/brand';
+
+/**
+ * One honest line under payment CTAs: payments settle directly between
+ * wallets and the platform takes nothing. Rendered ONLY when the seller
+ * actually has a wallet connected — never as marketing on a dead CTA.
+ */
+export function PaymentExpectationNote({ className = '' }: { className?: string }) {
+  return (
+    <p className={`text-xs text-fg-secondary text-center ${className}`.trim()}>
+      Pays wallet-to-wallet via Lightning/Bitcoin — {APP_NAME} takes 0%
+    </p>
+  );
+}

--- a/src/components/payment/PublicEntityPaymentSection.tsx
+++ b/src/components/payment/PublicEntityPaymentSection.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/Button';
 import { useAuth } from '@/hooks/useAuth';
 import { useSellerPaymentMethods } from '@/hooks/useSellerPaymentMethods';
 import { PaymentButton } from './PaymentButton';
+import { PaymentExpectationNote } from './PaymentExpectationNote';
 import { SellerWalletBanner } from './SellerWalletBanner';
 import { OwnerCollectPanel } from './OwnerCollectPanel';
 import { PublicPayPanel } from './PublicPayPanel';
@@ -103,7 +104,7 @@ export function PublicEntityPaymentSection({
         <CardContent className="pt-6 space-y-3">
           {!sellerReceive ? (
             <p className="text-sm text-fg-secondary text-center">
-              This {meta.name.toLowerCase()} isn&apos;t set up to receive Bitcoin yet.
+              This creator hasn&apos;t connected a wallet yet.
             </p>
           ) : (
             <>
@@ -116,6 +117,7 @@ export function PublicEntityPaymentSection({
               <p className="text-xs text-fg-secondary text-center">
                 Sign in to pay via the seller&apos;s connected wallet
               </p>
+              <PaymentExpectationNote />
             </>
           )}
         </CardContent>
@@ -153,10 +155,25 @@ export function PublicEntityPaymentSection({
     );
   }
 
-  // Logged in, NOT the seller — show payment button
+  // Logged in, NOT the seller, seller has no wallet — no purchase CTA. A greyed
+  // "No wallet connected" button promised an action that could never complete;
+  // say the true thing instead.
+  if (!hasWallet) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-sm text-fg-secondary text-center">
+            This creator hasn&apos;t connected a wallet yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Logged in, NOT the seller — show payment button + what the payment means.
   return (
     <Card>
-      <CardContent className="pt-6">
+      <CardContent className="pt-6 space-y-3">
         <PaymentButton
           entityType={entityType}
           entityId={entityId}
@@ -167,6 +184,7 @@ export function PublicEntityPaymentSection({
           sellerHasWallet={hasWallet}
           className="w-full min-h-11"
         />
+        <PaymentExpectationNote />
       </CardContent>
     </Card>
   );

--- a/src/components/payment/PublicPayPanel.tsx
+++ b/src/components/payment/PublicPayPanel.tsx
@@ -22,6 +22,7 @@ import { Bitcoin, Zap, Copy, Check, ExternalLink } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { cn } from '@/lib/utils';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { PaymentExpectationNote } from './PaymentExpectationNote';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { displayBTC } from '@/services/currency';
 
@@ -197,6 +198,7 @@ export function PublicPayPanel({
           Scan the QR or tap Open in wallet — pay from any {isOnchain ? 'Bitcoin' : 'Lightning'}{' '}
           wallet, no account needed.
         </p>
+        <PaymentExpectationNote />
         {signInHref && (
           <p className="text-xs text-fg-tertiary text-center">
             Have an account?{' '}

--- a/src/components/payment/index.ts
+++ b/src/components/payment/index.ts
@@ -7,5 +7,6 @@ export { PaymentDialog } from './PaymentDialog';
 export { PaymentQRCode } from './PaymentQRCode';
 export { PaymentStatusIndicator } from './PaymentStatusIndicator';
 export { ContributionAmountInput } from './ContributionAmountInput';
+export { PaymentExpectationNote } from './PaymentExpectationNote';
 export { SellerWalletBanner } from './SellerWalletBanner';
 export { PublicEntityPaymentSection } from './PublicEntityPaymentSection';

--- a/src/components/profile/ProfileOverviewTab.tsx
+++ b/src/components/profile/ProfileOverviewTab.tsx
@@ -74,36 +74,55 @@ export default function ProfileOverviewTab({
   const publicContactEmail = profile.contact_email;
   const { formatAmountBtc } = useDisplayCurrency();
 
+  // Visitors get real content only — empty-state placeholders ("No website
+  // added yet.") and zero stats are owner-facing prompts, not information.
+  // The owner keeps them so gaps stay visible and fixable.
+  const hasSocialLinks =
+    !!profile.social_links &&
+    typeof profile.social_links === 'object' &&
+    'links' in profile.social_links &&
+    Array.isArray(profile.social_links.links) &&
+    (profile.social_links.links as SocialLink[]).length > 0;
+  const showBioCard = !!profile.bio || isOwnProfile;
+  const showProjectStat = !!stats && (isOwnProfile || stats.projectCount > 0);
+  const showRaisedStat = !!stats && (isOwnProfile || stats.totalRaised > 0);
+  const showWebsiteRow = !!profile.website || isOwnProfile;
+  const showLinksRow = hasSocialLinks || isOwnProfile;
+  const showEmailRow = !!publicContactEmail || isOwnProfile;
+  const showPhoneRow = !!profile.phone || isOwnProfile;
+
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Bio Section - always visible; prompts to fill in when empty */}
-      <Card>
-        <CardHeader className="p-4 sm:p-6">
-          <h3 className="text-base sm:text-lg font-semibold flex items-center gap-2">
-            <User className="w-4 h-4 sm:w-5 sm:h-5 text-fg-secondary" />
-            About
-          </h3>
-        </CardHeader>
-        <CardContent className="p-4 sm:p-6 pt-0">
-          {profile.bio ? (
-            <p className="text-sm sm:text-base text-fg-primary whitespace-pre-wrap leading-relaxed">
-              {profile.bio}
-            </p>
-          ) : isOwnProfile && isDashboardView ? (
-            <a
-              href={`${ROUTES.DASHBOARD.INFO_EDIT}#bio`}
-              className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline group text-sm sm:text-base"
-            >
-              <span className="text-fg-tertiary italic group-hover:text-fg-primary">
-                Tell people more about yourself
-              </span>
-              <span className="text-xs uppercase tracking-wide">Add bio</span>
-            </a>
-          ) : (
-            <p className="text-sm sm:text-base text-fg-tertiary italic">No bio yet.</p>
-          )}
-        </CardContent>
-      </Card>
+      {/* Bio Section — prompts to fill in when empty (owner only) */}
+      {showBioCard && (
+        <Card>
+          <CardHeader className="p-4 sm:p-6">
+            <h3 className="text-base sm:text-lg font-semibold flex items-center gap-2">
+              <User className="w-4 h-4 sm:w-5 sm:h-5 text-fg-secondary" />
+              About
+            </h3>
+          </CardHeader>
+          <CardContent className="p-4 sm:p-6 pt-0">
+            {profile.bio ? (
+              <p className="text-sm sm:text-base text-fg-primary whitespace-pre-wrap leading-relaxed">
+                {profile.bio}
+              </p>
+            ) : isOwnProfile && isDashboardView ? (
+              <a
+                href={`${ROUTES.DASHBOARD.INFO_EDIT}#bio`}
+                className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline group text-sm sm:text-base"
+              >
+                <span className="text-fg-tertiary italic group-hover:text-fg-primary">
+                  Tell people more about yourself
+                </span>
+                <span className="text-xs uppercase tracking-wide">Add bio</span>
+              </a>
+            ) : (
+              <p className="text-sm sm:text-base text-fg-tertiary italic">No bio yet.</p>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {/* Projects — explore the owner's work and back any of it without leaving. */}
       {visibleProjects.length > 0 && (
@@ -149,107 +168,117 @@ export default function ProfileOverviewTab({
 
       <ProfileSupportSection profile={profile} />
 
-      {/* Stats Grid */}
-      {stats && (
-        <div className="grid grid-cols-2 gap-3 sm:gap-4">
-          <Card>
-            <CardContent className="pt-4 sm:pt-6">
-              <div className="text-center">
-                <div className="text-xl sm:text-2xl md:text-3xl font-bold text-fg-primary">
-                  {stats.projectCount}
+      {/* Stats Grid — visitors only see stats that exist; "0 Projects" and
+          "CHF 0.00 Total Raised" say nothing worth a card. */}
+      {stats && (showProjectStat || showRaisedStat) && (
+        <div
+          className={`grid gap-3 sm:gap-4 ${
+            showProjectStat && showRaisedStat ? 'grid-cols-2' : 'grid-cols-1'
+          }`}
+        >
+          {showProjectStat && (
+            <Card>
+              <CardContent className="pt-4 sm:pt-6">
+                <div className="text-center">
+                  <div className="text-xl sm:text-2xl md:text-3xl font-bold text-fg-primary">
+                    {stats.projectCount}
+                  </div>
+                  <div className="text-xs sm:text-sm text-fg-secondary mt-1">
+                    {stats.projectCount === 1
+                      ? ENTITY_REGISTRY.project.name
+                      : ENTITY_REGISTRY.project.namePlural}
+                  </div>
                 </div>
-                <div className="text-xs sm:text-sm text-fg-secondary mt-1">
-                  {stats.projectCount === 1
-                    ? ENTITY_REGISTRY.project.name
-                    : ENTITY_REGISTRY.project.namePlural}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          )}
 
-          <Card>
-            <CardContent className="pt-4 sm:pt-6">
-              <div className="text-center">
-                {/* Success green only signals an actual raise — a zero balance
-                    rendered green reads as a positive metric it isn't. */}
-                <div
-                  className={`text-lg sm:text-xl md:text-2xl lg:text-3xl font-bold ${
-                    stats.totalRaised > 0 ? 'text-status-positive' : 'text-fg-primary'
-                  }`}
-                >
-                  {formatAmountBtc(stats.totalRaised)}
+          {showRaisedStat && (
+            <Card>
+              <CardContent className="pt-4 sm:pt-6">
+                <div className="text-center">
+                  {/* Success green only signals an actual raise — a zero balance
+                      rendered green reads as a positive metric it isn't. */}
+                  <div
+                    className={`text-lg sm:text-xl md:text-2xl lg:text-3xl font-bold ${
+                      stats.totalRaised > 0 ? 'text-status-positive' : 'text-fg-primary'
+                    }`}
+                  >
+                    {formatAmountBtc(stats.totalRaised)}
+                  </div>
+                  <div className="text-xs sm:text-sm text-fg-secondary mt-1">Total Raised</div>
                 </div>
-                <div className="text-xs sm:text-sm text-fg-secondary mt-1">Total Raised</div>
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          )}
         </div>
       )}
 
-      {/* Online presence / credibility */}
-      <Card>
-        <CardHeader className="p-4 sm:p-6">
-          <h3 className="text-base sm:text-lg font-semibold">Online presence</h3>
-        </CardHeader>
-        <CardContent className="p-4 sm:p-6 pt-0 space-y-2 sm:space-y-3">
-          {/* Website */}
-          <div className="flex items-center gap-3 text-fg-primary">
-            <Globe className="w-5 h-5 text-fg-tertiary" />
-            <div className="flex-1">
-              <div className="text-sm text-fg-secondary">Website</div>
-              {profile.website ? (
-                <a
-                  href={profile.website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline break-all text-sm sm:text-base"
-                >
-                  {profile.website.replace(/^https?:\/\//, '')}
-                </a>
-              ) : isOwnProfile && isDashboardView ? (
-                <a
-                  href={`${ROUTES.DASHBOARD.INFO_EDIT}#website`}
-                  className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
-                >
-                  <span className="text-fg-tertiary italic">Add a website</span>
-                  <span className="text-xs uppercase tracking-wide">Edit</span>
-                </a>
-              ) : (
-                <span className="text-sm sm:text-base text-fg-tertiary italic">
-                  No website added yet.
-                </span>
-              )}
-            </div>
-          </div>
-
-          {/* Social Media & Links */}
-          <div className="pt-3 border-t border-default">
-            {profile.social_links &&
-            typeof profile.social_links === 'object' &&
-            'links' in profile.social_links &&
-            profile.social_links.links &&
-            Array.isArray(profile.social_links.links) &&
-            (profile.social_links.links as SocialLink[]).length > 0 ? (
-              <SocialLinksDisplay
-                links={profile.social_links.links as SocialLink[]}
-                compact={true}
-              />
-            ) : isOwnProfile && isDashboardView ? (
-              <a
-                href={`${ROUTES.DASHBOARD.INFO_EDIT}#socialLinks`}
-                className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
-              >
-                <span className="text-fg-tertiary italic">Add social links or profiles</span>
-                <span className="text-xs uppercase tracking-wide">Edit</span>
-              </a>
-            ) : (
-              <span className="text-sm sm:text-base text-fg-tertiary italic">
-                No links added yet.
-              </span>
+      {/* Online presence / credibility — visitors only see rows with content */}
+      {(showWebsiteRow || showLinksRow) && (
+        <Card>
+          <CardHeader className="p-4 sm:p-6">
+            <h3 className="text-base sm:text-lg font-semibold">Online presence</h3>
+          </CardHeader>
+          <CardContent className="p-4 sm:p-6 pt-0 space-y-2 sm:space-y-3">
+            {/* Website */}
+            {showWebsiteRow && (
+              <div className="flex items-center gap-3 text-fg-primary">
+                <Globe className="w-5 h-5 text-fg-tertiary" />
+                <div className="flex-1">
+                  <div className="text-sm text-fg-secondary">Website</div>
+                  {profile.website ? (
+                    <a
+                      href={profile.website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline break-all text-sm sm:text-base"
+                    >
+                      {profile.website.replace(/^https?:\/\//, '')}
+                    </a>
+                  ) : isOwnProfile && isDashboardView ? (
+                    <a
+                      href={`${ROUTES.DASHBOARD.INFO_EDIT}#website`}
+                      className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
+                    >
+                      <span className="text-fg-tertiary italic">Add a website</span>
+                      <span className="text-xs uppercase tracking-wide">Edit</span>
+                    </a>
+                  ) : (
+                    <span className="text-sm sm:text-base text-fg-tertiary italic">
+                      No website added yet.
+                    </span>
+                  )}
+                </div>
+              </div>
             )}
-          </div>
-        </CardContent>
-      </Card>
+
+            {/* Social Media & Links */}
+            {showLinksRow && (
+              <div className={showWebsiteRow ? 'pt-3 border-t border-default' : undefined}>
+                {hasSocialLinks ? (
+                  <SocialLinksDisplay
+                    links={(profile.social_links as { links: SocialLink[] }).links}
+                    compact={true}
+                  />
+                ) : isOwnProfile && isDashboardView ? (
+                  <a
+                    href={`${ROUTES.DASHBOARD.INFO_EDIT}#socialLinks`}
+                    className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
+                  >
+                    <span className="text-fg-tertiary italic">Add social links or profiles</span>
+                    <span className="text-xs uppercase tracking-wide">Edit</span>
+                  </a>
+                ) : (
+                  <span className="text-sm sm:text-base text-fg-tertiary italic">
+                    No links added yet.
+                  </span>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {/* Contact: how to reach this person */}
       <Card>
@@ -258,60 +287,64 @@ export default function ProfileOverviewTab({
         </CardHeader>
         <CardContent className="p-4 sm:p-6 pt-0 space-y-2 sm:space-y-3">
           {/* Contact Email (public) */}
-          <div className="flex items-center gap-3 text-fg-primary pt-3 border-t border-default">
-            <Mail className="w-5 h-5 text-fg-tertiary" />
-            <div className="flex-1">
-              <div className="text-sm text-fg-secondary">Contact email</div>
-              {publicContactEmail ? (
-                <a
-                  href={`mailto:${publicContactEmail}`}
-                  className="text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline break-all text-sm sm:text-base"
-                >
-                  {publicContactEmail}
-                </a>
-              ) : isOwnProfile && isDashboardView ? (
-                <a
-                  href={`${ROUTES.DASHBOARD.INFO_EDIT}#contactEmail`}
-                  className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
-                >
-                  <span className="text-fg-tertiary italic">Add a public contact email</span>
-                  <span className="text-xs uppercase tracking-wide">Edit</span>
-                </a>
-              ) : (
-                <span className="text-sm sm:text-base text-fg-tertiary italic">
-                  No public email added.
-                </span>
-              )}
+          {showEmailRow && (
+            <div className="flex items-center gap-3 text-fg-primary pt-3 border-t border-default">
+              <Mail className="w-5 h-5 text-fg-tertiary" />
+              <div className="flex-1">
+                <div className="text-sm text-fg-secondary">Contact email</div>
+                {publicContactEmail ? (
+                  <a
+                    href={`mailto:${publicContactEmail}`}
+                    className="text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline break-all text-sm sm:text-base"
+                  >
+                    {publicContactEmail}
+                  </a>
+                ) : isOwnProfile && isDashboardView ? (
+                  <a
+                    href={`${ROUTES.DASHBOARD.INFO_EDIT}#contactEmail`}
+                    className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
+                  >
+                    <span className="text-fg-tertiary italic">Add a public contact email</span>
+                    <span className="text-xs uppercase tracking-wide">Edit</span>
+                  </a>
+                ) : (
+                  <span className="text-sm sm:text-base text-fg-tertiary italic">
+                    No public email added.
+                  </span>
+                )}
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Phone */}
-          <div className="flex items-center gap-3 text-fg-primary">
-            <Phone className="w-5 h-5 text-fg-tertiary" />
-            <div className="flex-1">
-              <div className="text-sm text-fg-secondary">Phone</div>
-              {profile.phone ? (
-                <a
-                  href={`tel:${profile.phone}`}
-                  className="text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
-                >
-                  {profile.phone}
-                </a>
-              ) : isOwnProfile && isDashboardView ? (
-                <a
-                  href={`${ROUTES.DASHBOARD.INFO_EDIT}#phone`}
-                  className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
-                >
-                  <span className="text-fg-tertiary italic">Add a phone number</span>
-                  <span className="text-xs uppercase tracking-wide">Edit</span>
-                </a>
-              ) : (
-                <span className="text-sm sm:text-base text-fg-tertiary italic">
-                  No phone number added.
-                </span>
-              )}
+          {showPhoneRow && (
+            <div className="flex items-center gap-3 text-fg-primary">
+              <Phone className="w-5 h-5 text-fg-tertiary" />
+              <div className="flex-1">
+                <div className="text-sm text-fg-secondary">Phone</div>
+                {profile.phone ? (
+                  <a
+                    href={`tel:${profile.phone}`}
+                    className="text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
+                  >
+                    {profile.phone}
+                  </a>
+                ) : isOwnProfile && isDashboardView ? (
+                  <a
+                    href={`${ROUTES.DASHBOARD.INFO_EDIT}#phone`}
+                    className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
+                  >
+                    <span className="text-fg-tertiary italic">Add a phone number</span>
+                    <span className="text-xs uppercase tracking-wide">Edit</span>
+                  </a>
+                ) : (
+                  <span className="text-sm sm:text-base text-fg-tertiary italic">
+                    No phone number added.
+                  </span>
+                )}
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Joined Date (contextual meta) */}
           {profile.created_at && (

--- a/src/components/public/PublicEntityDetailPage.tsx
+++ b/src/components/public/PublicEntityDetailPage.tsx
@@ -26,6 +26,7 @@ import { resolveSellerReceiveInfo, type SellerReceiveInfo } from '@/domain/payme
 import { currencyConverter } from '@/services/currency';
 import { type CurrencyCode } from '@/config/currencies';
 import { fetchEntityOwner } from '@/lib/entities/fetchEntityOwner';
+import { fetchProfileListingCounts } from '@/services/profile/listingCounts';
 import { ROUTES } from '@/config/routes';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { Z_INDEX_CLASSES } from '@/constants/z-index';
@@ -186,6 +187,12 @@ export default async function PublicEntityDetailPage({
   }
 
   const owner = await fetchEntityOwner(supabase, entity);
+  // Provider trust: how many things this person publicly offers. Head-only
+  // count queries (see listingCounts.ts) — same filter shape as the profile
+  // tabs, so the number matches what clicking through to the profile shows.
+  const ownerListingCount = owner?.user_id
+    ? (await fetchProfileListingCounts(supabase, owner.user_id)).total
+    : 0;
   // The viewer owns this entity (published or draft) → show a manage bar. This is
   // also the owner's dashboard detail view: one layout, buyers see the listing,
   // the owner sees it + Edit (no separate flat-grid dashboard page).
@@ -316,7 +323,11 @@ export default async function PublicEntityDetailPage({
 
             <div className="space-y-6">
               {owner && (
-                <PublicEntityOwnerCard owner={owner} label={config.ownerLabel || 'Owner'} />
+                <PublicEntityOwnerCard
+                  owner={owner}
+                  label={config.ownerLabel || 'Owner'}
+                  activeListingCount={ownerListingCount}
+                />
               )}
 
               <EntityShare

--- a/src/components/public/PublicEntityOwnerCard.tsx
+++ b/src/components/public/PublicEntityOwnerCard.tsx
@@ -1,17 +1,36 @@
 import Link from 'next/link';
-import { User } from 'lucide-react';
+import { User, CalendarDays, LayoutGrid } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { ROUTES } from '@/config/routes';
+import { APP_NAME } from '@/config/brand';
 import type { EntityOwner } from '@/lib/entities/fetchEntityOwner';
 
 interface PublicEntityOwnerCardProps {
   owner: EntityOwner;
   label: string;
+  /**
+   * The owner's publicly visible listing count (fetchProfileListingCounts).
+   * Rendered only when > 0 — real numbers only, zero adds no trust.
+   */
+  activeListingCount?: number;
 }
 
-export default function PublicEntityOwnerCard({ owner, label }: PublicEntityOwnerCardProps) {
+/**
+ * Provider trust block on public entity pages: who is this, how long have
+ * they been here, what else do they offer. Every line is grounded in real
+ * data (profiles.created_at, live listing counts) — never a fake metric.
+ */
+export default function PublicEntityOwnerCard({
+  owner,
+  label,
+  activeListingCount,
+}: PublicEntityOwnerCardProps) {
   const profileHref = owner.username ? ROUTES.PROFILES.VIEW(owner.username) : '#';
   const isClickable = !!owner.username;
+  const memberSince = owner.created_at
+    ? new Date(owner.created_at).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+    : null;
+  const showListings = typeof activeListingCount === 'number' && activeListingCount > 0;
 
   return (
     <Card>
@@ -42,6 +61,27 @@ export default function PublicEntityOwnerCard({ owner, label }: PublicEntityOwne
             {owner.username && <div className="text-sm text-fg-secondary">@{owner.username}</div>}
           </div>
         </Link>
+
+        {(memberSince || showListings) && (
+          <div className="mt-3 space-y-1.5 border-t border-default pt-3">
+            {memberSince && (
+              <div className="flex items-center gap-2 text-sm text-fg-secondary">
+                <CalendarDays className="h-4 w-4 shrink-0 text-fg-tertiary" />
+                <span>
+                  On {APP_NAME} since {memberSince}
+                </span>
+              </div>
+            )}
+            {showListings && (
+              <div className="flex items-center gap-2 text-sm text-fg-secondary">
+                <LayoutGrid className="h-4 w-4 shrink-0 text-fg-tertiary" />
+                <span>
+                  {activeListingCount} active {activeListingCount === 1 ? 'listing' : 'listings'}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/public/detail-configs/service.tsx
+++ b/src/components/public/detail-configs/service.tsx
@@ -4,6 +4,7 @@ import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailP
 import { ROUTES } from '@/config/routes';
 import { BookEntityButton } from '@/components/bookings/BookEntityButton';
 import { hasAvailability, formatAvailabilityLines } from '@/lib/availability';
+import { formatDurationMinutes } from '@/utils/dates';
 
 // user_services stores its price in `fixed_price` (or `hourly_rate`) in the entity's
 // chosen `currency` — NOT price_btc (no such column) and NOT in BTC. Read the real
@@ -65,7 +66,7 @@ export const serviceDetailConfig: EntityDetailConfig = {
           {durationMinutes && (
             <div className="flex items-center justify-between">
               <span className="text-fg-secondary">Duration</span>
-              <span className="font-medium">{durationMinutes} minutes</span>
+              <span className="font-medium">{formatDurationMinutes(durationMinutes)}</span>
             </div>
           )}
           {hasAvailability(entity.availability_schedule) && (

--- a/src/lib/entities/fetchEntityOwner.ts
+++ b/src/lib/entities/fetchEntityOwner.ts
@@ -7,6 +7,8 @@ export interface EntityOwner {
   username: string | null;
   name: string | null;
   avatar_url: string | null;
+  /** profiles.created_at — drives the "On OrangeCat since <month year>" trust line. */
+  created_at: string | null;
 }
 
 /**
@@ -29,13 +31,18 @@ export async function fetchEntityOwner(
       .maybeSingle();
     if (actorData) {
       type ActorRow = { id: string; user_id: string | null };
-      type ProfileRow = { username: string | null; name: string | null; avatar_url: string | null };
+      type ProfileRow = {
+        username: string | null;
+        name: string | null;
+        avatar_url: string | null;
+        created_at: string | null;
+      };
       const actor = actorData as unknown as ActorRow;
       let profile: ProfileRow | null = null;
       if (actor.user_id) {
         const { data: profileData } = await supabase
           .from(DATABASE_TABLES.PROFILES)
-          .select('username, name, avatar_url')
+          .select('username, name, avatar_url, created_at')
           .eq('id', actor.user_id)
           .maybeSingle();
         profile = profileData as ProfileRow | null;
@@ -46,6 +53,7 @@ export async function fetchEntityOwner(
         username: profile?.username || null,
         name: profile?.name || null,
         avatar_url: profile?.avatar_url || null,
+        created_at: profile?.created_at || null,
       };
     }
   }
@@ -55,7 +63,7 @@ export async function fetchEntityOwner(
   if (profileId) {
     const { data: profileData } = await supabase
       .from(DATABASE_TABLES.PROFILES)
-      .select('username, name, avatar_url')
+      .select('username, name, avatar_url, created_at')
       .eq('id', profileId)
       .maybeSingle();
     if (profileData) {
@@ -66,6 +74,7 @@ export async function fetchEntityOwner(
         username: profile.username,
         name: profile.name,
         avatar_url: profile.avatar_url,
+        created_at: profile.created_at,
       };
     }
   }

--- a/src/services/profile/listingCounts.ts
+++ b/src/services/profile/listingCounts.ts
@@ -1,0 +1,68 @@
+/**
+ * Public listing counts for a profile — SSOT for "what does this person offer".
+ *
+ * Used by:
+ *  - /profiles/[username] (per-type tab badges)
+ *  - entity-detail trust block ("N active listings" on the provider card)
+ *
+ * Filter shape matches the public profile tabs (exclude drafts, respect
+ * show_on_profile) so the trust-block number always equals what a visitor
+ * finds when they click through to the profile. Real counts only — never
+ * a placeholder.
+ */
+import { getTableName, type EntityType } from '@/config/entity-registry';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+
+/**
+ * Entity types counted on a public profile, with the column that links the
+ * row to its owner. `owner_id` for asset vs. `user_id` everywhere else is
+ * legacy schema drift, not a convention to copy.
+ */
+export const PROFILE_LISTING_COUNT_CONFIG: ReadonlyArray<{
+  type: EntityType;
+  userField: string;
+}> = [
+  { type: 'project', userField: 'user_id' },
+  { type: 'product', userField: 'user_id' },
+  { type: 'service', userField: 'user_id' },
+  { type: 'cause', userField: 'user_id' },
+  { type: 'event', userField: 'user_id' },
+  { type: 'loan', userField: 'user_id' },
+  { type: 'asset', userField: 'owner_id' },
+  { type: 'ai_assistant', userField: 'user_id' },
+];
+
+export interface ProfileListingCounts {
+  /** Per-entity-type public listing counts. */
+  counts: Partial<Record<EntityType, number>>;
+  /** Sum across all counted types — the trust block's "N active listings". */
+  total: number;
+}
+
+/**
+ * Count a profile's publicly visible listings, in parallel (head-only count
+ * queries — no rows transferred).
+ */
+export async function fetchProfileListingCounts(
+  supabase: AnySupabaseClient,
+  profileId: string
+): Promise<ProfileListingCounts> {
+  const results = await Promise.all(
+    PROFILE_LISTING_COUNT_CONFIG.map(({ type, userField }) =>
+      supabase
+        .from(getTableName(type))
+        .select('*', { count: 'exact', head: true })
+        .eq(userField, profileId)
+        .neq('status', 'draft')
+        .neq('show_on_profile', false)
+    )
+  );
+
+  const counts = Object.fromEntries(
+    PROFILE_LISTING_COUNT_CONFIG.map(({ type }, i) => [type, results[i].count || 0])
+  ) as Partial<Record<EntityType, number>>;
+
+  const total = Object.values(counts).reduce((sum, n) => sum + (n || 0), 0);
+
+  return { counts, total };
+}

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -23,6 +23,24 @@ export function formatShortTime(date: string | Date): string {
   return format(typeof date === 'string' ? new Date(date) : date, 'HH:mm');
 }
 
+/**
+ * Human-readable duration from minutes: 45 → "45 min", 180 → "3 h",
+ * 90 → "1 h 30 min". Returns '' for non-positive/invalid input so callers
+ * can conditionally render.
+ */
+export function formatDurationMinutes(minutes: number | null | undefined): string {
+  if (!minutes || !Number.isFinite(minutes) || minutes <= 0) {
+    return '';
+  }
+  const whole = Math.round(minutes);
+  const hours = Math.floor(whole / 60);
+  const mins = whole % 60;
+  if (hours === 0) {
+    return `${mins} min`;
+  }
+  return mins === 0 ? `${hours} h` : `${hours} h ${mins} min`;
+}
+
 export function formatRelativeTimeCompact(date: string | Date): string {
   const d = typeof date === 'string' ? new Date(date) : date;
   const days = Math.floor((Date.now() - d.getTime()) / (1000 * 60 * 60 * 24));


### PR DESCRIPTION
## What

Two founder-verified surfaces brought to the x.ai bar (monochrome, honest, no tackiness):

### A — Entity detail trust (`PublicEntityDetailPage`)

1. **Provider card → trust block** (`PublicEntityOwnerCard`): avatar, display name linking to the profile, "On OrangeCat since \<month year\>" from `profiles.created_at`, and "N active listings". Counts come from the new `src/services/profile/listingCounts.ts` — head-only count queries with the exact filter shape of the profile tabs, so the trust number always matches what clicking through shows. Zero counts are suppressed; **no fake metrics ever**.
2. **Honest payment expectation** (`PublicEntityPaymentSection`):
   - Seller **has** a wallet → payment CTA + one line: *"Pays wallet-to-wallet via Lightning/Bitcoin — OrangeCat takes 0%"* (new `PaymentExpectationNote`, also under the anonymous `PublicPayPanel` and the NWC sign-in path).
   - Seller has **no** wallet → the dead grey "No wallet connected" button is gone; the purchase CTA is hidden and replaced with *"This creator hasn't connected a wallet yet."* — shown only when actually true.
3. **Duration formatting**: service duration renders as "3 h" / "1 h 30 min" via `formatDurationMinutes` in the shared dates util (SSOT, unit-tested).

### B — Public profile (`/profiles/[username]`)

1. **Visitor zero-suppression** (`ProfileOverviewTab`): no "0 Projects", no "CHF 0.00 Total Raised", no "No website/links/email/phone added" placeholder rows — empty cards collapse entirely for visitors. Owner keeps every prompt so gaps stay visible and fixable. Zero-count tabs were already hidden for visitors; Overview now leads with real content (bio, projects, joined date).
2. **`/<username>` shortlink**: new `src/app/[username]/page.tsx` resolves the username and redirects to the canonical `/profiles/<username>`, 404 on no match, `/me` mirrors the `/profiles/me` convention. Next.js static-over-dynamic precedence guarantees no existing top-level route is shadowed (documented in the route file); `npm run audit:routes` clean.

### SSOT refactor

`/profiles/[username]/page.tsx`'s inline `ENTITY_COUNT_CONFIG` moved into `listingCounts.ts` so tab badges and the trust block share one definition of "public listing".

## Gates

- `type-check`: 0 errors
- `lint`: clean
- `jest __tests__/unit`: 58 suites / 681 tests green (incl. new `formatDurationMinutes` tests)
- `audit:routes`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)