### PR TITLE
chore(deploy): harden deploy gates, enforce migration safety, speed CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Cancel superseded runs on the same ref — a newer push makes the older build
+# obsolete. On main this means only the latest commit's CI (and thus its CD)
+# proceeds, which is what we want: deploy the newest, not a stale in-flight one.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-smoke:
     runs-on: ubuntu-latest
@@ -59,6 +66,16 @@ jobs:
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
+
+      - name: Cache Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          # Re-key when deps or source change; restore the newest same-deps cache
+          # otherwise so incremental compilation is reused across runs.
+          key: nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('src/**/*.[jt]s', 'src/**/*.[jt]sx') }}
+          restore-keys: |
+            nextjs-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Build
         env:

--- a/.github/workflows/migration-replay.yml
+++ b/.github/workflows/migration-replay.yml
@@ -78,3 +78,27 @@ jobs:
       - name: Tear down
         if: always()
         run: supabase stop --no-backup || true
+
+  # Fast, independent gate: contract-phase (destructive) DDL in the migrations
+  # changed by this PR must be intentional. Auto-rollback reverts code but not an
+  # applied migration, so an unacknowledged DROP/RENAME breaks rollback safety.
+  safety-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check changed migrations for contract-phase DDL
+        run: |
+          git fetch -q origin main || true
+          changed=$(git diff --name-only origin/main...HEAD -- 'supabase/migrations/*.sql' || true)
+          if [ -z "$changed" ]; then
+            echo "No migration changes vs main — nothing to check."
+            exit 0
+          fi
+          echo "Changed migrations:"; echo "$changed"
+          # shellcheck disable=SC2086
+          node scripts/db/check-migration-safety.mjs $changed

--- a/scripts/db/check-migration-safety.mjs
+++ b/scripts/db/check-migration-safety.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Flags contract-phase (destructive) DDL in the migration files passed as args.
+//
+// Why: the self-host deploy applies migrations BEFORE the atomic swap, and the
+// auto-rollback reverts the CODE but NOT an already-applied migration. So a
+// migration that DROPs/RENAMEs something the previous release still references
+// turns "rollback" into "old code against a schema it can't use". The safe shape
+// is expand/contract: add the new thing, ship code that uses it, and only drop
+// the old thing in a LATER migration once no running code needs it.
+//
+// This check does not forbid contract steps — it makes them explicit. Acknowledge
+// an intentional one by adding a line to the migration:
+//     -- migration-safety: contract-ok <short reason>
+//
+// Usage: node scripts/db/check-migration-safety.mjs <file.sql> [<file.sql> ...]
+// Exits non-zero if any passed file has unacknowledged contract-phase DDL.
+
+import { readFileSync } from 'node:fs';
+
+const files = process.argv.slice(2).filter(Boolean);
+
+const PATTERNS = [
+  [/\bDROP\s+TABLE\b/i, 'DROP TABLE'],
+  [/\bDROP\s+COLUMN\b/i, 'DROP COLUMN'],
+  [/\bTRUNCATE\b/i, 'TRUNCATE'],
+  [/\bRENAME\s+COLUMN\b/i, 'RENAME COLUMN'],
+  [/\bALTER\s+COLUMN\b.+\bTYPE\b/i, 'ALTER COLUMN ... TYPE'],
+  [/\bDROP\s+(NOT\s+NULL|CONSTRAINT|DEFAULT)\b/i, 'DROP constraint/default/not-null'],
+];
+
+let violations = 0;
+
+for (const file of files) {
+  let sql;
+  try {
+    sql = readFileSync(file, 'utf8');
+  } catch {
+    continue; // deleted/renamed file — nothing to scan
+  }
+  // Whole-file acknowledgement marker → skip (author has justified the contract).
+  if (/--\s*migration-safety:\s*contract-ok/i.test(sql)) continue;
+
+  sql.split('\n').forEach((line, idx) => {
+    const code = line.replace(/--.*$/, ''); // ignore trailing comments
+    for (const [re, label] of PATTERNS) {
+      if (re.test(code)) {
+        console.log(
+          `::warning file=${file},line=${idx + 1}::Contract-phase DDL (${label}). ` +
+            `Prefer expand/contract; if intentional, add "-- migration-safety: contract-ok <reason>".`
+        );
+        violations++;
+      }
+    }
+  });
+}
+
+if (violations > 0) {
+  console.error(
+    `\n✗ ${violations} unacknowledged contract-phase statement(s) in changed migrations.\n` +
+      `  Deploy applies migrations before the swap and auto-rollback reverts only code —\n` +
+      `  a DROP/RENAME the previous release still uses breaks rollback. Make it\n` +
+      `  expand/contract, or add "-- migration-safety: contract-ok <reason>" to acknowledge.`
+  );
+  process.exit(1);
+}
+
+console.log(`✓ migration-safety: ${files.length} file(s) checked, no unacknowledged contract-phase DDL.`);

--- a/scripts/deploy-selfhost.sh
+++ b/scripts/deploy-selfhost.sh
@@ -86,21 +86,34 @@ echo "=== schema-drift gate (deployed code vs LIVE box schema) ==="
 # REAL post-migration schema and fail the deploy if the code references a table/
 # column that isn't there, BEFORE the swap — turning silent prod 500s into a loud
 # deploy-time stop. Known pre-existing gaps are allowlisted in audit-schema-drift.mjs
