### PR TITLE
feat(chrome+edit): one nav system per audience; complete generic ?edit= flow for all entity types

### DIFF
--- a/__tests__/unit/config/entity-edit-convention.test.ts
+++ b/__tests__/unit/config/entity-edit-convention.test.ts
@@ -1,0 +1,69 @@
+/**
+ * SSOT edit-convention guard.
+ *
+ * Every entity type with a create page edits through the SAME form via
+ * `createPath?edit=<id>` (PR #376 convention). This test pins each list
+ * config's editPath to that convention so a one-off `/x/[id]/edit` route
+ * can't silently reappear for a single entity type.
+ */
+
+import { ENTITY_REGISTRY, type EntityType } from '@/config/entity-registry';
+import { assetEntityConfig } from '@/config/entities/assets';
+import { aiAssistantEntityConfig } from '@/config/entities/ai-assistants';
+import { causeEntityConfig } from '@/config/entities/causes';
+import { circleEntityConfig } from '@/config/entities/circles';
+import { documentEntityConfig } from '@/config/entities/documents';
+import { eventEntityConfig } from '@/config/entities/events';
+import { investmentEntityConfig } from '@/config/entities/investments';
+import { loanEntityConfig } from '@/config/entities/loans';
+import { productEntityConfig } from '@/config/entities/products';
+import { projectEntityConfig } from '@/config/entities/projects';
+import { researchEntityConfig } from '@/config/entities/research';
+import { serviceEntityConfig } from '@/config/entities/services';
+import { wishlistEntityConfig } from '@/config/entities/wishlists';
+
+// wallet is intentionally absent: it has no create form (managed inline by
+// WalletManager). group has no list config; its edit entry point is the
+// GroupDetail "Edit Group" action, covered below.
+const LIST_CONFIGS = [
+  aiAssistantEntityConfig,
+  assetEntityConfig,
+  causeEntityConfig,
+  circleEntityConfig,
+  documentEntityConfig,
+  eventEntityConfig,
+  investmentEntityConfig,
+  loanEntityConfig,
+  productEntityConfig,
+  projectEntityConfig,
+  researchEntityConfig,
+  serviceEntityConfig,
+  wishlistEntityConfig,
+];
+
+describe('entity edit convention (createPath?edit=<id>)', () => {
+  it.each(LIST_CONFIGS.map(c => [c.entityType, c] as const))(
+    '%s editPath follows the convention',
+    (entityType, config) => {
+      const meta = ENTITY_REGISTRY[entityType as EntityType];
+      expect(meta).toBeDefined();
+      expect(config.editPath?.('abc-123')).toBe(`${meta.createPath}?edit=abc-123`);
+    }
+  );
+
+  it('covers every entity type that has a create form', () => {
+    const covered = new Set(LIST_CONFIGS.map(c => c.entityType));
+    const expected = (Object.keys(ENTITY_REGISTRY) as EntityType[]).filter(
+      // wallet: no create form; group: edit entry point lives on GroupDetail
+      t => t !== 'wallet' && t !== 'group'
+    );
+    expected.forEach(t => expect(covered.has(t)).toBe(true));
+  });
+
+  it('group edit uses the same convention (id-addressed createPath)', () => {
+    // GroupDetail builds its Edit link inline; pin the convention pieces.
+    const meta = ENTITY_REGISTRY['group'];
+    expect(meta.createPath).toBe('/dashboard/groups/create');
+    expect(`${meta.createPath}?edit=g-1`).toBe('/dashboard/groups/create?edit=g-1');
+  });
+});

