### PR TITLE
fix(health): send apikey to GoTrue probe + gate liveness on DB only

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -48,6 +48,12 @@ jobs:
           disk=$(jq -r '.data.host.disk_used_pct // empty' /tmp/body 2>/dev/null || true)
           echo "disk=$disk" >> "$GITHUB_OUTPUT"
           echo "Box disk used: ${disk:-unknown}%"
+          # Auth (GoTrue) status — reported by /api/health but deliberately NOT part
+          # of the 200/503 liveness gate (a GoTrue blip must not roll back a deploy).
+          # So page on it here instead, off the critical path.
+          authsvc=$(jq -r '.data.services.authentication // empty' /tmp/body 2>/dev/null || true)
+          echo "auth=$authsvc" >> "$GITHUB_OUTPUT"
+          echo "Auth service: ${authsvc:-unknown}"
           # Backup freshness — read while /tmp/body is still the health response. A
           # broken pg-backup timer otherwise stays silent until a restore is needed.
           backup_age=$(jq -r '.data.host.last_backup_age_hours // empty' /tmp/body 2>/dev/null || true)
@@ -131,5 +137,30 @@ jobs:
               }
             } else if (open) {
               await github.rest.issues.createComment({ owner, repo, issue_number: open.number, body: `✅ Backups fresh again (${ageH}h) at ${now} — closing.` });
+              await github.rest.issues.update({ owner, repo, issue_number: open.number, state: 'closed' });
+            }
+
+      # Real GoTrue outage alert — kept off the 200/503 liveness gate so it can
+      # never roll back a deploy, but a genuine auth outage still needs a page.
+      - name: Auth-outage alert / resolve
+        if: ${{ steps.probe.outputs.auth != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const auth = '${{ steps.probe.outputs.auth }}';
+            const { owner, repo } = context.repo;
+            const open = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'auth-outage', per_page: 1,
+            })).data[0];
+            const now = new Date().toISOString();
+            if (auth === 'outage') {
+              const body = `GoTrue auth probe reports **outage** as of ${now} (site is still up; login/signup likely failing). Check the supabase-auth container.`;
+              if (open) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: open.number, body: `Still down at ${now}.` });
+              } else {
+                await github.rest.issues.create({ owner, repo, title: '🔴 orangecat auth (GoTrue) outage', body, labels: ['auth-outage'] });
+              }
+            } else if (open) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: open.number, body: `✅ Auth recovered (${auth}) at ${now} — closing.` });
               await github.rest.issues.update({ owner, repo, issue_number: open.number, state: 'closed' });
             }

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -46,15 +46,22 @@ async function probeDatabase(): Promise<ServiceStatus> {
 }
 
 // Probe GoTrue directly — auth can be down while the DB is up (the old code
-// inferred "db up ⇒ auth up", which hid a GoTrue-only outage).
+// inferred "db up ⇒ auth up", which hid a GoTrue-only outage). The self-host's
+// Kong gateway enforces `apikey` on /auth/v1/* (401 without it), so the probe
+// MUST send the anon key — otherwise it always reads 'outage'.
 async function probeAuth(): Promise<ServiceStatus> {
   const base = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const apikey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
   if (!base) {
     return 'outage';
   }
   try {
     const res = await withTimeout(
-      fetch(`${base}/auth/v1/health`, { cache: 'no-store' }),
+      fetch(`${base}/auth/v1/health`, {
+        cache: 'no-store',
+        headers: apikey ? { apikey } : {},
+      }),
       PROBE_TIMEOUT_MS
     );
     return res.ok ? 'operational' : 'outage';
@@ -100,11 +107,13 @@ export async function checkHealth(): Promise<HealthReport> {
     { name: 'Bitcoin Integration', status: 'operational' },
   ];
 
-  // Only the CRITICAL dependencies (DB, auth) can flip the site to unhealthy and
-  // page the uptime monitor. Cache degradation is surfaced for visibility but
-  // stays non-paging (the in-memory fallback keeps the site working).
-  const overall: ServiceStatus =
-    dbStatus === 'outage' || authStatus === 'outage' ? 'outage' : 'operational';
+  // The 200/503 that the DEPLOY health-gate and uptime monitor key on reflects
+  // core LIVENESS only: the app is serving + the DB is reachable. Auth and cache
+  // are probed and reported in `services` for visibility, but a GoTrue/Redis blip
+  // must NOT flip the endpoint to 503 — that would roll back a healthy deploy (it
+  // did: a bugged auth probe took every deploy down). Alert on a real auth outage
+  // off this critical path (uptime.yml reads services.authentication).
+  const overall: ServiceStatus = dbStatus === 'outage' ? 'outage' : 'operational';
 
   return { overall, timestamp, services };
 }


### PR DESCRIPTION
**Urgent — unblocks deploys.** A regression from #390 made every self-host deploy roll back; main is currently undeployable.

## Root cause (confirmed on the box)
The new health check's `probeAuth` fetched `/auth/v1/health` **without an `apikey`**. The self-host's Kong gateway enforces `apikey` on `/auth/v1/*` (`401` without it), so auth always read `outage` → `/api/health` returned `503` → the deploy's health gate failed → **auto-rollback**, every time. The failed build actually started fine (`Ready in 168ms`); it was the 503 from `authentication: outage`. `curl` verified: `401` without apikey, `200` with it.

## Fix
1. **Send the anon key** as `apikey` on the GoTrue probe.
2. **Gate 200/503 on core liveness only** (app serving + DB reachable). Auth and cache are still probed and reported in `services[]` for visibility, but a GoTrue/Redis blip can no longer flip the endpoint to 503 and roll back a healthy deploy.
3. **Keep auth-outage alerting off the critical path**: `uptime.yml` reads `services.authentication` and opens an `auth-outage` issue on a genuine outage (site stays up, login failing).

## Notes
- The auto-rollback worked correctly the whole time — the box was never down (served the previous release).
- Lesson: a health-probe change only differs under production env, so it must be **box-verified before merge**. Adding that to the resilience runbook.

Verified: type-check + lint clean; apikey behavior confirmed against the live box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)