### PR TITLE
fix Cat Credits metering and refresh AI model registry

### DIFF
--- a/__tests__/unit/cat/credit-metering.test.ts
+++ b/__tests__/unit/cat/credit-metering.test.ts
@@ -54,7 +54,13 @@ describe('calculateCostBtc returns BTC, not satoshis', () => {
     expect(cost).toBeGreaterThanOrEqual(0.00000001);
   });
 
-  it('unknown models cost 0', () => {
+  it('provider-resolved paid model ids use the registered model price', () => {
+    expect(calculateCostBtc(`${PAID_MODEL}-20260708`, 1000, 1000)).toBe(
+      calculateCostBtc(PAID_MODEL, 1000, 1000)
+    );
+  });
+
+  it('unknown models cost 0 until a registry model can be resolved', () => {
     expect(calculateCostBtc('no-such-model', 1000, 1000)).toBe(0);
   });
 });
@@ -62,7 +68,9 @@ describe('calculateCostBtc returns BTC, not satoshis', () => {
 describe('isPlatformMeteredModel', () => {
   it('true for paid registry models only', () => {
     expect(isPlatformMeteredModel(PAID_MODEL)).toBe(true);
+    expect(isPlatformMeteredModel(`${PAID_MODEL}-20260708`)).toBe(true);
     expect(isPlatformMeteredModel(FREE_MODEL)).toBe(false);
+    expect(isPlatformMeteredModel(`${FREE_MODEL.replace(/:free$/, '')}-20260708:free`)).toBe(false);
     expect(isPlatformMeteredModel('not-in-registry')).toBe(false);
     expect(isPlatformMeteredModel(undefined)).toBe(false);
   });
@@ -121,6 +129,37 @@ describe('meterCreditUsage', () => {
       ref: 'r2',
     });
     expect(appendCreditEntry).not.toHaveBeenCalled();
+  });
+
+  it('bills provider-resolved paid model ids instead of treating them as unknown', async () => {
+    appendCreditEntry.mockResolvedValue(0.001);
+    const charged = await meterCreditUsage(admin, 'u1', {
+      model: `${PAID_MODEL}-20260708`,
+      inputTokens: 100000,
+      outputTokens: 100000,
+      ref: 'resolved-model',
+    });
+
+    expect(charged).toBeGreaterThan(0);
+    expect(appendCreditEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers provider-reported request cost over the registry estimate when available', async () => {
+    appendCreditEntry.mockResolvedValue(0.001);
+    const providerReportedRawCostBtc = 0.00000234;
+    const charged = await meterCreditUsage(admin, 'u1', {
+      model: PAID_MODEL,
+      inputTokens: 100000,
+      outputTokens: 100000,
+      rawCostBtc: providerReportedRawCostBtc,
+      ref: 'provider-cost',
+    });
+
+    const expectedCharge = Math.ceil(providerReportedRawCostBtc * CREDIT_USAGE_MARKUP * 1e8) / 1e8;
+    expect(charged).toBe(expectedCharge);
+    const [, , entry] = appendCreditEntry.mock.calls[0] as [unknown, string, any];
+    expect(entry.metadata.rawCostBtc).toBe(providerReportedRawCostBtc);
+    expect(entry.metadata.pricingSource).toBe('provider_reported');
   });
 
   it('returns 0 (never throws) when the ledger append fails', async () => {

--- a/__tests__/unit/cat/model-display-name.test.ts
+++ b/__tests__/unit/cat/model-display-name.test.ts
@@ -15,9 +15,9 @@ describe('getModelDisplayName', () => {
   });
 
   it('resolves dated snapshot ids to the registered model name', () => {
-    // The founder-reported case: gemma snapshot id printed raw under replies.
-    expect(getModelDisplayName('google/gemma-4-31b-it-20260402:free')).toBe(
-      AI_MODEL_REGISTRY['google/gemma-4-31b-it:free'].name
+    // Providers can append snapshot suffixes to current free-model ids too.
+    expect(getModelDisplayName('meta-llama/llama-4-scout-20260402:free')).toBe(
+      AI_MODEL_REGISTRY['meta-llama/llama-4-scout:free'].name
     );
   });
 

--- a/__tests__/unit/services/ai/openrouter.test.ts
+++ b/__tests__/unit/services/ai/openrouter.test.ts
@@ -1,0 +1,162 @@
+/**
+ * OpenRouter cost plumbing — prefer provider-reported usage.cost, fall back to registry.
+ */
+
+import { ReadableStream as NodeReadableStream } from 'stream/web';
+import { TextDecoder as NodeTextDecoder } from 'util';
+import { OpenRouterService } from '@/services/ai/openrouter';
+import { calculateCostBtc } from '@/config/ai-models';
+
+// @ts-expect-error Jest/node lacks Web TextDecoder
+global.TextDecoder = NodeTextDecoder;
+
+const PAID_MODEL = 'deepseek/deepseek-v4-flash';
+const FREE_MODEL = 'openai/gpt-oss-120b:free';
+const BTC_PRICE_USD = 100_000;
+
+function mockJsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}
+
+function mockSseResponse(lines: string[]): Response {
+  const stream = new NodeReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(new Uint8Array(Buffer.from(`${line}\n`)));
+      }
+      controller.close();
+    },
+  });
+  return { ok: true, status: 200, body: stream } as Response;
+}
+
+function completionBody(usage: Record<string, unknown>) {
+  return {
+    id: 'gen-test',
+    model: PAID_MODEL,
+    choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop', index: 0 }],
+    usage,
+    created: 0,
+  };
+}
+
+describe('OpenRouterService chatCompletion cost', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('uses OpenRouter usage.cost converted to BTC when present', async () => {
+    const reportedUsd = 0.01;
+    fetchSpy.mockResolvedValue(
+      mockJsonResponse(
+        completionBody({
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          cost: reportedUsd,
+        })
+      )
+    );
+
+    const svc = new OpenRouterService('sk-test', { btcPriceUsd: BTC_PRICE_USD });
+    const result = await svc.chatCompletion({
+      model: PAID_MODEL,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    const expectedBtc = Math.ceil((reportedUsd / BTC_PRICE_USD) * 1e8) / 1e8;
+    expect(result.costBtc).toBe(expectedBtc);
+    expect(result.costBtc).not.toBe(calculateCostBtc(PAID_MODEL, 100, 50, BTC_PRICE_USD));
+  });
+
+  it('falls back to registry token pricing when usage.cost is absent', async () => {
+    fetchSpy.mockResolvedValue(
+      mockJsonResponse(
+        completionBody({
+          prompt_tokens: 1000,
+          completion_tokens: 1000,
+          total_tokens: 2000,
+        })
+      )
+    );
+
+    const svc = new OpenRouterService('sk-test', { btcPriceUsd: BTC_PRICE_USD });
+    const result = await svc.chatCompletion({
+      model: PAID_MODEL,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    expect(result.costBtc).toBe(calculateCostBtc(PAID_MODEL, 1000, 1000, BTC_PRICE_USD));
+  });
+
+  it('never bills free models even when OpenRouter returns a positive usage.cost', async () => {
+    fetchSpy.mockResolvedValue(
+      mockJsonResponse({
+        ...completionBody({
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          cost: 0.05,
+        }),
+        model: FREE_MODEL,
+      })
+    );
+
+    const svc = new OpenRouterService('sk-test', { btcPriceUsd: BTC_PRICE_USD });
+    const result = await svc.chatCompletion({
+      model: FREE_MODEL,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    expect(result.costBtc).toBe(0);
+    expect(result.isFreeModel).toBe(true);
+  });
+});
+
+describe('OpenRouterService streamChatCompletion cost', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('includes costBtc on the final usage chunk when streaming', async () => {
+    const reportedUsd = 0.02;
+    fetchSpy.mockResolvedValue(
+      mockSseResponse([
+        'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null,"index":0}]}',
+        `data: {"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"cost":${reportedUsd}}}`,
+        'data: [DONE]',
+      ])
+    );
+
+    const svc = new OpenRouterService('sk-test', { btcPriceUsd: BTC_PRICE_USD });
+    let finalUsage: { costBtc?: number } | undefined;
+
+    for await (const chunk of svc.streamChatCompletion({
+      model: PAID_MODEL,
+      messages: [{ role: 'user', content: 'hi' }],
+    })) {
+      if (chunk.done && chunk.usage) {
+        finalUsage = chunk.usage;
+      }
+    }
+
+    const expectedBtc = Math.ceil((reportedUsd / BTC_PRICE_USD) * 1e8) / 1e8;
+    expect(finalUsage?.costBtc).toBe(expectedBtc);
+  });
+});

--- a/docs/architecture/CAT_CREDITS.md
+++ b/docs/architecture/CAT_CREDITS.md
@@ -1,5 +1,13 @@
 # Cat Credits — Bitcoin-paid access to frontier models
 
+---
+
+created_date: 2026-06-25
+last_modified_date: 2026-07-08
+last_modified_summary: Wire Cat Credits usage metering to OpenRouter’s real per-request cost and refresh the 2026 model roster.
+
+---
+
 **Status:** Phases 1–2 built (ledger + Lightning top-up). Authored 2026-06-25.
 **Companion to:** the Settings → AI "sovereignty ladder" (Free → BYOK → Local) and the in-chat upgrade nudge (shipped).
 
@@ -77,8 +85,12 @@ index (user_id, seq desc)
 ### Usage (metered debit)
 
 1. A frontier request runs on **OC's managed OpenRouter key** (see §5).
-2. `chatCompletion` already returns `costBtc` + token counts. Convert `costBtc → sats` at the live rate (`currencyConverter`), apply pricing policy (§2.1), and append a `usage` entry `−cost` referencing `cat_messages.id`.
-3. Done **after** the response, like `saveMessages` — non-blocking, in a balance-guarding transaction.
+2. OpenRouter now returns a per-request `usage.cost` field (USD) alongside token counts. The platform:
+   - converts that real request cost → BTC at the live rate (`convertFromBTC`),
+   - applies pricing policy (§2.1) as a markup on top of the raw BTC cost, and
+   - appends a `usage` entry `−cost` referencing `cat_messages.id`.
+3. If OpenRouter omits `usage.cost` (older responses, non-OpenRouter providers), the system falls back to the curated model registry (`AI_MODEL_REGISTRY`) to estimate cost from token counts.
+4. Done **after** the response, like `saveMessages` — non-blocking, in a balance-guarding transaction. Ledger metadata records whether each debit used `provider_reported` or `registry_estimate` pricing.
 
 ### Pre-flight gate
 

--- a/docs/development/ai/MODEL_SYSTEM.md
+++ b/docs/development/ai/MODEL_SYSTEM.md
@@ -1,491 +1,258 @@
+---
+created_date: 2026-01-18
+last_modified_date: 2026-07-08
+last_modified_summary: Rewrote to match the real architecture (ai-models.ts SSOT + provider-resolver chain + Cat Credits metering) and the refreshed 2026 model roster; removed references to the retired UnifiedAIClient/ModelStatusBadge and /api/chat.
+---
+
 # AI Model System - Complete Guide
 
-**Last Updated:** 2026-01-18
 **Status:** Implemented
 
 ---
 
 ## Overview
 
-OrangeCat's AI model system is designed to be **effortless for beginners** while **powerful for advanced users**.
+OrangeCat's AI model system is **effortless for beginners** and **powerful for advanced users**.
 
-**The golden rule:** Users can start chatting with AI immediately, without any setup or configuration.
+**The golden rule:** users can start chatting with My Cat immediately, without any setup or configuration.
+
+The system runs on a **sovereignty ladder**:
+
+| Rung           | Pays              | Pseudonymous? | For                          |
+| -------------- | ----------------- | ------------- | ---------------------------- |
+| Free (managed) | nobody            | yes           | everyone, baseline           |
+| Cat Credits    | OC, in Bitcoin    | yes           | most upgraders               |
+| BYOK           | provider directly | no (card)     | power users, max sovereignty |
+| Local (Ollama) | nobody            | yes           | run-it-yourself              |
+
+See `docs/architecture/CAT_CREDITS.md` for the Bitcoin-paid frontier rung.
 
 ---
 
 ## User Experience
 
-### For Non-Technical Users (Default)
+### For non-technical users (default)
 
-```
-1. Sign up to OrangeCat
-2. Open My Cat chat
-3. Start talking immediately
-   ↓
-✓ Free AI model automatically selected
-✓ Zero configuration needed
-✓ 100% private (no data stored)
-✓ 10 free messages per day
-```
+1. Sign up to OrangeCat.
+2. Open My Cat chat.
+3. Start talking immediately.
 
-**Model Used:** Llama 4 Maverick (free tier via OpenRouter)
+A free model is auto-selected, no configuration is needed, and no conversation
+content is persisted on the ephemeral path. The daily free-message allowance is
+**database-driven** (`ai_platform_usage.daily_limit`), not hardcoded — surfaced
+to the client as `freeMessagesPerDay` / `freeMessagesRemaining`.
 
-- Fast responses
-- Good quality
-- No API costs
-- Rate limited to prevent abuse
+**Default free model:** `DEFAULT_FREE_MODEL_ID` (`openai/gpt-oss-120b:free`).
+The platform provider chain (see below) can also answer on Groq's
+`llama-3.3-70b-versatile` when it leads the chain.
 
-### For Power Users (Optional Upgrade)
+### For power users (optional upgrade)
 
-Users can optionally:
-
-1. **Add API Key** (BYOK - Bring Your Own Key)
-   - OpenRouter key → Access to 200+ models
-   - OR individual keys (OpenAI, Anthropic, Google, etc.)
-
-2. **Run Locally** (Ultimate Privacy)
-   - Install Ollama
-   - Download models
-   - 100% private, zero cloud data
-
-3. **Choose Specific Models**
-   - GPT-4o for best quality
-   - Claude 3.5 for reasoning
-   - Gemini 2.0 for huge context
-   - Grok for real-time data
+1. **Cat Credits** — pay OrangeCat in Bitcoin/Lightning, spend on frontier
+   models. No card, no per-provider account. (`docs/architecture/CAT_CREDITS.md`)
+2. **BYOK (Bring Your Own Key)** — an OpenRouter key unlocks 200+ models; or add
+   individual provider keys (OpenAI, Anthropic, Google, DeepSeek, xAI, Together).
+3. **Local (Ollama)** — point the platform at a self-hosted model for full
+   sovereignty.
 
 ---
 
 ## Technical Architecture
 
-### Model Registry (SSOT)
+### Model registry (SSOT)
 
-**Location:** `src/config/model-registry.ts`
+**Location:** `src/config/ai-models.ts` — `AI_MODEL_REGISTRY`.
 
-Single source of truth for all AI models:
+This is the single source of truth for every curated, platform-served model:
+pricing, context window, capabilities, tier, and free-vs-paid status. Tiers are
+`free | economy | standard | premium` (`MODEL_TIERS`).
 
 ```typescript
-export const MODEL_REGISTRY: Record<string, ModelMetadata> = {
-  'groq/mixtral-8x7b': {
-    id: 'groq/mixtral-8x7b',
-    name: 'Mixtral 8x7B',
-    provider: 'Groq',
-    tier: 'freemium',
-    availability: 'cloud',
-    requiresApiKey: false, // Use server key
-    // ... more metadata
-  },
-
-  'openai/gpt-4o': {
-    id: 'openai/gpt-4o',
-    name: 'GPT-4o',
+export const AI_MODEL_REGISTRY: Record<string, AIModelMetadata> = {
+  'openai/gpt-oss-120b:free': {
+    id: 'openai/gpt-oss-120b:free',
+    name: 'GPT-OSS 120B (Free)',
     provider: 'OpenAI',
-    tier: 'paid',
-    requiresApiKey: true, // User must provide
-    // ... more metadata
-  },
-
-  'local/llama-3.1-8b': {
-    id: 'local/llama-3.1-8b',
-    name: 'Llama 3.1 8B (Local)',
-    provider: 'Meta (via Ollama)',
     tier: 'free',
-    availability: 'local',
-    requiresApiKey: false, // Runs on user's computer
-    // ... more metadata
+    isFree: true,
+    inputCostPer1M: 0,
+    outputCostPer1M: 0,
+    // ...more metadata
   },
+  // ...
 };
 ```
 
-**Benefits:**
+**Compatibility adapter:** `src/config/model-registry.ts` exposes the legacy
+`MODEL_REGISTRY` shape, but it is a thin **projection generated from
+`AI_MODEL_REGISTRY`** — never a second hand-maintained list. New code should read
+`ai-models.ts` directly.
 
-- ✅ One place to define all models
-- ✅ Easy to add new models
-- ✅ Consistent metadata across app
-- ✅ Type-safe model selection
+Helper functions (all in `ai-models.ts`):
 
----
+- `getModelMetadata(id)` / `getRegisteredModelId(id)` — resolve provider-reported
+  snapshot ids (e.g. `...-20260708`) back to the registered model.
+- `getModelDisplayName(id)` — never surface a raw slug in the UI.
+- `getModelsByTier(tier)`, `getAvailableModels()`, `getFreeModels()`.
+- `calculateCostBtc(id, inputTokens, outputTokens, btcPriceUsd)` — registry-based
+  cost estimate (fallback for metering).
 
-### Unified AI Client
+### Provider services
 
-**Location:** `src/lib/ai/unified-client.ts`
+Each provider is a small service class with a shared `chatCompletion` /
+`streamChatCompletion` interface so the resolver can swap implementations:
 
-Single interface for all providers:
+- `src/services/ai/openrouter.ts` — `OpenRouterService` (BTC cost tracking;
+  prefers OpenRouter's returned `usage.cost`).
+- `src/services/ai/groq.ts` — `GroqService` (ultra-fast free tier).
+- `src/services/ai/openai-compat.ts` — `OpenAICompatibleService` (OpenAI,
+  Together, DeepSeek, xAI, Ollama, LM Studio — anything OpenAI-wire-compatible).
 
-```typescript
-const client = new UnifiedAIClient(config);
+### Platform provider chain
 
-// Works with ANY model
-const response = await client.chat({
-  model: 'groq/mixtral-8x7b', // OR 'openai/gpt-4o' OR 'local/llama-3.1-8b'
-  messages: [{ role: 'user', content: 'Hello!' }],
-  stream: true,
-});
-```
+**Location:** `src/services/ai/platform-providers.ts`.
 
-**Supported Providers:**
+For non-BYOK users, `buildPlatformProviders(message)` composes an ordered chain,
+first available wins and the rest become rate-limit fallbacks:
 
-- ✅ OpenRouter (200+ models, one API key)
-- ✅ OpenAI (GPT-4o, GPT-4o-mini, etc.)
-- ✅ Anthropic (Claude 3.5 Sonnet, Opus 4)
-- ✅ Google (Gemini 2.0 Flash, Pro)
-- ✅ X.AI (Grok 2)
-- ✅ Groq (ultra-fast inference)
-- ✅ Together AI (open models)
-- ✅ Ollama (local models)
-- ✅ LM Studio (local models)
+1. **Groq** — fastest inference, generous free tier.
+2. **OpenRouter** — the free model pool (one entry per free model).
+3. **Together AI** — backup free pool.
+4. **Platform Ollama** — Hetzner-hosted small model, sovereignty backstop.
 
----
+Each is enabled by the presence of its env var, so the chain shrinks gracefully.
 
-### API Endpoint
+### Provider resolution
 
-**Location:** `src/app/api/cat/chat/route.ts`
+**Location:** `src/services/cat/provider-resolver.ts`.
 
-**Default Behavior:**
+`resolveProvider(...)` builds the merged, fully-ordered chain: per-request header
+keys → stored BYOK keys (user order) → the platform chain. It also decides
+whether a request is a **credit-metered frontier** call and returns the primary
+service plus an ordered `fallbacks[]`.
 
-```typescript
-// Non-technical user sends message
-POST /api/cat/chat
-{
-  "message": "I want to make money"
-}
+### Chat endpoint + orchestration
 
-// Response uses FREE model automatically
-// No configuration needed
-// User doesn't even know which model was used (unless they check)
-```
+**Endpoint:** `POST /api/cat/chat` (`src/app/api/cat/chat/route.ts`) — a thin
+wrapper: auth + rate limit + body validation.
 
-**Power User with BYOK:**
+**Orchestrator:** `src/services/cat/chat-orchestrator.ts` (`orchestrateCatChat`)
+owns provider resolution, context/memory, tool use, the model call with the
+rate-limit fallback chain, streaming vs non-streaming responses, persistence, and
+the post-response Cat Credits debit.
 
-```typescript
-// User with API key can choose model
-POST /api/cat/chat
-Headers: { 'x-openrouter-key': 'sk-...' }
-{
-  "message": "I want to make money",
-  "model": "anthropic/claude-3.5-sonnet" // Specific model
-}
-
-// OR auto-select best model
-{
-  "message": "Complex reasoning task",
-  "model": "auto" // Auto-router selects best model
-}
-```
+See `docs/reference/api/chat.md` for the request/response contract.
 
 ---
 
-## Model Selection Logic
+## Cost tracking & Cat Credits metering
 
-### Priority System
-
-```
-1. User Specifies Model → Use that model
-2. User Has BYOK → Auto-select from all models
-3. User on Free Tier → Auto-select from free models only
-4. Fallback → DEFAULT_FREE_MODEL_ID
-```
-
-### Auto-Router
-
-Smart model selection based on task:
-
-```typescript
-const route = autoRouter.selectModel({
-  message: "Write a complex function",
-  conversationHistory: [...],
-  allowedModels: availableModels,
-});
-
-// Returns best model for the task
-// - Code tasks → Models with function calling
-// - Creative tasks → Models with large context
-// - Vision tasks → Models with vision support
-```
+- `OpenRouterService.chatCompletion` / `streamChatCompletion` return `costBtc`.
+  It **prefers OpenRouter's real per-request `usage.cost`** (converted USD→BTC),
+  and falls back to `calculateCostBtc` (registry token pricing) when the field is
+  absent (older responses, non-OpenRouter providers).
+- Free models always meter to `costBtc: 0`.
+- For credit-paid frontier requests, the orchestrator calls
+  `meterCreditUsage(...)` (`src/services/cat/credit-metering.ts`) with the real
+  `rawCostBtc` when available. The debit is `rawCost × CREDIT_USAGE_MARKUP`,
+  rounded up to 1e-8 BTC. Ledger metadata records `pricingSource` as
+  `provider_reported` or `registry_estimate`.
+- BYOK usage is never metered to Cat Credits (the user pays their provider).
 
 ---
 
-## Security
+## Model selection logic
 
-### API Key Storage
+### Priority
 
-**Three Tiers:**
-
-#### 1. Free Tier (Zero User Risk)
-
-```typescript
-// Server uses its own API key
-const apiKey = process.env.GROQ_API_KEY; // Server-side only
-
-// User never sees this
-// User never pays for this
-// It's OrangeCat's cost
+```
+1. User specifies a concrete model  → use it (BYOK trusts any OpenRouter model)
+2. User has BYOK                     → auto-select across allowed models
+3. Free tier                         → auto-select from free models only
+4. Fallback                          → DEFAULT_FREE_MODEL_ID
 ```
 
-#### 2. Ephemeral BYOK (Most Secure)
+### Auto-router
 
-```typescript
-// User's key sent per-request in header
-// NEVER stored in database
-// Cleared from memory after use
+**Location:** `src/services/ai/auto-router.ts`.
 
-fetch('/api/cat/chat', {
-  headers: {
-    'x-openrouter-key': userKey, // Ephemeral
-  },
-});
-```
-
-#### 3. Encrypted Storage (Opt-In Convenience)
-
-```typescript
-// User explicitly opts in
-// Password-based encryption
-// Zero-knowledge (server can't decrypt)
-
-const encrypted = await encryptApiKey(apiKey, userPassword);
-// Store encrypted blob in DB
-// Decrypt on client with password
-```
-
-**Default:** Ephemeral (most secure)
+`createAutoRouter().selectModel({ message, conversationHistory, allowedModels })`
+scores message complexity and picks a tier, then the cheapest suitable model
+within it. It is also used to order the OpenRouter free pool per request.
 
 ---
 
-## Model Categories
+## Current roster (refreshed 2026-07-08)
 
-### Free Tier
+Prices are per 1M tokens (input / output), verified against live OpenRouter /
+provider pages.
 
-- ✅ Llama 4 Maverick (default)
-- ✅ Llama 3.3 70B
-- ✅ Gemini 2.0 Flash
-- ✅ DeepSeek R1
-- ✅ Qwen QWQ 32B
+### Free tier (rate limited: 50/day free accounts, 1000/day with $10+ credits)
 
-**Limits:** 10 messages/day on platform key
+- `openai/gpt-oss-120b:free` — GPT-OSS 120B (default free model)
+- `openai/gpt-oss-20b:free` — GPT-OSS 20B
+- `meta-llama/llama-3.3-70b-instruct:free` — Llama 3.3 70B
+- `meta-llama/llama-4-scout:free` — Llama 4 Scout (multimodal, huge context)
 
-### Premium (BYOK Required)
+### Economy
 
-- 💎 GPT-4o (best overall)
-- 💎 Claude 3.5 Sonnet (best reasoning)
-- 💎 Claude Opus 4 (most capable)
-- 💎 Gemini 2.0 Pro (2M context)
-- 💎 Grok 2 (real-time data)
+- `meta-llama/llama-3.1-8b-instruct` — $0.02 / $0.03
+- `openai/gpt-oss-120b` — $0.03 / $0.15
+- `deepseek/deepseek-v4-flash` — $0.09 / $0.18 (1M context)
 
-**Limits:** User's API key limits
+### Standard
 
-### Local (Ultimate Privacy)
+- `qwen/qwen3-32b` — $0.08 / $0.28
+- `anthropic/claude-sonnet-5` — $2 / $10 (intro pricing through 2026-08-31)
 
-- 🔒 Llama 3.1 8B (fast, 16GB RAM)
-- 🔒 Llama 3.1 70B (best quality, 64GB RAM)
-- 🔒 Mistral 7B (lightweight, 8GB RAM)
+### Premium
 
-**Limits:** Hardware only
+- `anthropic/claude-opus-4.8` — $5 / $25 (1M context)
+- `anthropic/claude-fable-5` — $10 / $50 (1M context)
 
----
-
-## User Interface
-
-### Model Status Badge
-
-**Location:** `src/components/ai-chat/ModelStatusBadge.tsx`
-
-Shows current model with hover details:
-
-```tsx
-<ModelStatusBadge
-  modelName="Llama 4 Maverick"
-  isFree={true}
-  messagesRemaining={7}
-  onUpgrade={() => showModelSelector()}
-/>
-```
-
-**Appearance:**
-
-```
-┌─────────────┐
-│ ⚡ Free     │  ← Hover for details
-└─────────────┘
-```
-
-**On Hover:**
-
-```
-┌──────────────────────────────────┐
-│ ✨ Current Model                 │
-│ Llama 4 Maverick                 │
-│                                  │
-│ ┌────────────────────────────┐  │
-│ │ Free Messages  7 remaining │  │
-│ │                            │  │
-│ │ You're using a free AI     │  │
-│ │ model. No setup required.  │  │
-│ │                            │  │
-│ │ [Upgrade to Premium]       │  │
-│ └────────────────────────────┘  │
-│                                  │
-│ ✓ Benefits:                      │
-│ • No data stored                 │
-│ • 100% private                   │
-│ • Fast responses                 │
-└──────────────────────────────────┘
-```
-
-**For BYOK Users:**
-
-```
-┌─────────────┐
-│ 👑 GPT-4o   │  ← Crown icon
-└─────────────┘
-```
+> Keep this list in sync with `AI_MODEL_REGISTRY`. The registry is authoritative;
+> this section is a human-readable snapshot.
 
 ---
 
-## Implementation Status
+## API key security
 
-### ✅ Completed
+**Three tiers, default is ephemeral:**
 
-- [x] Model Registry created
-- [x] UnifiedAIClient built
-- [x] Cat chat API updated
-- [x] Default free tier working
-- [x] BYOK support implemented
-- [x] Model status badge created
-- [x] Security measures in place
-
-### 🚧 Next Steps
-
-- [ ] Model selector UI component
-- [ ] Local model detection & setup wizard
-- [ ] OpenRouter integration testing
-- [ ] Add model switching to chat UI
-- [ ] Model comparison view
-- [ ] Usage tracking per model
-- [ ] Cost calculator for paid models
+1. **Free tier** — the server uses its own provider key; the user never sees or
+   pays for it.
+2. **Ephemeral BYOK** — the user's key is sent per-request in a header, never
+   stored.
+3. **Encrypted storage** — opt-in convenience; keys are encrypted at rest.
 
 ---
 
-## Adding New Models
+## Adding a new curated model
 
-### 1. Add to Registry
-
-```typescript
-// src/config/model-registry.ts
-
-'newprovider/newmodel': {
-  id: 'newprovider/newmodel',
-  name: 'New Model Name',
-  provider: 'New Provider',
-  tier: 'free', // or 'paid'
-  availability: 'cloud', // or 'local' or 'both'
-  requiresApiKey: true, // or false
-  // ... other metadata
-},
-```
-
-### 2. Add Provider Handler (if needed)
-
-```typescript
-// src/lib/ai/unified-client.ts
-
-private async chatNewProvider(options, modelMeta) {
-  const apiKey = this.config.apiKeys?.newprovider;
-
-  return fetch('https://api.newprovider.com/chat', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model: options.model,
-      messages: options.messages,
-    }),
-  });
-}
-```
-
-### 3. Route in Main Client
-
-```typescript
-// src/lib/ai/unified-client.ts
-
-case 'New Provider':
-  return this.chatNewProvider(options, modelMeta);
-```
-
-### 4. Done!
-
-Model is now available everywhere:
-
-- ✅ Cat chat
-- ✅ AI assistants
-- ✅ Auto-router
-- ✅ Model selector UI
-
----
-
-## Best Practices
-
-### For Developers
-
-**DO:**
-
-- ✅ Always use MODEL_REGISTRY for model metadata
-- ✅ Use UnifiedAIClient for all AI calls
-- ✅ Handle streaming responses properly
-- ✅ Show loading states
-- ✅ Handle errors gracefully
-- ✅ Track usage for free tier users
-
-**DON'T:**
-
-- ❌ Hardcode model IDs in components
-- ❌ Bypass the unified client
-- ❌ Store API keys in plaintext
-- ❌ Expose API keys in client code
-- ❌ Make assumptions about model availability
-
-### For UX
-
-**DO:**
-
-- ✅ Default to free tier (zero friction)
-- ✅ Show which model is being used (badge)
-- ✅ Explain upgrade benefits clearly
-- ✅ Make model switching easy
-- ✅ Show usage limits transparently
-
-**DON'T:**
-
-- ❌ Force users to configure before use
-- ❌ Hide which model is being used
-- ❌ Surprise users with costs
-- ❌ Make local setup too technical
-- ❌ Overwhelm with model choices
+1. Add an entry to `AI_MODEL_REGISTRY` in `src/config/ai-models.ts` (id, name,
+   provider, tier, pricing, context, capabilities, `isFree`).
+2. If it needs a new provider transport, add it to
+   `src/services/ai/openai-compat.ts` (or a dedicated service) and wire it into
+   `provider-resolver.ts` / `platform-providers.ts`.
+3. That's it — the legacy `MODEL_REGISTRY`, tier UIs, auto-router, and selectors
+   all read from the SSOT automatically.
 
 ---
 
 ## References
 
-- **Model Registry:** `src/config/model-registry.ts`
-- **Unified Client:** `src/lib/ai/unified-client.ts`
-- **Chat API:** `src/app/api/cat/chat/route.ts`
-- **Status Badge:** `src/components/ai-chat/ModelStatusBadge.tsx`
-- **Existing Models:** `src/config/ai-models.ts`
+- **Registry (SSOT):** `src/config/ai-models.ts`
+- **Legacy compat adapter:** `src/config/model-registry.ts`
+- **Provider services:** `src/services/ai/{openrouter,groq,openai-compat}.ts`
+- **Platform chain:** `src/services/ai/platform-providers.ts`
+- **Provider resolver:** `src/services/cat/provider-resolver.ts`
+- **Auto-router:** `src/services/ai/auto-router.ts`
+- **Chat orchestrator:** `src/services/cat/chat-orchestrator.ts`
+- **Chat endpoint:** `src/app/api/cat/chat/route.ts`
+- **Cat Credits metering:** `src/services/cat/credit-metering.ts`
+- **Cat Credits design:** `docs/architecture/CAT_CREDITS.md`
 
 ---
 
-## Support
-
-For questions or issues:
-
-- Check model registry for available models
-- Verify API keys are correctly configured
-- Check free tier usage limits
-- Test with different models
-- Review error messages in console
-
----
-
-**Remember:** The goal is **instant AI access** for everyone, with optional power features for those who want them.
+**Remember:** the goal is **instant AI access** for everyone, with optional
+Bitcoin-paid and BYOK power features for those who want them.

--- a/docs/reference/api/chat.md
+++ b/docs/reference/api/chat.md
@@ -1,172 +1,171 @@
-# 🤖 Chat API
+# My Cat Chat API
+
+**Created**: 2025-12-09
+**Last Modified**: 2026-07-08
+**Last Modified Summary**: Rewrote to document the current authenticated `POST /api/cat/chat` endpoint (provider chain, streaming SSE, Cat Credits metering) — the old public `/api/chat` Gemini widget no longer exists.
 
 ## Overview
 
-The Chat API provides access to OrangeCat's AI assistant powered by Google Gemini 2.0 Flash-Lite. This is the cheapest available LLM, making it cost-effective for user assistance.
+The Chat API powers **My Cat**, OrangeCat's AI assistant. Requests run through a
+provider chain (Groq → OpenRouter free pool → Together → Ollama) for free-tier
+users, or through the user's own key (BYOK) / Cat Credits for frontier models.
+Model metadata is sourced from `src/config/ai-models.ts` (`AI_MODEL_REGISTRY`).
 
-## Endpoints
+The ephemeral path does **not** persist conversation content; when a
+`conversationId` is supplied, messages are saved to the user's conversation.
 
-### POST `/api/chat`
+## Authentication
 
-Send a message to the AI assistant and receive a response.
+All requests require an authenticated OrangeCat session (`withAuth`). There is no
+unauthenticated public chat endpoint.
+
+## Endpoint
+
+### POST `/api/cat/chat`
+
+Send a message to My Cat and receive a response (buffered JSON or streaming SSE).
 
 #### Request
 
 ```javascript
-POST /api/chat
+POST /api/cat/chat
 Content-Type: application/json
 
 {
   "message": "How does OrangeCat work?",
-  "systemPrompt": "You are OrangeCat's AI assistant..." // optional
+  "model": "auto",              // optional: registry id, "auto", or "any"
+  "stream": false,               // optional: true → SSE stream
+  "conversationId": "<uuid>",   // optional: omit for the default conversation
+  "preferredCurrency": "CHF",   // optional runtime hint
+  "locale": "de-CH",            // optional runtime hint
+  "lastVisitedPath": "/discover" // optional runtime hint
 }
 ```
+
+Optional BYOK headers (per-request, never stored):
+
+- `x-openrouter-key: sk-or-...`
+- `x-groq-api-key: gsk_...`
 
 #### Parameters
 
-| Parameter      | Type   | Required | Description                                       |
-| -------------- | ------ | -------- | ------------------------------------------------- |
-| `message`      | string | Yes      | The user's message (max 10,000 characters)        |
-| `systemPrompt` | string | No       | Custom system prompt to override default behavior |
+| Parameter           | Type    | Required | Description                                                       |
+| ------------------- | ------- | -------- | ----------------------------------------------------------------- |
+| `message`           | string  | Yes      | The user's message (see `AI_MESSAGE_MAX_CHARS`).                  |
+| `model`             | string  | No       | Registry model id, `"auto"`, or `"any"`. Defaults to auto-select. |
+| `stream`            | boolean | No       | When `true`, response is an SSE stream.                           |
+| `conversationId`    | uuid    | No       | Target conversation; omitted → the user's default conversation.   |
+| `preferredCurrency` | string  | No       | Runtime hint for price quoting.                                   |
+| `locale`            | string  | No       | Runtime hint for reply language.                                  |
+| `lastVisitedPath`   | string  | No       | Runtime hint for recent-page awareness.                           |
 
-#### Response
+#### Response — non-streaming (200)
 
-**Success (200)**:
-
-```javascript
-{
-  "message": "OrangeCat is a Bitcoin-native crowdfunding platform where users can fund projects directly with Bitcoin...",
-  "model": "gemini-2.0-flash-lite",
-  "timestamp": "2025-12-09T10:30:00.000Z"
-}
-```
-
-**Error Responses**:
-
-**400 Bad Request**:
+Uses the standard API envelope (`{ success, data }`):
 
 ```javascript
 {
-  "error": "Message is required and must be a string"
+  "success": true,
+  "data": {
+    "message": "OrangeCat is a Bitcoin-native platform...",
+    "actions": [ /* parsed exec_action blocks, if any */ ],
+    "quickReplies": [ "Tell me more", "Show me projects" ],
+    "execResults": [ /* results of executed actions, if any */ ],
+    "toolCalls": [ /* tool lifecycle events, if any */ ],
+    "prefillProposals": [ /* prefilled entity form drafts, if any */ ],
+    "modelUsed": "openai/gpt-oss-120b:free",
+    "provider": "openrouter",
+    "suggestUpgrade": false,
+    "fallback": null,
+    "usage": {
+      "inputTokens": 320,
+      "outputTokens": 210,
+      "totalTokens": 530,
+      "apiCostBtc": 0,
+      "isFreeModel": true,
+      "usedByok": false
+    },
+    "userStatus": {
+      "hasByok": false,
+      "freeMessagesPerDay": 25,
+      "freeMessagesRemaining": 18
+    }
+  }
 }
 ```
 
-**429 Rate Limited**:
+#### Response — streaming (200, `text/event-stream`)
+
+When `stream: true`, the endpoint emits Server-Sent Events. Each event is a
+`data: <json>` line. Notable payloads:
+
+- `{ "model": "...", "provider": "..." }` — active model/provider (sent again on fallback).
+- `{ "content": "..." }` — an incremental token chunk.
+- `{ "tool_call": { ... } }` — a tool lifecycle event.
+- `{ "prefill_proposal": { ... } }` — a prefilled entity form draft.
+- `{ "fallback": { "from": "...", "to": "...", "model": "...", "reason": "rate_limit" } }` — provider swap before content streamed.
+- Final: `{ "done": true, "usage": { ... }, "model": "...", "provider": "...", "actions": [...], "execResults": [...], "quickReplies": [...], "suggestUpgrade": false }`.
+- On failure: an `event: error` line followed by `data: { "error": "...", "code": "..." }`.
+
+#### Error responses
+
+**400 Bad Request** — invalid body (fails `catChatBodySchema`):
 
 ```javascript
-{
-  "error": "Rate limit exceeded",
-  "code": "RATE_LIMIT_EXCEEDED",
-  "limit": 5,
-  "remaining": 0,
-  "resetTime": 1733740200000,
-  "resetDate": "Mon, 09 Dec 2025 10:30:00 GMT"
-}
+{ "success": false, "error": "Invalid request", "details": { /* zod flatten */ } }
 ```
+
+**429 Rate Limited** — write-tier rate limit or all providers exhausted. Includes
+standard rate-limit headers; non-streaming errors use codes such as
+`AI_RATE_LIMITED` or `ALL_PROVIDERS_DOWN`.
 
 **500 Internal Server Error**:
 
 ```javascript
-{
-  "error": "Failed to generate response"
-}
+{ "success": false, "error": "Failed to generate response" }
 ```
 
-### GET `/api/chat`
+## Rate limiting
 
-Get information about the chat service and current model.
+- Uses the **write-tier** per-user rate limit (`rateLimitWriteAsync`).
+- Standard rate-limit headers are applied to responses:
+  - `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `Retry-After`.
+- Free-tier users additionally have a **daily message allowance**
+  (`ai_platform_usage.daily_limit`), surfaced as `freeMessagesRemaining`.
 
-#### Response
+## Cost & metering
 
-```javascript
-{
-  "status": "healthy",
-  "model": "gemini-2.0-flash-lite",
-  "provider": "Google Gemini",
-  "pricing": {
-    "input": "$0.075 per 1M tokens",
-    "output": "$0.30 per 1M tokens"
-  },
-  "timestamp": "2025-12-09T10:30:00.000Z"
-}
-```
-
-## Rate Limiting
-
-- **5 requests per 5 minutes** per IP address
-- Rate limit headers are included in responses:
-  - `X-RateLimit-Limit`: Maximum requests allowed
-  - `X-RateLimit-Remaining`: Remaining requests in current window
-  - `X-RateLimit-Reset`: Timestamp when limit resets
-  - `Retry-After`: Seconds until limit resets
-
-## Error Handling
-
-The API handles various error conditions:
-
-- **Invalid Input**: Message validation failures
-- **API Key Issues**: Authentication problems with Gemini API
-- **Quota Exceeded**: Gemini API usage limits reached
-- **Content Filtering**: Messages blocked by safety filters
-- **Network Issues**: Connection problems with Gemini API
+- Free models report `apiCostBtc: 0`.
+- Paid frontier models served on the platform key are metered to **Cat Credits**,
+  preferring OpenRouter's real `usage.cost` and falling back to registry token
+  pricing. See `docs/architecture/CAT_CREDITS.md`.
+- BYOK requests are never metered to Cat Credits (the user pays their provider).
 
 ## Security
 
-- API keys are stored server-side only
-- Input validation prevents malicious payloads
-- Rate limiting prevents abuse
-- Content filtering through Gemini's safety features
-- Error messages don't expose sensitive information
+- Provider/API keys are handled server-side; BYOK header keys are ephemeral and
+  never persisted.
+- Input is validated at the boundary (`catChatBodySchema`).
+- Raw provider error messages are never echoed to the client (they can contain
+  credentials); errors are logged server-side and returned as structured codes.
 
-## Usage Examples
-
-### Basic Chat
+## Usage example
 
 ```javascript
-const response = await fetch('/api/chat', {
+const response = await fetch('/api/cat/chat', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({
-    message: 'What is Bitcoin crowdfunding?',
-  }),
+  body: JSON.stringify({ message: 'What is Bitcoin crowdfunding?' }),
 });
 
-const data = await response.json();
-console.log(data.message);
+const { data } = await response.json();
+console.log(data.message, data.modelUsed);
 ```
 
-### Custom System Prompt
+## References
 
-```javascript
-const response = await fetch('/api/chat', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({
-    message: 'Explain Bitcoin to a beginner',
-    systemPrompt: 'You are a patient teacher explaining complex topics simply.',
-  }),
-});
-```
-
-## Cost Information
-
-- **Input**: $0.075 per 1 million tokens
-- **Output**: $0.30 per 1 million tokens
-- **Model**: Google Gemini 2.0 Flash-Lite
-- **Context Window**: 128K tokens
-
-## Frontend Integration
-
-The chat feature is integrated as a floating chat widget available site-wide. The component handles:
-
-- Real-time message exchange
-- Auto-scrolling message history
-- Error states and loading indicators
-- Keyboard shortcuts and accessibility
-- Responsive design for mobile and desktop
-
----
-
-**Created**: 2025-12-09
-**Last Modified**: 2025-12-09
-**Last Modified Summary**: Initial API documentation for chat endpoint
+- **Endpoint:** `src/app/api/cat/chat/route.ts`
+- **Orchestrator:** `src/services/cat/chat-orchestrator.ts`
+- **Provider resolver:** `src/services/cat/provider-resolver.ts`
+- **Model registry (SSOT):** `src/config/ai-models.ts`
+- **Model system guide:** `docs/development/ai/MODEL_SYSTEM.md`

--- a/docs/research/2026-07-08-deep-research-handoff.md
+++ b/docs/research/2026-07-08-deep-research-handoff.md
@@ -1,0 +1,95 @@
+# OrangeCat — Deep-Research Findings + Handoff (2026-07-08)
+
+**Why this doc exists:** a research pass over OrangeCat's open external-technology decisions was started but hit the **session usage limit** (resets ~15:50 Europe/Zurich). This captures what's done, what's directional, and a precise handoff so a fresh agent can finish it. Author: prior agent session.
+
+**Status legend:**
+
+- `[VERIFIED]` — web-researched + adversarially verified by the deep-research harness (cited).
+- `[SOURCED]` — gathered from primary sources, but adversarial verification was cut off by the limit; trust as "well-sourced, not independently cross-checked."
+- `[ANALYSIS]` — my own reasoning from the code review; **not web-verified**. Directional only.
+
+---
+
+## How we got here
+
+A 4-agent code review surfaced **31 open decisions** across payments / infra / AI / security (grounded in file paths). Those were consolidated into **10 research questions**. Deep-research runs are **very heavy** (~9M tokens, ~75 min each) and MUST run **one at a time** — firing 5 in parallel tripped a global rate limit and returned empty shells. Completed: Q1 (verified) + Q2 (sourced, verification cut off). The session limit then stopped the rest.
+
+---
+
+## COMPLETED RESEARCH
+
+### Q1 — 2026-H2 LLM roster + pricing `[VERIFIED]`
+
+Our `src/config/ai-models.ts` `AI_MODEL_REGISTRY` is **stale** (lists claude-opus-4, gpt-4o, gemini-2.0-pro, grok-2). Current Pareto frontier (verified vs live Groq/OpenRouter):
+
+- **Frontier:** Claude **Opus 4.8** ($5/$25, 1M ctx). **Fable 5** ($10/$50) now sits above it.
+- **Capable / agentic tool-use:** Claude **Sonnet 5** ($2/$10 intro → $3/$15 after 2026-08-31, 1M ctx); **Groq GPT-OSS 120B** ($0.15/$0.60, native tools) — best cheap-agentic.
+- **Cheap chat:** Groq **Llama 3.1 8B** ($0.05/$0.08); **DeepSeek V4 Flash** ($0.09/$0.18, 1M ctx, MIT); Gemini Flash-Lite (~$0.10/$0.40).
+- **Free pool:** Groq Free Plan (gpt-oss-120b/20b, llama-3.3-70b, llama-3.1-8b, llama-4-scout, qwen3-32b, compound); OpenRouter free collection / `openrouter/free` meta-router.
+- **Key fact for metering:** OpenRouter passes provider pricing through with **no markup**.
+- Full cited report: `tasks/wy8phyeom.output` (this session's scratch).
+- **Action:** rewrite `AI_MODEL_REGISTRY` to the above; re-map the 3 capability tiers + free pool.
+
+### Q2 — Which NWC wallet to provision for `PLATFORM_NWC_URI` `[SOURCED]` (verification cut off)
+
+Primary sources: getAlby/hub, albyhub.com, LNbits nwcprovider (riccardobl), getAlby/awesome-nwc, Alby guides.
+
+- **Recommendation: Alby Hub.** Self-custodial (the _platform_ holds keys — good, it's OC's own revenue wallet), supports the required `make_invoice` + `lookup_invoice` **plus payment-notification events** (`nwc_payment_received/sent`) — which means we can move settlement detection off polling (see payments finding #2). **LSPS2 just-in-time channels** solve inbound liquidity (fee deducted from the incoming payment). No KYC. Open-source, self-hostable; Alby also offers a hosted option + a capabilities-discovery endpoint (`api.getalby.com/nwc/nip47/info`).
+- **Alternatives:** **LNbits + NWCProvider extension** if already running LNbits (supports make/lookup_invoice, per-connection permissions + budgets → can mint a _receive-only, non-spending_ credential; depends on a Nostr relay + LNbits uptime you maintain). **Coinos** = zero-ops but **custodial** (provider holds funds — conflicts with the "never hold funds" ethos).
+- **⚠️ Re-verify** the NIP-47 method support + notification events (the value claim; verification didn't complete). Then wire the chosen URI into `src/lib/bitcoin/platform-wallet.ts`.
+
+---
+
+## DIRECTIONAL SYNTHESES (`[ANALYSIS]`, not web-verified — confirm before acting)
+
+### Warm-standby / HA for self-hosted Supabase (infra#2,7)
+
+IaC the box first (cloud-init/Ansible) — biggest RTO win per €. Then a cold nightly-restore standby. Streaming-replication HA only if an RTO target demands it; failover must handle GoTrue signing keys + Kong + Realtime (Storage already on R2 = stateless, good). **>1 instance forces self-hosted Valkey/Redis** (in-memory rate-limit fallback is single-instance-only) — bundle Valkey before any standby work.
+
+### LLM gateways + embeddings (AI#2,4,5,8)
+
+Highest-value: **fix Cat-Credits metering** — bill off OpenRouter's real per-request cost (it returns generation cost; no markup) instead of the stale hardcoded table in `ai-models.ts`/`credit-metering.ts` (today, models absent from the table bill **$0** = revenue leak). Evaluate a self-hosted **LiteLLM proxy** to replace hand-rolled `provider-resolver.ts` + `auto-router.ts` (routing + failover + budgets + cost-tracking in one, sovereign). Embeddings: only move off OpenAI if sovereignty is hard-required; pick a **1536-dim** open model to avoid a `vector(1536)` reindex of `cat_memories`.
+
+### Sovereign ops (infra#3,4,5,6)
+
+B2 Object-Lock: restic `prune` conflicts with append-only → canonical pattern is **no-delete key on the box + delete-capable key on a separate host running `forget --prune`** (web-verify the exact restic+object-lock interaction). Secrets: **SOPS + age** encrypted `.env` in the config backup, age key in ≥2 offline copies (no daemon = no DR chicken-and-egg). Cloudflare: values call — buys origin-hiding + edge DDoS/WAF + lets you drop the HTTP/3 kill-guard, costs TLS-termination sovereignty; sovereign middle path = Caddy rate-limit + self-hosted WAF (Coraza/Anubis) or bunny.net. Defer CF until bot/DDoS pressure is real.
+
+### Nostr E2E messaging + OIDC hardening (sec#4,5)
+
+E2E DMs: modern path is **NIP-44 v2 + NIP-17 gift-wrap** (not legacy NIP-04); hard part is per-user Nostr key management vs Supabase-auth identity + migrating existing plaintext threads — a real project, scope deliberately. **OIDC hardening to do regardless of research:** JWKS **key rotation with overlap** (single key today = can't rotate without breaking live tokens), a **consent-revocation** endpoint, **refresh-token reuse detection**, and fix the `[INSERT SECURITY EMAIL]` placeholder in `docs/security/SECURITY.md`.
+
+---
+
+## REMAINING DEEP-RESEARCH QUEUE (for the next agent)
+
+Run **ONE AT A TIME** (see operational lessons). Framed questions:
+
+1. **Self-hosted error tracking** — GlitchTip vs Sentry-self-hosted vs Bugsink vs Loki log-shipping on a capacity-constrained shared Hetzner box (footprint/retention/setup); is a Sentry-SDK-compatible receiver the right coupling for the existing `setErrorSink()` hook in `src/utils/logger.ts`?
+2. **Compliance** — under Swiss FINMA/DLT-Act, EU MiCA, FATF Travel Rule: does non-withdrawable single-purpose prepaid Bitcoin service credit stay outside VASP/e-money licensing, and what non-custodial/progressive-KYC patterns keep pseudonymous P2P `loan`/`investment` entities lawful? (payments#4 + sec#3)
+3. **Agentic prompt-injection defense + agent eval harness (2026)** — for a tool-using agent that reads untrusted web/user content and drafts economic entities (AI#3,6).
+4. **Supabase authz + Next.js 15 security** — RLS-as-enforced-defense vs compile-enforced app-layer scoping when the server uses the service-role key; Next.js App Router auth post-CVE-2025-29927; strict enforcing CSP (nonce vs hash) for a UGC site (sec#1,2,6).
+5. **Re-run Q2 (NWC)** to complete adversarial verification, OR the settlement-reliability question (NIP-47 notifications vs polling, NIP-04→NIP-44, LUD-21 verify coverage — payments#2,3,8).
+
+(Lower priority, already covered by directional syntheses above: warm-standby, LLM-gateways, sovereign-ops, Nostr/OIDC — deep-research them only if a decision needs citations.)
+
+---
+
+## ⚠️ OPERATIONAL LESSONS FOR THE NEXT AGENT
+
+1. **Run deep-research workflows strictly ONE AT A TIME.** Each fans out ~100 agents / ~9M tokens. 5 in parallel = global rate-limit → empty results.
+2. **Resume, don't restart:** a run that failed on rate/session limits can be resumed — `Workflow({scriptPath: "<the deep-research-wf_*.js path from the launch output>", resumeFromRunId: "wf_..."})` — completed agents return cached, only failed searches/fetches re-run. Script paths + run IDs are in this session's launch outputs.
+3. **Watch the session usage limit**, not just per-minute rate limits — it's a hard daily wall (this pass hit it mid-Q2).
+4. Invoke via the skill: `Workflow({ name: "deep-research", args: "<question>" })`.
+
+---
+
+## IMMEDIATELY ACTIONABLE — no research needed
+
+- ✅ **DONE 2026-07-08** — **Update `AI_MODEL_REGISTRY`** to the Q1-verified 2026 roster; consolidated the two registries so `model-registry.ts` is now a generated projection of `ai-models.ts` (one SSOT).
+- ✅ **DONE 2026-07-08** — **Fix Cat-Credits metering** to bill off OpenRouter's real per-request `usage.cost` (registry estimate is the fallback); the "$0 for unknown model" leak is guarded and pinned by tests (`__tests__/unit/cat/credit-metering.test.ts`, `__tests__/unit/services/ai/openrouter.test.ts`).
+- **OIDC:** JWKS rotation-with-overlap; real security contact in `SECURITY.md`. _(still open)_
+- **GlitchTip hook** is already in place (`setErrorSink`) — only needs a provider + DSN (pending Q-error-tracking). _(still open)_
+
+---
+
+_Full code-review reports (31 findings, file-cited) are in this session's agent transcripts; the four subsystem reviews (payments/infra/AI/security) each returned a ranked list. Re-run them if this doc lacks a needed detail._

--- a/src/config/ai-models.ts
+++ b/src/config/ai-models.ts
@@ -8,7 +8,7 @@
  * Free models have rate limits: 50/day (free accounts) or 1000/day ($10+ balance)
  *
  * Created: 2026-01-07
- * Last Modified: 2026-01-08
+ * Last Modified: 2026-07-08
  */
 
 import { BADGE_COLORS } from '@/config/badge-colors';
@@ -54,38 +54,21 @@ export interface AIModelMetadata {
 
 export const AI_MODEL_REGISTRY: Record<string, AIModelMetadata> = {
   // ==================== FREE TIER ====================
-  // No API cost - rate limited (50-1000/day depending on account)
-  // Updated 2026-01-20 with verified OpenRouter free models
-
-  'meta-llama/llama-3.3-70b-instruct:free': {
-    id: 'meta-llama/llama-3.3-70b-instruct:free',
-    name: 'Llama 3.3 70B (Free)',
-    provider: 'Meta',
-    description: 'Powerful 70B parameter model - free tier',
-    contextWindow: 128000,
-    maxOutputTokens: 8192,
-    inputCostPer1M: 0,
-    outputCostPer1M: 0,
-    capabilities: ['text', 'streaming'],
-    tier: 'free',
-    recommendedFor: ['complex reasoning', 'detailed analysis', 'coding'],
-    isAvailable: true,
-    isFree: true,
-    rateLimit: '50-1000/day',
-  },
+  // No API cost - rate limited (50/day on free accounts, 1000/day with $10+ credits)
+  // Refreshed 2026-07-08 against live OpenRouter model pages/docs.
 
   'openai/gpt-oss-120b:free': {
     id: 'openai/gpt-oss-120b:free',
     name: 'GPT-OSS 120B (Free)',
     provider: 'OpenAI',
-    description: 'OpenAI open-weights 120B - strong general model, free tier',
+    description: 'Best free general model for coding, reasoning, and tool-friendly chat',
     contextWindow: 131072,
     maxOutputTokens: 8192,
     inputCostPer1M: 0,
     outputCostPer1M: 0,
-    capabilities: ['text', 'streaming'],
+    capabilities: ['text', 'function_calling', 'json_mode', 'streaming'],
     tier: 'free',
-    recommendedFor: ['complex reasoning', 'detailed analysis', 'coding'],
+    recommendedFor: ['coding', 'complex reasoning', 'general chat'],
     isAvailable: true,
     isFree: true,
     rateLimit: '50-1000/day',
@@ -95,65 +78,48 @@ export const AI_MODEL_REGISTRY: Record<string, AIModelMetadata> = {
     id: 'openai/gpt-oss-20b:free',
     name: 'GPT-OSS 20B (Free)',
     provider: 'OpenAI',
-    description: 'OpenAI open-weights 20B - fast, free tier',
+    description: 'Fast free open-weight model with tool use and structured output support',
     contextWindow: 131072,
     maxOutputTokens: 8192,
     inputCostPer1M: 0,
     outputCostPer1M: 0,
-    capabilities: ['text', 'streaming'],
+    capabilities: ['text', 'function_calling', 'json_mode', 'streaming'],
     tier: 'free',
-    recommendedFor: ['general purpose', 'fast responses', 'instruction following'],
+    recommendedFor: ['fast responses', 'simple tasks', 'tool-friendly chat'],
     isAvailable: true,
     isFree: true,
     rateLimit: '50-1000/day',
   },
 
-  'google/gemma-4-31b-it:free': {
-    id: 'google/gemma-4-31b-it:free',
-    name: 'Gemma 4 31B (Free)',
-    provider: 'Google',
-    description: 'Open-weights Google model, large context - free tier',
-    contextWindow: 262144,
+  'meta-llama/llama-3.3-70b-instruct:free': {
+    id: 'meta-llama/llama-3.3-70b-instruct:free',
+    name: 'Llama 3.3 70B (Free)',
+    provider: 'Meta',
+    description: 'Strong multilingual free model for analysis and everyday coding',
+    contextWindow: 65536,
     maxOutputTokens: 8192,
     inputCostPer1M: 0,
     outputCostPer1M: 0,
     capabilities: ['text', 'streaming'],
     tier: 'free',
-    recommendedFor: ['general purpose', 'large context', 'instruction following'],
+    recommendedFor: ['general purpose', 'multilingual chat', 'analysis'],
     isAvailable: true,
     isFree: true,
     rateLimit: '50-1000/day',
   },
 
-  'google/gemma-4-26b-a4b-it:free': {
-    id: 'google/gemma-4-26b-a4b-it:free',
-    name: 'Gemma 4 26B (Free)',
-    provider: 'Google',
-    description: 'Efficient open-weights Google model - free tier',
-    contextWindow: 262144,
+  'meta-llama/llama-4-scout:free': {
+    id: 'meta-llama/llama-4-scout:free',
+    name: 'Llama 4 Scout (Free)',
+    provider: 'Meta',
+    description: 'Free multimodal long-context model for image-aware and document-heavy prompts',
+    contextWindow: 10000000,
     maxOutputTokens: 8192,
     inputCostPer1M: 0,
     outputCostPer1M: 0,
-    capabilities: ['text', 'streaming'],
+    capabilities: ['text', 'vision', 'streaming'],
     tier: 'free',
-    recommendedFor: ['general purpose', 'fast responses'],
-    isAvailable: true,
-    isFree: true,
-    rateLimit: '50-1000/day',
-  },
-
-  'nvidia/nemotron-3-super-120b-a12b:free': {
-    id: 'nvidia/nemotron-3-super-120b-a12b:free',
-    name: 'Nemotron 3 Super 120B (Free)',
-    provider: 'NVIDIA',
-    description: 'Large reasoning model, very large context - free tier',
-    contextWindow: 1000000,
-    maxOutputTokens: 8192,
-    inputCostPer1M: 0,
-    outputCostPer1M: 0,
-    capabilities: ['text', 'streaming'],
-    tier: 'free',
-    recommendedFor: ['complex reasoning', 'math', 'large context'],
+    recommendedFor: ['vision tasks', 'huge context', 'multimodal chat'],
     isAvailable: true,
     isFree: true,
     rateLimit: '50-1000/day',
@@ -162,215 +128,157 @@ export const AI_MODEL_REGISTRY: Record<string, AIModelMetadata> = {
   // ==================== ECONOMY TIER ====================
   // Fast & cheap for simple tasks
 
-  'google/gemini-2.0-flash-lite': {
-    id: 'google/gemini-2.0-flash-lite',
-    name: 'Gemini 2.0 Flash Lite',
-    provider: 'Google',
-    description: 'Fastest, cheapest model for simple tasks',
-    contextWindow: 128000,
+  'meta-llama/llama-3.1-8b-instruct': {
+    id: 'meta-llama/llama-3.1-8b-instruct',
+    name: 'Llama 3.1 8B Instruct',
+    provider: 'Meta',
+    description: 'Ultra-cheap chat model for short prompts and high-volume utility work',
+    contextWindow: 131072,
     maxOutputTokens: 8192,
-    inputCostPer1M: 0.075,
-    outputCostPer1M: 0.3,
+    inputCostPer1M: 0.02,
+    outputCostPer1M: 0.03,
     capabilities: ['text', 'streaming'],
     tier: 'economy',
-    recommendedFor: ['simple questions', 'quick responses', 'high volume'],
+    recommendedFor: ['simple questions', 'high volume', 'cheap chat'],
     isAvailable: true,
   },
 
-  'anthropic/claude-3-haiku': {
-    id: 'anthropic/claude-3-haiku',
-    name: 'Claude 3 Haiku',
-    provider: 'Anthropic',
-    description: 'Fast and efficient for everyday tasks',
-    contextWindow: 200000,
-    maxOutputTokens: 4096,
-    inputCostPer1M: 0.25,
-    outputCostPer1M: 1.25,
-    capabilities: ['text', 'vision', 'streaming'],
-    tier: 'economy',
-    recommendedFor: ['customer support', 'quick analysis', 'summarization'],
-    isAvailable: true,
-  },
-
-  'anthropic/claude-3.5-haiku': {
-    id: 'anthropic/claude-3.5-haiku',
-    name: 'Claude 3.5 Haiku',
-    provider: 'Anthropic',
-    description: 'Upgraded Haiku with better reasoning',
-    contextWindow: 200000,
-    maxOutputTokens: 8192,
-    inputCostPer1M: 1.0,
-    outputCostPer1M: 5.0,
-    capabilities: ['text', 'vision', 'streaming'],
-    tier: 'economy',
-    recommendedFor: ['coding', 'analysis', 'creative writing'],
-    isAvailable: true,
-  },
-
-  'openai/gpt-4o-mini': {
-    id: 'openai/gpt-4o-mini',
-    name: 'GPT-4o Mini',
+  'openai/gpt-oss-120b': {
+    id: 'openai/gpt-oss-120b',
+    name: 'GPT-OSS 120B',
     provider: 'OpenAI',
-    description: 'Affordable GPT-4 level intelligence',
-    contextWindow: 128000,
-    maxOutputTokens: 16384,
-    inputCostPer1M: 0.15,
-    outputCostPer1M: 0.6,
-    capabilities: ['text', 'vision', 'function_calling', 'json_mode', 'streaming'],
+    description: 'Low-cost open-weight agentic model with native tools and strong coding utility',
+    contextWindow: 131072,
+    maxOutputTokens: 8192,
+    inputCostPer1M: 0.03,
+    outputCostPer1M: 0.15,
+    capabilities: ['text', 'function_calling', 'json_mode', 'streaming'],
     tier: 'economy',
-    recommendedFor: ['general purpose', 'structured output', 'vision'],
+    recommendedFor: ['coding', 'agentic flows', 'cheap reasoning'],
+    isAvailable: true,
+  },
+
+  'deepseek/deepseek-v4-flash': {
+    id: 'deepseek/deepseek-v4-flash',
+    name: 'DeepSeek V4 Flash',
+    provider: 'DeepSeek',
+    description: 'Best-value 1M-context model for responsive coding and long-document work',
+    contextWindow: 1000000,
+    maxOutputTokens: 8192,
+    inputCostPer1M: 0.09,
+    outputCostPer1M: 0.18,
+    capabilities: ['text', 'streaming'],
+    tier: 'economy',
+    recommendedFor: ['large documents', 'coding', 'cost-efficient analysis'],
     isAvailable: true,
   },
 
   // ==================== STANDARD TIER ====================
   // Balanced performance & cost
 
-  'anthropic/claude-3.5-sonnet': {
-    id: 'anthropic/claude-3.5-sonnet',
-    name: 'Claude 3.5 Sonnet',
-    provider: 'Anthropic',
-    description: 'Best balance of speed, quality, and cost',
-    contextWindow: 200000,
+  'qwen/qwen3-32b': {
+    id: 'qwen/qwen3-32b',
+    name: 'Qwen3 32B',
+    provider: 'Qwen',
+    description: 'Strong mid-tier reasoning and tool-use model with unusually low cost',
+    contextWindow: 131072,
     maxOutputTokens: 8192,
-    inputCostPer1M: 3.0,
-    outputCostPer1M: 15.0,
-    capabilities: ['text', 'vision', 'function_calling', 'streaming'],
+    inputCostPer1M: 0.08,
+    outputCostPer1M: 0.28,
+    capabilities: ['text', 'function_calling', 'streaming'],
     tier: 'standard',
-    recommendedFor: ['coding', 'analysis', 'creative writing', 'research'],
+    recommendedFor: ['tool use', 'reasoning', 'multilingual work'],
     isAvailable: true,
   },
 
-  'anthropic/claude-sonnet-4': {
-    id: 'anthropic/claude-sonnet-4',
-    name: 'Claude Sonnet 4',
+  'anthropic/claude-sonnet-5': {
+    id: 'anthropic/claude-sonnet-5',
+    name: 'Claude Sonnet 5',
     provider: 'Anthropic',
-    description: 'Latest Sonnet with improved capabilities',
-    contextWindow: 200000,
-    maxOutputTokens: 8192,
-    inputCostPer1M: 3.0,
-    outputCostPer1M: 15.0,
-    capabilities: ['text', 'vision', 'function_calling', 'streaming'],
-    tier: 'standard',
-    recommendedFor: ['coding', 'analysis', 'complex reasoning'],
-    isAvailable: true,
-  },
-
-  'openai/gpt-4o': {
-    id: 'openai/gpt-4o',
-    name: 'GPT-4o',
-    provider: 'OpenAI',
-    description: 'Versatile multimodal model',
-    contextWindow: 128000,
-    maxOutputTokens: 16384,
-    inputCostPer1M: 2.5,
-    outputCostPer1M: 10.0,
-    capabilities: ['text', 'vision', 'function_calling', 'json_mode', 'streaming'],
-    tier: 'standard',
-    recommendedFor: ['general purpose', 'vision tasks', 'structured output'],
-    isAvailable: true,
-  },
-
-  'google/gemini-2.0-flash': {
-    id: 'google/gemini-2.0-flash',
-    name: 'Gemini 2.0 Flash',
-    provider: 'Google',
-    description: 'Fast multimodal with large context',
+    description: 'Best coding and professional-work balance in the current frontier',
     contextWindow: 1000000,
     maxOutputTokens: 8192,
-    inputCostPer1M: 0.1,
-    outputCostPer1M: 0.4,
+    inputCostPer1M: 2.0,
+    outputCostPer1M: 10.0,
     capabilities: ['text', 'vision', 'function_calling', 'streaming'],
     tier: 'standard',
-    recommendedFor: ['large documents', 'multimodal', 'fast responses'],
+    recommendedFor: ['coding', 'agents', 'professional writing', 'research'],
     isAvailable: true,
   },
 
   // ==================== PREMIUM TIER ====================
   // Maximum capability for complex tasks
 
-  'anthropic/claude-3-opus': {
-    id: 'anthropic/claude-3-opus',
-    name: 'Claude 3 Opus',
+  'anthropic/claude-opus-4.8': {
+    id: 'anthropic/claude-opus-4.8',
+    name: 'Claude Opus 4.8',
     provider: 'Anthropic',
-    description: 'Most capable for complex reasoning',
-    contextWindow: 200000,
-    maxOutputTokens: 4096,
-    inputCostPer1M: 15.0,
-    outputCostPer1M: 75.0,
-    capabilities: ['text', 'vision', 'function_calling', 'streaming'],
-    tier: 'premium',
-    recommendedFor: ['complex reasoning', 'research', 'nuanced analysis'],
-    isAvailable: true,
-  },
-
-  'anthropic/claude-opus-4': {
-    id: 'anthropic/claude-opus-4',
-    name: 'Claude Opus 4',
-    provider: 'Anthropic',
-    description: 'Latest Opus with breakthrough capabilities',
-    contextWindow: 200000,
+    description: 'Highest-quality generally available Anthropic model for hard autonomous work',
+    contextWindow: 1000000,
     maxOutputTokens: 8192,
-    inputCostPer1M: 15.0,
-    outputCostPer1M: 75.0,
+    inputCostPer1M: 5.0,
+    outputCostPer1M: 25.0,
     capabilities: ['text', 'vision', 'function_calling', 'streaming'],
     tier: 'premium',
-    recommendedFor: ['complex reasoning', 'research', 'expert-level tasks'],
+    recommendedFor: ['complex reasoning', 'research', 'high-stakes coding'],
     isAvailable: true,
   },
 
-  'openai/gpt-4-turbo': {
-    id: 'openai/gpt-4-turbo',
-    name: 'GPT-4 Turbo',
-    provider: 'OpenAI',
-    description: 'High capability with vision support',
-    contextWindow: 128000,
-    maxOutputTokens: 4096,
+  'anthropic/claude-fable-5': {
+    id: 'anthropic/claude-fable-5',
+    name: 'Claude Fable 5',
+    provider: 'Anthropic',
+    description: 'Top-end long-horizon model for complex autonomous knowledge work',
+    contextWindow: 1000000,
+    maxOutputTokens: 8192,
     inputCostPer1M: 10.0,
-    outputCostPer1M: 30.0,
-    capabilities: ['text', 'vision', 'function_calling', 'json_mode', 'streaming'],
-    tier: 'premium',
-    recommendedFor: ['complex tasks', 'vision', 'tool use'],
-    isAvailable: true,
-  },
-
-  'google/gemini-2.0-pro': {
-    id: 'google/gemini-2.0-pro',
-    name: 'Gemini 2.0 Pro',
-    provider: 'Google',
-    description: "Google's most capable model",
-    contextWindow: 2000000,
-    maxOutputTokens: 8192,
-    inputCostPer1M: 1.25,
-    outputCostPer1M: 5.0,
+    outputCostPer1M: 50.0,
     capabilities: ['text', 'vision', 'function_calling', 'streaming'],
     tier: 'premium',
-    recommendedFor: ['very large context', 'complex analysis', 'multimodal'],
-    isAvailable: true,
-  },
-
-  'x-ai/grok-2': {
-    id: 'x-ai/grok-2',
-    name: 'Grok 2',
-    provider: 'xAI',
-    description: 'Real-time knowledge with wit',
-    contextWindow: 131072,
-    maxOutputTokens: 8192,
-    inputCostPer1M: 2.0,
-    outputCostPer1M: 10.0,
-    capabilities: ['text', 'function_calling', 'streaming'],
-    tier: 'premium',
-    recommendedFor: ['current events', 'creative tasks', 'reasoning'],
+    recommendedFor: ['autonomous agents', 'long-running tasks', 'deep research'],
     isAvailable: true,
   },
 };
 
 // ==================== UTILITY FUNCTIONS ====================
 
+const stripFreeSuffix = (id: string): string => id.replace(/:free$/, '');
+
+// "a" is a prefix of "b" ending at a segment boundary ("-", ".", ":" or end).
+const isBoundaryPrefix = (a: string, b: string): boolean =>
+  b.startsWith(a) && (b.length === a.length || ['-', '.', ':'].includes(b[a.length]));
+
 /**
- * Get metadata for a specific model
+ * Resolve a provider-reported model id back to a registered id.
+ *
+ * Providers can return snapshot/resolved ids that carry date/build suffixes
+ * after the requested id. Billing and display must still hit the registry
+ * instead of treating that known paid model as an unknown/free model.
+ */
+export function getRegisteredModelId(modelId: string): string | undefined {
+  if (AI_MODEL_REGISTRY[modelId]) {
+    return modelId;
+  }
+
+  const base = stripFreeSuffix(modelId);
+  let match: AIModelMetadata | undefined;
+  for (const model of Object.values(AI_MODEL_REGISTRY)) {
+    const registryBase = stripFreeSuffix(model.id);
+    if (isBoundaryPrefix(registryBase, base)) {
+      if (!match || registryBase.length > stripFreeSuffix(match.id).length) {
+        match = model;
+      }
+    }
+  }
+  return match?.id;
+}
+
+/**
+ * Get metadata for a specific model, including provider-resolved snapshot ids.
  */
 export function getModelMetadata(modelId: string): AIModelMetadata | undefined {
-  return AI_MODEL_REGISTRY[modelId];
+  const registeredId = getRegisteredModelId(modelId);
+  return registeredId ? AI_MODEL_REGISTRY[registeredId] : undefined;
 }
 
 /**
@@ -390,28 +298,14 @@ export function getModelDisplayName(modelId: string): string {
     return exact.name;
   }
 
-  const stripFree = (id: string) => id.replace(/:free$/, '');
-  const base = stripFree(modelId);
-  // "a" is a prefix of "b" ending at a segment boundary ("-", ".", ":" or end).
-  const boundaryPrefix = (a: string, b: string) =>
-    b.startsWith(a) && (b.length === a.length || ['-', '.', ':'].includes(b[a.length]));
-
-  let match: AIModelMetadata | undefined;
-  for (const model of Object.values(AI_MODEL_REGISTRY)) {
-    const registryBase = stripFree(model.id);
-    if (boundaryPrefix(registryBase, base) || boundaryPrefix(base, registryBase)) {
-      if (!match || registryBase.length > stripFree(match.id).length) {
-        match = model;
-      }
-    }
-  }
-  if (match) {
-    return match.name;
+  const registeredId = getRegisteredModelId(modelId);
+  if (registeredId) {
+    return AI_MODEL_REGISTRY[registeredId].name;
   }
 
   // Unknown model: prettify the slug ("mistralai/devstral-small-2505" → "Devstral Small 2505").
   const isFree = modelId.endsWith(':free');
-  const slug = base.split('/').pop() ?? base;
+  const slug = stripFreeSuffix(modelId).split('/').pop() ?? stripFreeSuffix(modelId);
   const pretty = slug
     .replace(/-\d{8}$/, '') // drop trailing date snapshot
     .split('-')
@@ -459,7 +353,7 @@ export function calculateCostBtc(
   outputTokens: number,
   btcPriceUsd: number = 100000
 ): number {
-  const model = AI_MODEL_REGISTRY[modelId];
+  const model = getModelMetadata(modelId);
   if (!model) {
     return 0;
   }
@@ -521,6 +415,6 @@ export function getFreeModels(): AIModelMetadata[] {
  * Check if a model is free
  */
 export function isModelFree(modelId: string): boolean {
-  const model = AI_MODEL_REGISTRY[modelId];
+  const model = getModelMetadata(modelId);
   return model?.isFree === true;
 }

--- a/src/config/model-registry.ts
+++ b/src/config/model-registry.ts
@@ -1,19 +1,21 @@
 /**
- * Model Registry - SSOT for All AI Models
+ * Compatibility adapter for the legacy chat model selector.
  *
- * This registry contains metadata for all available AI models across providers.
- * It enables users to choose between free, paid, open source, and proprietary models.
+ * The canonical AI model source is `ai-models.ts`. Keep this file as a thin
+ * projection so older UI code does not drift into a second pricing/model list.
  */
 
-interface ModelMetadata {
+import { AI_MODEL_REGISTRY, type AIModelMetadata } from '@/config/ai-models';
+
+export interface ModelMetadata {
   id: string;
   name: string;
   provider: string;
 
   // Economics
   tier: 'free' | 'freemium' | 'paid';
-  costPerMessage?: number; // in USD
-  costPer1MTokens?: number; // in USD
+  costPerMessage?: number;
+  costPer1MTokens?: number;
 
   // Capabilities
   contextWindow: number;
@@ -29,14 +31,14 @@ interface ModelMetadata {
   // Deployment
   availability: 'cloud' | 'local' | 'both';
   localRequirements?: {
-    minRAM: number; // GB
-    minVRAM?: number; // GB
-    diskSpace: number; // GB
+    minRAM: number;
+    minVRAM?: number;
+    diskSpace: number;
   };
 
   // Performance
   speed: 'slow' | 'medium' | 'fast' | 'instant';
-  quality: 1 | 2 | 3 | 4 | 5; // stars
+  quality: 1 | 2 | 3 | 4 | 5;
 
   // Access
   apiEndpoint: string;
@@ -44,409 +46,76 @@ interface ModelMetadata {
   openRouterCompatible: boolean;
   ollamaCompatible: boolean;
 
-  // Description
   description?: string;
 }
 
-export const MODEL_REGISTRY: Record<string, ModelMetadata> = {
-  // ============================================
-  // FREE TIER - Default options
-  // ============================================
+const OPEN_PROVIDERS = new Set(['Meta', 'Mistral', 'NVIDIA', 'DeepSeek', 'Qwen']);
+const OPEN_WEIGHT_MODEL_IDS = new Set([
+  'openai/gpt-oss-120b',
+  'openai/gpt-oss-120b:free',
+  'openai/gpt-oss-20b',
+  'openai/gpt-oss-20b:free',
+]);
 
-  'meta-llama/llama-4-maverick:free': {
-    id: 'meta-llama/llama-4-maverick:free',
-    name: 'Llama 4 Maverick',
-    provider: 'Meta',
+function toLegacyTier(model: AIModelMetadata): ModelMetadata['tier'] {
+  if (model.isFree || model.tier === 'free') {
+    return 'free';
+  }
+  return model.tier === 'economy' ? 'freemium' : 'paid';
+}
 
-    tier: 'free',
-    costPerMessage: 0,
-    costPer1MTokens: 0,
+function toCostPer1MTokens(model: AIModelMetadata): number {
+  return Math.max(model.inputCostPer1M, model.outputCostPer1M);
+}
 
-    type: 'open',
-    license: 'Llama 4 License',
+function toSpeed(model: AIModelMetadata): ModelMetadata['speed'] {
+  if (model.tier === 'free' || model.tier === 'economy') {
+    return 'fast';
+  }
+  return model.tier === 'premium' ? 'medium' : 'fast';
+}
 
+function toQuality(model: AIModelMetadata): ModelMetadata['quality'] {
+  if (model.tier === 'premium') {
+    return 5;
+  }
+  if (model.tier === 'standard') {
+    return 4;
+  }
+  return model.contextWindow >= 128000 ? 4 : 3;
+}
+
+function toLegacyModel(model: AIModelMetadata): ModelMetadata {
+  const costPer1MTokens = toCostPer1MTokens(model);
+  return {
+    id: model.id,
+    name: model.name,
+    provider: model.provider,
+    tier: toLegacyTier(model),
+    costPerMessage: model.isFree ? 0 : undefined,
+    costPer1MTokens,
+    contextWindow: model.contextWindow,
+    maxOutputTokens: model.maxOutputTokens,
+    supportsVision: model.capabilities.includes('vision'),
+    supportsFunctionCalling: model.capabilities.includes('function_calling'),
+    supportsStreaming: model.capabilities.includes('streaming'),
+    type:
+      OPEN_PROVIDERS.has(model.provider) || OPEN_WEIGHT_MODEL_IDS.has(model.id)
+        ? 'open'
+        : 'proprietary',
     availability: 'cloud',
-
-    contextWindow: 128000,
-    maxOutputTokens: 8192,
-    supportsVision: false,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'fast',
-    quality: 5,
-
+    speed: toSpeed(model),
+    quality: toQuality(model),
     apiEndpoint: 'https://openrouter.ai/api/v1/chat/completions',
-    requiresApiKey: false,
+    requiresApiKey: !model.isFree,
     openRouterCompatible: true,
     ollamaCompatible: false,
-
-    description:
-      'Latest Llama 4 MoE model with 128 experts. Free tier: 50-1000 requests/day on OpenRouter.',
-  },
-
-  'groq/mixtral-8x7b': {
-    id: 'groq/mixtral-8x7b',
-    name: 'Mixtral 8x7B',
-    provider: 'Groq',
-
-    tier: 'freemium',
-    costPerMessage: 0, // Free tier: 14,400 requests/day
-    costPer1MTokens: 0.27,
-
-    type: 'open',
-    license: 'Apache 2.0',
-
-    availability: 'cloud',
-
-    contextWindow: 32768,
-    maxOutputTokens: 32768,
-    supportsVision: false,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'instant',
-    quality: 4,
-
-    apiEndpoint: 'https://api.groq.com/openai/v1/chat/completions',
-    requiresApiKey: false, // Use server key for free tier
-    openRouterCompatible: false,
-    ollamaCompatible: false,
-
-    description:
-      'Fast, high-quality open source model. Perfect for getting started with no setup required.',
-  },
-
-  'together/llama-3.1-8b': {
-    id: 'together/llama-3.1-8b',
-    name: 'Llama 3.1 8B',
-    provider: 'Together AI',
-
-    tier: 'freemium',
-    costPerMessage: 0,
-    costPer1MTokens: 0.2,
-
-    type: 'open',
-    license: 'Llama 3.1 License',
-
-    availability: 'both',
-    localRequirements: {
-      minRAM: 16,
-      minVRAM: 8,
-      diskSpace: 10,
-    },
-
-    contextWindow: 131072,
-    maxOutputTokens: 4096,
-    supportsVision: false,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'fast',
-    quality: 4,
-
-    apiEndpoint: 'https://api.together.xyz/v1/chat/completions',
-    requiresApiKey: false,
-    openRouterCompatible: true,
-    ollamaCompatible: true,
-
-    description: 'Excellent balance of quality and speed. Can run locally or in the cloud.',
-  },
-
-  'google/gemini-2.0-flash': {
-    id: 'google/gemini-2.0-flash',
-    name: 'Gemini 2.0 Flash',
-    provider: 'Google',
-
-    tier: 'freemium',
-    costPerMessage: 0,
-    costPer1MTokens: 0.075,
-
-    type: 'proprietary',
-
-    availability: 'cloud',
-
-    contextWindow: 1000000,
-    maxOutputTokens: 8192,
-    supportsVision: true,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'instant',
-    quality: 4,
-
-    apiEndpoint:
-      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent',
-    requiresApiKey: true,
-    openRouterCompatible: true,
-    ollamaCompatible: false,
-
-    description: 'Massive 1M token context window. Great for analyzing large documents.',
-  },
-
-  // ============================================
-  // PROPRIETARY PAID - Best Quality
-  // ============================================
-
-  'openai/gpt-4o': {
-    id: 'openai/gpt-4o',
-    name: 'GPT-4o',
-    provider: 'OpenAI',
-
-    tier: 'paid',
-    costPerMessage: 0.03,
-    costPer1MTokens: 5.0,
-
-    type: 'proprietary',
-
-    availability: 'cloud',
-
-    contextWindow: 128000,
-    maxOutputTokens: 16384,
-    supportsVision: true,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'medium',
-    quality: 5,
-
-    apiEndpoint: 'https://api.openai.com/v1/chat/completions',
-    requiresApiKey: true,
-    openRouterCompatible: true,
-    ollamaCompatible: false,
-
-    description: 'Top-tier model with vision and function calling. Best overall performance.',
-  },
-
-  'openai/gpt-4o-mini': {
-    id: 'openai/gpt-4o-mini',
-    name: 'GPT-4o Mini',
-    provider: 'OpenAI',
-
-    tier: 'paid',
-    costPerMessage: 0.002,
-    costPer1MTokens: 0.15,
-
-    type: 'proprietary',
-
-    availability: 'cloud',
-
-    contextWindow: 128000,
-    maxOutputTokens: 16384,
-    supportsVision: true,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'fast',
-    quality: 4,
-
-    apiEndpoint: 'https://api.openai.com/v1/chat/completions',
-    requiresApiKey: true,
-    openRouterCompatible: true,
-    ollamaCompatible: false,
-
-    description: 'Affordable GPT-4 quality. Great value for most use cases.',
-  },
-
-  'anthropic/claude-3.5-sonnet': {
-    id: 'anthropic/claude-3.5-sonnet',
-    name: 'Claude 3.5 Sonnet',
-    provider: 'Anthropic',
-
-    tier: 'paid',
-    costPerMessage: 0.03,
-    costPer1MTokens: 3.0,
-
-    type: 'proprietary',
-
-    availability: 'cloud',
-
-    contextWindow: 200000,
-    maxOutputTokens: 8192,
-    supportsVision: true,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'medium',
-    quality: 5,
-
-    apiEndpoint: 'https://api.anthropic.com/v1/messages',
-    requiresApiKey: true,
-    openRouterCompatible: true,
-    ollamaCompatible: false,
-
-    description: 'Exceptional reasoning and analysis. 200k context window.',
-  },
-
-  'xai/grok-beta': {
-    id: 'xai/grok-beta',
-    name: 'Grok',
-    provider: 'X.AI',
-
-    tier: 'paid',
-    costPerMessage: 0.02,
-    costPer1MTokens: 5.0,
-
-    type: 'proprietary',
-
-    availability: 'cloud',
-
-    contextWindow: 131072,
-    maxOutputTokens: 4096,
-    supportsVision: false,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'fast',
-    quality: 4,
-
-    apiEndpoint: 'https://api.x.ai/v1/chat/completions',
-    requiresApiKey: true,
-    openRouterCompatible: true,
-    ollamaCompatible: false,
-
-    description: 'Fast, witty responses. Real-time access to X/Twitter context.',
-  },
-
-  // ============================================
-  // OPEN SOURCE - Run Locally
-  // ============================================
-
-  'local/llama-3.1-8b': {
-    id: 'local/llama-3.1-8b',
-    name: 'Llama 3.1 8B (Local)',
-    provider: 'Meta (via Ollama)',
-
-    tier: 'free',
-    costPerMessage: 0,
-
-    type: 'open',
-    license: 'Llama 3.1 License',
-
-    availability: 'local',
-    localRequirements: {
-      minRAM: 16,
-      minVRAM: 8,
-      diskSpace: 10,
-    },
-
-    contextWindow: 131072,
-    maxOutputTokens: 4096,
-    supportsVision: false,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'medium',
-    quality: 4,
-
-    apiEndpoint: 'http://localhost:11434/api/chat',
-    requiresApiKey: false,
-    openRouterCompatible: false,
-    ollamaCompatible: true,
-
-    description: '100% private. Runs on your computer. No data sent to cloud.',
-  },
-
-  'local/mistral-7b': {
-    id: 'local/mistral-7b',
-    name: 'Mistral 7B (Local)',
-    provider: 'Mistral AI (via Ollama)',
-
-    tier: 'free',
-    costPerMessage: 0,
-
-    type: 'open',
-    license: 'Apache 2.0',
-
-    availability: 'local',
-    localRequirements: {
-      minRAM: 8,
-      minVRAM: 6,
-      diskSpace: 5,
-    },
-
-    contextWindow: 32768,
-    maxOutputTokens: 8192,
-    supportsVision: false,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'fast',
-    quality: 3,
-
-    apiEndpoint: 'http://localhost:11434/api/chat',
-    requiresApiKey: false,
-    openRouterCompatible: false,
-    ollamaCompatible: true,
-
-    description: 'Lightweight local model. Good for lower-end hardware.',
-  },
-
-  'local/llama-3.1-70b': {
-    id: 'local/llama-3.1-70b',
-    name: 'Llama 3.1 70B (Local)',
-    provider: 'Meta (via Ollama)',
-
-    tier: 'free',
-    costPerMessage: 0,
-
-    type: 'open',
-    license: 'Llama 3.1 License',
-
-    availability: 'local',
-    localRequirements: {
-      minRAM: 64,
-      minVRAM: 48,
-      diskSpace: 40,
-    },
-
-    contextWindow: 131072,
-    maxOutputTokens: 4096,
-    supportsVision: false,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'slow',
-    quality: 5,
-
-    apiEndpoint: 'http://localhost:11434/api/chat',
-    requiresApiKey: false,
-    openRouterCompatible: false,
-    ollamaCompatible: true,
-
-    description: 'Highest quality local model. Requires powerful hardware.',
-  },
-
-  // ============================================
-  // OPENROUTER - Universal Access
-  // ============================================
-
-  'openrouter/auto': {
-    id: 'openrouter/auto',
-    name: 'OpenRouter Auto',
-    provider: 'OpenRouter',
-
-    tier: 'freemium',
-    costPerMessage: 0.001, // Varies by selected model
-
-    type: 'open', // Mixed (aggregator)
-
-    availability: 'cloud',
-
-    contextWindow: 200000, // Varies
-    maxOutputTokens: 16384, // Varies
-    supportsVision: true,
-    supportsFunctionCalling: true,
-    supportsStreaming: true,
-
-    speed: 'medium',
-    quality: 5,
-
-    apiEndpoint: 'https://openrouter.ai/api/v1/chat/completions',
-    requiresApiKey: true,
-    openRouterCompatible: true,
-    ollamaCompatible: false,
-
-    description: 'Access 200+ models with one API key. Automatic fallbacks and best pricing.',
-  },
-};
+    description: model.description,
+  };
+}
+
+export const MODEL_REGISTRY: Record<string, ModelMetadata> = Object.fromEntries(
+  Object.values(AI_MODEL_REGISTRY)
+    .filter(model => model.isAvailable)
+    .map(model => [model.id, toLegacyModel(model)])
+);

--- a/src/services/ai/openrouter.ts
+++ b/src/services/ai/openrouter.ts
@@ -51,6 +51,12 @@ interface OpenRouterResponse {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    cost?: number;
+    cost_details?: {
+      upstream_inference_cost?: number | null;
+      upstream_inference_prompt_cost?: number;
+      upstream_inference_completions_cost?: number;
+    };
   };
   created: number;
 }
@@ -70,6 +76,12 @@ interface OpenRouterStreamChunk {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    cost?: number;
+    cost_details?: {
+      upstream_inference_cost?: number | null;
+      upstream_inference_prompt_cost?: number;
+      upstream_inference_completions_cost?: number;
+    };
   };
 }
 
@@ -94,6 +106,7 @@ interface StreamChunk {
     inputTokens: number;
     outputTokens: number;
     totalTokens: number;
+    costBtc?: number;
   };
 }
 
@@ -198,15 +211,18 @@ export class OpenRouterService {
     // Check if this is a free model
     const isFreeModel = isModelFree(model);
 
-    // Calculate cost in sats (0 for free models)
+    // Prefer OpenRouter's returned request charge when present; otherwise fall
+    // back to the registry estimate so older/partial responses still meter.
+    const reportedCostBtc = toBtcFromOpenRouterUsage(response.usage, this.btcPriceUsd);
     const costBtc = isFreeModel
       ? 0
-      : calculateCostBtc(
+      : (reportedCostBtc ??
+        calculateCostBtc(
           model,
           response.usage.prompt_tokens,
           response.usage.completion_tokens,
           this.btcPriceUsd
-        );
+        ));
 
     return {
       content: response.choices[0]?.message?.content || '',
@@ -270,7 +286,9 @@ export class OpenRouterService {
 
     const decoder = new TextDecoder();
     let buffer = '';
-    let usage: { inputTokens: number; outputTokens: number; totalTokens: number } | undefined;
+    let usage:
+      | { inputTokens: number; outputTokens: number; totalTokens: number; costBtc?: number }
+      | undefined;
 
     try {
       while (true) {
@@ -301,6 +319,7 @@ export class OpenRouterService {
                   inputTokens: parsed.usage.prompt_tokens,
                   outputTokens: parsed.usage.completion_tokens,
                   totalTokens: parsed.usage.total_tokens,
+                  costBtc: toBtcFromOpenRouterUsage(parsed.usage, this.btcPriceUsd),
                 };
               }
 
@@ -428,6 +447,26 @@ export class OpenRouterService {
 
     return response.json();
   }
+}
+
+function toBtcFromOpenRouterUsage(
+  usage:
+    | {
+        cost?: number;
+        cost_details?: {
+          upstream_inference_cost?: number | null;
+          upstream_inference_prompt_cost?: number;
+          upstream_inference_completions_cost?: number;
+        };
+      }
+    | undefined,
+  btcPriceUsd: number
+): number | undefined {
+  const reportedUsd = usage?.cost;
+  if (!Number.isFinite(reportedUsd) || reportedUsd === undefined || reportedUsd <= 0) {
+    return undefined;
+  }
+  return Math.ceil((reportedUsd / btcPriceUsd) * 1e8) / 1e8;
 }
 
 // ==================== ERROR CLASS ====================

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -287,7 +287,12 @@ export async function orchestrateCatChat(
         let attemptedFallback = false;
         try {
           let usage:
-            | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
+            | {
+                inputTokens?: number;
+                outputTokens?: number;
+                totalTokens?: number;
+                costBtc?: number;
+              }
             | undefined;
           let fullContent = '';
           controller.enqueue(
@@ -471,6 +476,7 @@ export async function orchestrateCatChat(
               model: activeModel,
               inputTokens: usage.inputTokens ?? 0,
               outputTokens: usage.outputTokens ?? 0,
+              rawCostBtc: usage.costBtc,
               ref: meterRef,
               conversationId,
             });
@@ -598,6 +604,7 @@ export async function orchestrateCatChat(
       model: result.model,
       inputTokens: result.inputTokens,
       outputTokens: result.outputTokens,
+      rawCostBtc: result.costBtc,
       ref: meterRef,
       conversationId,
     });

--- a/src/services/cat/credit-metering.ts
+++ b/src/services/cat/credit-metering.ts
@@ -77,12 +77,14 @@ export async function meterCreditUsage(
     model: string;
     inputTokens: number;
     outputTokens: number;
+    /** Real request cost from the provider response when available. */
+    rawCostBtc?: number;
     /** Stable per-request id — the ledger idempotency ref. */
     ref: string;
     conversationId?: string | null;
   }
 ): Promise<number> {
-  const { model, inputTokens, outputTokens, ref, conversationId } = args;
+  const { model, inputTokens, outputTokens, rawCostBtc, ref, conversationId } = args;
   if (!isPlatformMeteredModel(model)) {
     return 0;
   }
@@ -97,11 +99,14 @@ export async function meterCreditUsage(
     /* keep conservative default */
   }
 
-  const rawCostBtc = calculateCostBtc(model, inputTokens, outputTokens, btcPriceUsd);
-  if (rawCostBtc <= 0) {
+  const meteredRawCostBtc =
+    Number.isFinite(rawCostBtc) && (rawCostBtc ?? 0) > 0
+      ? (rawCostBtc as number)
+      : calculateCostBtc(model, inputTokens, outputTokens, btcPriceUsd);
+  if (meteredRawCostBtc <= 0) {
     return 0;
   }
-  const chargeBtc = ceilBtc(rawCostBtc * CREDIT_USAGE_MARKUP);
+  const chargeBtc = ceilBtc(meteredRawCostBtc * CREDIT_USAGE_MARKUP);
 
   const newBalance = await appendCreditEntry(admin, userId, {
     kind: 'usage',
@@ -112,7 +117,11 @@ export async function meterCreditUsage(
       model,
       inputTokens,
       outputTokens,
-      rawCostBtc,
+      rawCostBtc: meteredRawCostBtc,
+      pricingSource:
+        Number.isFinite(rawCostBtc) && (rawCostBtc ?? 0) > 0
+          ? 'provider_reported'
+          : 'registry_estimate',
       markup: CREDIT_USAGE_MARKUP,
       conversationId: conversationId ?? null,
     },


### PR DESCRIPTION
## Summary
- prefer OpenRouter's provider-reported `usage.cost` for Cat Credits metering, with registry pricing as the fallback and regression coverage for buffered + streamed responses
- refresh the 2026 curated AI model roster in `AI_MODEL_REGISTRY` and make `model-registry.ts` a generated compatibility projection instead of a drift-prone duplicate
- update the AI system, chat API, and research handoff docs so they match the current architecture and completed work

## Test plan
- [x] `npm test -- --runTestsByPath __tests__/unit/cat/credit-metering.test.ts __tests__/unit/services/ai/openrouter.test.ts __tests__/unit/cat/model-display-name.test.ts`
- [x] `npm run type-check`
- [x] pre-commit hooks (`eslint --fix`, `prettier --write`) passed during both commits

Made with [Cursor](https://cursor.com)