--- a/__tests__/unit/create/entityFormSubmitAction.test.ts
+++ b/__tests__/unit/create/entityFormSubmitAction.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for the generic entity form submit action — the single code
+ * path every entity type's create AND edit form goes through.
+ *
+ * Locks in the SSOT edit convention:
+ *   create → POST `config.apiEndpoint`            (+ actor_id when acting as group)
+ *   edit   → PUT  `${config.apiEndpoint}/${id}`   (never reassigns actor_id)
+ */
+
+import { z } from 'zod';
+import { executeEntityFormSubmit } from '@/components/create/EntityForm/hooks/entityFormSubmitAction';
+import type { EntityConfig } from '@/components/create/types';
+
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+jest.mock('@/lib/analytics', () => ({
+  entityEvents: { created: jest.fn() },
+}));
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+jest.mock('@/config/api-routes', () => ({
+  API_ROUTES: { ENTITY_WALLETS: '/api/entity-wallets' },
+}));
+
+type TestData = { title: string; description?: string };
+
+function makeConfig(overrides: Partial<EntityConfig<TestData>> = {}): EntityConfig<TestData> {
+  return {
+    type: 'cause',
+    name: 'Cause',
+    apiEndpoint: '/api/causes',
+    successUrl: '/dashboard/causes/[id]',
+    validationSchema: z.object({
+      title: z.string().min(1),
+      description: z.string().optional(),
+    }),
+    defaultValues: { title: '' },
+    fieldGroups: [],
+    ...overrides,
+  } as unknown as EntityConfig<TestData>;
+}
+
+function makeParams(overrides: Record<string, unknown> = {}) {
+  return {
+    config: makeConfig(),
+    formStateData: { title: 'My cause' } as TestData,
+    mode: 'create' as const,
+    entityId: undefined as string | undefined,
+    user: { id: 'user-1' },
+    onSuccess: undefined as ((data: TestData & { id: string }) => void) | undefined,
+    onError: undefined,
+    clearDraft: jest.fn(),
+    setSubmitting: jest.fn(),
+    setErrors: jest.fn(),
+    onEntityCreated: jest.fn(),
+    router: { push: jest.fn() },
+    existingWalletLinkIdRef: { current: undefined as string | undefined },
+    wizardMode: undefined,
+    actorId: undefined as string | null | undefined,
+    ...overrides,
+  };
+}
+
+function mockFetchOk(data: Record<string, unknown>) {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ success: true, data }),
+    clone() {
+      return this;
+    },
+  });
+}
+
+describe('executeEntityFormSubmit', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('create mode POSTs to config.apiEndpoint', async () => {
+    global.fetch = mockFetchOk({ id: 'new-1', title: 'My cause' }) as unknown as typeof fetch;
+    const params = makeParams();
+
+    await executeEntityFormSubmit(params);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/causes',
+      expect.objectContaining({ method: 'POST' })
+    );
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({ title: 'My cause' });
+    expect(params.clearDraft).toHaveBeenCalled();
+    expect(params.onEntityCreated).toHaveBeenCalledWith({ id: 'new-1', title: 'My cause' });
+  });
+
+  it('create mode merges actor_id when acting as a group', async () => {
+    global.fetch = mockFetchOk({ id: 'new-1' }) as unknown as typeof fetch;
+    const params = makeParams({ actorId: 'actor-9' });
+
+    await executeEntityFormSubmit(params);
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.actor_id).toBe('actor-9');
+  });
+
+  it('edit mode PUTs to `${apiEndpoint}/${entityId}` and never sends actor_id', async () => {
+    global.fetch = mockFetchOk({ id: 'e-42', title: 'My cause' }) as unknown as typeof fetch;
+    const onSuccess = jest.fn();
+    const params = makeParams({
+      mode: 'edit' as const,
+      entityId: 'e-42',
+      actorId: 'actor-9', // must be ignored in edit mode
+      onSuccess,
+    });
+
+    await executeEntityFormSubmit(params);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/causes/e-42',
+      expect.objectContaining({ method: 'PUT' })
+    );
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.actor_id).toBeUndefined();
+    // Edit must NOT clear the create-draft or fire the created analytics event
+    expect(params.clearDraft).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith({ id: 'e-42', title: 'My cause' });
+  });
+
+  it('edit mode redirects via successUrl with tokens filled from the response', async () => {
+    global.fetch = mockFetchOk({ id: 'e-42', slug: 'my-slug' }) as unknown as typeof fetch;
+    const params = makeParams({
+      config: makeConfig({ successUrl: '/groups/[slug]' }),
+      mode: 'edit' as const,
+      entityId: 'e-42',
+    });
+
+    await executeEntityFormSubmit(params);
+
+    expect(params.router.push).toHaveBeenCalledWith('/groups/my-slug');
+  });
+
+  it('does not fetch when validation fails; surfaces field errors', async () => {
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    const params = makeParams({ formStateData: { title: '' } as TestData });
+
+    await executeEntityFormSubmit(params);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(params.setErrors).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.any(String) })
+    );
+  });
+
+  it('surfaces API errors as a general error without redirecting', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: 'You can only update your own causes' }),
+      clone() {
+        return this;
+      },
+    }) as unknown as typeof fetch;
+    const params = makeParams({ mode: 'edit' as const, entityId: 'e-42' });
+
+    await executeEntityFormSubmit(params);
+
+    expect(params.setErrors).toHaveBeenCalledWith({
+      general: 'You can only update your own causes',
+    });
+    expect(params.router.push).not.toHaveBeenCalled();
+    expect(params.setSubmitting).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/__tests__/unit/hooks/useEntityCreateEdit.test.ts
+++ b/__tests__/unit/hooks/useEntityCreateEdit.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for useEntityCreateEdit — the shared hook behind every
+ * entity create page that implements the SSOT edit convention
+ * (`createPath?edit=<id>` → fetch entity → prefill the same form).
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEntityCreateEdit } from '@/hooks/useEntityCreateEdit';
+
+let searchParams = new URLSearchParams();
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => searchParams,
+}));
+
+const mockAuth: { user: { id: string } | null; hydrated: boolean } = {
+  user: { id: 'user-1' },
+  hydrated: true,
+};
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockAuth,
+}));
+
+const mockPrefill: { initialData: Record<string, unknown> | undefined } = {
+  initialData: undefined,
+};
+jest.mock('@/hooks/useCreatePrefill', () => ({
+  useCreatePrefill: jest.fn(() => mockPrefill),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+import { useCreatePrefill } from '@/hooks/useCreatePrefill';
+
+describe('useEntityCreateEdit', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    searchParams = new URLSearchParams();
+    mockPrefill.initialData = undefined;
+  });
+
+  it('create mode (no ?edit): no fetch, prefill enabled, not loading', async () => {
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    mockPrefill.initialData = { title: 'From Cat' };
+
+    const { result } = renderHook(() => useEntityCreateEdit('cause'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.editId).toBeNull();
+    expect(result.current.entityData).toBeNull();
+    expect(result.current.initialData).toEqual({ title: 'From Cat' });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(useCreatePrefill).toHaveBeenCalledWith({ entityType: 'cause', enabled: true });
+  });
+
+  it('edit mode: fetches `${apiEndpoint}/${id}` and exposes the entity for prefill', async () => {
+    searchParams = new URLSearchParams('edit=cause-1');
+    const row = { id: 'cause-1', title: 'Clean water', target_amount: 500 };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, data: row }),
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useEntityCreateEdit('cause'));
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/causes/cause-1');
+    expect(result.current.editId).toBe('cause-1');
+    expect(result.current.entityData).toEqual(row);
+    expect(result.current.editError).toBeNull();
+    // URL/localStorage prefill must be disabled in edit mode
+    expect(useCreatePrefill).toHaveBeenCalledWith({ entityType: 'cause', enabled: false });
+  });
+
+  it('edit mode uses the registry apiEndpoint per entity type', async () => {
+    searchParams = new URLSearchParams('edit=g-1');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, data: { id: 'g-1', name: 'DAO' } }),
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useEntityCreateEdit('group'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(global.fetch).toHaveBeenCalledWith('/api/groups/g-1');
+    expect(result.current.entityData).toEqual({ id: 'g-1', name: 'DAO' });
+  });
+
+  it('edit mode: 404 → "not found" edit error, no entity data', async () => {
+    searchParams = new URLSearchParams('edit=missing');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ success: false }),
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useEntityCreateEdit('cause'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.editError).toBe('Cause not found');
+    expect(result.current.entityData).toBeNull();
+  });
+
+  it('edit mode waits for auth hydration before fetching', () => {
+    searchParams = new URLSearchParams('edit=cause-1');
+    mockAuth.hydrated = false;
+    global.fetch = jest.fn() as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useEntityCreateEdit('cause'));
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(true);
+    mockAuth.hydrated = true;
+  });
+});

