### PR TITLE
chore(ci): supply-chain, E2E-gate, migration-replay & backup-freshness hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,18 @@ jobs:
             fi
           done
           if [ "$missing" -ne 0 ]; then
-            echo "⚠️  E2E secrets not configured - skipping P0 matrix tests"
-            echo "has_secrets=false" >> $GITHUB_OUTPUT
+            # PRs (especially from forks) legitimately lack these secrets → soft-skip.
+            # But a push/dispatch to main is what CD deploys on: a green build there
+            # MUST mean the P0 E2E suite actually ran, never "secrets were missing so
+            # we skipped." Fail hard so the deploy gate can't pass untested.
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "⚠️  E2E secrets not configured - skipping P0 matrix (PR / fork build)"
+              echo "has_secrets=false" >> $GITHUB_OUTPUT
+            else
+              echo "❌ E2E secrets missing on a ${{ github.event_name }} to ${{ github.ref }}."
+              echo "   Refusing to report a green build with zero end-to-end coverage — CD deploys on this."
+              exit 1
+            fi
           else
             echo "has_secrets=true" >> $GITHUB_OUTPUT
           fi
@@ -120,3 +130,39 @@ jobs:
           E2E_TEST_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
           E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
         run: npm run test:e2e:matrix:p0
+
+  # Supply-chain gate: catch committed secrets and known-vuln dependencies before
+  # they ship. Runs in parallel with build-and-smoke (independent). The
+  # `security:scan` npm script existed but nothing invoked it — this wires it in.
+  security:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # gitleaks scans git history for leaked secrets — needs the full log,
+          # not the default shallow clone.
+          fetch-depth: 0
+
+      - name: Secret scan (gitleaks)
+        # Free for public repos; no license needed. Fails the job on any finding.
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Dependency audit
+        # Staged rollout: CRITICAL advisories block the build now; HIGH+ are
+        # reported (annotation) but non-blocking so this gate can land without
+        # being held hostage by pre-existing debt. Escalate the second line to
+        # `--audit-level=high` (blocking) once the tree is clean.
+        run: |
+          npm audit --audit-level=critical --omit=dev
+          npm audit --audit-level=high --omit=dev \
+            || echo "::warning title=Dependency audit::HIGH-severity advisories present — triage and escalate this gate to blocking."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+# Static application security testing (SAST) via GitHub CodeQL — free for public
+# repos. Complements the CI `security` job (secrets + dependency CVEs): this finds
+# code-level vulnerabilities (injection, unsafe flows) and surfaces them in the
+# repo Security tab. Runs on PRs, on main, and weekly to catch newly-published
+# query updates against unchanged code.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1' # Mondays 03:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # 'security-and-quality' adds maintainability queries on top of the
+          # default security set — a slightly larger but richer sweep.
+          queries: security-and-quality
+
+      # JS/TS is interpreted — no compile step. autobuild is a safe no-op here.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/migration-replay.yml
+++ b/.github/workflows/migration-replay.yml
@@ -1,0 +1,75 @@
+name: Migration Replay
+
+# Applies supabase/migrations/* to a FRESH database from zero, in order, via the
+# Supabase CLI. The box's DB is only ever migrated forward incrementally and the
+# restore drill restores *data* (a dump), so the from-scratch schema build is
+# otherwise never exercised — a migration that can't build on an empty DB (bad
+# ordering, missing prerequisite, non-idempotent replay) would only surface when
+# provisioning a new box during a disaster. This job turns that into a PR-time
+# check, and doubles as the missing pre-prod gate for migration changes.
+#
+# Deliberately a SEPARATE workflow, not a job in CI: CD deploys on the `CI`
+# workflow_run succeeding, and we don't want a from-scratch DB spin-up (heavier,
+# and new) sitting in that critical path. This is advisory-but-visible on the PR.
+#
+# Runs when migrations / config / this workflow change (so it self-tests on the PR
+# that introduces it) and on demand.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+      - 'supabase/config.toml'
+      - '.github/workflows/migration-replay.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+      - 'supabase/config.toml'
+      - '.github/workflows/migration-replay.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: migration-replay-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Apply all migrations from an empty DB
+        # `supabase start` boots a fresh local stack and applies supabase/migrations/*
+        # in filename order as part of DB init. A migration error fails startup and
+        # this step exits non-zero — that IS the gate. Exclude non-DB services we
+        # don't need for a schema build to keep it fast (the auth/storage schemas are
+        # seeded by the DB image itself, independent of those service containers).
+        run: |
+          supabase start -x realtime,storage-api,imgproxy,kong,inbucket,edge-runtime,studio,logflare,vector,supavisor,pooler
+
+      - name: Confirm the applied-migration count
+        run: |
+          COUNT=$(psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -tAc \
+            "select count(*) from supabase_migrations.schema_migrations;")
+          echo "Applied $COUNT migrations from scratch."
+          # Guard against a silent no-op (e.g. CLI applied nothing) — the repo has 100+.
+          if [ "${COUNT:-0}" -lt 50 ]; then
+            echo "::error::Expected the full migration set to apply from scratch; only $COUNT recorded."
+            exit 1
+          fi
+
+      - name: Tear down
+        if: always()
+        run: supabase stop --no-backup || true