-# so this only blocks on NEW drift. A dump failure is non-fatal (don't block deploys
-# on an ssh hiccup).
+# so this only blocks on NEW drift.
+#
+# Reachability: the dump is retried (a transient ssh blip must not silently
+# disable the gate), and if the box schema genuinely can't be read after retries
+# we BLOCK rather than ship unguarded — every later step (swap, restart) needs
+# ssh anyway, so "can't read the schema" is not a benign hiccup here.
 LIVE_SCHEMA_TMP="$(mktemp)"
-if OC_BOX="$OC_BOX" bash scripts/db/dump-live-schema.sh > "$LIVE_SCHEMA_TMP" 2>/dev/null && [ -s "$LIVE_SCHEMA_TMP" ]; then
-  if ! LIVE_SCHEMA_PATH="$LIVE_SCHEMA_TMP" node scripts/db/audit-schema-drift.mjs; then
-    rm -f "$LIVE_SCHEMA_TMP"
-    echo "ERROR: schema drift — deployed code references DB objects missing from the box (above)." >&2
-    echo "       Add the missing migration (or allowlist if intentional). Aborting deploy; live release untouched." >&2
-    exit 1
+dump_ok=0
+for attempt in 1 2 3; do
+  if OC_BOX="$OC_BOX" bash scripts/db/dump-live-schema.sh > "$LIVE_SCHEMA_TMP" 2>/dev/null && [ -s "$LIVE_SCHEMA_TMP" ]; then
+    dump_ok=1; break
   fi
+  echo "live-schema dump attempt $attempt failed; retrying…" >&2
+  sleep 3
+done
+if [ "$dump_ok" != 1 ]; then
   rm -f "$LIVE_SCHEMA_TMP"
-else
-  rm -f "$LIVE_SCHEMA_TMP"
-  echo "WARN: could not dump live schema for the drift gate — skipping (non-fatal)." >&2
+  echo "ERROR: could not dump the live box schema for the drift gate after 3 attempts —" >&2
+  echo "       refusing to deploy unguarded. Check box reachability and retry." >&2
+  exit 1
 fi
+if ! LIVE_SCHEMA_PATH="$LIVE_SCHEMA_TMP" node scripts/db/audit-schema-drift.mjs; then
+  rm -f "$LIVE_SCHEMA_TMP"
+  echo "ERROR: schema drift — deployed code references DB objects missing from the box (above)." >&2
+  echo "       Add the missing migration (or allowlist if intentional). Aborting deploy; live release untouched." >&2
+  exit 1
+fi
+rm -f "$LIVE_SCHEMA_TMP"
 
 echo "=== boot-test + atomic swap + health-check (with rollback) ==="
 ssh "${SSH_OPTS[@]}" "$OC_BOX" \
@@ -158,8 +171,12 @@ if [ "$live" != "200" ]; then
   exit 1
 fi
 
-rm -rf "$BASE/app-old"
-echo "DEPLOY_OK (local health 200)"
+# Keep the previous release at app-old as a manual-rollback target until the NEXT
+# deploy (which removes it at its start, above). Deleting it here left zero
+# rollback target between deploys. NOTE: we do NOT auto-rollback on a failed
+# PUBLIC health check below — local health already passed, so a public failure is
+# a Caddy/DNS/network issue, and reverting a healthy app would not fix that.
+echo "DEPLOY_OK (local health 200) — previous release kept at app-old for manual rollback"
 REMOTE
 
 echo "=== ensure Caddy kills HTTP/3 (Brave/QUIC self-heal) ==="


### PR DESCRIPTION
DevOps overhaul — batch 1 of N (pipeline reliability). All changes verifiable without a live deploy.

## Deploy gate hardening (`scripts/deploy-selfhost.sh`)
- **Drift gate no longer fails open.** The live-schema dump is retried 3×; if the box schema genuinely can't be read, the deploy **blocks** instead of silently skipping the gate. Every later step (swap, restart) needs ssh anyway, so an unreadable schema isn't a benign hiccup.
- **Keep the previous release for rollback.** `app-old` is retained until the next deploy (it was deleted on success, leaving no rollback target between deploys). Deliberately **not** auto-rolling-back on a failed *public* health check — local health already passed, so a public failure is Caddy/DNS and reverting a healthy app wouldn't fix it.

## Expand/contract migration safety (new gate)
`scripts/db/check-migration-safety.mjs` flags unacknowledged contract-phase DDL (`DROP TABLE/COLUMN`, `TRUNCATE`, `RENAME COLUMN`, `ALTER … TYPE`, `DROP constraint/default`) in the migrations changed by a PR — run as a fast `safety-lint` job in `migration-replay.yml`. Auto-rollback reverts code but not an applied migration, so a destructive migration the previous release still uses breaks rollback. Acknowledge intentional contract steps with `-- migration-safety: contract-ok <reason>`. (Self-tested: flags unacked DROP, respects the ack marker, baseline is clean.)

## CI speed (`ci.yml`)
- `concurrency` group with `cancel-in-progress` — a newer push supersedes the older build, so only the latest commit's CI (and its CD) proceeds.
- Cache `.next/cache` across runs for faster incremental builds.

## Verification
Deploy script `bash -n` clean; safety lint unit-tested (bad→exit 1, acked→0, baseline→0); all workflow YAML validates.

Next batches: app hardening + DX (CSP, deeper health check, rate-limiter consolidation, self-hosted GlitchTip error tracking, local-dev fix), reproducible build-once artifact (deploy-path, will flag for review), and box-side resilience prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)