### PR TITLE
feat(observability): fix prod logging, deepen health check, add CSP report-only

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -166,6 +166,27 @@ const nextConfig = {
                   key: 'Strict-Transport-Security',
                   value: 'max-age=63072000; includeSubDomains; preload',
                 },
+                // Content-Security-Policy in REPORT-ONLY first: it never blocks,
+                // only reports violations, so we can tune the policy against real
+                // traffic before switching to an enforcing `Content-Security-Policy`
+                // header. The app renders user-generated content, so an XSS-limiting
+                // CSP is the biggest header-layer gap. connect-src covers the
+                // self-hosted Supabase (REST + realtime ws) and R2 media.
+                {
+                  key: 'Content-Security-Policy-Report-Only',
+                  value: [
+                    "default-src 'self'",
+                    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+                    "style-src 'self' 'unsafe-inline'",
+                    "img-src 'self' data: blob: https:",
+                    "font-src 'self' data:",
+                    "connect-src 'self' https://supabase.orangecat.ch wss://supabase.orangecat.ch https://*.cloudflarestorage.com",
+                    "frame-ancestors 'none'",
+                    "base-uri 'self'",
+                    "form-action 'self'",
+                    "object-src 'none'",
+                  ].join('; '),
+                },
               ]
             : []),
           // Disable caching in development

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from '@/lib/supabase/server';
 import { DATABASE_TABLES } from '@/config/database-tables';
+import { Redis } from '@upstash/redis';
 
 export type ServiceStatus = 'operational' | 'degraded' | 'outage';
 
@@ -14,36 +15,96 @@ interface HealthReport {
   services: ServiceHealth[];
 }
 
-export async function checkHealth(): Promise<HealthReport> {
-  const timestamp = new Date().toISOString();
-  let dbStatus: ServiceStatus = 'operational';
+const PROBE_TIMEOUT_MS = 3000;
 
+// Bound every probe so one slow dependency can't hang the health endpoint (and
+// thus the uptime monitor). A timed-out probe is treated as failed by its caller.
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  let t: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    t = setTimeout(() => reject(new Error('probe timeout')), ms);
+  });
+  try {
+    return await Promise.race([p, timeout]);
+  } finally {
+    clearTimeout(t!);
+  }
+}
+
+// Real round-trip to the DB (not an inference). Any error/timeout = outage.
+async function probeDatabase(): Promise<ServiceStatus> {
   try {
     const supabase = await createServerClient();
-    const { error } = await supabase.from(DATABASE_TABLES.PROFILES).select('id').limit(1);
-    if (error) {
-      dbStatus = 'outage';
-    }
+    const { error } = await withTimeout(
+      Promise.resolve(supabase.from(DATABASE_TABLES.PROFILES).select('id').limit(1)),
+      PROBE_TIMEOUT_MS
+    );
+    return error ? 'outage' : 'operational';
   } catch {
-    dbStatus = 'outage';
+    return 'outage';
   }
+}
 
