### PR TITLE
fix(trust): scrub founder-verified trust issues (nudges, discover, create forms)

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -24,7 +24,6 @@ export default function DiscoverPage() {
     loading,
     loansLoading,
     assetsLoading,
-    totalResults,
     hasMore,
     isLoadingMore,
 
@@ -45,7 +44,6 @@ export default function DiscoverPage() {
     investmentsLoading,
     genericLoading,
     tabCounts,
-    stats,
 
     // UI state
     activeTab,
@@ -81,25 +79,6 @@ export default function DiscoverPage() {
     clearFilters,
   } = useDiscoverState();
 
-  // The total the page shows as "N results found" — single source for the UI and
-  // the demand log below. Mirrors the per-tab handling: useSearch only counts
-  // projects/profiles/all; entity tabs add their own loaded lengths.
-  const resultsFound =
-    (activeTab === 'all' || activeTab === 'projects' || activeTab === 'profiles'
-      ? totalResults
-      : 0) +
-    loans.length +
-    investments.length +
-    assets.length +
-    causes.length +
-    events.length +
-    products.length +
-    services.length +
-    groups.length +
-    wishlists.length +
-    research.length +
-    aiAssistants.length;
-
   // Shared filter props to avoid duplication between desktop and mobile
   const filterProps = {
     searchTerm,
@@ -129,11 +108,7 @@ export default function DiscoverPage() {
   return (
     <div className={`min-h-screen ${GRADIENTS.pageBg}`}>
       {/* Hero Section */}
-      <DiscoverHero
-        totalProjects={stats.totalProjects}
-        totalProfiles={stats.totalProfiles}
-        totalFinancial={stats.totalFinancial}
-      />
+      <DiscoverHero />
 
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -235,7 +210,6 @@ export default function DiscoverPage() {
                   wishlists={wishlists}
                   research={research}
                   aiAssistants={aiAssistants}
-                  totalResults={resultsFound}
                   loading={
                     loading || loansLoading || investmentsLoading || assetsLoading || genericLoading
                   }

--- a/src/app/discover/useDiscoverState.ts
+++ b/src/app/discover/useDiscoverState.ts
@@ -215,12 +215,6 @@ export function useDiscoverState() {
     aiAssistants: generic.aiAssistants,
     totalInvestmentsCount: counts.totalInvestmentsCount,
     tabCounts,
-    stats: {
-      totalProjects: counts.totalProjectsCount,
-      totalProfiles: counts.totalProfilesCount,
-      totalFinancial:
-        counts.totalLoansCount + counts.totalInvestmentsCount + counts.totalAssetsCount,
-    },
     activeTab,
     viewMode,
     setViewMode,

--- a/src/components/create/EntityForm/hooks/useEntityFormState.ts
+++ b/src/components/create/EntityForm/hooks/useEntityFormState.ts
@@ -19,14 +19,17 @@ export function useEntityFormState<T extends Record<string, unknown>>({
   mode,
 }: UseEntityFormStateOptions<T>) {
   const initialFormData = useMemo(() => {
-    const data = { ...config.defaultValues, ...initialValues } as T;
+    let data = { ...config.defaultValues, ...initialValues } as T;
     if ('currency' in data && !initialValues?.currency) {
       if (data.currency === undefined || data.currency === null || data.currency === '') {
         (data as Record<string, unknown>).currency = userCurrency;
       }
     }
+    if (config.deriveInitialValues) {
+      data = { ...data, ...config.deriveInitialValues(data) };
+    }
     return data;
-  }, [config.defaultValues, initialValues, userCurrency]);
+  }, [config, initialValues, userCurrency]);
 
   const [formState, setFormState] = useState<FormState<T>>({
     data: initialFormData,
@@ -42,14 +45,20 @@ export function useEntityFormState<T extends Record<string, unknown>>({
   });
 
   useEffect(() => {
-    setFormState(prev => ({
-      ...prev,
-      data: { ...config.defaultValues, ...initialValues } as T,
-      errors: {},
-      isDirty: false,
-      activeField: null,
-    }));
-  }, [initialValues, config.defaultValues]);
+    setFormState(prev => {
+      let data = { ...config.defaultValues, ...initialValues } as T;
+      if (config.deriveInitialValues) {
+        data = { ...data, ...config.deriveInitialValues(data) };
+      }
+      return {
+        ...prev,
+        data,
+        errors: {},
+        isDirty: false,
+        activeField: null,
+      };
+    });
+  }, [initialValues, config]);
 
   const { lastSavedAt, clearDraft } = useEntityFormDraft({
     mode,
@@ -66,6 +75,15 @@ export function useEntityFormState<T extends Record<string, unknown>>({
 
       if (field === 'name' && config.type === 'group') {
         (updatedData as Record<string, unknown>).slug = slugify(value as string);
+      }
+
+      // Mode-toggle fields declare clearOnChange: reset the listed siblings so a
+      // value entered under the previous mode never rides along invisibly.
+      const fieldConfig = config.fieldGroups
+        .flatMap(g => g.fields ?? [])
+        .find(f => f.name === field);
+      for (const sibling of fieldConfig?.clearOnChange ?? []) {
+        (updatedData as Record<string, unknown>)[sibling] = null;
       }
 
       setFormState(prev => ({
@@ -86,7 +104,7 @@ export function useEntityFormState<T extends Record<string, unknown>>({
         return prev;
       });
     },
-    [formState.data, config.type]
+    [formState.data, config.type, config.fieldGroups]
   );
 
   const handleFieldFocus = useCallback((field: string) => {

--- a/src/components/create/EntityForm/index.tsx
+++ b/src/components/create/EntityForm/index.tsx
@@ -7,9 +7,8 @@ import Loading from '@/components/Loading';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 
 import { GuidancePanel } from '../GuidancePanel';
-import { TemplatePicker } from '../templates/TemplatePicker';
 import { AIPrefillBar } from '../AIPrefillBar';
-import type { EntityConfig, EntityTemplate } from '../types';
+import type { EntityConfig } from '../types';
 import { FORM_THEME } from '@/config/theme-colors';
 
 import { EntityCreationSuccess } from '../EntityCreationSuccess';
@@ -68,7 +67,6 @@ export function EntityForm<T extends Record<string, unknown>>({
     formState,
     aiGeneratedFields,
     lastSavedAt,
-    initialFormData,
     handleFieldChange,
     handleFieldFocus,
     handleAIPrefill,
@@ -107,14 +105,6 @@ export function EntityForm<T extends Record<string, unknown>>({
     wizardMode,
     actorId,
   });
-
-  const handleTemplateSelect = useCallback(
-    (template: EntityTemplate<T>) => {
-      handleFieldChange('__template__' as keyof T, { ...initialFormData, ...template.defaults });
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    },
-    [initialFormData, handleFieldChange]
-  );
 
   if (!hydrated || authLoading) {
     return <Loading fullScreen message="Loading..." />;
@@ -188,15 +178,9 @@ export function EntityForm<T extends Record<string, unknown>>({
         </div>
       )}
 
-      {config.templates && config.templates.length > 0 && mode === 'create' && !wizardMode && (
-        <div className="mt-8 pt-8 border-t border-default">
-          <TemplatePicker
-            label={config.namePlural}
-            templates={config.templates as EntityTemplate<T>[]}
-            onSelectTemplate={handleTemplateSelect}
-          />
-        </div>
-      )}
+      {/* No in-form template panel: templates live ONLY in the wizard's step-1
+          picker. A second "Need inspiration?" panel inside the form duplicated
+          that step and could silently overwrite fields already filled in. */}
 
       <FormActions
         isSubmitting={formState.isSubmitting}

--- a/src/components/create/FormField.tsx
+++ b/src/components/create/FormField.tsx
@@ -103,6 +103,7 @@ export function FormField({
             userCurrency={userCurrency}
             showBreakdown={false} // Don't show breakdown by default (no sats!)
             allowCurrencySwitch={true}
+            isGoal={config.isGoal}
             min={min}
             max={max}
           />

--- a/src/components/create/types.ts
+++ b/src/components/create/types.ts
@@ -74,6 +74,18 @@ export interface FieldConfig {
     field: string;
     value: string | string[] | boolean;
   };
+  /**
+   * Sibling fields reset to null when THIS field's value changes — for
+   * mode-toggle fields (e.g. hourly vs fixed pricing) so a value entered under
+   * the previous mode never rides along invisibly into the submit.
+   */
+  clearOnChange?: string[];
+  /**
+   * Currency fields only: true when the amount is a FUNDING GOAL (project /
+   * cause / event goals) — enables the goal explainer under the input. Price
+   * and amount fields must leave this unset.
+   */
+  isGoal?: boolean;
   /** Field depends on another field's value */
   dependsOn?:
     | string
@@ -224,6 +236,12 @@ export interface EntityConfig<T extends Record<string, any> = Record<string, any
   successRedirectDelay?: number;
   /** Optional wizard configuration for multi-step creation flow */
   wizardConfig?: WizardConfig;
+  /**
+   * Derive UI-only form values from loaded data (create defaults or an edit
+   * row) — e.g. infer the service pricing toggle from which price is set.
+   * Runs after defaults + initialValues are merged.
+   */
+  deriveInitialValues?: (data: T) => Partial<T>;
 }
 
 // ==================== FORM STATE ====================

--- a/src/components/dashboard/CatNudges.tsx
+++ b/src/components/dashboard/CatNudges.tsx
@@ -20,6 +20,10 @@ interface Nudge {
   cta_url: string | null;
 }
 
+// The dashboard shows only the top suggestions (API returns them ordered by
+// confidence score, highest first) — two focused cards beat a wall of five.
+const DASHBOARD_NUDGE_CAP = 2;
+
 export function CatNudges() {
   const [nudges, setNudges] = useState<Nudge[] | null>(null);
 
@@ -29,7 +33,7 @@ export function CatNudges() {
       .then(r => (r.ok ? r.json() : null))
       .then(d => {
         if (on && d?.success) {
-          setNudges(d.nudges || []);
+          setNudges((d.nudges || []).slice(0, DASHBOARD_NUDGE_CAP));
         }
       })
       .catch(() => {

--- a/src/components/discover/DiscoverHero.tsx
+++ b/src/components/discover/DiscoverHero.tsx
@@ -1,20 +1,8 @@
-import Link from 'next/link';
 import { Plus, ArrowRight } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
 import Button from '@/components/ui/Button';
-import Card from '@/components/ui/Card';
 
-interface DiscoverHeroProps {
-  totalProjects: number;
-  totalProfiles: number;
-  totalFinancial?: number;
-}
-
-export default function DiscoverHero({
-  totalProjects,
-  totalProfiles,
-  totalFinancial = 0,
-}: DiscoverHeroProps) {
+export default function DiscoverHero() {
   return (
     <section className="relative overflow-hidden bg-surface-page border-b border-default">
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
@@ -28,26 +16,6 @@ export default function DiscoverHero({
             Projects, causes, products, services, loans, investments, events, and more — from
             creators and communities around the world.
           </p>
-
-          {/* Stats - Compact */}
-          <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-xl mx-auto">
-            <Link href={`${ROUTES.DISCOVER}?type=projects`} className="block">
-              <Card className="p-4 transition-colors hover:border-strong">
-                <div className="text-fluid-xl font-bold text-fg-primary">{totalProjects}</div>
-                <div className="text-sm text-fg-secondary mt-1">Active Projects</div>
-              </Card>
-            </Link>
-            <Link href={`${ROUTES.DISCOVER}?type=profiles`} className="block">
-              <Card className="p-4 transition-colors hover:border-strong">
-                <div className="text-fluid-xl font-bold text-fg-primary">{totalProfiles}</div>
-                <div className="text-sm text-fg-secondary mt-1">People</div>
-              </Card>
-            </Link>
-            <Card className="p-4">
-              <div className="text-fluid-xl font-bold text-fg-primary">{totalFinancial}</div>
-              <div className="text-sm text-fg-secondary mt-1">Finance</div>
-            </Card>
-          </div>
 
           {/* Creator CTA */}
           <div className="mt-6">

--- a/src/components/discover/DiscoverResults.tsx
+++ b/src/components/discover/DiscoverResults.tsx
@@ -49,7 +49,6 @@ interface DiscoverResultsProps {
   wishlists?: GenericPublicEntity[];
   research?: GenericPublicEntity[];
   aiAssistants?: GenericPublicEntity[];
-  totalResults: number;
   loading: boolean;
   hasMore: boolean;
   isLoadingMore: boolean;
@@ -73,7 +72,6 @@ export default function DiscoverResults({
   wishlists = [],
   research = [],
   aiAssistants = [],
-  totalResults,
   loading,
   hasMore,
   isLoadingMore,
@@ -173,22 +171,15 @@ export default function DiscoverResults({
     investments.length +
     genericTabs.reduce((sum, t) => sum + t.items.length, 0);
 
+  // ONE counting source: the entities actually rendered below. The header used
+  // to mix a search-service total with loaded-array lengths, which disagreed
+  // with the tab badges ("All 76" vs "52 results (showing 46)") — a trust bug.
   const resultsHeader = (
     <div className="flex items-center justify-between mb-6">
       <h2 className="text-2xl font-semibold text-fg-primary">
-        {totalResults > 0 ? (
-          <>
-            {totalResults} result{totalResults !== 1 ? 's' : ''} found
-            {displayedCount < totalResults && (
-              <span className="text-fg-secondary text-lg font-normal ml-2">
-                {' '}
-                (showing {displayedCount})
-              </span>
-            )}
-          </>
-        ) : (
-          'No results found'
-        )}
+        {displayedCount > 0
+          ? `Showing ${displayedCount} result${displayedCount !== 1 ? 's' : ''}`
+          : 'No results found'}
       </h2>
     </div>
   );

--- a/src/components/ui/CurrencyInput.tsx
+++ b/src/components/ui/CurrencyInput.tsx
@@ -22,6 +22,12 @@ interface CurrencyInputProps {
   disabled?: boolean;
   showBreakdown?: boolean;
   allowCurrencySwitch?: boolean;
+  /**
+   * True ONLY for funding-goal fields (project/cause/event goals). Shows the
+   * "goal can be reached by contributions OR Bitcoin price appreciation"
+   * explainer — that copy is meaningless (and confusing) on price fields.
+   */
+  isGoal?: boolean;
   onFocus?: () => void;
   onBlur?: () => void;
   min?: number;
@@ -43,6 +49,7 @@ export function CurrencyInput({
   disabled = false,
   showBreakdown = false,
   allowCurrencySwitch = true,
+  isGoal = false,
   onFocus,
   onBlur,
   min,
@@ -115,7 +122,7 @@ export function CurrencyInput({
       {error && <p className="text-destructive text-sm">{error}</p>}
       {hint && !error && <p className="text-xs text-muted-foreground">{hint}</p>}
 
-      {!error && !hint && value && value > 0 && (
+      {isGoal && !error && !hint && value && value > 0 && (
         <div className="text-xs text-muted-foreground mt-1">
           <span className="flex items-center gap-1">
             <Info className="w-3 h-3" />

--- a/src/config/entity-configs/base-config-factory.ts
+++ b/src/config/entity-configs/base-config-factory.ts
@@ -130,6 +130,8 @@ export interface BaseConfigOptions<T extends Record<string, any>> {
   successRedirectDelay?: number;
   /** Optional wizard configuration for multi-step creation flow */
   wizardConfig?: WizardConfig;
+  /** Optional derivation of UI-only form values from loaded data (see EntityConfig) */
+  deriveInitialValues?: (data: T) => Partial<T>;
 }
 
 /**
@@ -183,5 +185,6 @@ export function createEntityConfig<T extends Record<string, any>>(
     successMessage: options.successMessage,
     successRedirectDelay: options.successRedirectDelay,
     wizardConfig: options.wizardConfig,
+    deriveInitialValues: options.deriveInitialValues,
   };
 }

--- a/src/config/entity-configs/cause-config.ts
+++ b/src/config/entity-configs/cause-config.ts
@@ -62,6 +62,7 @@ const fieldGroups: FieldGroup[] = [
         name: 'goal_amount',
         label: 'Goal Amount',
         type: 'currency',
+        isGoal: true,
         placeholder: '10000.00',
         min: 1,
         hint: 'Leave empty for open-ended fundraising. Enter in your preferred currency.',

--- a/src/config/entity-configs/event-config.ts
+++ b/src/config/entity-configs/event-config.ts
@@ -247,6 +247,7 @@ const fieldGroups: FieldGroup[] = [
         name: 'funding_goal',
         label: 'Funding Goal (Optional)',
         type: 'currency',
+        isGoal: true,
         placeholder: '10000.00',
         min: 1,
         hint: 'Optional: Set a funding goal to cover event costs.',

--- a/src/config/entity-configs/project-config.ts
+++ b/src/config/entity-configs/project-config.ts
@@ -57,6 +57,7 @@ const fieldGroups: FieldGroup[] = [
         name: 'goal_amount',
         label: 'Funding Goal',
         type: 'currency',
+        isGoal: true,
         placeholder: '10000',
         hint: 'Optional: Set a funding target for your project. Currency selector is included in this field.',
       },

--- a/src/config/entity-configs/service-config.ts
+++ b/src/config/entity-configs/service-config.ts
@@ -81,8 +81,25 @@ const fieldGroups: FieldGroup[] = [
   {
     id: 'pricing',
     title: 'Pricing',
-    description: 'Set at least one pricing option (hourly or fixed price)',
+    description: 'Choose how you charge — by the hour or a fixed price',
     fields: [
+      {
+        name: 'pricing_model',
+        label: 'How do you charge?',
+        type: 'radio',
+        options: [
+          { value: 'hourly', label: 'Hourly rate', description: 'You bill for your time' },
+          {
+            value: 'fixed',
+            label: 'Fixed price',
+            description: 'One price for the whole service',
+          },
+        ],
+        // Switching modes resets the price inputs so a value entered under the
+        // other mode never rides along invisibly into the submit.
+        clearOnChange: ['hourly_rate', 'fixed_price'],
+        colSpan: 2,
+      },
       {
         name: 'hourly_rate',
         label: 'Hourly Rate',
@@ -90,6 +107,7 @@ const fieldGroups: FieldGroup[] = [
         placeholder: '50.00',
         min: 1,
         hint: 'Your rate per hour. Enter in your preferred currency.',
+        showWhen: { field: 'pricing_model', value: 'hourly' },
       },
       {
         name: 'fixed_price',
@@ -98,6 +116,7 @@ const fieldGroups: FieldGroup[] = [
         placeholder: '500.00',
         min: 1,
         hint: 'Fixed project price. Enter in your preferred currency.',
+        showWhen: { field: 'pricing_model', value: 'fixed' },
       },
       {
         name: 'duration_minutes',
@@ -166,6 +185,7 @@ const defaultValues: UserServiceFormData = {
   title: '',
   description: '',
   category: '',
+  pricing_model: 'hourly',
   hourly_rate: null,
   fixed_price: null,
   currency: undefined, // Will be set from user's profile preference in EntityForm
@@ -196,6 +216,11 @@ export const serviceConfig = createEntityConfig<UserServiceFormData>({
   fieldGroups,
   validationSchema: userServiceSchema,
   defaultValues,
+  // Edit mode / templates: infer the pricing toggle from which price is set,
+  // so a fixed-price service opens with the fixed field visible.
+  deriveInitialValues: data => ({
+    pricing_model: data.fixed_price && !data.hourly_rate ? 'fixed' : 'hourly',
+  }),
   guidanceContent: serviceGuidanceContent,
   defaultGuidance: serviceDefaultGuidance,
   templates: SERVICE_TEMPLATES as unknown as ServiceTemplate[],

--- a/src/lib/validation/commerce.ts
+++ b/src/lib/validation/commerce.ts
@@ -109,9 +109,14 @@ export const userServiceSchema = z
     show_on_profile: z.boolean().optional().default(true),
     status: z.enum(SERVICE_STATUSES).default(ENTITY_STATUS.DRAFT),
   })
-  .refine(data => data.hourly_rate || data.fixed_price, {
-    message: 'At least one pricing method (hourly or fixed) is required',
-    path: ['hourly_rate'], // This will show the error on hourly_rate field
+  .superRefine((data, ctx) => {
+    if (!data.hourly_rate && !data.fixed_price) {
+      // Flag BOTH price fields: the form shows only one at a time (hourly vs
+      // fixed toggle), so the error must land on whichever is visible.
+      const message = 'At least one pricing method (hourly or fixed) is required';
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['hourly_rate'] });
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['fixed_price'] });
+    }
   });
 
 export const userCauseSchema = z.object({
@@ -129,5 +134,10 @@ export const userCauseSchema = z.object({
 
 // Types
 export type UserProductFormData = z.infer<typeof userProductSchema>;
-export type UserServiceFormData = z.infer<typeof userServiceSchema>;
+/** The service pricing toggle — which ONE price field the form shows. */
+export type ServicePricingModel = 'hourly' | 'fixed';
+export type UserServiceFormData = z.infer<typeof userServiceSchema> & {
+  /** UI-only (not in the schema): zod .parse strips it, so it's never persisted. */
+  pricing_model?: ServicePricingModel;
+};
 export type UserCauseFormData = z.infer<typeof userCauseSchema>;

--- a/src/services/cat/nudge-copy.ts
+++ b/src/services/cat/nudge-copy.ts
@@ -1,0 +1,146 @@
+/**
+ * Nudge copy SSOT — every user-facing nudge string, per language.
+ *
+ * One language per user: the language is resolved ONCE from the user's profile
+ * (profile.language, falling back to a preferred-currency heuristic) and every
+ * nudge — deterministic templates AND LLM-written reasons — uses it. Mixed
+ * English/German cards on one dashboard were a founder-verified trust bug.
+ */
+
+import { ENTITY_REGISTRY, type EntityType } from '@/config/entity-registry';
+
+export type NudgeLanguage = 'en' | 'de';
+
+/**
+ * Resolve the ONE language all nudges for this user are written in.
+ * profile.language is authoritative; with no explicit language, an explicit
+ * CHF currency preference (Swiss-focused platform) implies German. Default English.
+ */
+export function resolveNudgeLanguage(
+  profile: { language?: string | null; currency?: string | null } | null | undefined
+): NudgeLanguage {
+  const lang = (profile?.language ?? '').toLowerCase();
+  if (lang.startsWith('de')) {
+    return 'de';
+  }
+  if (lang.startsWith('en')) {
+    return 'en';
+  }
+  if ((profile?.currency ?? '').toUpperCase() === 'CHF') {
+    return 'de';
+  }
+  return 'en';
+}
+
+interface CopyBlock {
+  title: string;
+  body: string;
+  cta: string;
+}
+
+export interface NudgeCopy {
+  /** Human name for the LLM instruction ("write in <languageName>"). */
+  languageName: string;
+  /** Localized entity noun (falls back to the registry display name). */
+  entityNoun(type: EntityType): string;
+  completionBio: CopyBlock;
+  publishDraft(title: string): CopyBlock;
+  growthSkill(args: {
+    skill: string;
+    noun: string;
+    kind: 'product' | 'service';
+    wanted: boolean;
+  }): CopyBlock;
+  growthAsset(args: { asset: string; wanted: boolean }): CopyBlock;
+  activation(args: { title: string; noun: string }): { title: string; cta: string };
+  connection(name: string): { title: string; cta: string };
+}
+
+const NOUN_DE: Partial<Record<EntityType, string>> = {
+  service: 'Dienstleistung',
+  product: 'Produkt',
+  project: 'Projekt',
+  cause: 'Cause',
+  event: 'Event',
+  wishlist: 'Wunschliste',
+  asset: 'Asset',
+};
+
+export const NUDGE_COPY: Record<NudgeLanguage, NudgeCopy> = {
+  en: {
+    languageName: 'English',
+    entityNoun: type => ENTITY_REGISTRY[type].name.toLowerCase(),
+    completionBio: {
+      title: 'Add a bio so people — and the Cat — can find you',
+      body: 'A few lines about what you do lets the Cat match you to the right people, work, and opportunities.',
+      cta: 'Add your bio',
+    },
+    publishDraft: title => ({
+      title: `Publish your draft "${title}"`,
+      body: `It's still a draft, so no one can find it yet. A couple of clicks makes it live.`,
+      cta: 'Review & publish',
+    }),
+    growthSkill: ({ skill, noun, kind, wanted }) => ({
+      title: `Turn "${skill}" into a ${noun}`,
+      body: wanted
+        ? `People on OrangeCat are already asking for ${skill} — and you have it, but it isn't listed yet. Drafting it takes one tap.`
+        : kind === 'product'
+          ? `You make ${skill}, but it isn't listed yet — people here can only buy what they can see. Drafting it takes one tap.`
+          : `You can do ${skill}, but it isn't listed yet — people here can only hire you for what they can see. Drafting it takes one tap.`,
+      cta: `Draft a ${skill} ${noun}`,
+    }),
+    growthAsset: ({ asset, wanted }) => ({
+      title: `Put your ${asset} to work`,
+      body: wanted
+        ? `People here are looking for things like ${asset} — and yours mostly sits idle. Listed as an asset, it can earn.`
+        : `Your ${asset} mostly sits idle. Listed as an asset, it can earn while you're not using it.`,
+      cta: `List your ${asset}`,
+    }),
+    activation: ({ title, noun }) => ({
+      title: `Offer "${title}" as a ${noun}`,
+      cta: `Create ${noun}`,
+    }),
+    connection: name => ({
+      title: `You should meet ${name}`,
+      cta: 'View profile',
+    }),
+  },
+  de: {
+    languageName: 'German (Deutsch)',
+    entityNoun: type => NOUN_DE[type] ?? ENTITY_REGISTRY[type].name,
+    completionBio: {
+      title: 'Füge eine Bio hinzu, damit Menschen — und die Cat — dich finden',
+      body: 'Ein paar Zeilen darüber, was du machst, lassen die Cat dich mit den richtigen Menschen, Aufträgen und Chancen zusammenbringen.',
+      cta: 'Bio hinzufügen',
+    },
+    publishDraft: title => ({
+      title: `Veröffentliche deinen Entwurf „${title}“`,
+      body: 'Er ist noch ein Entwurf — niemand kann ihn finden. Zwei Klicks machen ihn live.',
+      cta: 'Prüfen & veröffentlichen',
+    }),
+    growthSkill: ({ skill, noun, kind, wanted }) => ({
+      title: `Biete „${skill}“ als ${noun} an`,
+      body: wanted
+        ? `Auf OrangeCat wird ${skill} bereits gesucht — du kannst es, aber es ist noch nicht gelistet. Ein Entwurf ist einen Tipp entfernt.`
+        : kind === 'product'
+          ? `Du machst ${skill}, aber es ist noch nicht gelistet — hier kann man nur kaufen, was sichtbar ist. Ein Entwurf ist einen Tipp entfernt.`
+          : `Du kannst ${skill}, aber es ist noch nicht gelistet — man kann dich nur für das buchen, was sichtbar ist. Ein Entwurf ist einen Tipp entfernt.`,
+      cta: `Entwurf anlegen: ${skill}`,
+    }),
+    growthAsset: ({ asset, wanted }) => ({
+      title: `Lass „${asset}“ für dich arbeiten`,
+      body: wanted
+        ? `Genau so etwas wie ${asset} wird hier gesucht — und deins liegt meist ungenutzt. Als Asset gelistet kann es verdienen.`
+        : `Dein ${asset} liegt meist ungenutzt. Als Asset gelistet kann es verdienen, während du es nicht brauchst.`,
+      cta: `„${asset}“ listen`,
+    }),
+    activation: ({ title, noun }) => ({
+      title: `Biete „${title}“ als ${noun} an`,
+      cta: `${noun} erstellen`,
+    }),
+    connection: name => ({
+      title: `Du solltest ${name} kennenlernen`,
+      cta: 'Profil ansehen',
+    }),
+  },
+};

--- a/src/services/cat/nudges.ts
+++ b/src/services/cat/nudges.ts
@@ -8,10 +8,15 @@
  *  - growth:      a skill/asset they HAVE but haven't listed → one-tap prefilled draft,
  *                 preferring (and flagging) ones real platform demand is asking for
  *
- * Activation + connection are LLM-reasoned (grounded: never invents a skill they
- * didn't state or a person not surfaced by semantic search). Completion is
- * rule-based (always correct). Results are cached in user_nudges; dismissed ones
- * never reappear (dedupe_key). This is the agentic loop pointed at user growth.
+ * Trust rules (founder-verified):
+ *  - Names are always entity display titles — never raw URLs or slugs.
+ *  - One language per user (profile.language / currency heuristic) across ALL copy.
+ *  - Every nudge is grounded in the user's actual entities, profile, and economic
+ *    profile — LLM proposals that don't overlap that grounding are dropped
+ *    (the "haircuts to a ceramicist" bug).
+ *
+ * Activation + connection are LLM-reasoned; completion + growth are rule-based.
+ * Results are cached in user_nudges; dismissed ones never reappear (dedupe_key).
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -21,6 +26,7 @@ import { ROUTES } from '@/config/routes';
 import { DEFAULT_FREE_MODEL_ID } from '@/config/ai-models';
 import { createOpenRouterService } from '@/services/ai';
 import { searchPlatform } from './platform-search';
+import { NUDGE_COPY, resolveNudgeLanguage, type NudgeCopy } from './nudge-copy';
 import {
   getEconomicProfile,
   suggestedEntityForSkill,
@@ -51,16 +57,28 @@ const usernameFromUrl = (url: string): string | null => {
   return m ? m[1] : null;
 };
 
+/** True when a string is a URL/path/slug — never acceptable as a display name. */
+const looksLikeUrl = (s: string): boolean =>
+  /^https?:\/\//i.test(s) || s.startsWith('/') || /\.[a-z]{2,}(\/|$)/i.test(s);
+
+interface NeighborPerson {
+  username: string;
+  /** Always a real display name (profile name or username) — never a URL. */
+  title: string;
+  description: string;
+}
+
 export async function generateNudges(supabase: any, userId: string): Promise<Nudge[]> {
   const { data: profile } = await supabase
     .from(DATABASE_TABLES.PROFILES)
-    .select('id, username, name, bio, location_city')
+    .select('id, username, name, bio, background, location_city, language, currency')
     .eq('id', userId)
     .maybeSingle();
   if (!profile?.username) {
     return [];
   }
 
+  const copy = NUDGE_COPY[resolveNudgeLanguage(profile)];
   const nudges: Nudge[] = [];
 
   // ── User's own entities (active + drafts) ──────────────────────────────────
@@ -72,6 +90,7 @@ export async function generateNudges(supabase: any, userId: string): Promise<Nud
     .maybeSingle();
   const created: Record<string, { active: number; drafts: Array<{ id: string; title: string }> }> =
     {};
+  const ownEntityTitles: string[] = [];
   if (actor?.id) {
     for (const { type } of ENTITY_SOURCE) {
       const meta = ENTITY_REGISTRY[type];
@@ -85,6 +104,11 @@ export async function generateNudges(supabase: any, userId: string): Promise<Nud
           .filter((e: any) => e.status === 'draft')
           .map((e: any) => ({ id: e.id, title: e.title })),
       };
+      for (const e of data ?? []) {
+        if (e?.title) {
+          ownEntityTitles.push(String(e.title).toLowerCase());
+        }
+      }
     }
   }
 
@@ -92,9 +116,9 @@ export async function generateNudges(supabase: any, userId: string): Promise<Nud
   if (!profile.bio) {
     nudges.push({
       nudge_type: 'completion',
-      title: 'Add a bio so people — and the Cat — can find you',
-      body: 'A few lines about what you do lets the Cat match you to the right people, work, and opportunities.',
-      cta_label: 'Add your bio',
+      title: copy.completionBio.title,
+      body: copy.completionBio.body,
+      cta_label: copy.completionBio.cta,
       cta_url: ROUTES.DASHBOARD.INFO_EDIT,
       dedupe_key: 'completion:bio',
       score: 0.6,
@@ -102,11 +126,12 @@ export async function generateNudges(supabase: any, userId: string): Promise<Nud
   }
   for (const { type } of ENTITY_SOURCE) {
     for (const d of created[type]?.drafts ?? []) {
+      const c = copy.publishDraft(d.title);
       nudges.push({
         nudge_type: 'completion',
-        title: `Publish your draft "${d.title}"`,
-        body: `It's still a draft, so no one can find it yet. A couple of clicks makes it live.`,
-        cta_label: 'Review & publish',
+        title: c.title,
+        body: c.body,
+        cta_label: c.cta,
         cta_url: ENTITY_REGISTRY[type].basePath,
         dedupe_key: `completion:publish:${d.id}`,
         score: 0.7,
@@ -115,13 +140,12 @@ export async function generateNudges(supabase: any, userId: string): Promise<Nud
   }
 
   // ── Growth nudges (deterministic, grounded in the economic profile) ─────────
-  // A skill or asset they HAVE but haven't turned into a listing → the smallest
-  // publishable next step, one tap from a prefilled draft. The "gap is the gift".
+  let econ: EconomicProfile | null = null;
   if (actor?.id) {
     try {
-      const econ = await getEconomicProfile(supabase, userId);
+      econ = await getEconomicProfile(supabase, userId);
       if (econ) {
-        nudges.push(...(await growthNudges(supabase, actor.id, econ)));
+        nudges.push(...(await growthNudges(supabase, actor.id, econ, copy)));
       }
     } catch (err) {
       logger.warn('nudges: growth generation failed', { err }, 'Nudges');
@@ -130,7 +154,7 @@ export async function generateNudges(supabase: any, userId: string): Promise<Nud
 
   // ── Smart nudges (activation + connection), only with a bio to reason from ──
   if (profile.bio) {
-    let neighbors: Array<{ username: string; title: string; description: string }> = [];
+    let neighbors: NeighborPerson[] = [];
     try {
       const results = await searchPlatform(
         supabase,
@@ -145,12 +169,13 @@ export async function generateNudges(supabase: any, userId: string): Promise<Nud
         }))
         .filter(n => n.username && n.username !== profile.username)
         .slice(0, 4);
+      neighbors = await resolveNeighborNames(supabase, neighbors);
     } catch (err) {
       logger.warn('nudges: neighbor search failed', { err }, 'Nudges');
     }
 
     try {
-      const smart = await smartNudges(profile, created, neighbors);
+      const smart = await smartNudges(profile, created, neighbors, econ, ownEntityTitles, copy);
       nudges.push(...smart);
     } catch (err) {
       logger.warn('nudges: smart generation failed', { err }, 'Nudges');
@@ -165,6 +190,42 @@ export async function generateNudges(supabase: any, userId: string): Promise<Nud
     .slice(0, 5);
 }
 
+/**
+ * Guarantee neighbor names are DISPLAY TITLES: look each username up in profiles
+ * and use name → username. Search-result titles have rendered raw URLs/slugs as
+ * people's names on suggestion cards (founder-verified); never trust them alone.
+ */
+async function resolveNeighborNames(
+  supabase: any,
+  neighbors: NeighborPerson[]
+): Promise<NeighborPerson[]> {
+  if (neighbors.length === 0) {
+    return neighbors;
+  }
+  const names = new Map<string, string>();
+  try {
+    const { data } = await supabase
+      .from(DATABASE_TABLES.PROFILES)
+      .select('username, name')
+      .in(
+        'username',
+        neighbors.map(n => n.username)
+      );
+    for (const row of data ?? []) {
+      if (row?.username) {
+        names.set(row.username, row.name || row.username);
+      }
+    }
+  } catch (err) {
+    logger.warn('nudges: neighbor name resolve failed', { err }, 'Nudges');
+  }
+  return neighbors.map(n => {
+    const resolved = names.get(n.username);
+    const safe = resolved ?? (n.title && !looksLikeUrl(n.title) ? n.title : n.username);
+    return { ...n, title: safe };
+  });
+}
+
 /** Stem-aware substring match — conservative, so a "match" is a real signal. */
 function termMatches(term: string, haystack: string[]): boolean {
   const x = term.toLowerCase().trim();
@@ -173,6 +234,46 @@ function termMatches(term: string, haystack: string[]): boolean {
   }
   const stem = x.slice(0, Math.max(4, Math.round(x.length * 0.6)));
   return haystack.some(h => h.includes(x) || h.includes(stem));
+}
+
+/**
+ * The user's actual grounding: bio + background + economic profile terms + their
+ * own entity titles, lowercased. LLM proposals must overlap this or they're stale
+ * context (old chat scraps) and get dropped.
+ */
+function groundingCorpus(
+  profile: { bio?: string | null; background?: string | null },
+  econ: EconomicProfile | null,
+  ownEntityTitles: string[]
+): string[] {
+  const corpus: string[] = [...ownEntityTitles];
+  if (profile.bio) {
+    corpus.push(String(profile.bio).toLowerCase());
+  }
+  if (profile.background) {
+    corpus.push(String(profile.background).toLowerCase());
+  }
+  if (econ) {
+    for (const s of econ.skills) {
+      corpus.push(s.name.toLowerCase());
+    }
+    for (const a of econ.assets) {
+      corpus.push(a.name.toLowerCase());
+    }
+    for (const w of econ.askedFor) {
+      corpus.push(w.toLowerCase());
+    }
+  }
+  return corpus.filter(Boolean);
+}
+
+/** True when the text shares at least one significant term with the corpus. */
+function isGrounded(text: string, corpus: string[]): boolean {
+  const tokens = text
+    .toLowerCase()
+    .split(/[^a-zà-öø-ÿäöüß0-9]+/i)
+    .filter(t => t.length >= 4);
+  return tokens.some(t => termMatches(t, corpus));
 }
 
 /**
@@ -249,7 +350,8 @@ async function gatherPlatformDemand(supabase: any): Promise<string[]> {
 async function growthNudges(
   supabase: any,
   actorId: string,
-  econ: EconomicProfile
+  econ: EconomicProfile,
+  copy: NudgeCopy
 ): Promise<Nudge[]> {
   if (econ.skills.length === 0 && econ.assets.length === 0) {
     return [];
@@ -282,16 +384,17 @@ async function growthNudges(
     const isWanted = wanted(skill);
     const et = suggestedEntityForSkill(skill);
     const meta = ENTITY_REGISTRY[et];
-    const noun = meta.name.toLowerCase();
+    const c = copy.growthSkill({
+      skill,
+      noun: copy.entityNoun(et),
+      kind: et,
+      wanted: isWanted,
+    });
     out.push({
       nudge_type: 'growth',
-      title: `Turn "${skill}" into a ${noun}`,
-      body: isWanted
-        ? `People on OrangeCat are already asking for ${skill} — and you have it, but it isn't listed yet. Drafting it takes one tap.`
-        : et === 'product'
-          ? `You make ${skill}, but it isn't listed yet — people here can only buy what they can see. Drafting it takes one tap.`
-          : `You can do ${skill}, but it isn't listed yet — people here can only hire you for what they can see. Drafting it takes one tap.`,
-      cta_label: `Draft a ${skill} ${noun}`,
+      title: c.title,
+      body: c.body,
+      cta_label: c.cta,
       cta_url: `${meta.createPath}?title=${encodeURIComponent(skill)}`,
       dedupe_key: `growth:skill:${skill.toLowerCase()}`,
       score: isWanted ? 0.88 : 0.82,
@@ -302,13 +405,12 @@ async function growthNudges(
   const asset = uncoveredAssets.find(wanted) ?? uncoveredAssets[0];
   if (asset) {
     const isWanted = wanted(asset);
+    const c = copy.growthAsset({ asset, wanted: isWanted });
     out.push({
       nudge_type: 'growth',
-      title: `Put your ${asset} to work`,
-      body: isWanted
-        ? `People here are looking for things like ${asset} — and yours mostly sits idle. Listed as an asset, it can earn.`
-        : `Your ${asset} mostly sits idle. Listed as an asset, it can earn while you're not using it.`,
-      cta_label: `List your ${asset}`,
+      title: c.title,
+      body: c.body,
+      cta_label: c.cta,
       cta_url: `${ENTITY_REGISTRY.asset.createPath}?title=${encodeURIComponent(asset)}`,
       dedupe_key: `growth:asset:${asset.toLowerCase()}`,
       score: isWanted ? 0.86 : 0.8,
@@ -321,16 +423,20 @@ async function growthNudges(
 async function smartNudges(
   profile: any,
   created: Record<string, { active: number; drafts: Array<{ id: string; title: string }> }>,
-  neighbors: Array<{ username: string; title: string; description: string }>
+  neighbors: NeighborPerson[],
+  econ: EconomicProfile | null,
+  ownEntityTitles: string[],
+  copy: NudgeCopy
 ): Promise<Nudge[]> {
-  const system = `You are the proactive engine of OrangeCat's Cat. Given a user's profile, what they've already created, and real people on the platform related to them, propose specific, GROUNDED nudges that help them succeed.
+  const system = `You are the proactive engine of OrangeCat's Cat. Given a user's profile, what they've already created, their economic profile, and real people on the platform related to them, propose specific, GROUNDED nudges that help them succeed.
 
 STRICT RULES:
 - Ground everything in the data given. NEVER invent a skill they didn't state or a person not in the provided list.
 - Two kinds of nudge:
-  1. "activation" — if their bio clearly implies an offering they have NOT already created, suggest creating ONE entity. entityType must be one of: service, product, project, cause, event, wishlist. Give a concrete title and a one-sentence reason.
+  1. "activation" — if their bio or economic profile clearly implies an offering they have NOT already created, suggest creating ONE entity. entityType must be one of: service, product, project, cause, event, wishlist. Give a concrete title and a one-sentence reason.
   2. "connection" — suggest meeting ONE of the listed people, with a one-sentence reason tied to BOTH bios.
 - Don't suggest creating an entity type they already have active. If nothing is genuinely useful, return [].
+- Write every "title" and "reason" in ${copy.languageName} — the user's language. Never mix languages.
 
 Return ONLY a JSON array (max 3), each item exactly:
 {"type":"activation","entityType":"service","title":"<entity title>","reason":"<one sentence>"}
@@ -338,6 +444,13 @@ or {"type":"connection","username":"<one of the provided usernames>","reason":"<
 
   const payload = {
     profile: { name: profile.name, bio: profile.bio, location: profile.location_city },
+    economicProfile: econ
+      ? {
+          skills: econ.skills.map(s => s.name),
+          assets: econ.assets.map(a => a.name),
+          askedFor: econ.askedFor,
+        }
+      : null,
     alreadyCreated: Object.fromEntries(
       Object.entries(created).map(([k, v]) => [k, { active: v.active }])
     ),
@@ -365,30 +478,45 @@ or {"type":"connection","username":"<one of the provided usernames>","reason":"<
     return [];
   }
 
+  // Activation proposals must overlap the user's ACTUAL grounding (bio, background,
+  // economic profile, own entities). A weak model reasoning from stale chat scraps
+  // ("haircuts" for a ceramicist) fails this check and is dropped.
+  const corpus = groundingCorpus(profile, econ, ownEntityTitles);
+
   const neighborUsernames = new Set(neighbors.map(n => n.username));
   const out: Nudge[] = [];
   for (const p of parsed) {
     if (p?.type === 'activation' && SUGGESTABLE.has(p.entityType) && p.title) {
       const meta = ENTITY_REGISTRY[p.entityType as keyof typeof ENTITY_REGISTRY];
-      if (!meta) {
+      const proposedTitle = String(p.title).slice(0, 80);
+      if (!meta || looksLikeUrl(proposedTitle)) {
         continue;
       }
+      if (!isGrounded(`${proposedTitle} ${p.reason ?? ''}`, corpus)) {
+        logger.info('nudges: dropped ungrounded activation', { title: proposedTitle }, 'Nudges');
+        continue;
+      }
+      const c = copy.activation({
+        title: proposedTitle,
+        noun: copy.entityNoun(p.entityType as keyof typeof ENTITY_REGISTRY),
+      });
       out.push({
         nudge_type: 'activation',
-        title: `Offer "${String(p.title).slice(0, 80)}" as a ${meta.name}`,
+        title: c.title,
         body: String(p.reason || '').slice(0, 240),
-        cta_label: `Create ${meta.name}`,
+        cta_label: c.cta,
         cta_url: meta.createPath,
         dedupe_key: `activation:${p.entityType}`,
         score: 0.85,
       });
     } else if (p?.type === 'connection' && neighborUsernames.has(p.username)) {
       const n = neighbors.find(x => x.username === p.username)!;
+      const c = copy.connection(n.title);
       out.push({
         nudge_type: 'connection',
-        title: `You should meet ${n.title}`,
+        title: c.title,
         body: String(p.reason || '').slice(0, 240),
-        cta_label: 'View profile',
+        cta_label: c.cta,
         cta_url: `/profiles/${p.username}`,
         dedupe_key: `connection:${p.username}`,
         score: 0.8,

--- a/src/services/search/discoverCounts.ts
+++ b/src/services/search/discoverCounts.ts
@@ -1,5 +1,5 @@
 /**
- * Public entity counts for /discover (hero stats + tab badges).
+ * Public entity counts for /discover (tab badges).
  *
  * Filter shapes mirror discoverGenericFetcher.ts so badge totals match the
  * entity-tab views. Runs on the server (admin client) so anonymous visitors


### PR DESCRIPTION
Founder-verified trust scrub (x.ai bar). Four workstreams + prod DB cleanup.

## 1. Public test content (prod DB — already applied)
- **Deleted** wishlist `4d1896fe-35e0-41b8-bff5-798b4128f723` — "Test Wishlist for Proof Upload" (public, active, 0 items)
- **Cancelled** (unpublished) 2 active test loans: `e16ab177…` "API Test Fixed Final", `73edf4dd…` "Test Loan Workflow"
- Everything else matching test/smoke/demo across entity tables is already non-public (drafts / archived / private groups) — left untouched

## 2. Cat suggestion cards
- **No raw URLs as names**: neighbor names resolved from `profiles` (display name → username); URL-shaped LLM titles dropped
- **Dashboard cap**: top 2 highest-confidence nudges only
- **One language per user**: `resolveNudgeLanguage` (profile.language → CHF-currency heuristic) + new `nudge-copy.ts` SSOT (en/de) for ALL deterministic copy; LLM instructed to write titles/reasons in that same language
- **Grounding**: activation proposals must overlap the user's actual bio/background/economic-profile/entity titles — the "haircuts to a ceramicist" class of stale-context nudges is dropped (logged); economic profile now feeds the smart-nudge prompt

Note: existing cached nudges regenerate on the next dashboard load after the 24h staleness window (or on profile update).

## 3. Discover
- 3-stat hero cards removed entirely (headline + CTA stay)
- One counting source: results header now says only `Showing N results` (what is actually rendered); the fabricated mixed total (`52 results (showing 46)` vs tab badge `All 76`) is gone. Tab badges remain the server-counted SSOT (`discoverCounts`)

## 4. Create forms
- In-form duplicate "Need inspiration?" template panel removed (wizard step-1 picker stays)
- "Fiat goal: …contributions OR Bitcoin price appreciation" no longer leaks onto price fields — `CurrencyInput` gains opt-in `isGoal`, set only on project/cause/event funding-goal fields
- Services: explicit **Hourly vs Fixed** radio toggle, one price field visible at a time; switching resets the hidden price (`clearOnChange`); edit mode/templates infer the toggle from which price is set (`deriveInitialValues`); the at-least-one-price rule now flags both fields so the visible one always shows the error

## Gates
- `type-check`: 0 errors (non-incremental)
- `lint`: clean
- `npx jest __tests__/unit --silent`: 58 suites / 677 tests green
- `npm run audit:routes`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)