--- a/.github/workflows/migration-replay.yml
+++ b/.github/workflows/migration-replay.yml
@@ -57,7 +57,10 @@ jobs:
         # don't need for a schema build to keep it fast (the auth/storage schemas are
         # seeded by the DB image itself, independent of those service containers).
         run: |
-          supabase start -x realtime,storage-api,imgproxy,kong,inbucket,edge-runtime,studio,logflare,vector,supavisor,pooler
+          # -x names must match the CLI's valid container set (mailpit, not inbucket;
+          # supavisor is the pooler). Keep gotrue/storage-api/postgrest running since
+          # migrations may reference the auth/storage schemas.
+          supabase start -x realtime,imgproxy,kong,edge-runtime,studio,logflare,vector,supavisor,mailpit,postgres-meta
 
       - name: Confirm the applied-migration count
         run: |

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -48,6 +48,11 @@ jobs:
           disk=$(jq -r '.data.host.disk_used_pct // empty' /tmp/body 2>/dev/null || true)
           echo "disk=$disk" >> "$GITHUB_OUTPUT"
           echo "Box disk used: ${disk:-unknown}%"
+          # Backup freshness — read while /tmp/body is still the health response. A
+          # broken pg-backup timer otherwise stays silent until a restore is needed.
+          backup_age=$(jq -r '.data.host.last_backup_age_hours // empty' /tmp/body 2>/dev/null || true)
+          echo "backup_age=$backup_age" >> "$GITHUB_OUTPUT"
+          echo "Last backup age: ${backup_age:-unknown} h"
           check "https://orangecat.ch/" || fail=1
           echo "down=$fail" >> "$GITHUB_OUTPUT"
 
@@ -98,5 +103,33 @@ jobs:
               }
             } else if (open) {
               await github.rest.issues.createComment({ owner, repo, issue_number: open.number, body: `✅ Disk back to ${disk}% at ${now} — closing.` });
+              await github.rest.issues.update({ owner, repo, issue_number: open.number, state: 'closed' });
+            }
+
+      # Separate, non-fatal alert: backups run off a timer on the box, and a broken
+      # timer is invisible until a restore is attempted. Alert when the newest local
+      # dump is older than a day + slack (nightly cadence). Skipped when the metric is
+      # absent (older build, or the app can't read the backup dir) — no false alarms.
+      - name: Backup-freshness alert / resolve
+        if: ${{ steps.probe.outputs.backup_age != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ageH = parseInt('${{ steps.probe.outputs.backup_age }}', 10);
+            const THRESHOLD = 26; // nightly backup + a few hours of slack
+            const { owner, repo } = context.repo;
+            const open = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'backup-stale', per_page: 1,
+            })).data[0];
+            const now = new Date().toISOString();
+            if (Number.isFinite(ageH) && ageH >= THRESHOLD) {
+              const body = `Newest local DB backup is **${ageH}h old** (≥${THRESHOLD}h) as of ${now}. The pg-backup timer may have stopped — check it before the gap widens (restic → B2 ships from these dumps).`;
+              if (open) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: open.number, body: `Still ${ageH}h stale at ${now}.` });
+              } else {
+                await github.rest.issues.create({ owner, repo, title: `🟠 orangecat backups stale (${ageH}h)`, body, labels: ['backup-stale'] });
+              }
+            } else if (open) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: open.number, body: `✅ Backups fresh again (${ageH}h) at ${now} — closing.` });
               await github.rest.issues.update({ owner, repo, issue_number: open.number, state: 'closed' });
             }

