### PR TITLE
ops(migrations): auto-apply SSOT script + hardened deploy wiring

### DIFF
--- a/docs/operations/MIGRATIONS.md
+++ b/docs/operations/MIGRATIONS.md
@@ -1,0 +1,92 @@
+# Database Migrations (Self-Hosted)
+
+**SSOT script**: `scripts/apply-migrations.sh` — the only sanctioned way SQL from
+`supabase/migrations/*.sql` reaches the box DB. Manual `psql` of a migration is the
+drift class this exists to kill: the file runs but is never recorded, or is recorded
+but never ran, and prod 500s appear weeks later.
+
+## Where the database lives
+
+OrangeCat's DB is the **`postgres` database inside the `supabase-db` container** on
+bitbaum (`root@167.233.22.31`) — never the box-system Postgres. All access goes
+through `docker exec supabase-db psql -U postgres -d postgres`.
+
+## Tracking
+
+Applied files are recorded in **`public.schema_migrations`**:
+
+```sql
+CREATE TABLE public.schema_migrations (
+  filename   text PRIMARY KEY,          -- e.g. 20260702000000_payment_intents_lnurl_verify.sql
+  applied_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+There is no Supabase-CLI tracking (`supabase_migrations` schema does not exist on the
+self-host); this table is ours and it is the truth. It was one-time **backfilled on
+2026-06-18** with the 147 migrations that pre-dated tracking, so historical files are
+never re-run. Reconciled 2026-07-03: 162 tracked rows == 162 repo files, zero pending.
+
+## How it runs
+
+`scripts/deploy-selfhost.sh` calls `scripts/apply-migrations.sh` **before** the
+boot-test/atomic-swap, so the schema is ready before new code goes live. A migration
+failure **aborts the deploy non-zero** with the failing filename — the current live
+release is untouched. CD (`.github/workflows/cd.yml`) runs `deploy-selfhost.sh
+--no-build`, so merged migrations auto-apply on every deploy.
+
+Per file, the script:
+
+1. Ensures the tracking table exists (`CREATE TABLE IF NOT EXISTS`).
+2. Computes pending = repo files minus tracked filenames, in filename order.
+3. Runs each pending file in a **single transaction** (`psql -1 -v ON_ERROR_STOP=1`)
+   — a mid-file failure rolls back _every_ statement. (Without `-1`, a migration that
+   drops a view then fails later leaves the schema half-applied; that was a real prod
+   regression on 2026-06-19. Corollary: **no `CREATE INDEX CONCURRENTLY`** in
+   migrations — it can't run inside a transaction.)
+4. Records the filename **only after** the file succeeds.
+5. Aborts on first failure, printing the failing filename.
+
+### Safety guards (each earned by a real incident)
+
+- **List-fetch integrity check**: the tracked list and its `count(*)` are fetched in
+  one psql call and must agree, else abort. A silently-truncated list over ssh once
+  made an already-applied 2025 migration look pending and re-execute against prod
+  (observed 2026-07-03 during testing; harmless that time — `CREATE OR REPLACE` only).
+- **Per-file recheck**: immediately before executing a file, the DB is asked again
+  whether it's recorded; if yes, it's skipped. Never trust a cached list to run SQL.
+- **Backfill guard**: if the tracking table is empty but core app tables
+  (`profiles`/`actors`) exist, the script refuses to run and demands `--backfill` —
+  replaying 160+ historical migrations against a populated DB would be catastrophic.
+
+## Usage
+
+```bash
+scripts/apply-migrations.sh --dry-run    # list pending, change nothing
+scripts/apply-migrations.sh              # apply + record pending
+scripts/apply-migrations.sh --backfill   # bootstrap only: record ALL current files as
+                                         # applied WITHOUT running them (fresh tracking
+                                         # table on a DB that already has the schema)
+```
+
+Config via env: `OC_BOX` (default `root@167.233.22.31`), `OC_DB_CONTAINER`
+(default `supabase-db`), `OC_MIGRATIONS_DIR` (default `supabase/migrations`).
+
+## Writing migrations
+
+- Filename: `YYYYMMDDHHMMSS_description.sql` — order is lexicographic.
+- Idempotent by habit (`IF NOT EXISTS` / `OR REPLACE` / `ON CONFLICT`): the tracking
+  table prevents re-runs, but idempotency is the second parachute.
+- Never edit a migration after it's merged/applied — write a new one.
+- No `CREATE INDEX CONCURRENTLY` (see single-transaction rationale above).
+- Migrations apply on the _next deploy_. If code in the same PR needs the schema,
+  that's fine — migrations run before the swap. If the schema must change _without_
+  a deploy, run `scripts/apply-migrations.sh` directly from the repo.
+
+## Known caveat: backfill lies
+
+Backfilling marks a file applied without proof it ever ran. At least one backfilled
+file (`20250130000001_add_postgis_search.sql`) had in fact never run on the box
+(PostGIS RPCs; callers degrade gracefully). The schema-drift gate in
+`deploy-selfhost.sh` (`scripts/db/audit-schema-drift.mjs` vs a live schema dump)
+exists to catch exactly this "recorded but not real" class before a swap.

--- a/scripts/apply-migrations.sh
+++ b/scripts/apply-migrations.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# OrangeCat self-host migration apply — the SSOT for getting supabase/migrations/*
+# onto the box DB. Kills the "manually psql a migration and forget" drift class
+# that caused a whole family of prod 500s.
+#
+# The self-host has no Supabase-CLI migration tracking. Applied files are recorded
+# in public.schema_migrations (filename text PK, applied_at timestamptz), one-time
+# backfilled with the 147 pre-existing migrations on 2026-06-18. This script:
+#
+#   1. Ensures the tracking table exists (CREATE TABLE IF NOT EXISTS).
+#   2. Refuses to run a full replay against an already-populated DB: if the
+#      tracking table is EMPTY but core app tables exist, it aborts and tells you
+#      to run --backfill (mark everything up-to-now as applied, never re-run).
+#   3. Applies pending *.sql in filename order, EACH inside a single transaction
+#      (`psql -1`), recording the filename only after success.
+#   4. Aborts non-zero on the first failure, printing the failing filename —
+#      callers (deploy) must treat that as a hard stop.
+#
+# `-1` (single-transaction) is CRITICAL: it wraps each migration in BEGIN/COMMIT
+# so a mid-file failure ROLLS BACK every statement. Without it, a migration that
+# drops a view early then fails later leaves the schema half-applied — it dropped
+# a live view the app needs but never recreated it (a real prod regression on
+# 2026-06-19). No migration uses CREATE INDEX CONCURRENTLY (verified), so
+# single-txn mode is safe.
+#
+# Usage:
+#   scripts/apply-migrations.sh              # apply pending, record, abort on failure
+#   scripts/apply-migrations.sh --dry-run    # list pending only, change nothing
+#   scripts/apply-migrations.sh --backfill   # bootstrap: record ALL current files as
+#                                            # applied WITHOUT running them (only for a
+#                                            # DB that predates tracking / already has
+#                                            # the schema). Idempotent.
+#
+# Config (env, with proven defaults):
+#   OC_BOX             SSH target                    (default root@167.233.22.31)
+#   OC_DB_CONTAINER    supabase-db container name    (default supabase-db)
+#   OC_MIGRATIONS_DIR  migrations dir                (default supabase/migrations)
+#
+# NOTE: OC lives in the supabase-db CONTAINER's `postgres` DB — never the
+# box-system Postgres. All DB access goes through `docker exec supabase-db psql`.
+set -euo pipefail
+
+OC_BOX="${OC_BOX:-root@167.233.22.31}"
+OC_DB_CONTAINER="${OC_DB_CONTAINER:-supabase-db}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OC_MIGRATIONS_DIR="${OC_MIGRATIONS_DIR:-$REPO_ROOT/supabase/migrations}"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o BatchMode=yes -o ServerAliveInterval=15 -o ServerAliveCountMax=4)
+
+MODE="apply"
+case "${1:-}" in
+  --dry-run)  MODE="dry-run" ;;
+  --backfill) MODE="backfill" ;;
+  '') ;;
+  *) echo "Usage: $0 [--dry-run|--backfill]" >&2; exit 2 ;;
+esac
+
+[ -d "$OC_MIGRATIONS_DIR" ] || { echo "ERROR: migrations dir not found: $OC_MIGRATIONS_DIR" >&2; exit 1; }
+
+# The ONE channel for DB statements (SSOT for the connection path). SQL always
+# arrives via STDIN — never `-c` — so nothing needs shell-quoting across the
+# local-shell → ssh → remote-shell → docker-exec boundary.
+box_psql() {
+  ssh "${SSH_OPTS[@]}" "$OC_BOX" \
+    "docker exec -i $OC_DB_CONTAINER psql -U postgres -d postgres -v ON_ERROR_STOP=1 $*"
+}
+
+record_applied() { # $1 = filename (recorded only after a successful apply)
+  printf "INSERT INTO public.schema_migrations(filename) VALUES ('%s') ON CONFLICT DO NOTHING;\n" \
+    "${1//\'/\'\'}" | box_psql -q
+}
+
+# --- 1. Ensure tracking table -------------------------------------------------
+box_psql -q <<'SQL'
+SET client_min_messages TO WARNING; -- silence the "already exists, skipping" NOTICE
+CREATE TABLE IF NOT EXISTS public.schema_migrations (
+  filename   text PRIMARY KEY,
+  applied_at timestamptz NOT NULL DEFAULT now()
+);
+SQL
+
+# --- 2. Read tracked + compute pending (filename order) ------------------------
+# Integrity-checked fetch: emit the row count first, then the rows, in ONE psql
+# call, and verify they agree. A silently-truncated list over ssh would otherwise
+# mark an already-applied OLD migration as pending and re-execute it against prod
+# (observed once during live testing — this guard exists because of that).
+applied_raw="$(box_psql -tA <<'SQL'
+SELECT count(*) FROM public.schema_migrations;
+SELECT filename FROM public.schema_migrations;
+SQL
+)"
+expected_count="$(printf '%s\n' "$applied_raw" | head -1)"
+applied="$(printf '%s\n' "$applied_raw" | tail -n +2)"
+applied_count="$(printf '%s' "$applied" | grep -c . || true)"
+if [ "$applied_count" != "$expected_count" ]; then
+  echo "ERROR: tracking-list fetch integrity check failed (expected $expected_count rows, got $applied_count) — refusing to compute pending from a corrupt list" >&2
+  exit 1
+fi
+
+pending=()
+for mig in "$OC_MIGRATIONS_DIR"/*.sql; do
+  [ -e "$mig" ] || break
+  fn="$(basename "$mig")"
+  printf '%s\n' "$applied" | grep -qxF "$fn" || pending+=("$fn")
+done
+
+# --- 3. Backfill mode: record everything up to now as applied, run nothing -----
+if [ "$MODE" = "backfill" ]; then
+  echo "=== backfill: recording ${#pending[@]} unrecorded file(s) as applied (no SQL executed) ==="
+  for fn in "${pending[@]}"; do
+    record_applied "$fn"
+    echo "  ✓ recorded $fn"
+  done
+  echo "backfill complete ($applied_count previously tracked, ${#pending[@]} added)"
+  exit 0
+fi
+
+# --- Safety guard: empty tracking + populated DB = you forgot --backfill --------
+# Replaying 160+ historical migrations against a live schema would be
+# catastrophic (old files are NOT all idempotent). Detect a pre-tracking DB by
+# core tables that have existed since the beginning.
+if [ "$applied_count" = "0" ] && [ "${#pending[@]}" -gt 0 ]; then
+  has_core="$(echo "SELECT count(*) FROM information_schema.tables
+               WHERE table_schema='public' AND table_name IN ('profiles','actors');" | box_psql -tA)"
+  if [ "${has_core:-0}" -gt 0 ]; then
+    echo "ERROR: tracking table is empty but the DB already has core app tables." >&2
+    echo "       This DB predates migration tracking — run '$0 --backfill' ONCE first" >&2
+    echo "       (marks all current files as applied; old files must never re-run)." >&2
+    exit 1
+  fi
+fi
+
+# --- 4. Dry-run: list pending, change nothing ----------------------------------
+if [ "$MODE" = "dry-run" ]; then
+  if [ "${#pending[@]}" -eq 0 ]; then
+    echo "dry-run: 0 pending migrations ($applied_count tracked, all up to date)"
+  else
+    echo "dry-run: ${#pending[@]} pending migration(s):"
+    printf '  → %s\n' "${pending[@]}"
+  fi
+  exit 0
+fi
+
+# --- 5. Apply pending, in filename order, one transaction each ------------------
+if [ "${#pending[@]}" -eq 0 ]; then
+  echo "migrations up to date ($applied_count tracked, 0 pending)"
+  exit 0
+fi
+
+echo "=== applying ${#pending[@]} pending migration(s) ==="
+for fn in "${pending[@]}"; do
+  # Last-line-of-defense recheck straight against the DB (not the cached list):
+  # NEVER execute a file the DB already has recorded. Pending is normally 0–3
+  # files, so the extra round trip is free.
+  already="$(printf "SELECT count(*) FROM public.schema_migrations WHERE filename='%s';\n" \
+    "${fn//\'/\'\'}" | box_psql -tA)"
+  if [ "${already:-0}" != "0" ]; then
+    echo "  ↷ skipping $fn — already recorded in the DB (stale local list)"
+    continue
+  fi
+  echo "  → applying $fn"
+  if box_psql -1 -q < "$OC_MIGRATIONS_DIR/$fn"; then
+    record_applied "$fn"
+    echo "  ✓ applied + recorded $fn"
+  else
+    echo "ERROR: migration FAILED: $fn — aborting (transaction rolled back, nothing recorded)" >&2
+    exit 1
+  fi
+done
+echo "✅ all migrations applied"

--- a/scripts/deploy-selfhost.sh
+++ b/scripts/deploy-selfhost.sh
@@ -67,36 +67,17 @@ for attempt in 1 2 3; do
 done
 
 echo "=== apply pending DB migrations → box ==="
-# The self-host has no Supabase-CLI migration tracking, so the box silently drifted
-# from supabase/migrations/* (the root cause of a whole class of prod 500s — a missed
-# migration). Applied files are recorded in public.schema_migrations (one-time
-# backfilled with the 147 pre-existing migrations on 2026-06-18, so only NEW files
-# run). Apply any *.sql not yet recorded, in filename order, BEFORE the boot-test so
-# the schema is ready before the new code runs. ON_ERROR_STOP + abort-on-fail leaves
-# the current live release untouched, and we record a file only after it succeeds
-# (re-runs stay safe because new migrations are written idempotently — IF NOT
-# EXISTS / OR REPLACE).
-#
-# `-1` (single-transaction) is CRITICAL: it wraps each migration in BEGIN/COMMIT so a
-# mid-file failure ROLLS BACK every statement. Without it, a migration that drops a
-# view early then fails later (e.g. a stale out-of-order migration referencing a
-# since-renamed column) leaves the schema half-applied — it dropped a live view the
-# app needs but never recreated it (a real prod regression on 2026-06-19). No
-# migration uses CREATE INDEX CONCURRENTLY (verified), so single-txn mode is safe.
-applied="$(ssh "${SSH_OPTS[@]}" "$OC_BOX" "docker exec supabase-db psql -U postgres -tAc 'SELECT filename FROM public.schema_migrations'" 2>/dev/null || true)"
-for mig in supabase/migrations/*.sql; do
-  fn="$(basename "$mig")"
-  printf '%s\n' "$applied" | grep -qxF "$fn" && continue
-  echo "  → applying $fn"
-  if cat "$mig" | ssh "${SSH_OPTS[@]}" "$OC_BOX" "docker exec -i supabase-db psql -U postgres -1 -v ON_ERROR_STOP=1 -q"; then
-    ssh "${SSH_OPTS[@]}" "$OC_BOX" \
-      "docker exec supabase-db psql -U postgres -q -c \"INSERT INTO public.schema_migrations(filename) VALUES ('$fn') ON CONFLICT DO NOTHING\"" >/dev/null
-  else
-    echo "ERROR: migration $fn failed — aborting deploy (live release untouched)" >&2
-    exit 1
-  fi
-done
-echo "  migrations up to date"
+# Delegated to the SSOT script (ensure-tracking-table + backfill guard + per-file
+# transactions + record-on-success + abort-on-first-failure with the failing
+# filename). Runs BEFORE the boot-test/swap so the schema is ready before the new
+# code goes live, and a migration failure aborts the deploy loudly with the
+# current live release untouched. See scripts/apply-migrations.sh and
+# docs/operations/MIGRATIONS.md for the full rationale (single-txn `-1` mode,
+# 2026-06-19 half-applied-view regression, etc.).
+OC_BOX="$OC_BOX" bash scripts/apply-migrations.sh || {
+  echo "ERROR: migrations failed — aborting deploy (live release untouched)" >&2
+  exit 1
+}
 
 echo "=== schema-drift gate (deployed code vs LIVE box schema) ==="
 # Migrations applying is necessary but not sufficient: the box can still lack an


### PR DESCRIPTION
## What

Extracts the inline migration-apply block from `deploy-selfhost.sh` into a standalone, hardened SSOT script **`scripts/apply-migrations.sh`**, and documents the full self-host migration story in **`docs/operations/MIGRATIONS.md`**. Kills the manual-psql drift class for good.

## How tracking was reconciled

The box already had `public.schema_migrations` (filename PK, applied_at; one-time backfilled 2026-06-18) with **162 rows == 162 repo files, 0 pending** — the existing table is sane and is reused as-is. No `supabase_migrations` (CLI) schema exists on the self-host; `public.schema_migrations` is the truth.

## The script

- Ensures the tracking table (`CREATE TABLE IF NOT EXISTS`)
- `--backfill` bootstrap mode (record all current files as applied, run **nothing**) + guard: refuses a full replay when tracking is empty but core tables (`profiles`/`actors`) exist
- Applies pending files in filename order, each in a **single transaction** (`psql -1 -v ON_ERROR_STOP=1`), records only after success, aborts non-zero on first failure with the failing filename
- `--dry-run` lists pending only
- **Integrity-checked list fetch** (count + rows in one psql call, must agree) and a **per-file DB recheck** immediately before executing — earned live: a truncated ssh fetch during testing made an already-applied 2025 file look pending and re-execute (harmless — `CREATE OR REPLACE FUNCTION` only, and those PostGIS RPC callers degrade gracefully; tracking row untouched via `ON CONFLICT DO NOTHING`)
- All SQL travels via stdin (never `-c`) — no nested quoting across shell→ssh→docker-exec

## Wiring

`deploy-selfhost.sh` now delegates to the script **before** the boot-test/atomic-swap; migration failure aborts the deploy loudly with the live release untouched. `cd.yml` already runs `deploy-selfhost.sh --no-build`, so merged migrations auto-apply on every deploy — no workflow change needed.

## Live-test proof (against the box)

```
$ scripts/apply-migrations.sh --dry-run
dry-run: 0 pending migrations (162 tracked, all up to date)

# no-op test migration:
  → applying 20260703000000_test_autoapply_noop.sql
  ✓ applied + recorded 20260703000000_test_autoapply_noop.sql   # verified in DB, then row+file removed

# failure path (scratch dir, SELECT 1/0):
  → applying 20990101000001_zz_test_fail.sql
ERROR:  division by zero
ERROR: migration FAILED: 20990101000001_zz_test_fail.sql — aborting (transaction rolled back, nothing recorded)
EXIT=1                                                          # verified NOT recorded; test rows cleaned up
```

Final state: box back at exactly 162 tracked == 162 files, 0 pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)