-  // Auth shares Supabase — if DB is up, auth is up.
-  const authStatus = dbStatus;
+// Probe GoTrue directly — auth can be down while the DB is up (the old code
+// inferred "db up ⇒ auth up", which hid a GoTrue-only outage).
+async function probeAuth(): Promise<ServiceStatus> {
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!base) {
+    return 'outage';
+  }
+  try {
+    const res = await withTimeout(
+      fetch(`${base}/auth/v1/health`, { cache: 'no-store' }),
+      PROBE_TIMEOUT_MS
+    );
+    return res.ok ? 'operational' : 'outage';
+  } catch {
+    return 'outage';
+  }
+}
+
+// PING the rate-limit Redis. Non-paging: when Upstash isn't configured the app
+// falls back to an in-memory limiter (fine in dev), and a Redis blip degrades
+// rate limiting but not the site — so this never flips `overall` to outage.
+async function probeCache(): Promise<ServiceStatus> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    return 'operational';
+  }
+  try {
+    const redis = new Redis({ url, token });
+    const pong = await withTimeout(redis.ping(), PROBE_TIMEOUT_MS);
+    return pong === 'PONG' ? 'operational' : 'degraded';
+  } catch {
+    return 'degraded';
+  }
+}
+
+export async function checkHealth(): Promise<HealthReport> {
+  const timestamp = new Date().toISOString();
+
+  const [dbStatus, authStatus, cacheStatus] = await Promise.all([
+    probeDatabase(),
+    probeAuth(),
+    probeCache(),
+  ]);
 
   const services: ServiceHealth[] = [
+    // Website + API are trivially operational: this endpoint is serving the request.
     { name: 'Website', status: 'operational' },
     { name: 'API', status: 'operational' },
     { name: 'Database', status: dbStatus },
     { name: 'Authentication', status: authStatus },
+    { name: 'Cache', status: cacheStatus },
     { name: 'Bitcoin Integration', status: 'operational' },
   ];
 
-  const overall: ServiceStatus = services.some(s => s.status === 'outage')
-    ? 'outage'
-    : services.some(s => s.status === 'degraded')
-      ? 'degraded'
-      : 'operational';
+  // Only the CRITICAL dependencies (DB, auth) can flip the site to unhealthy and
+  // page the uptime monitor. Cache degradation is surfaced for visibility but
+  // stays non-paging (the in-memory fallback keeps the site working).
+  const overall: ServiceStatus =
+    dbStatus === 'outage' || authStatus === 'outage' ? 'outage' : 'operational';
 
   return { overall, timestamp, services };
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -52,6 +52,19 @@ const LOG_LEVELS = {
 };
 
 // =====================================================================
+// 🔌 ERROR SINK (pluggable)
+// =====================================================================
+// Optional forward target for error-level logs. An integration (e.g. a
+// self-hosted GlitchTip via @sentry/nextjs) registers via setErrorSink() once at
+// startup; until then this is a no-op, so the logger stays dependency-free.
+type ErrorSink = (entry: LogEntry) => void;
+let errorSink: ErrorSink | null = null;
+
+export function setErrorSink(sink: ErrorSink | null): void {
+  errorSink = sink;
+}
+
+// =====================================================================
 // 🔧 LOGGER IMPLEMENTATION
 // =====================================================================
 
@@ -78,13 +91,24 @@ class Logger {
   private output(entry: LogEntry): void {
     const { timestamp, level, message, data, source } = entry;
 
-    // In production, use structured logging
+    // In production, emit structured JSON to stdout/stderr so the systemd journal
+    // (journald) captures a durable, queryable trail. shouldLog() has already
+    // gated by activeLevel (warn+ in prod), so everything reaching here MUST be
+    // emitted — previously only `error` was, silently dropping every warn.
     if (LOGGER_CONFIG.environment === 'production') {
-      // Send to proper logging service in production
-      // For now, use console for critical errors only
+      const line = JSON.stringify(entry);
       if (level === 'error') {
         // eslint-disable-next-line no-console
-        console.error(JSON.stringify(entry));
+        console.error(line);
+        // Forward to the error tracker when one is registered (see setErrorSink).
+        try {
+          errorSink?.(entry);
+        } catch {
+          // Never let error reporting break the request path.
+        }
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(line);
       }
       return;
     }


### PR DESCRIPTION
DevOps overhaul — batch 2 (observability & security). All in-repo, no new heavy deps, fully verifiable (type-check + lint clean).

## Production logging was dropping `warn`
`logger.output()` emitted **only** `error` in production — every `warn` (including the "Upstash not configured" rate-limit warning) was built and thrown away. Now it emits `warn`+`error` as structured JSON to stdout/stderr, so the **systemd journal** captures a durable, queryable trail. Adds a pluggable `setErrorSink()` hook so a self-hosted GlitchTip integration (next batch) can forward errors without the logger taking a dependency.

## Health check now probes for real
Was: a DB round-trip only, with **auth inferred from DB** and Website/API/Bitcoin hardcoded `operational` — so a GoTrue-only outage or a down Redis reported "healthy". Now:
- real **DB** probe, real **GoTrue** `/auth/v1/health` probe, **Redis** `PING` — each bounded by a 3s timeout so one slow dep can't hang the endpoint.
- Only **DB/auth** outages flip the site unhealthy (page the uptime monitor). **Cache** degradation is surfaced in `services[]` for visibility but stays **non-paging** (in-memory rate-limit fallback keeps the site up), so a Redis blip won't wake anyone.

## CSP (report-only)
Adds `Content-Security-Policy-Report-Only` in production — it never blocks, just reports violations, so the policy can be tuned against real traffic before switching to an enforcing header. Biggest header-layer gap for a UGC app. `connect-src` covers the self-hosted Supabase (REST + realtime ws) and R2 media.

## Remaining overhaul queue
Self-hosted GlitchTip SDK wiring (needs a DSN from you) · consolidate the messaging in-memory rate limiter onto Upstash · reproducible build-once-in-CI artifact (deploy-path, will flag for review) · box-side resilience prep (IaC, B2 Object-Lock, non-root deploy, vendor pg-backup + systemd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)