--- a/src/app/api/groups/[slug]/route.ts
+++ b/src/app/api/groups/[slug]/route.ts
@@ -30,6 +30,13 @@ interface RouteContext {
   params: Promise<{ slug: string }>;
 }
 
+// The segment accepts either a slug or a UUID id. The generic entity edit
+// flow (`createPath?edit=<id>` → GET/PUT `${apiEndpoint}/${id}`) addresses
+// groups by id like every other entity; human-facing URLs use the slug.
+// Slugs are never UUID-shaped, so the two are unambiguous.
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const isBySlug = (identifier: string) => !UUID_PATTERN.test(identifier);
+
 export async function GET(_request: NextRequest, context: RouteContext) {
   try {
     const { slug } = await context.params;
@@ -38,8 +45,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     // whose auth.getUser()/queries fail server-side and 500 this public endpoint.
     const supabase = await createServerClient();
 
-    // Get group by slug (second param is bySlug=true)
-    const result = await groupsService.getGroup(slug, true, supabase);
+    const result = await groupsService.getGroup(slug, isBySlug(slug), supabase);
 
     if (!result.success) {
       if (result.error?.includes('not found')) {
@@ -48,7 +54,9 @@ export async function GET(_request: NextRequest, context: RouteContext) {
       return apiInternalError(result.error || 'Failed to fetch group');
     }
 
-    return apiSuccess({ group: result.group });
+    // Standard entity shape: `data` IS the group — consumed by the generic
+    // edit flow (useEntityCreateEdit). Don't re-wrap as `{ group }`.
+    return apiSuccess(result.group);
   } catch (error) {
     logger.error('Error in GET /api/groups/[slug]:', error);
     return apiInternalError();
@@ -75,7 +83,7 @@ export const PUT = withAuth(async (request: AuthenticatedRequest, context: Route
     }
 
     // Get group first to check permissions (use the authenticated server client)
-    const groupResult = await groupsService.getGroup(slug, true, request.supabase);
+    const groupResult = await groupsService.getGroup(slug, isBySlug(slug), request.supabase);
     if (!groupResult.success || !groupResult.group) {
       return apiNotFound('Group not found');
     }
@@ -101,7 +109,9 @@ export const PUT = withAuth(async (request: AuthenticatedRequest, context: Route
       return apiInternalError(result.error || 'Failed to update group');
     }
 
-    return apiSuccess({ group: result.group });
+    // Standard entity shape: `data` IS the group — the generic edit form
+    // reads `data.slug` to build its success redirect.
+    return apiSuccess(result.group);
   } catch (error) {
     logger.error('Error in PUT /api/groups/[slug]:', error);
     return apiInternalError();
@@ -121,7 +131,7 @@ export const DELETE = withAuth(async (request: AuthenticatedRequest, context: Ro
     const { slug } = await context.params;
 
     // Get group first to check permissions (use the authenticated server client)
-    const groupResult = await groupsService.getGroup(slug, true, request.supabase);
+    const groupResult = await groupsService.getGroup(slug, isBySlug(slug), request.supabase);
     if (!groupResult.success || !groupResult.group) {
       return apiNotFound('Group not found');
     }

--- a/src/app/api/groups/route.ts
+++ b/src/app/api/groups/route.ts
@@ -83,8 +83,11 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       return apiInternalError(result.error || 'Failed to create group');
     }
 
-    // Return in format expected by EntityForm (data property)
-    return apiCreated({ data: result.group, group: result.group });
+    // Standard entity shape: apiCreated already wraps in `data`, so pass
+    // the group itself. (The old `{ data, group }` double-wrap made
+    // `result.data.id`/`result.data.slug` undefined in EntityForm, which
+    // broke the post-create redirect.)
+    return apiCreated(result.group);
   } catch (error) {
     logger.error('Error in POST /api/groups:', error);
     return apiInternalError('Internal server error');

--- a/src/components/groups/GroupDetail.tsx
+++ b/src/components/groups/GroupDetail.tsx
@@ -55,11 +55,13 @@ export function GroupDetail({ groupSlug }: GroupDetailProps) {
     );
   }
 
+  // SSOT edit convention: createPath?edit=<id> (the old
+  // /groups/[slug]/settings route never existed — dead link).
   const headerActions = isOwner ? (
-    <Link href={`${ENTITY_REGISTRY['group'].publicBasePath}/${group.slug}/settings`}>
+    <Link href={`${ENTITY_REGISTRY['group'].createPath}?edit=${group.id}`}>
       <Button variant="outline">
         <Settings className="h-4 w-4 mr-2" />
-        Settings
+        Edit Group
       </Button>
     </Link>
   ) : null;

--- a/src/components/icons/BrandIcons.tsx
+++ b/src/components/icons/BrandIcons.tsx
@@ -1,0 +1,39 @@
+/**
+ * Brand icons (X, GitHub)
+ *
+ * lucide-react removed brand icons, so social links were rendering a
+ * generic Globe placeholder for every network — two identical globes in
+ * the footer. These are the official brand marks as inline SVGs, typed
+ * to the same `ComponentType<SVGProps<SVGSVGElement>>` shape the
+ * navigation config expects, so they drop in wherever a lucide icon fits.
+ */
+
+import type { SVGProps } from 'react';
+
+export function XBrandIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.451-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117l11.966 15.644Z" />
+    </svg>
+  );
+}
+
+export function GitHubIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -8,6 +8,7 @@ import Logo from './Logo';
 import { usePathname } from 'next/navigation';
 import { ArrowUp } from 'lucide-react';
 import { APP_NAME } from '@/config/brand';
+import { useAuth } from '@/hooks/useAuth';
 
 const footerLinkClass =
   'group flex items-center text-sm text-fg-secondary hover:text-fg-primary transition-colors py-1.5 rounded-md min-h-9';
@@ -15,6 +16,7 @@ const footerHeadingClass = 'text-xs font-medium text-fg-secondary uppercase trac
 
 const Footer = React.memo(function Footer() {
   const pathname = usePathname();
+  const { user, hydrated } = useAuth();
   const shouldRender = shouldShowFooter(pathname ?? '/');
 
   const scrollToTop = () => {
@@ -23,8 +25,11 @@ const Footer = React.memo(function Footer() {
     }
   };
 
-  // Don't render footer on authenticated pages to avoid layout conflicts with sidebar
-  if (!shouldRender) {
+  // Marketing footer is for anonymous visitors only. Signed-in users keep
+  // the app chrome everywhere — including public pages and 404/error pages
+  // — instead of getting a second marketing nav system. Also never render
+  // on app surfaces (layout conflicts with the sidebar).
+  if (!shouldRender || (hydrated && !!user)) {
     return null;
   }
 
@@ -75,7 +80,7 @@ const Footer = React.memo(function Footer() {
 
           {/* Navigation Links */}
           <div className="space-y-6">
-            <h3 className={footerHeadingClass}>[ Navigation ]</h3>
+            <h3 className={footerHeadingClass}>Navigation</h3>
             <ul className="space-y-3">
               {footerNavigation.product.map(item => (
                 <li key={item.name}>
@@ -89,7 +94,7 @@ const Footer = React.memo(function Footer() {
 
           {/* Company Links */}
           <div className="space-y-6">
-            <h3 className={footerHeadingClass}>[ Company ]</h3>
+            <h3 className={footerHeadingClass}>Company</h3>
             <ul className="space-y-3">
               {footerNavigation.company.map(item => (
                 <li key={item.name}>
@@ -114,7 +119,7 @@ const Footer = React.memo(function Footer() {
 
           {/* Legal Links */}
           <div className="space-y-6">
-            <h3 className={footerHeadingClass}>[ Legal ]</h3>
+            <h3 className={footerHeadingClass}>Legal</h3>
             <ul className="space-y-3">
               {footerNavigation.legal.map(item => (
                 <li key={item.name}>
@@ -128,7 +133,7 @@ const Footer = React.memo(function Footer() {
 
           {/* Newsletter/CTA Section */}
           <div className="space-y-6 sm:col-span-2 lg:col-span-1">
-            <h3 className={footerHeadingClass}>[ Stay Updated ]</h3>
+            <h3 className={footerHeadingClass}>Stay Updated</h3>
             <div className="space-y-4">
               <p className="text-sm text-fg-secondary leading-relaxed">
                 Get the latest updates on economic freedom, Bitcoin, and building on {APP_NAME}.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -56,7 +56,13 @@ export function Header({
   const { isScrolled, isHidden } = useHeaderScroll();
   const mobileMenu = useMobileMenu();
   const isAuthRoute = useIsAuthRoute();
-  const navigation = getHeaderNavigationItems(authState.user);
+  const navigation = getHeaderNavigationItems();
+
+  // Marketing nav (top links + hamburger menu) is for anonymous visitors
+  // only. Signed-in users get ONE navigation system — the app sidebar +
+  // header actions — everywhere, including public pages and 404/error
+  // pages, instead of a second competing marketing nav.
+  const showMarketingNav = !isAuthRoute && !authStatus.authenticated;
 
   // Mobile menu animation state
   const { menuRef, buttonRef, isClosing, handleClose } = useMobileMenuAnimation({
@@ -84,7 +90,7 @@ export function Header({
             {/* Sidebar/Menu Toggle - Always first, proper touch target */}
             {showSidebarToggle && onToggleSidebar ? (
               <MenuToggleButton onClick={onToggleSidebar} ariaLabel="Toggle sidebar" />
-            ) : !isAuthRoute ? (
+            ) : showMarketingNav ? (
               <MenuToggleButton
                 ref={buttonRef}
                 onClick={() => mobileMenu.open()}
@@ -98,11 +104,11 @@ export function Header({
               <Logo showText={true} size="md" className="hidden sm:flex" />
             </div>
 
-            {/* Desktop Navigation Links — public/marketing routes only. On
-                authenticated app routes the left sidebar owns section nav, so
-                showing these here was a second, redundant nav (it even renamed
-                the same destinations: top "Discover" = sidebar "Explore"). */}
-            {!isAuthRoute && <DesktopNavigation items={navigation} />}
+            {/* Desktop Navigation Links — anonymous marketing surfaces only.
+                Signed-in users navigate via the sidebar; rendering these for
+                them (e.g. on 404/error or public pages) was a second,
+                redundant nav system. */}
+            {showMarketingNav && <DesktopNavigation items={navigation} />}
           </div>
 
           {/* Center Section: Search trigger (Desktop only). Opens the
@@ -177,8 +183,8 @@ export function Header({
         />
       )}
 
-      {/* Mobile Menu (public routes only) */}
-      {!isAuthRoute && (
+      {/* Mobile Menu (anonymous marketing surfaces only) */}
+      {showMarketingNav && (
         <MobileMenu
           isOpen={mobileMenu.isOpen}
           isClosing={isClosing}

--- a/src/components/layout/HeaderNavigation.tsx
+++ b/src/components/layout/HeaderNavigation.tsx
@@ -11,9 +11,9 @@
 
 'use client';
 
-import { useState, useRef, useEffect, useId } from 'react';
+import { useState, useRef, useEffect, useId, type ComponentType, type SVGProps } from 'react';
 import Link from 'next/link';
-import { ChevronDown, type LucideIcon } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface NavigationItem {
@@ -37,7 +37,9 @@ interface MobileDrawerProps {
     product?: Array<{ name: string; href: string }>;
     company?: Array<{ name: string; href: string }>;
     legal?: Array<{ name: string; href: string }>;
-    social?: Array<{ name: string; href: string; icon?: LucideIcon }>;
+    // Matches NavigationItem.icon in @/config/navigation — lucide icons and
+    // local brand SVGs (BrandIcons) are both plain SVG components.
+    social?: Array<{ name: string; href: string; icon?: ComponentType<SVGProps<SVGSVGElement>> }>;
   };
   onClose: () => void;
 }

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -17,7 +17,7 @@
 import { ComponentType, SVGProps } from 'react';
 import { generateEntityNavigation } from './navigation-generator';
 import { ROUTES } from './routes';
-import type { User as SupabaseUser } from '@supabase/supabase-js';
+import { XBrandIcon, GitHubIcon } from '@/components/icons/BrandIcons';
 import {
   Home,
   Users,
@@ -77,20 +77,12 @@ interface NavItem {
 /**
  * Header navigation configuration
  *
- * SSOT for all header navigation items.
- * Organized by authentication state.
+ * SSOT for the marketing/public header links. This nav is for anonymous
+ * visitors only — signed-in users get ONE navigation system (the app
+ * sidebar + header actions), never a second marketing nav on top of it.
  */
 const headerNavigationConfig = {
-  /** Navigation for authenticated users */
-  authenticated: [
-    { name: 'Home', href: ROUTES.FEED },
-    { name: 'Dashboard', href: ROUTES.DASHBOARD.HOME },
-    { name: 'Discover', href: ROUTES.DISCOVER },
-    { name: 'Collaborate', href: ROUTES.COLLABORATE },
-    { name: 'Community', href: ROUTES.COMMUNITY },
-  ],
-
-  /** Navigation for unauthenticated users */
+  /** Navigation for unauthenticated visitors (marketing surfaces) */
   unauthenticated: [
     { name: 'Discover', href: ROUTES.DISCOVER },
     { name: 'Community', href: ROUTES.COMMUNITY },
@@ -99,15 +91,12 @@ const headerNavigationConfig = {
 };
 
 /**
- * Get navigation items based on authentication state for header
- *
- * @param user - Supabase User object or null
- * @returns Array of navigation items appropriate for the auth state
+ * Get the marketing header navigation items (anonymous visitors only).
+ * Signed-in users never see this nav — their navigation lives in the
+ * app sidebar and the header action cluster.
  */
-export function getHeaderNavigationItems(user: SupabaseUser | null): NavigationItem[] {
-  return user
-    ? [...headerNavigationConfig.authenticated]
-    : [...headerNavigationConfig.unauthenticated];
+export function getHeaderNavigationItems(): NavigationItem[] {
+  return [...headerNavigationConfig.unauthenticated];
 }
 
 /**
@@ -306,14 +295,14 @@ export const footerNavigation = {
   ],
   social: [
     {
-      name: 'Twitter',
-      href: 'https://twitter.com/orangecat',
-      icon: Globe,
+      name: 'X',
+      href: 'https://x.com/orangecat',
+      icon: XBrandIcon,
     },
     {
       name: 'GitHub',
       href: 'https://github.com/g-but/orangecat',
-      icon: Globe,
+      icon: GitHubIcon,
     },
   ],
   // Compact bottom-bar links (rendered next to the copyright line in

--- a/src/lib/social-platforms.ts
+++ b/src/lib/social-platforms.ts
@@ -10,14 +10,16 @@
  */
 
 import { MessageCircle, Globe, Heart } from 'lucide-react';
+import { XBrandIcon, GitHubIcon } from '@/components/icons/BrandIcons';
 
-// Brand icons were removed in lucide-react 0.400+
-// Using Globe as a generic fallback for social platforms
-const Twitter = Globe;
+// Brand icons were removed in lucide-react 0.400+.
+// Real brand marks live in @/components/icons/BrandIcons (SSOT); Globe is
+// only a generic fallback for platforms we don't have a mark for yet.
+const Twitter = XBrandIcon;
 const Instagram = Globe;
 const Facebook = Globe;
 const Linkedin = Globe;
-const Github = Globe;
+const Github = GitHubIcon;
 const Youtube = Globe;
 
 export type SocialPlatformId =


### PR DESCRIPTION
## A. Chrome unification — one header/footer system per audience

**Problem:** logged-in users hitting 404/error pages (or any public page) got a second, competing marketing nav (Home/Dashboard/Discover/Collaborate/Community top links) plus the marketing footer with `[ NAVIGATION ]` bracket labels and two identical unlabeled globe icons.

**Fix (SSOT — decided once in the chrome layer, covers every page):**
- `Header.tsx`: marketing top-nav + hamburger/`MobileMenu` render for **anonymous visitors only** (`showMarketingNav = !isAuthRoute && !authenticated`). Signed-in users keep the same neutral app chrome everywhere — logo, search, messages, notifications, theme, avatar — on 404/error and public pages alike. No second nav system.
- `navigation.ts`: removed the now-dead authenticated header-nav variant; `getHeaderNavigationItems()` is the anonymous marketing list only.
- `Footer.tsx`: auth-gated (anonymous only) in addition to the existing public-surface pathname gate; bracket labels `[ Navigation ] / [ Company ] / [ Legal ] / [ Stay Updated ]` → plain headings.
- Two identical Globe icons were Twitter + GitHub placeholders (lucide dropped brand icons). Added `src/components/icons/BrandIcons.tsx` (X + GitHub marks) and wired them into the footer social config **and** `social-platforms.ts` (same Globe-for-everything fallback on profile social links). Twitter link modernized to `x.com`.

## B. Generic edit — SSOT convention `createPath?edit=<id>` for every entity type

The generic pipeline from #376 (`EntityCreateEditPage` → `useEntityCreateEdit` → same `EntityForm` in `mode="edit"` → `PUT ${meta.apiEndpoint}/${id}`, owner-checked server-side via the CRUD factory / withAuth handlers) already reaches all 14 create-page types. Verified per type and fixed the one broken chain — **group**, which failed three ways:

1. `/api/groups/[slug]` only resolved slugs → now accepts a UUID id **or** slug (edit flow addresses groups by id like every other entity; slugs are never UUID-shaped).
2. GET/PUT wrapped the row as `{ group }` → now return the group as `data` directly (standard entity shape the edit hook and form redirect consume).
3. `POST /api/groups` double-wrapped `{ data, group }` inside `apiCreated` → `result.data.id/slug` were undefined, breaking the post-create redirect. Normalized.

Also: `GroupDetail` owner action now links to `/dashboard/groups/create?edit=<id>` instead of the never-existing `/groups/[slug]/settings` dead link (label: "Edit Group").

**Entity types with working edit (14):** project, product, service, cause, ai_assistant, group, circle, asset, loan, investment, event, research, wishlist, document. Skipped: wallet (no create form; managed inline by WalletManager).

## Tests (26 new)

- `entityFormSubmitAction.test.ts` — create POSTs endpoint / edit PUTs `endpoint/id`; `actor_id` merged on create only; successUrl token redirect from response; validation errors block fetch; API errors surface without redirect.
- `useEntityCreateEdit.test.ts` — `?edit=` fetch + prefill hand-off, registry-driven endpoint per type, 404 → edit error, auth-hydration gate, URL-prefill disabled in edit mode.
- `entity-edit-convention.test.ts` — pins every list config's `editPath` to `createPath?edit=<id>` + coverage of all form-backed types, so a one-off `/x/[id]/edit` route can't silently reappear.

## Gates

- `npm run type-check` — 0 errors
- `npm run lint` — clean
- `npx jest __tests__/unit --silent` — 62 suites, 713 tests green
- `npm run audit:routes` — clean (every declared/emitted link resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)