--- a/src/lib/host-metrics.ts
+++ b/src/lib/host-metrics.ts
@@ -1,4 +1,5 @@
-import { statfs } from 'node:fs/promises';
+import { statfs, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import os from 'node:os';
 
 /**
@@ -10,14 +11,51 @@ import os from 'node:os';
  * monitor (.github/workflows/uptime.yml) alert on disk/memory pressure — the single
  * box is the whole platform's failure domain, and a silent disk-full = hard outage.
  *
- * Percentages only — no paths, sizes, or anything sensitive — so this is safe on the
- * public health endpoint.
+ * Percentages / ages only — no paths, sizes, or anything sensitive — so this is safe
+ * on the public health endpoint.
  */
 export interface HostMetrics {
   /** Root filesystem usage %, or null if statfs is unavailable on this runtime. */
   disk_used_pct: number | null;
   /** RAM usage % (used / total). */
   mem_used_pct: number;
+  /**
+   * Hours since the most recent local DB backup file was written, or null when
+   * the backup dir is absent/unreadable/empty (e.g. dev, CI, or a perms issue on
+   * the box). Lets the off-box monitor alert if backups silently stop — a broken
+   * pg-backup timer otherwise surfaces only when a restore is attempted.
+   */
+  last_backup_age_hours: number | null;
+}
+
+// Where the box's local Postgres dumps land (restic then ships these off-site to
+// B2). Overridable so the box can point elsewhere without a code change. The app
+// process only needs read+traverse on this dir; if it lacks that, the metric is
+// null (no false "stale" alert — absence of signal, not a bad signal).
+const BACKUP_DIR = process.env.OC_BACKUP_DIR || '/opt/backups/pg';
+
+async function getLastBackupAgeHours(): Promise<number | null> {
+  try {
+    const entries = await readdir(BACKUP_DIR);
+    let newestMtimeMs = 0;
+    for (const name of entries) {
+      try {
+        const st = await stat(join(BACKUP_DIR, name));
+        if (st.isFile() && st.mtimeMs > newestMtimeMs) {
+          newestMtimeMs = st.mtimeMs;
+        }
+      } catch {
+        // Unreadable entry — skip it, don't fail the whole scan.
+      }
+    }
+    if (newestMtimeMs === 0) {
+      return null; // dir exists but holds no backup files yet
+    }
+    return Math.round((Date.now() - newestMtimeMs) / 3_600_000);
+  } catch {
+    // Dir missing/unreadable (dev, CI, restricted perms) → unknown, not stale.
+    return null;
+  }
 }
 
 export async function getHostMetrics(): Promise<HostMetrics> {
@@ -37,5 +75,7 @@ export async function getHostMetrics(): Promise<HostMetrics> {
   const total = os.totalmem();
   const mem_used_pct = total > 0 ? Math.round((1 - os.freemem() / total) * 100) : 0;
 
-  return { disk_used_pct, mem_used_pct };
+  const last_backup_age_hours = await getLastBackupAgeHours();
+
+  return { disk_used_pct, mem_used_pct, last_backup_age_hours };
 }


### PR DESCRIPTION
DevOps hardening from the pipeline audit. The self-host pipeline is already mature (atomic deploys + auto-rollback, migration tracking, schema-drift gate, off-box uptime, restic→B2 with a proven restore drill). These five changes close the remaining last-mile gaps. Each is self-contained.

## 1. E2E gate can no longer ship untested `[HIGH]`
`ci.yml` — missing P0 E2E secrets used to **soft-skip and exit green**, and CD deploys on that green. Now a `push`/`workflow_dispatch` to `main` **hard-fails** when secrets are missing; PRs (incl. forks that legitimately lack secrets) still soft-skip. A green build on main now provably means the E2E suite ran.

## 2. Supply-chain gate `[HIGH]`
New `security` job in `ci.yml` wires up the `security:scan` intent that lived in `package.json` but nothing invoked:
- **gitleaks** secret scan over full history — blocking (free for public repos).
- **`npm audit`** — **critical blocks**, high reported as a non-blocking annotation (staged rollout so this PR isn't held hostage by pre-existing dep debt; escalate to blocking once clean).

## 3. CodeQL SAST `[HIGH]`
New `codeql.yml` — code-level vulnerability scanning on PRs/main/weekly, free for this public repo, results in the Security tab.

## 4. From-scratch migration replay `[MED — closes no-staging + untested-migrations]`
New `migration-replay.yml` applies all 165 `supabase/migrations/*` to a **fresh DB from zero** via the Supabase CLI. The box is only ever migrated forward incrementally and DR restores a *data dump*, so the from-scratch schema build (needed when provisioning a new box) is otherwise never exercised. **Deliberately a separate workflow** so this heavier spin-up stays out of the CI→CD critical path — advisory-but-visible on the PR. Triggers on migration/config/self changes + manual dispatch.

## 5. Backup-freshness alerting `[MED — guards the highest-consequence silent failure]`
`/api/health` now reports `last_backup_age_hours` (`src/lib/host-metrics.ts`, newest file in `OC_BACKUP_DIR`, default `/opt/backups/pg`), and the off-box `uptime.yml` monitor opens/auto-resolves a `backup-stale` GitHub issue when it exceeds **26h**. A broken `pg-backup` timer otherwise stays silent until a restore is attempted. Metric is `null` (→ no false alarm) where the dir is absent/unreadable (dev, CI).

---

### Verification
All workflow YAML validates; `type-check` + ESLint clean. **CodeQL and migration-replay run for the first time on this PR** — watch those two checks; a red migration-replay is a genuine "can't build from scratch" finding to fix, not noise.

### Two follow-ups (founder / box-side)
- [ ] Ensure the `orangecat-app` process has read+traverse on `/opt/backups/pg` (else #5 reports null — no coverage, but no false alarms). Adjust `OC_BACKUP_DIR` if the path differs.
- [ ] Once the dependency tree is clean, flip the `npm audit --audit-level=high` line to blocking.

### Not included (bigger, separate)
Auto-rollback/migration ordering (expand-contract invariant), reproducible SELF_HOST=1 artifact, B2 Object-Lock, IaC box provisioning, non-root deploy user — tracked from the audit for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)