### PR TITLE
perf(ci/cd): build the shippable standalone once, ship that exact artifact

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,12 +83,32 @@ jobs:
         if: steps.guard.outputs.ok == 'true'
         run: npm ci
 
-      - name: Build standalone (SELF_HOST=1)
+      - name: Download standalone artifact from the triggering CI run
+        # Ship the EXACT artifact CI built + tested (tested == shipped), and skip
+        # the rebuild. Best-effort: if the download fails — or this is a manual
+        # dispatch with no CI run behind it — the next step falls back to building,
+        # so a broken artifact path can never break deploys (worst case = today).
+        if: steps.guard.outputs.ok == 'true' && github.event_name == 'workflow_run'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: standalone-${{ github.event.workflow_run.head_sha }}
+          path: .next/standalone
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build standalone if no artifact (fallback / manual dispatch)
         if: steps.guard.outputs.ok == 'true'
         env:
           NODE_ENV: production
           SELF_HOST: '1'
-        run: npm run build
+        run: |
+          if [ -f .next/standalone/server.js ]; then
+            echo "Using the CI-built standalone artifact — skipping rebuild."
+          else
+            echo "No artifact (manual dispatch or download failed) — building standalone."
+            npm run build
+          fi
 
       - name: Configure SSH
         if: steps.guard.outputs.ok == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,38 @@ jobs:
           restore-keys: |
             nextjs-${{ hashFiles('**/package-lock.json') }}-
 
-      - name: Build
+      - name: Build (standalone — the exact bundle CD ships)
         env:
           NODE_ENV: production
+          # Build the SELF_HOST standalone here so CI tests the same artifact CD
+          # deploys (tested == shipped). On main this artifact is uploaded and
+          # shipped verbatim; PRs build it too (dummy env) to catch standalone-only
+          # breakage. Bake the same client vars CD bakes — public receiving
+          # addresses; empty on PRs/forks, which is fine for a test build.
+          SELF_HOST: '1'
+          NEXT_PUBLIC_LIGHTNING_ADDRESS: ${{ vars.NEXT_PUBLIC_LIGHTNING_ADDRESS }}
+          NEXT_PUBLIC_BITCOIN_ADDRESS: ${{ vars.NEXT_PUBLIC_BITCOIN_ADDRESS }}
         run: npm run build
 
-      - name: Start server
+      - name: Assemble standalone (static + public)
+        # Copy the assets into the standalone tree so both the E2E run below and
+        # the uploaded artifact are complete and runnable as-is.
         run: |
-          npm start &
+          cp -r .next/static .next/standalone/.next/static
+          [ -d public ] && cp -r public .next/standalone/public || true
+
+      - name: Upload standalone artifact (main → shipped by CD)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: standalone-${{ github.sha }}
+          path: .next/standalone
+          include-hidden-files: true # .next/* is hidden; excluded by default
+          retention-days: 3
+
+      - name: Start server (standalone — the shipped entrypoint)
+        run: |
+          PORT=3000 node .next/standalone/server.js &
           npx wait-on http://localhost:3000
 
       - name: Validate required P0 E2E env

--- a/scripts/deploy-selfhost.sh
+++ b/scripts/deploy-selfhost.sh
@@ -54,7 +54,12 @@ ST="$REPO_ROOT/.next/standalone"
 [ -d "$ST" ] || { echo "ERROR: no .next/standalone — build with SELF_HOST=1 first" >&2; exit 1; }
 
 echo "=== assemble standalone (static + public) ==="
-cp -r "$REPO_ROOT/.next/static" "$ST/.next/static"
+# When CD ships a pre-assembled artifact (CI built the standalone with static +
+# public already copied in), the repo-root .next/static / public won't exist —
+# skip the copy rather than failing. A freshly-built tree still has them and
+# assembles normally. The artifact is ALWAYS pre-assembled before upload, so a
+# skipped copy here never means missing assets.
+[ -d "$REPO_ROOT/.next/static" ] && cp -r "$REPO_ROOT/.next/static" "$ST/.next/static"
 [ -d "$REPO_ROOT/public" ] && cp -r "$REPO_ROOT/public" "$ST/public"
 
 echo "=== rsync → $OC_BOX:$OC_APP_BASE/app-next ==="


### PR DESCRIPTION
DevOps overhaul — reproducible artifact (Phase 1 + 2). **tested == shipped**, and CD stops rebuilding. Built defensively so it can never break deploys.

## Phase 1 — CI tests the shipped bundle (`ci.yml`)
- Build the **`SELF_HOST=1` standalone** (not the default output), baking the same client env CD bakes (adds `NEXT_PUBLIC_LIGHTNING/BITCOIN` vars for parity).
- Assemble static+public into the standalone tree, then run **E2E against `node .next/standalone/server.js`** — the exact entrypoint CD ships. CI now tests the shipped bundle, not a different `next start` build.
- Validated locally: standalone server `Ready in 405ms`, `/` → 200, `/api/health` → healthy (auth operational).

## Phase 2 — CD ships that artifact (`cd.yml`)
- Upload the assembled standalone as an artifact on main pushes; CD **downloads it from the triggering CI run** and deploys `--no-build`, removing the second ~7-min build.
- **Defensive:** the download is `continue-on-error`, and a follow-up step **builds if the artifact is absent** (download failure *or* manual `workflow_dispatch`). So a broken artifact path degrades to today's behavior — it can never break a deploy.

## Supporting
- `deploy-selfhost.sh`: the static/public assembly step now skips missing sources, so a pre-assembled downloaded artifact deploys cleanly (a fresh build still assembles as before).

## Safety / how this self-tests
- **This PR's own CI** exercises Phase 1 (standalone build + standalone-server E2E) — if the approach were wrong, it's red here, not on main.
- Phase 2's artifact path activates on merge; the build fallback + the deploy's auto-rollback are the two safety nets. I'll watch the first artifact-based deploy closely.

Follows the overhaul's stabilized deploy (health-gate fix #392). Remaining queue: GlitchTip (needs a DSN), rate-limiter consolidation (recommended deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)