### PR TITLE
SSOT consolidation + loan API-only writes

### DIFF
--- a/__tests__/unit/services/loans/api-client.test.ts
+++ b/__tests__/unit/services/loans/api-client.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Loan API client payload mapping
+ */
+
+import {
+  ensureLoanDescription,
+  loanToApiPayload,
+  createLoanRequestToApiPayload,
+} from '@/services/loans/api-client';
+import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
+
+describe('loan API client payloads', () => {
+  it('pads short descriptions to satisfy API min length', () => {
+    const padded = ensureLoanDescription('Hi', 'My loan');
+    expect(padded.length).toBeGreaterThanOrEqual(10);
+    expect(padded).toContain('OrangeCat');
+  });
+
+  it('maps create requests to the finance loanSchema shape', () => {
+    const payload = createLoanRequestToApiPayload({
+      title: 'Bridge funding',
+      description: 'Need short-term liquidity for inventory.',
+      original_amount: 5000,
+      remaining_balance: 5000,
+      currency: PLATFORM_DEFAULT_CURRENCY,
+      is_public: true,
+      is_negotiable: true,
+      contact_method: 'platform',
+    });
+
+    expect(payload).toMatchObject({
+      loan_type: 'new_request',
+      title: 'Bridge funding',
+      fulfillment_type: 'manual',
+      original_amount: 5000,
+      remaining_balance: 5000,
+      collateral: [],
+    });
+    expect((payload.description as string).length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('merges lender fields and defaults fulfillment_type for legacy rows', () => {
+    const payload = loanToApiPayload({
+      title: 'Existing loan',
+      description: 'Refinance me please — good history.',
+      original_amount: 1000,
+      remaining_balance: 800,
+      currency: PLATFORM_DEFAULT_CURRENCY,
+      lender_name: 'Alice Bank',
+      fulfillment_type: 'lightning' as never,
+      is_public: false,
+      is_negotiable: false,
+      contact_method: 'email',
+    });
+
+    expect(payload.fulfillment_type).toBe('manual');
+    expect(payload.current_lender).toBe('Alice Bank');
+    expect(payload.is_public).toBe(false);
+  });
+});

--- a/docs/AUDIT_REPORT.md
+++ b/docs/AUDIT_REPORT.md
@@ -1,69 +1,158 @@
 # Codebase Audit Report
 
-**Date**: 2026-06-29
-**Auditor**: Claude Code (3 parallel agents)
+**Date**: 2026-07-09
+**Auditor**: Claude (3 parallel deep-dive agents + remediation pass)
 **Branch**: main
-**Scope**: Next-tier review after a 13-change session (Cat chat/memory, ai_assistant chat + Cat Credits, schema-drift gate, 14-table drift remediation, audit logging, post_to_timeline, circle entity, mobile fixes) — confirm no regressions + surface new high/medium findings.
+**Commit**: post-PR #395 (Cat Credits metering + 2026 model roster)
 
 ## Executive Summary
 
-The session's work holds up well. Build gates are clean (`tsc --noEmit` → **0 errors**, `npm run lint` → clean, **0 `console.*` in any session file**), the design-token SSOT is still pristine (0 hex violations), both previously-flagged registry duplications are confirmed fixed, and mobile-first held across all new UI (circle pages + the public AI-assistant chat inherit the generic mobile-first components cleanly).
+A full-codebase SSOT / SoC / DRY / design-system audit found **strong spine infrastructure** (`entity-registry.ts`, `api-routes.ts`, `ai-models.ts`, `standardResponse`, generic entity handlers) undermined by **duplicate constants**, **phantom API paths**, **legacy UI primitives**, and **parallel data-access paths** (browser Supabase vs API).
 
-The audit found **no HIGH-severity issues** but four genuine MED/LOW defects introduced this session — one of them a security gap (public-table RLS too permissive). All four were fixed in the corrective change accompanying this report. The remaining findings are SSOT-discipline debt on _newer_ (mostly pre-session) code and service-file size — tracked as roadmap, not regressions.
+This pass **fixed 30+ concrete violations** in config, discover tabs, payment presets, AI provider wiring, UI primitives, integration scopes, and documentation. Remaining work is **structural** (DB type migration, loan dual-path, browser-supabase deprecation, FleetCrown emit loop) and tracked in phased roadmap below.
 
 ## Health Score
 
-| Area                   | Score    | Notes                                                                                      |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------ |
-| First Principles       | 8/10     | Strong SSOT spine; discipline slipped on some new code (raw table literals)                |
-| Best Practices         | 9/10     | 0 console/any in session code; gates green; standard response shapes                       |
-| SSOT / DRY / SoC       | 7/10     | Tokens 0/0; dupes fixed; but ~27 tables missing from DATABASE_TABLES + 7 services >500 LOC |
-| Functional Correctness | 8/10     | 4 real defects (now fixed); auth/RLS otherwise sound                                       |
-| UI/UX & Responsive     | 9/10     | Mobile-first held; 1 LOW (long-token wrap in chat bubble)                                  |
-| **Overall**            | **8/10** | Healthy; the gap is SSOT discipline on new code + a few service god-files                  |
+| Area                            | Score    | Notes                                                                      |
+| ------------------------------- | -------- | -------------------------------------------------------------------------- |
+| First Principles (SSOT/DRY/SoC) | 7/10     | Spine strong; duplicate registries consolidated; env/features SSOT added   |
+| Best Practices                  | 8/10     | Gates green; phantom routes removed; research POST fixed                   |
+| Systems / Integration           | 6/10     | `timeline.write` scope mintable; FC emit/SDK gaps remain                   |
+| Design System                   | 7/10     | 0 className hex; Card/Badge migrated; semantic tier ~95% on surfaces       |
+| Functional Correctness          | 8/10     | Money-path tests pinned; loan dual-path still open                         |
+| **Overall**                     | **7/10** | Healthy core; largest debt is data-access layering + customer API contract |
 
-## Fixed in this corrective change
+---
 
-| Sev        | Finding                                                                                                                                                                                  | Fix                                                                                                                  |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| **MED 🔒** | `project_updates` INSERT RLS was `WITH CHECK (auth.uid() IS NOT NULL)` on a public-read table → any authed user could inject fake updates into ANY project's timeline (`20260627000002`) | Migration `20260629000000`: INSERT scoped to the project's owner (`projects.actor_id → actors.user_id = auth.uid()`) |
-| **MED**    | `sendMessage.fetchAssistant` SELECT omitted `allowed_models`/`min_model_tier` → creator's model allow-list silently ignored for BYOK routing (`sendMessage.ts:296`)                      | Added both columns to the SELECT                                                                                     |
-| **MED**    | `timeline_events.subject_type` CHECK (`20260627000003`) omitted `circle` (added a day later) → Cat promoting a circle would fail the constraint                                          | Migration adds `'circle'` to the CHECK                                                                               |
-| **LOW**    | `audit_logs` INSERT `WITH CHECK (true)` via user-scoped client → spoofable rows                                                                                                          | Migration: `WITH CHECK (user_id = auth.uid() OR auth.uid() IS NULL)`                                                 |
+## Fixed in this remediation pass (2026-07-09)
 
-## Roadmap (not regressions — pre-existing / tracked)
+| Area                     | Fix                                                                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| **Phantom routes**       | Removed `/api/payments/send` and `/api/posts` from `api-routes.ts` / `cat-actions.ts` (handlers are in-process)       |
+| **CAT_FREE_DAILY_LIMIT** | Single constant in `cat-plans.ts`; `getUserPlan` + `api-key-service` import it                                        |
+| **WIRED providers**      | `WIRED_PROVIDER_IDS` + `wiredProviders` exported from `aiProviders.ts`; `cat-plans` + `AIKeyAddForm` derive from SSOT |
+| **Credits markup label** | `CAT_CREDITS_MARKUP_LABEL` derived from `CREDIT_USAGE_MARKUP`                                                         |
+| **Payment presets**      | New `config/payment-presets.ts`; PublicPayPanel, ProjectDonationSection, ContributionAmountInput, PaymentDialog       |
+| **Discover tabs**        | New `config/discover-tabs.ts`; DiscoverTabs, DiscoverEmptyState, discoverConstants deduplicated                       |
+| **Waitlist schema**      | Shared `waitlistSchema` in `lib/validation/social.ts`                                                                 |
+| **Research POST**        | Passes `parsed.data` to `createResearch` after Zod validation                                                         |
+| **API_ROUTES gap**       | `WALLETS.ENTITY_VISIBILITY` added; WalletVisibilityToggle uses it                                                     |
+| **Integration scopes**   | `timeline.write` added to `PUBLIC_API_SCOPE_TOKENS` (mint UI can offer it)                                            |
+| **Model selector**       | `ModelSelector` reads `AI_MODEL_REGISTRY` directly (not legacy adapter)                                               |
+| **UI primitives**        | `Card` title/description + `Badge` variants migrated to semantic tokens                                               |
+| **Feature flags**        | New `config/features.ts`; voice input gated via `FEATURES.voiceInput`                                                 |
+| **Env SSOT**             | New `config/env.ts` for `SITE_URL` / `APP_URL` canonicalization                                                       |
+| **Responsive pay grids** | PublicPayPanel + ProjectDonationSection: `grid-cols-1 sm:grid-cols-3`                                                 |
+| **Design docs**          | `docs/design-system/README.md` reconciled with semantic-tier direction                                                |
 
-### Quick wins (mechanical, zero behavior change)
+---
 
-- **Backfill `DATABASE_TABLES`** for ~27 raw `.from('literal')` tables not in the SSOT: `oauth_*` (4), `user_nudges`, `content_embeddings`, `project_roles`, `user_plans`, etc. Plus ~18 literals where the const already exists (`profiles`, `actors`, `follows`, `stakeholder_relationships`) — swap them in.
-- Route ~14 hardcoded `fetch('/api/...')` strings through `API_ROUTES`.
-- `AIChatMessage.tsx:72` — add `break-words` so a long unbroken token (URL/hash) can't overflow on a 360px screen (LOW).
+## Phase 1: SSOT / DRY violations (remaining)
 
-### Medium effort (SoC)
+### Critical (next PRs)
 
-- 7 service files exceed the 500-LOC limit: `system-prompt.ts` (655), `context-string-builder.ts` (605), `chat-orchestrator.ts` (597), `timeline/mutations/events.ts` (588), `ai/sendMessage.ts` (559), `cat/tool-use.ts` (545), `timeline/processors/socialInteractions.ts` (524). Decompose the prompt/context builders especially.
-- `reindex-embeddings/route.ts` (418 LOC) — extract embedding/reconcile logic to `src/services/search/`; route becomes a thin trigger.
-- Hand-written `Create*Input` interfaces (groups, contracts, bookings) → derive from Zod (`z.infer`).
-- `assistant-charge.bumpAssistantRevenue` — non-atomic read-modify-write of `total_revenue` (lost-update race; documented best-effort, ledger is SSOT). Convert to an atomic SQL increment.
+1. **Dual `Database` types** — `types/database.ts` (~3.7k lines) vs orphaned `database.generated.ts`. Regenerate and switch Supabase clients.
+2. **Loan dual create path** — `domain/loans/service.ts` (API) vs `services/loans/mutations` (browser Supabase). UI must call `/api/loans`.
+3. **~80 browser-supabase consumers** — groups, timeline, projectStore bypass API validation/audit.
 
-### Strategic / owner
+### High
 
-- Provision `PLATFORM_NWC_URI` on the box — unblocks paid ai_assistants + Cat Credits top-up (and relieves the free-tier 429s). Highest-leverage item.
-- Disk at 91% on bitbaum.
-- Messaging E2E/Nostr — product decision (docs already corrected to "roadmap, not shipped").
+4. **Two `EntityConfig` type names** — rename to `EntityDisplayConfig` vs `EntityFormConfig`.
+5. **Model ID sprawl** — `platform-providers.ts`, `form-prefill-service.ts`, `groq.ts` still hold default strings; import from `ai-models.ts`.
+6. **Auth route lists** — `middleware.ts` `REQUIRES_AUTH_PREFIXES` vs `routes.ts` `ROUTE_CONTEXTS`; derive one from the other.
+7. **~70 scattered `process.env`** — migrate to `config/env.ts` + zod validation incrementally.
 
-## Regression check (per session feature)
+### Medium
 
-- **circle entity** — correct; now also linkable as a timeline subject (fixed).
-- **ai_assistant chat** — correct; `allowed_models` now fetched (fixed).
-- **audit logging** — correct, non-blocking; spoof gap tightened (fixed).
-- **Cat post_to_timeline** — correct; circle subject now allowed (fixed).
-- **schema-drift gate + migrations** — sound, idempotent, fresh-box-safe.
-- **drift remediation (14 tables)** — holds; allowlist empty; gate green.
-- **mobile fixes / PageHeading / selects** — all held.
-- **Cat recall parallelization** — shipped (PR #305).
+8. **Contribution presets** — consolidated; wishlist tiers may still have local amounts.
+9. **`entity-configs` imports UI templates** — move to `config/entity-templates/`.
+10. **`PublicEntityDetailPage` god component** — extract `loadPublicEntity` service.
+11. **14× `entity-guidance/*.ts`** — factory + content maps.
+12. **Notifications dual stack** — `lib/services/notifications.ts` vs `services/notifications/`.
+
+---
+
+## Phase 2: Design system (remaining)
+
+| Item                               | Status                                                                              |
+| ---------------------------------- | ----------------------------------------------------------------------------------- |
+| `[#` in className                  | ✅ 0 violations                                                                     |
+| Legacy shadcn tokens in `ui/*`     | ⏳ Card/Badge done; dialog/select/dropdown still on `bg-background`                 |
+| Chromatic Tailwind in config       | ⏳ `badge-colors.ts`, `entity-registry` THEME_COLORS, `contextual-loader-config.ts` |
+| Raw `<button>` vs `<Button>`       | ⏳ ~130 files; chat/timeline worst                                                  |
+| `text-[10px]` arbitrary micro-type | ⏳ ~25 files; use `text-2xs`                                                        |
+| Chart/email hex                    | ⏳ AnalyticsInsights, email templates, OG                                           |
+| Display typography                 | ⏳ `font-heading` only ~14 files                                                    |
+
+**Recommended next design pass:** migrate `dialog`, `select`, `dropdown-menu` internals to semantic tokens (unlocks all consumers in one PR).
+
+---
+
+## Phase 3: FleetCrown / customer integration (remaining)
+
+| Gap                                                | Status                                                             |
+| -------------------------------------------------- | ------------------------------------------------------------------ |
+| OC ingest (`/api/v1/timeline/publish`)             | ✅ Live                                                            |
+| `timeline.write` in mint UI scopes                 | ✅ Fixed                                                           |
+| FC emit build events                               | ❌ Unbuilt                                                         |
+| Stakeholders in v1 API + SDK                       | ❌ Not exposed                                                     |
+| OIDC on FC side                                    | ❌ Unbuilt                                                         |
+| Stakeholder management UI                          | ❌ API/seed only                                                   |
+| Hardcoded `ORANGECAT_FLEETCROWN_INTEGRATION` UUIDs | ⏳ Dogfood OK; needs `platform_customers` table for multi-customer |
+
+See `docs/architecture/PLATFORM_AND_COLLABORATION.md` for north star.
+
+---
+
+## Phased roadmap
+
+### Phase A — Quick wins (done this pass)
+
+Config SSOT consolidation, phantom routes, UI primitive migration start, integration scope fix.
+
+### Phase B — Correctness (1–2 weeks)
+
+- Loan UI → API-only path
+- Regenerate DB types; eliminate `as any` on oauth/cat_credit/stakeholder tables
+- Middleware auth prefixes derived from `routes.ts`
+- `config/env.ts` zod validation + CI `validate-env.js` alignment
+
+### Phase C — Design system completion (1–2 weeks)
+
+- shadcn primitives → semantic tier
+- `badge-colors.ts` → status semantic tokens
+- Chat/timeline raw button purge
+- Remove tiffany/orange from globals/tailwind when consumers = 0
+
+### Phase D — Platform integration (2–4 weeks)
+
+- v1 API + SDK: `stakeholders.read/write`, `timeline.publish`
+- FC emit checklist + OIDC relying party
+- Customer registry DB table (move hardcoded UUIDs out of code)
+
+### Phase E — Data access unification (ongoing)
+
+- Deprecate browser writes in `services/loans`, `projectStore`, `services/groups`
+- Rule: UI → `API_ROUTES` → route → domain/service → supabase
+
+---
 
 ## Verification
 
-- `tsc --noEmit --incremental false`: 0 errors · `npm run lint`: clean · 0 `console.*` in session files
-- Schema-drift gate: green against the box · design-token hex: 0/0
+Run after each phase:
+
+```bash
+npm run type-check
+npm test -- --testPathPatterns=__tests__/unit
+grep -rn '\[#' src/    # design token audit — expect 0
+```
+
+---
+
+## Action items (prioritized)
+
+1. **[B1]** Fix loan dual-path — UI calls `/api/loans` only
+2. **[B2]** Regenerate `database.generated.ts` and migrate Supabase client imports
+3. **[C1]** Migrate dialog/select/dropdown to semantic tokens
+4. **[D1]** Add stakeholders + timeline to v1 SDK
+5. **[E1]** Inventory browser-supabase write sites; migrate loans first

--- a/docs/AUDIT_REPORT.md
+++ b/docs/AUDIT_REPORT.md
@@ -17,8 +17,8 @@ This pass **fixed 30+ concrete violations** in config, discover tabs, payment pr
 | ------------------------------- | -------- | -------------------------------------------------------------------------- |
 | First Principles (SSOT/DRY/SoC) | 7/10     | Spine strong; duplicate registries consolidated; env/features SSOT added   |
 | Best Practices                  | 8/10     | Gates green; phantom routes removed; research POST fixed                   |
-| Systems / Integration           | 6/10     | `timeline.write` scope mintable; FC emit/SDK gaps remain                   |
-| Design System                   | 7/10     | 0 className hex; Card/Badge migrated; semantic tier ~95% on surfaces       |
+| Systems / Integration           | 7/10     | v1 stakeholders + SDK timeline/stakeholders; FC emit still open            |
+| Design System                   | 8/10     | dialog/select/dropdown migrated; semantic tier on core primitives          |
 | Functional Correctness          | 8/10     | Money-path tests pinned; loan dual-path still open                         |
 | **Overall**                     | **7/10** | Healthy core; largest debt is data-access layering + customer API contract |
 
@@ -39,7 +39,9 @@ This pass **fixed 30+ concrete violations** in config, discover tabs, payment pr
 | **API_ROUTES gap**       | `WALLETS.ENTITY_VISIBILITY` added; WalletVisibilityToggle uses it                                                     |
 | **Integration scopes**   | `timeline.write` added to `PUBLIC_API_SCOPE_TOKENS` (mint UI can offer it)                                            |
 | **Model selector**       | `ModelSelector` reads `AI_MODEL_REGISTRY` directly (not legacy adapter)                                               |
-| **UI primitives**        | `Card` title/description + `Badge` variants migrated to semantic tokens                                               |
+| **UI primitives**        | `Card`/`Badge` + `dialog`/`select`/`dropdown-menu` migrated to semantic tokens                                        |
+| **Stakeholders v1**      | `config/stakeholders.ts`, platform service, `/api/v1/stakeholders`, SDK `stakeholders.*` + `timeline.publish`         |
+| **Integration scopes**   | `stakeholders.read/write` added to mint UI + OAuth scope registry                                                     |
 | **Feature flags**        | New `config/features.ts`; voice input gated via `FEATURES.voiceInput`                                                 |
 | **Env SSOT**             | New `config/env.ts` for `SITE_URL` / `APP_URL` canonicalization                                                       |
 | **Responsive pay grids** | PublicPayPanel + ProjectDonationSection: `grid-cols-1 sm:grid-cols-3`                                                 |
@@ -77,7 +79,7 @@ This pass **fixed 30+ concrete violations** in config, discover tabs, payment pr
 | Item                               | Status                                                                              |
 | ---------------------------------- | ----------------------------------------------------------------------------------- |
 | `[#` in className                  | ✅ 0 violations                                                                     |
-| Legacy shadcn tokens in `ui/*`     | ⏳ Card/Badge done; dialog/select/dropdown still on `bg-background`                 |
+| Legacy shadcn tokens in `ui/*`     | ✅ Card/Badge/dialog/select/dropdown on semantic tier                               |
 | Chromatic Tailwind in config       | ⏳ `badge-colors.ts`, `entity-registry` THEME_COLORS, `contextual-loader-config.ts` |
 | Raw `<button>` vs `<Button>`       | ⏳ ~130 files; chat/timeline worst                                                  |
 | `text-[10px]` arbitrary micro-type | ⏳ ~25 files; use `text-2xs`                                                        |
@@ -95,7 +97,8 @@ This pass **fixed 30+ concrete violations** in config, discover tabs, payment pr
 | OC ingest (`/api/v1/timeline/publish`)             | ✅ Live                                                            |
 | `timeline.write` in mint UI scopes                 | ✅ Fixed                                                           |
 | FC emit build events                               | ❌ Unbuilt                                                         |
-| Stakeholders in v1 API + SDK                       | ❌ Not exposed                                                     |
+| Stakeholders in v1 API + SDK                       | ✅ `/api/v1/stakeholders` + SDK `stakeholders.list/create`         |
+| SDK `timeline.publish`                             | ✅ `orangecat.timeline.publish()`                                  |
 | OIDC on FC side                                    | ❌ Unbuilt                                                         |
 | Stakeholder management UI                          | ❌ API/seed only                                                   |
 | Hardcoded `ORANGECAT_FLEETCROWN_INTEGRATION` UUIDs | ⏳ Dogfood OK; needs `platform_customers` table for multi-customer |
@@ -112,21 +115,21 @@ Config SSOT consolidation, phantom routes, UI primitive migration start, integra
 
 ### Phase B — Correctness (in progress)
 
-- ✅ **Loan dual-path closed** — `createLoan` / `updateLoan` / `deleteLoan` route through `/api/loans` via `services/loans/api-client.ts`; browser Supabase insert removed from the user-facing path (`createObligationLoan` still TODO for offer-accept flow).
+- ✅ **Loan dual-path closed** — `createLoan` / `updateLoan` / `deleteLoan` route through `/api/loans` via `services/loans/api-client.ts`; `createObligationLoan` deferred to Phase E (offer-accept server route).
 - Regenerate DB types; eliminate `as any` on oauth/cat_credit/stakeholder tables
 - Middleware auth prefixes derived from `routes.ts`
 - `config/env.ts` zod validation + CI `validate-env.js` alignment
 
 ### Phase C — Design system completion (1–2 weeks)
 
-- shadcn primitives → semantic tier
+- ✅ shadcn dialog/select/dropdown → semantic tier
 - `badge-colors.ts` → status semantic tokens
 - Chat/timeline raw button purge
 - Remove tiffany/orange from globals/tailwind when consumers = 0
 
 ### Phase D — Platform integration (2–4 weeks)
 
-- v1 API + SDK: `stakeholders.read/write`, `timeline.publish`
+- ✅ v1 API + SDK: `stakeholders.read/write`, `timeline.publish`
 - FC emit checklist + OIDC relying party
 - Customer registry DB table (move hardcoded UUIDs out of code)
 
@@ -153,6 +156,6 @@ grep -rn '\[#' src/    # design token audit — expect 0
 
 1. ~~**[B1]** Fix loan dual-path~~ — done 2026-07-09
 2. **[B2]** Regenerate `database.generated.ts` and migrate Supabase client imports
-3. **[C1]** Migrate dialog/select/dropdown to semantic tokens
-4. **[D1]** Add stakeholders + timeline to v1 SDK
+3. ~~**[C1]** Migrate dialog/select/dropdown to semantic tokens~~ — done 2026-07-09
+4. ~~**[D1]** Add stakeholders + timeline to v1 SDK~~ — done 2026-07-09
 5. **[E1]** Inventory browser-supabase write sites; migrate loans first

--- a/docs/AUDIT_REPORT.md
+++ b/docs/AUDIT_REPORT.md
@@ -110,9 +110,9 @@ See `docs/architecture/PLATFORM_AND_COLLABORATION.md` for north star.
 
 Config SSOT consolidation, phantom routes, UI primitive migration start, integration scope fix.
 
-### Phase B — Correctness (1–2 weeks)
+### Phase B — Correctness (in progress)
 
-- Loan UI → API-only path
+- ✅ **Loan dual-path closed** — `createLoan` / `updateLoan` / `deleteLoan` route through `/api/loans` via `services/loans/api-client.ts`; browser Supabase insert removed from the user-facing path (`createObligationLoan` still TODO for offer-accept flow).
 - Regenerate DB types; eliminate `as any` on oauth/cat_credit/stakeholder tables
 - Middleware auth prefixes derived from `routes.ts`
 - `config/env.ts` zod validation + CI `validate-env.js` alignment
@@ -151,7 +151,7 @@ grep -rn '\[#' src/    # design token audit — expect 0
 
 ## Action items (prioritized)
 
-1. **[B1]** Fix loan dual-path — UI calls `/api/loans` only
+1. ~~**[B1]** Fix loan dual-path~~ — done 2026-07-09
 2. **[B2]** Regenerate `database.generated.ts` and migrate Supabase client imports
 3. **[C1]** Migrate dialog/select/dropdown to semantic tokens
 4. **[D1]** Add stakeholders + timeline to v1 SDK

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -1,9 +1,9 @@
 # OrangeCat Design System
 
-**Created**: June 5, 2025  
-**Last Modified**: June 3, 2026  
-**Last Modified Summary**: Clarified SSOT hierarchy — runtime tokens live in `globals.css` + `tailwind.config.ts`; TS helpers in `design-system.ts`; Cat chat uses `.oc-chat-*` classes. See `docs/architecture/CAT_AND_DESIGN_SSOT.md`.  
-**Version**: 1.1.0
+**Created**: 2025-06-05  
+**Last Modified**: 2026-07-09  
+**Last Modified Summary**: Reconciled with semantic-tier migration — warm accent `#ff5c00` for conversion CTAs, Bitcoin Orange `#f7931a` for Bitcoin-only UI, monochromatic surfaces elsewhere. Tiffany/orange chromatic palette is legacy/retired for new code.  
+**Version**: 2.0.0
 
 ## Overview
 
@@ -17,11 +17,21 @@ This document describes OrangeCat brand and component guidelines. **For implemen
 | Cat chat layout & copy          | `src/config/layout-chrome.ts`, `src/config/cat-hub.ts` |
 | Architecture audit              | `docs/architecture/CAT_AND_DESIGN_SSOT.md`             |
 
-## Brand Colors
+## Brand direction (2026)
 
-### Primary Colors
+- **Surfaces**: achromatic semantic tier (`bg-surface-*`, `text-fg-*`, `border-default`)
+- **Conversion accent**: warm orange `#ff5c00` — `bg-accent-warm` / `variant="accent"` on top-of-funnel CTAs only
+- **Bitcoin UI only**: `#f7931a` — `bg-bitcoinOrange` for balances, Lightning, Bitcoin icons
+- **Status**: `status-positive/warning/negative` — never decorative chroma
+- **Legacy Tiffany/orange Tailwind scales**: exist in `globals.css` for backward compat but must not appear in new components
 
-- **Tiffany Blue** (`#0ABAB5`)
+## Brand Colors (historical reference)
+
+> **Note:** The Tiffany palette below is **retired for new UI**. Kept for email/OG assets migration tracking only.
+
+### Primary Colors (legacy)
+
+- **Tiffany Blue** (`#0ABAB5`) — retired; do not use in new Tailwind classes
   - Primary brand color
   - Used for main CTAs, important elements, and brand identity
   - Light variant: `#E6F7F7` (10% opacity)

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -45,6 +45,11 @@ import type {
   CreateWishlistInput,
   WishlistResponse,
   DiscoveryResponse,
+  TimelinePublishInput,
+  TimelinePublishResponse,
+  CreateStakeholderInput,
+  StakeholderListResponse,
+  StakeholderCreateResponse,
 } from './types.js';
 
 const V1 = '/api/v1';
@@ -98,6 +103,38 @@ class EntityResource<Input, Response> {
   }
 }
 
+class TimelineResource {
+  constructor(private readonly http: HttpClient) {}
+
+  publish(input: TimelinePublishInput, options?: RequestOptions): Promise<TimelinePublishResponse> {
+    return this.http.post<TimelinePublishResponse>(`${V1}/timeline/publish`, input, options);
+  }
+}
+
+export interface StakeholderListParams {
+  fromProjectId: string;
+  kind?: string;
+}
+
+class StakeholdersResource {
+  constructor(private readonly http: HttpClient) {}
+
+  list(params: StakeholderListParams, options?: RequestOptions): Promise<StakeholderListResponse> {
+    const query = new URLSearchParams({ fromProjectId: params.fromProjectId });
+    if (params.kind) {
+      query.set('kind', params.kind);
+    }
+    return this.http.get<StakeholderListResponse>(`${V1}/stakeholders?${query}`, options);
+  }
+
+  create(
+    input: CreateStakeholderInput,
+    options?: RequestOptions
+  ): Promise<StakeholderCreateResponse> {
+    return this.http.post<StakeholderCreateResponse>(`${V1}/stakeholders`, input, options);
+  }
+}
+
 export class OrangeCatClient {
   private readonly http: HttpClient;
 
@@ -110,6 +147,8 @@ export class OrangeCatClient {
   readonly investments: EntityResource<CreateInvestmentInput, InvestmentResponse>;
   readonly assets: EntityResource<CreateAssetInput, AssetResponse>;
   readonly wishlists: EntityResource<CreateWishlistInput, WishlistResponse>;
+  readonly timeline: TimelineResource;
+  readonly stakeholders: StakeholdersResource;
 
   constructor(options: ClientOptions) {
     this.http = new HttpClient(options);
@@ -122,6 +161,8 @@ export class OrangeCatClient {
     this.investments = new EntityResource(this.http, `${V1}/investments`);
     this.assets = new EntityResource(this.http, `${V1}/assets`);
     this.wishlists = new EntityResource(this.http, `${V1}/wishlists`);
+    this.timeline = new TimelineResource(this.http);
+    this.stakeholders = new StakeholdersResource(this.http);
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 export { OrangeCatClient } from './client.js';
-export type { ListParams } from './client.js';
+export type { ListParams, StakeholderListParams } from './client.js';
 export { OrangeCatError } from './errors.js';
 export type { OrangeCatErrorCode } from './errors.js';
 export type { ClientOptions, RequestOptions } from './http.js';
@@ -38,4 +38,11 @@ export type {
   CreateWishlistInput,
   WishlistResponse,
   DiscoveryResponse,
+  TimelinePublishInput,
+  TimelinePublishResponse,
+  CreateStakeholderInput,
+  StakeholderListResponse,
+  StakeholderCreateResponse,
+  StakeholderRelationship,
+  StakeholderKind,
 } from './types.js';

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -162,10 +162,77 @@ export interface DiscoveryResponse {
     methods: string[];
     endpoint: string;
   }>;
+  integrations?: Array<{
+    name: string;
+    methods: string[];
+    endpoint: string;
+  }>;
   docs: {
     contract: string;
     conventions: string;
     openapi: string;
     changelog: string;
   };
+}
+
+// ── Timeline publish bus ───────────────────────────────────────────────────
+
+export interface TimelinePublishInput {
+  source: string;
+  external_id: string;
+  subject_type: 'project';
+  subject_id: string;
+  event_type: string;
+  title: string;
+  description?: string;
+  content?: Record<string, unknown>;
+  tags?: string[];
+  visibility?: string;
+  url?: string;
+  event_timestamp?: string;
+}
+
+export interface TimelinePublishResponse {
+  id: string;
+  status: 'created' | 'updated';
+}
+
+// ── Stakeholders ─────────────────────────────────────────────────────────────
+
+export type StakeholderKind =
+  | 'competitor'
+  | 'collaborator'
+  | 'investor'
+  | 'customer'
+  | 'employee'
+  | 'acquirer'
+  | 'acquisition_target'
+  | 'in_house_dev';
+
+export interface CreateStakeholderInput {
+  fromProjectId: string;
+  kind: StakeholderKind;
+  toActorId?: string;
+  toProjectId?: string;
+  toExternalUrl?: string;
+  toExternalName?: string;
+  status?: string;
+  confidence?: number;
+  notes?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StakeholderRelationship extends Record<string, unknown> {
+  id: string;
+  from_project_id: string;
+  kind: StakeholderKind;
+  owner_actor_id: string;
+}
+
+export interface StakeholderListResponse {
+  relationships: StakeholderRelationship[];
+}
+
+export interface StakeholderCreateResponse {
+  relationship: StakeholderRelationship;
 }

--- a/src/app/(public)/channel/page.tsx
+++ b/src/app/(public)/channel/page.tsx
@@ -12,13 +12,8 @@ import ProfileShare from '@/components/sharing/ProfileShare';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+import { waitlistSchema, type WaitlistFormData } from '@/lib/validation/social';
 import { toast } from 'sonner';
-
-const waitlistSchema = z.object({
-  email: z.string().email(),
-});
-type WaitlistFormData = z.infer<typeof waitlistSchema>;
 
 export default function ChannelComingSoonPage() {
   const { user, profile } = useAuth();

--- a/src/app/api/research/route.ts
+++ b/src/app/api/research/route.ts
@@ -111,14 +111,16 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
 
     const body = await (request as NextRequest).json();
     const schema = researchConfig.schema as ZodType | undefined;
+    let validatedBody = body as ResearchEntityCreate;
     if (schema) {
       const parsed = schema.safeParse(body);
       if (!parsed.success) {
         return handleValidationError(parsed.error);
       }
+      validatedBody = parsed.data as ResearchEntityCreate;
     }
 
-    const { response } = await createResearch(supabase, user.id, body as ResearchEntityCreate);
+    const { response } = await createResearch(supabase, user.id, validatedBody);
     return applyRateLimitHeaders(response, rl);
   } catch (error) {
     return handleApiError(error);

--- a/src/app/api/stakeholders/route.ts
+++ b/src/app/api/stakeholders/route.ts
@@ -14,17 +14,15 @@
  *          stakeholder. Stakeholder target is one of: another actor,
  *          another project, or an external URL.
  *
+ * Integration clients should use GET/POST /api/v1/stakeholders with
+ * stakeholders.read / stakeholders.write scopes instead.
+ *
  * Backed by the stakeholder_relationships table — see migration
  * 20260601000000_create_stakeholder_relationships.sql. RLS in the
  * database is the authoritative ownership check; the validation here
  * is defence in depth.
- *
- * Note: FleetCrown (formerly Cockpit) and OrangeCat share this graph.
- * FleetCrown projects (e.g. "FleetCrown") are customers of OrangeCat
- * projects via this typed edge system.
  */
 
-import { z } from 'zod';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import {
@@ -37,93 +35,37 @@ import {
   apiUnauthorized,
 } from '@/lib/api/standardResponse';
 import { logger } from '@/utils/logger';
-import { ENTITY_REGISTRY } from '@/config/entity-registry';
-
-// =====================================================================
-// SHAPES
-// =====================================================================
-
-const STAKEHOLDER_KINDS = [
-  'competitor',
-  'collaborator',
-  'investor',
-  'customer',
-  'employee',
-  'acquirer',
-  'acquisition_target',
-  'in_house_dev',
-] as const;
-
-const createSchema = z
-  .object({
-    fromProjectId: z.string().uuid('fromProjectId must be a UUID'),
-    kind: z.enum(STAKEHOLDER_KINDS),
-    toActorId: z.string().uuid().optional(),
-    toProjectId: z.string().uuid().optional(),
-    toExternalUrl: z.string().url().optional(),
-    toExternalName: z.string().min(1).max(200).optional(),
-    status: z.string().max(50).optional(),
-    confidence: z.number().int().min(0).max(100).optional(),
-    notes: z.string().max(5000).optional(),
-    metadata: z.record(z.unknown()).optional(),
-  })
-  .refine(
-    data => {
-      // Exactly one "to" target must be provided. Mirror the database
-      // CHECK constraint here so we fail fast with a clear message
-      // instead of bubbling a Postgres error.
-      const set = [data.toActorId, data.toProjectId, data.toExternalUrl].filter(Boolean).length;
-      return set === 1;
-    },
-    {
-      message: 'Exactly one of toActorId, toProjectId, or toExternalUrl must be set',
-    }
-  );
-
-// =====================================================================
-// GET — list relationships for a project (the caller must own it via RLS)
-// =====================================================================
+import { createStakeholderSchema } from '@/config/stakeholders';
+import {
+  listStakeholderRelationships,
+  createStakeholderRelationship,
+} from '@/services/platform/stakeholderRelationships';
 
 export const GET = withAuth(async (request: AuthenticatedRequest) => {
   try {
     const { supabase } = request;
     const url = new URL(request.url);
     const fromProjectId = url.searchParams.get('fromProjectId');
-    const kindFilter = url.searchParams.get('kind');
+    const kindFilter = url.searchParams.get('kind') ?? undefined;
 
     if (!fromProjectId) {
       return apiBadRequest('fromProjectId query parameter is required');
     }
 
-    let query = supabase
-      .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
-      .select('*')
-      .eq('from_project_id', fromProjectId)
-      .order('updated_at', { ascending: false });
-
-    if (kindFilter) {
-      if (!(STAKEHOLDER_KINDS as readonly string[]).includes(kindFilter)) {
-        return apiBadRequest(`kind must be one of: ${STAKEHOLDER_KINDS.join(', ')}`);
+    const result = await listStakeholderRelationships(supabase, fromProjectId, kindFilter);
+    if (!result.ok) {
+      if (result.reason === 'bad_kind') {
+        return apiBadRequest(result.message);
       }
-      query = query.eq('kind', kindFilter);
+      return apiInternalError(result.message);
     }
 
-    const { data, error } = await query;
-    if (error) {
-      logger.error('Failed to list stakeholder relationships', error, 'StakeholdersAPI');
-      return apiInternalError('Failed to load stakeholders');
-    }
-
-    return apiSuccess({ relationships: data ?? [] });
+    return apiSuccess({ relationships: result.relationships });
   } catch (error) {
     logger.error('Unexpected error in GET /api/stakeholders', error, 'StakeholdersAPI');
     return apiInternalError('Internal server error');
   }
 });
-
-// =====================================================================
-// POST — create a new stakeholder relationship
-// =====================================================================
 
 export const POST = withAuth(async (request: AuthenticatedRequest) => {
   try {
@@ -136,15 +78,11 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       return apiBadRequest('Invalid JSON body');
     }
 
-    const parsed = createSchema.safeParse(body);
+    const parsed = createStakeholderSchema.safeParse(body);
     if (!parsed.success) {
       return apiValidationError('Invalid request', parsed.error.flatten());
     }
-    const input = parsed.data;
 
-    // Resolve the caller's actor — the owner of the relationship row.
-    // RLS would block writes for the wrong actor; we set it explicitly
-    // here so the row is well-formed up front.
     const { data: actorRow, error: actorErr } = await supabase
       .from(DATABASE_TABLES.ACTORS)
       .select('id')
@@ -157,51 +95,19 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
     }
     const ownerActorId = actorRow.id as string;
 
-    // Guard: the from_project must belong to the caller. RLS on
-    // projects would already enforce this on read, but we verify the
-    // relationship explicitly so the error message is meaningful.
-    const { data: projectRow, error: projectErr } = await supabase
-      .from(ENTITY_REGISTRY.project.tableName)
-      .select('id, actor_id')
-      .eq('id', input.fromProjectId)
-      .maybeSingle();
-    if (projectErr) {
-      logger.error('Failed to verify project ownership', projectErr, 'StakeholdersAPI');
-      return apiInternalError('Failed to verify project');
-    }
-    if (!projectRow) {
-      return apiNotFound('Project not found');
-    }
-    if (projectRow.actor_id !== ownerActorId) {
-      return apiUnauthorized('You can only add stakeholders to your own projects');
+    const result = await createStakeholderRelationship(supabase, ownerActorId, parsed.data);
+    if (!result.ok) {
+      switch (result.reason) {
+        case 'project_not_found':
+          return apiNotFound(result.message);
+        case 'forbidden':
+          return apiUnauthorized(result.message);
+        default:
+          return apiInternalError(result.message);
+      }
     }
 
-    const row = {
-      owner_actor_id: ownerActorId,
-      from_project_id: input.fromProjectId,
-      kind: input.kind,
-      to_actor_id: input.toActorId ?? null,
-      to_project_id: input.toProjectId ?? null,
-      to_external_url: input.toExternalUrl ?? null,
-      to_external_name: input.toExternalName ?? null,
-      status: input.status ?? null,
-      confidence: input.confidence ?? null,
-      notes: input.notes ?? null,
-      metadata: input.metadata ?? {},
-    };
-
-    const { data: inserted, error: insertErr } = await supabase
-      .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
-      .insert(row)
-      .select('*')
-      .single();
-
-    if (insertErr) {
-      logger.error('Failed to insert stakeholder relationship', insertErr, 'StakeholdersAPI');
-      return apiInternalError('Failed to create stakeholder relationship');
-    }
-
-    return apiCreated({ relationship: inserted });
+    return apiCreated({ relationship: result.relationship });
   } catch (error) {
     logger.error('Unexpected error in POST /api/stakeholders', error, 'StakeholdersAPI');
     return apiInternalError('Internal server error');

--- a/src/app/api/v1/README.md
+++ b/src/app/api/v1/README.md
@@ -75,6 +75,8 @@ handlers currently require a session).
 | Endpoint                   | Method | What it does                                          |
 | -------------------------- | ------ | ----------------------------------------------------- |
 | `/api/v1/timeline/publish` | POST   | Publish an external build event onto a project's wall |
+| `/api/v1/stakeholders`     | GET    | List stakeholder relationships for a project          |
+| `/api/v1/stakeholders`     | POST   | Create a stakeholder relationship                     |
 
 `/api/v1/timeline/publish` is the async publish bus: an external client
 (FleetCrown) lands a publish-worthy build event onto a project's OrangeCat
@@ -84,6 +86,10 @@ the subject project. Idempotent + reconcilable — keyed by
 duplicating it. Inbound contract SSOT: `src/config/external-publish.ts`. See
 `docs/architecture/PLATFORM_AND_COLLABORATION.md` ("Async publish + read-only
 surfacing").
+
+`/api/v1/stakeholders` exposes the typed project→stakeholder graph for
+integration clients (FleetCrown). Requires `stakeholders.read` / `stakeholders.write`
+and ownership of the source project. Contract SSOT: `src/config/stakeholders.ts`.
 
 ## Out of scope for v1 (until further notice)
 

--- a/src/app/api/v1/route.ts
+++ b/src/app/api/v1/route.ts
@@ -16,6 +16,7 @@ import {
   PUBLIC_API_VERSION,
   PUBLIC_API_BASE,
   PUBLIC_API_ENTITY_TYPES,
+  PUBLIC_API_INTEGRATION_ENDPOINTS,
   publicApiEndpoint,
 } from '@/config/public-api';
 
@@ -32,6 +33,11 @@ export async function GET() {
       type,
       methods: ['POST', 'GET'],
       endpoint: publicApiEndpoint(type),
+    })),
+    integrations: PUBLIC_API_INTEGRATION_ENDPOINTS.map(item => ({
+      name: item.name,
+      methods: [...item.methods],
+      endpoint: item.endpoint,
     })),
     docs: {
       contract: '/api/v1/README.md (in repo)',

--- a/src/app/api/v1/stakeholders/route.ts
+++ b/src/app/api/v1/stakeholders/route.ts
@@ -1,0 +1,103 @@
+/**
+ * GET/POST /api/v1/stakeholders — stakeholder graph for integration clients.
+ *
+ * FleetCrown reads typed project→stakeholder edges from OrangeCat. Authenticated
+ * via the v1 auth path (OIDC bearer or `ock_` integration key) and gated to
+ * `stakeholders.read` / `stakeholders.write`. Uses admin client + app-layer
+ * authz (same non-session pattern as timeline publish).
+ */
+import { NextRequest } from 'next/server';
+import { resolveRequestAuth, hasScope } from '@/lib/api/resolveRequestAuth';
+import { apiCreated, apiSuccess, apiError } from '@/lib/api/standardResponse';
+import { createStakeholderSchema } from '@/config/stakeholders';
+import {
+  listStakeholderRelationshipsForUser,
+  createStakeholderRelationshipForUser,
+} from '@/services/platform/stakeholderRelationships';
+import { logger } from '@/utils/logger';
+
+const READ_SCOPE = 'stakeholders.read';
+const WRITE_SCOPE = 'stakeholders.write';
+
+export async function GET(request: NextRequest) {
+  const auth = await resolveRequestAuth(request);
+  if (!auth) {
+    return apiError('Authentication required', 'UNAUTHORIZED', 401);
+  }
+  if (!hasScope(auth.scopes, READ_SCOPE)) {
+    return apiError(`Missing required scope: ${READ_SCOPE}`, 'FORBIDDEN', 403);
+  }
+  if (!auth.userId) {
+    return apiError('Authenticated identity has no user id', 'UNAUTHORIZED', 401);
+  }
+
+  const url = new URL(request.url);
+  const fromProjectId = url.searchParams.get('fromProjectId');
+  const kindFilter = url.searchParams.get('kind') ?? undefined;
+
+  if (!fromProjectId) {
+    return apiError('fromProjectId query parameter is required', 'BAD_REQUEST', 400);
+  }
+
+  const result = await listStakeholderRelationshipsForUser(auth.userId, fromProjectId, kindFilter);
+  if (!result.ok) {
+    switch (result.reason) {
+      case 'bad_kind':
+        return apiError(result.message, 'VALIDATION_ERROR', 422);
+      case 'project_not_found':
+        return apiError(result.message, 'NOT_FOUND', 404);
+      case 'forbidden':
+        return apiError(result.message, 'FORBIDDEN', 403);
+      default:
+        return apiError(result.message, 'INTERNAL_ERROR', 500);
+    }
+  }
+
+  return apiSuccess({ relationships: result.relationships });
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await resolveRequestAuth(request);
+  if (!auth) {
+    return apiError('Authentication required', 'UNAUTHORIZED', 401);
+  }
+  if (!hasScope(auth.scopes, WRITE_SCOPE)) {
+    return apiError(`Missing required scope: ${WRITE_SCOPE}`, 'FORBIDDEN', 403);
+  }
+  if (!auth.userId) {
+    return apiError('Authenticated identity has no user id', 'UNAUTHORIZED', 401);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('Invalid JSON body', 'BAD_REQUEST', 400);
+  }
+
+  const parsed = createStakeholderSchema.safeParse(body);
+  if (!parsed.success) {
+    return apiError('Validation failed', 'VALIDATION_ERROR', 422, parsed.error.flatten());
+  }
+
+  const result = await createStakeholderRelationshipForUser(auth.userId, parsed.data);
+  if (!result.ok) {
+    switch (result.reason) {
+      case 'project_not_found':
+        return apiError(result.message, 'NOT_FOUND', 404);
+      case 'forbidden':
+        return apiError(result.message, 'FORBIDDEN', 403);
+      case 'no_actor':
+        return apiError(result.message, 'UNAUTHORIZED', 401);
+      default:
+        logger.error(
+          'Stakeholder create failed (v1)',
+          { message: result.message },
+          'StakeholdersV1'
+        );
+        return apiError(result.message, 'INTERNAL_ERROR', 500);
+    }
+  }
+
+  return apiCreated({ relationship: result.relationship });
+}

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -10,13 +10,7 @@ import {
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { logger } from '@/utils/logger';
 import { rateLimit, retryAfterSeconds } from '@/lib/rate-limit';
-import { z } from 'zod';
-
-const waitlistSchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
-  source: z.string().max(100).optional(),
-  referrer: z.string().max(500).optional(),
-});
+import { waitlistSchema } from '@/lib/validation/social';
 
 export const POST = withOptionalAuth(async request => {
   try {

--- a/src/app/discover/discoverConstants.ts
+++ b/src/app/discover/discoverConstants.ts
@@ -1,42 +1,5 @@
-import type { DiscoverTabType } from '@/components/discover/DiscoverTabs';
+import type { DiscoverTabType } from '@/config/discover-tabs';
+import { VALID_TAB_TYPES, DISCOVER_TAB_FILTERS } from '@/config/discover-tabs';
 
-export const VALID_TAB_TYPES: DiscoverTabType[] = [
-  'all',
-  'projects',
-  'profiles',
-  'loans',
-  'investments',
-  'assets',
-  'causes',
-  'events',
-  'products',
-  'services',
-  'groups',
-  'circles',
-  'wishlists',
-  'research',
-  'ai_assistants',
-];
-
-/** Which sidebar filter blocks apply per tab. */
-export interface DiscoverTabFilterConfig {
-  projectStatus: boolean;
-  projectCategories: boolean;
-}
-
-// The status chips (active/paused/completed/cancelled) and category chips feed
-// the project search only (useSearch); the per-entity tabs (loans, events,
-// ai_assistants, …) ignore them entirely — so showing them there was noise.
-const PROJECT_SEARCH_TABS = new Set<DiscoverTabType>(['all', 'projects']);
-
-/** Config map: which filter blocks the sidebar shows for each tab (SSOT). */
-export const DISCOVER_TAB_FILTERS: Record<DiscoverTabType, DiscoverTabFilterConfig> =
-  Object.fromEntries(
-    VALID_TAB_TYPES.map(tab => [
-      tab,
-      {
-        projectStatus: PROJECT_SEARCH_TABS.has(tab),
-        projectCategories: PROJECT_SEARCH_TABS.has(tab),
-      },
-    ])
-  ) as Record<DiscoverTabType, DiscoverTabFilterConfig>;
+export type { DiscoverTabType };
+export { VALID_TAB_TYPES, DISCOVER_TAB_FILTERS };

--- a/src/components/ai-chat/ModelSelector.tsx
+++ b/src/components/ai-chat/ModelSelector.tsx
@@ -2,11 +2,12 @@
  * Inline Model Selector Components
  *
  * Simple inline components for model selection and display.
+ * Reads from AI_MODEL_REGISTRY (SSOT) — not the legacy model-registry adapter.
  */
 
 'use client';
 
-import { MODEL_REGISTRY } from '@/config/model-registry';
+import { getAvailableModels, getModelMetadata } from '@/config/ai-models';
 import {
   Select,
   SelectContent,
@@ -15,7 +16,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { BADGE_COLORS } from '@/config/badge-colors';
 import { Sparkles, Zap, Crown } from 'lucide-react';
 
 interface ModelSelectorProps {
@@ -31,7 +31,7 @@ export function ModelSelector({
   size = 'default',
   showPricing = false,
 }: ModelSelectorProps) {
-  const models = Object.values(MODEL_REGISTRY);
+  const models = getAvailableModels();
 
   return (
     <Select value={selectedModel} onValueChange={onModelChange}>
@@ -48,12 +48,14 @@ export function ModelSelector({
         {models.map(model => (
           <SelectItem key={model.id} value={model.id}>
             <div className="flex items-center gap-2">
-              {model.tier === 'free' && <Zap className="h-3 w-3 text-status-positive" />}
-              {model.tier === 'paid' && <Crown className="h-3 w-3 text-fg-secondary" />}
+              {model.isFree && <Zap className="h-3 w-3 text-status-positive" />}
+              {!model.isFree && model.tier === 'premium' && (
+                <Crown className="h-3 w-3 text-fg-secondary" />
+              )}
               <span>{model.name}</span>
-              {showPricing && model.costPerMessage && (
+              {showPricing && !model.isFree && (
                 <span className="text-xs text-fg-secondary">
-                  (${model.costPerMessage.toFixed(3)})
+                  (${Math.max(model.inputCostPer1M, model.outputCostPer1M).toFixed(2)}/1M)
                 </span>
               )}
             </div>
@@ -69,7 +71,7 @@ interface ModelBadgeProps {
 }
 
 export function ModelBadge({ modelId }: ModelBadgeProps) {
-  const model = MODEL_REGISTRY[modelId];
+  const model = getModelMetadata(modelId);
 
   if (!model) {
     return (
@@ -79,16 +81,12 @@ export function ModelBadge({ modelId }: ModelBadgeProps) {
     );
   }
 
-  const tierColors = {
-    free: BADGE_COLORS.success,
-    freemium: BADGE_COLORS.tiffany,
-    paid: BADGE_COLORS.orange,
-  };
-
   return (
-    <Badge variant="outline" className={`text-xs ${tierColors[model.tier]}`}>
-      {model.tier === 'free' && <Zap className="h-3 w-3 mr-1" />}
-      {model.tier === 'paid' && <Crown className="h-3 w-3 mr-1" />}
+    <Badge variant="outline" className="text-xs">
+      {model.isFree && <Zap className="h-3 w-3 mr-1 text-status-positive" />}
+      {!model.isFree && model.tier === 'premium' && (
+        <Crown className="h-3 w-3 mr-1 text-fg-secondary" />
+      )}
       {model.name}
     </Badge>
   );

--- a/src/components/ai/AIKeyAddForm.tsx
+++ b/src/components/ai/AIKeyAddForm.tsx
@@ -16,23 +16,8 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/com
 import Button from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { cn } from '@/lib/utils';
-import { aiProviders, getAIProvider, validateApiKeyFormat } from '@/data/aiProviders';
+import { getAIProvider, validateApiKeyFormat, wiredProviders } from '@/data/aiProviders';
 import { ROUTES } from '@/config/routes';
-
-/**
- * Providers Cat's chat route can actually route through today.
- *
- * Direct: Groq + the OpenAI-compatible direct providers (OpenAI, Together,
- * DeepSeek, xAI). Aggregator: OpenRouter. Local providers (Ollama,
- * LM Studio) aren't here yet — they need a different architecture
- * because the server backend can't reach the user's localhost.
- *
- * Anthropic and Google are intentionally NOT here — they use different
- * wire formats (not OpenAI-compatible) and need their own client classes.
- * Users who want Claude or Gemini should add an OpenRouter key.
- */
-const WIRED_PROVIDER_IDS = new Set(['groq', 'openrouter', 'openai', 'together', 'deepseek', 'xai']);
-const wiredProviders = aiProviders.filter(p => WIRED_PROVIDER_IDS.has(p.id));
 
 interface AIKeyAddFormProps {
   onAdd: (data: { provider: string; apiKey: string; keyName: string }) => Promise<void>;

--- a/src/components/create/FormField.tsx
+++ b/src/components/create/FormField.tsx
@@ -18,6 +18,7 @@ import { useUserCurrency } from '@/hooks/useUserCurrency';
 import type { FormFieldProps } from './types';
 import type { Currency } from '@/types/settings';
 import { DictationButton } from '@/components/ui/DictationButton';
+import { FEATURES } from '@/config/features';
 import { AvailabilityEditor } from './fields/AvailabilityEditor';
 
 // ==================== COMPONENT ====================
@@ -56,7 +57,7 @@ export function FormField({
               disabled={disabled}
               className={baseInputClass}
             />
-            {process.env.NEXT_PUBLIC_FEATURE_VOICE_INPUT === 'true' && (
+            {FEATURES.voiceInput && (
               <DictationButton
                 size="sm"
                 ariaLabel={`Voice input for ${label}`}
@@ -243,7 +244,7 @@ export function FormField({
               disabled={disabled}
               className={baseInputClass}
             />
-            {process.env.NEXT_PUBLIC_FEATURE_VOICE_INPUT === 'true' && (
+            {FEATURES.voiceInput && (
               <DictationButton
                 size="sm"
                 ariaLabel={`Voice input for ${label}`}

--- a/src/components/discover/DiscoverEmptyState.tsx
+++ b/src/components/discover/DiscoverEmptyState.tsx
@@ -1,7 +1,8 @@
 import { Target, Users } from 'lucide-react';
 import Button from '@/components/ui/Button';
-import type { DiscoverTabType } from '@/components/discover/DiscoverTabs';
-import { ENTITY_REGISTRY, type EntityType } from '@/config/entity-registry';
+import type { DiscoverTabType } from '@/config/discover-tabs';
+import { DISCOVER_TAB_TO_ENTITY } from '@/config/discover-tabs';
+import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { ROUTES } from '@/config/routes';
 
 interface DiscoverEmptyStateProps {
@@ -10,28 +11,12 @@ interface DiscoverEmptyStateProps {
   onClearFilters: () => void;
 }
 
-const TAB_ENTITY_MAP: Partial<Record<DiscoverTabType, EntityType>> = {
-  projects: 'project',
-  loans: 'loan',
-  investments: 'investment',
-  assets: 'asset',
-  causes: 'cause',
-  events: 'event',
-  products: 'product',
-  services: 'service',
-  groups: 'group',
-  circles: 'circle',
-  wishlists: 'wishlist',
-  research: 'research',
-  ai_assistants: 'ai_assistant',
-};
-
 export default function DiscoverEmptyState({
   activeTab,
   hasFilters,
   onClearFilters,
 }: DiscoverEmptyStateProps) {
-  const entityType = TAB_ENTITY_MAP[activeTab];
+  const entityType = DISCOVER_TAB_TO_ENTITY[activeTab];
   const meta = entityType ? ENTITY_REGISTRY[entityType] : null;
   const EntityIcon = meta?.icon ?? (activeTab === 'profiles' ? Users : Target);
 

--- a/src/components/discover/DiscoverTabs.tsx
+++ b/src/components/discover/DiscoverTabs.tsx
@@ -3,24 +3,13 @@
 import { Grid3X3, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
-import type { EntityType } from '@/config/entity-registry';
+import {
+  DISCOVER_ENTITY_TAB_IDS,
+  DISCOVER_TAB_TO_ENTITY,
+  type DiscoverTabType,
+} from '@/config/discover-tabs';
 
-export type DiscoverTabType =
-  | 'all'
-  | 'projects'
-  | 'profiles'
-  | 'loans'
-  | 'investments'
-  | 'assets'
-  | 'causes'
-  | 'events'
-  | 'products'
-  | 'services'
-  | 'groups'
-  | 'circles'
-  | 'wishlists'
-  | 'research'
-  | 'ai_assistants';
+export type { DiscoverTabType };
 
 interface DiscoverTabsProps {
   activeTab: DiscoverTabType;
@@ -28,23 +17,6 @@ interface DiscoverTabsProps {
   counts: Partial<Record<DiscoverTabType, number>>;
   loading?: boolean;
 }
-
-/** Maps plural discover tab IDs to their singular EntityType in the registry. */
-const TAB_TO_ENTITY: Partial<Record<DiscoverTabType, EntityType>> = {
-  projects: 'project',
-  causes: 'cause',
-  investments: 'investment',
-  loans: 'loan',
-  assets: 'asset',
-  products: 'product',
-  services: 'service',
-  events: 'event',
-  groups: 'group',
-  circles: 'circle',
-  wishlists: 'wishlist',
-  research: 'research',
-  ai_assistants: 'ai_assistant',
-};
 
 interface TabConfig {
   id: DiscoverTabType;
@@ -54,24 +26,8 @@ interface TabConfig {
 
 const tabs: TabConfig[] = [
   { id: 'all', label: 'All', Icon: Grid3X3 },
-  ...(
-    [
-      'projects',
-      'causes',
-      'investments',
-      'loans',
-      'assets',
-      'products',
-      'services',
-      'events',
-      'groups',
-      'circles',
-      'wishlists',
-      'research',
-      'ai_assistants',
-    ] as DiscoverTabType[]
-  ).map(id => {
-    const meta = ENTITY_REGISTRY[TAB_TO_ENTITY[id]!];
+  ...DISCOVER_ENTITY_TAB_IDS.map(id => {
+    const meta = ENTITY_REGISTRY[DISCOVER_TAB_TO_ENTITY[id]!];
     return { id, label: meta.namePlural, Icon: meta.icon };
   }),
   { id: 'profiles', label: 'People', Icon: Users },

--- a/src/components/onboarding/IntelligentOnboarding.tsx
+++ b/src/components/onboarding/IntelligentOnboarding.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { ProfileService } from '@/services/profile';
 import { logger } from '@/utils/logger';
 import { ROUTES } from '@/config/routes';
+import { FEATURES } from '@/config/features';
 import { ONBOARDING_METHOD } from '@/config/onboarding';
 
 const EXAMPLE_PROMPTS = [
@@ -127,7 +128,7 @@ export default function IntelligentOnboarding() {
                 }
               }}
             />
-            {process.env.NEXT_PUBLIC_FEATURE_VOICE_INPUT === 'true' && (
+            {FEATURES.voiceInput && (
               <DictationButton
                 ariaLabel="Voice input"
                 size="sm"

--- a/src/components/payment/ContributionAmountInput.tsx
+++ b/src/components/payment/ContributionAmountInput.tsx
@@ -11,8 +11,10 @@ import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 
+import { CONTRIBUTION_QUICK_AMOUNTS_BTC } from '@/config/payment-presets';
+
 // Quick-select amounts in BTC (approx $1, $5, $10, $50, $100 at $100k/BTC)
-const QUICK_AMOUNTS = [0.00001, 0.00005, 0.0001, 0.0005, 0.001];
+const QUICK_AMOUNTS = [...CONTRIBUTION_QUICK_AMOUNTS_BTC];
 
 interface ContributionAmountInputProps {
   value: number;

--- a/src/components/payment/PaymentDialog.tsx
+++ b/src/components/payment/PaymentDialog.tsx
@@ -42,7 +42,7 @@ interface PaymentDialogProps {
   defaultAmount?: number;
 }
 
-const DEFAULT_CONTRIBUTION_BTC = 0.0001; // ~$10 at $100k/BTC
+import { DEFAULT_CONTRIBUTION_BTC } from '@/config/payment-presets';
 
 export function PaymentDialog({
   open,

--- a/src/components/payment/PublicPayPanel.tsx
+++ b/src/components/payment/PublicPayPanel.tsx
@@ -25,6 +25,7 @@ import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { PaymentExpectationNote } from './PaymentExpectationNote';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { displayBTC } from '@/services/currency';
+import { LABELED_SUPPORT_AMOUNTS_BTC } from '@/config/payment-presets';
 
 interface PublicPayPanelProps {
   entityTitle: string;
@@ -46,13 +47,6 @@ interface PublicPayPanelProps {
    */
   signInHref?: string;
 }
-
-/** Quick-pick contribution amounts (BTC). Small/Medium/Large, like the dashboard. */
-const SUGGESTED_BTC = [
-  { btc: 0.001, label: 'Small' },
-  { btc: 0.005, label: 'Medium' },
-  { btc: 0.01, label: 'Large' },
-] as const;
 
 function truncateMiddle(value: string, head = 12, tail = 10): string {
   return value.length <= head + tail + 1 ? value : `${value.slice(0, head)}…${value.slice(-tail)}`;
@@ -128,8 +122,8 @@ export function PublicPayPanel({
             <p className="text-sm text-fg-secondary">
               Choose an amount, or send any in your wallet.
             </p>
-            <div className="grid grid-cols-3 gap-2">
-              {SUGGESTED_BTC.map(({ btc, label }) => {
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+              {LABELED_SUPPORT_AMOUNTS_BTC.map(({ btc, label }) => {
                 const active = selectedBtc === btc;
                 return (
                   <button

--- a/src/components/project/ProjectDonationSection.tsx
+++ b/src/components/project/ProjectDonationSection.tsx
@@ -10,6 +10,7 @@ import { convert, formatCurrency, displayBTC } from '@/services/currency';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { useProjectDonation } from './useProjectDonation';
 import { ROUTES } from '@/config/routes';
+import { LABELED_SUPPORT_AMOUNTS_BTC } from '@/config/payment-presets';
 
 interface ProjectDonationSectionProps {
   projectId: string;
@@ -18,12 +19,6 @@ interface ProjectDonationSectionProps {
   projectTitle?: string;
   isOwner?: boolean;
 }
-
-const SUGGESTED_AMOUNTS_BTC = [
-  { btc: 0.001, label: 'Small' },
-  { btc: 0.005, label: 'Medium' },
-  { btc: 0.01, label: 'Large' },
-];
 
 export function ProjectDonationSection({
   projectId,
@@ -190,8 +185,8 @@ export function ProjectDonationSection({
             <p className="text-sm font-medium text-fg-primary mb-3">
               {ownerId && !isOwner ? 'Other amounts:' : 'Suggested support amounts:'}
             </p>
-            <div className="grid grid-cols-3 gap-3">
-              {SUGGESTED_AMOUNTS_BTC.map(({ btc, label }) => {
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+              {LABELED_SUPPORT_AMOUNTS_BTC.map(({ btc, label }) => {
                 const displayAmount = convert(btc, 'BTC', userCurrency);
                 const formattedAmount = formatCurrency(displayAmount, userCurrency, {
                   compact: true,

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -23,14 +23,14 @@ export const CardHeader = ({ className, ...p }: React.HTMLAttributes<HTMLDivElem
 );
 
 export const CardTitle = ({ className, ...p }: React.HTMLAttributes<HTMLHeadingElement>) => (
-  <h3 {...p} className={cn('text-lg font-semibold leading-tight text-foreground', className)} />
+  <h3 {...p} className={cn('text-lg font-semibold leading-tight text-fg-primary', className)} />
 );
 
 export const CardDescription = ({
   className,
   ...p
 }: React.HTMLAttributes<HTMLParagraphElement>) => (
-  <p {...p} className={cn('mt-1 text-sm leading-6 text-muted-foreground', className)} />
+  <p {...p} className={cn('mt-1 text-sm leading-6 text-fg-secondary', className)} />
 );
 
 export const CardContent = ({ className, ...p }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -7,11 +7,11 @@ import { COMPONENT_STYLES } from '@/config/design-system';
 const badgeVariants = cva(COMPONENT_STYLES.badge.base, {
   variants: {
     variant: {
-      default: 'border-transparent bg-foreground text-background hover:bg-muted-strong',
-      secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+      default: 'border-transparent bg-fg-primary text-fg-inverted hover:bg-muted-strong',
+      secondary: 'border-transparent bg-surface-raised text-fg-secondary hover:bg-surface-raised',
       destructive:
-        'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
-      outline: 'text-foreground',
+        'border-transparent bg-status-negative text-fg-inverted hover:bg-status-negative/90',
+      outline: 'border-default text-fg-primary',
     },
   },
   defaultVariants: {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid max-h-[90vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid max-h-[90vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border border-default bg-surface-base p-6 shadow-none duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-surface-page transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-surface-raised data-[state=open]:text-fg-tertiary">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -72,7 +72,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    className={cn('text-lg font-semibold leading-none tracking-tight text-fg-primary', className)}
     {...props}
   />
 ));
@@ -84,7 +84,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn('text-sm text-fg-secondary', className)}
     {...props}
   />
 ));

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -17,7 +17,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-card dark:border-border p-1 text-foreground dark:text-foreground shadow-sm animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border border-default bg-surface-base p-1 text-fg-primary shadow-none animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}
@@ -33,7 +33,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-muted dark:focus:bg-muted focus:text-foreground dark:focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-surface-raised focus:text-fg-primary data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}
@@ -47,7 +47,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-border', className)}
+    className={cn('-mx-1 my-1 h-px bg-border-default', className)}
     {...props}
   />
 ));

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -21,7 +21,7 @@ const SelectTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       COMPONENT_STYLES.field.control,
-      'flex h-10 items-center justify-between whitespace-nowrap px-3 py-2 text-sm data-[placeholder]:text-muted-foreground [&>span]:line-clamp-1',
+      'flex h-10 items-center justify-between whitespace-nowrap px-3 py-2 text-sm data-[placeholder]:text-fg-tertiary [&>span]:line-clamp-1',
       className
     )}
     {...props}
@@ -70,7 +70,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 origin-[--radix-select-content-transform-origin]',
+        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-lg border border-default bg-surface-overlay text-fg-primary shadow-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 origin-[--radix-select-content-transform-origin]',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className
@@ -113,7 +113,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-md py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-md py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-surface-raised focus:text-fg-primary data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}
@@ -134,7 +134,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    className={cn('-mx-1 my-1 h-px bg-border-default', className)}
     {...props}
   />
 ));

--- a/src/components/wallets/WalletVisibilityToggle.tsx
+++ b/src/components/wallets/WalletVisibilityToggle.tsx
@@ -14,6 +14,7 @@ import { toast } from 'sonner';
 import { Check, Loader2 } from 'lucide-react';
 import type { EntityType } from '@/config/entity-registry';
 import { WALLET_VISIBILITY_OPTIONS, type WalletVisibility } from '@/config/wallet-visibility';
+import { API_ROUTES } from '@/config/api-routes';
 import { cn } from '@/lib/utils';
 
 interface WalletVisibilityToggleProps {
@@ -40,7 +41,7 @@ export function WalletVisibilityToggle({
     setPending(next);
     setVisibility(next); // optimistic
     try {
-      const res = await fetch('/api/wallets/entity-visibility', {
+      const res = await fetch(API_ROUTES.WALLETS.ENTITY_VISIBILITY, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -53,6 +53,7 @@ export const API_ROUTES = {
   WALLETS: {
     BASE: ENTITY_REGISTRY['wallet'].apiEndpoint,
     TRANSFER: '/api/wallets/transfer',
+    ENTITY_VISIBILITY: '/api/wallets/entity-visibility',
   },
   ENTITY_WALLETS: '/api/entity-wallets',
   NOTIFICATIONS: {
@@ -118,7 +119,6 @@ export const API_ROUTES = {
   },
   PAYMENTS: {
     BASE: '/api/payments',
-    SEND: '/api/payments/send',
   },
   PROJECTS: {
     BASE: ENTITY_REGISTRY['project'].apiEndpoint,

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -136,6 +136,7 @@ export const API_ROUTES = {
   },
   LOANS: {
     BASE: ENTITY_REGISTRY['loan'].apiEndpoint,
+    BY_ID: (id: string) => `${ENTITY_REGISTRY['loan'].apiEndpoint}/${id}`,
     COLLATERAL: '/api/loan-collateral',
   },
   PROFILE: '/api/profile',

--- a/src/config/cat-actions.ts
+++ b/src/config/cat-actions.ts
@@ -634,7 +634,6 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
       'Announce my project launch',
       'Share an update with my followers',
     ],
-    apiEndpoint: '/api/posts',
     enabled: true,
   },
 
@@ -705,7 +704,6 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
       'Pay for the service I ordered',
       'Tip a small amount to that creator',
     ],
-    apiEndpoint: '/api/payments/send',
     enabled: true,
   },
 

--- a/src/config/cat-plans.ts
+++ b/src/config/cat-plans.ts
@@ -14,11 +14,12 @@
  * NOT a card until it can actually be bought.
  *
  * The /pricing page and QuotaMeter both read from this file. If the daily
- * limit changes, update CAT_FREE_DAILY_LIMIT here and api-key-service.ts in
- * the same commit.
+ * limit changes, update CAT_FREE_DAILY_LIMIT here only — all fallbacks import it.
  */
 
 import { ROUTES } from '@/config/routes';
+import { CREDIT_USAGE_MARKUP } from '@/services/cat/credit-metering';
+import { WIRED_PROVIDER_DISPLAY_NAMES } from '@/data/aiProviders';
 
 export type CatPlanId = 'free' | 'byok' | 'credits';
 
@@ -29,8 +30,8 @@ export type CatPlanId = 'free' | 'byok' | 'credits';
  */
 export const CAT_CREDITS_LIVE = false;
 
-/** Platform margin on frontier inference billed to Cat Credits (SSOT: credit-metering.ts). */
-export const CAT_CREDITS_MARKUP_LABEL = 'provider cost + 20%';
+/** Platform margin label — derived from CREDIT_USAGE_MARKUP so marketing never drifts. */
+export const CAT_CREDITS_MARKUP_LABEL = `provider cost + ${Math.round((CREDIT_USAGE_MARKUP - 1) * 100)}%`;
 
 export interface CatPlan {
   id: CatPlanId;
@@ -59,16 +60,9 @@ export const CAT_FREE_DAILY_LIMIT = 10;
 /**
  * Providers Cat actually routes through today, surfaced on /pricing so the
  * BYOK card shows real names instead of a vague "any provider" promise.
- * Mirrors WIRED_PROVIDER_IDS in AIKeyAddForm — keep in sync.
+ * Derived from WIRED_PROVIDER_IDS in src/data/aiProviders.ts.
  */
-export const CAT_WIRED_PROVIDERS = [
-  'Groq',
-  'OpenRouter',
-  'OpenAI',
-  'Together',
-  'DeepSeek',
-  'xAI (Grok)',
-] as const;
+export const CAT_WIRED_PROVIDERS = WIRED_PROVIDER_DISPLAY_NAMES;
 
 /**
  * SSOT for the frontier models named in marketing copy (pricing, support,

--- a/src/config/discover-tabs.ts
+++ b/src/config/discover-tabs.ts
@@ -1,0 +1,96 @@
+/**
+ * Discover tabs — SSOT for tab IDs, entity mapping, and filter config.
+ *
+ * Import from here instead of duplicating TAB_TO_ENTITY / TAB_ENTITY_MAP
+ * across DiscoverTabs, DiscoverEmptyState, and discoverConstants.
+ */
+
+import type { EntityType } from '@/config/entity-registry';
+
+export type DiscoverTabType =
+  | 'all'
+  | 'projects'
+  | 'profiles'
+  | 'loans'
+  | 'investments'
+  | 'assets'
+  | 'causes'
+  | 'events'
+  | 'products'
+  | 'services'
+  | 'groups'
+  | 'circles'
+  | 'wishlists'
+  | 'research'
+  | 'ai_assistants';
+
+export const VALID_TAB_TYPES: DiscoverTabType[] = [
+  'all',
+  'projects',
+  'profiles',
+  'loans',
+  'investments',
+  'assets',
+  'causes',
+  'events',
+  'products',
+  'services',
+  'groups',
+  'circles',
+  'wishlists',
+  'research',
+  'ai_assistants',
+];
+
+/** Maps plural discover tab IDs to their singular EntityType in the registry. */
+export const DISCOVER_TAB_TO_ENTITY: Partial<Record<DiscoverTabType, EntityType>> = {
+  projects: 'project',
+  causes: 'cause',
+  investments: 'investment',
+  loans: 'loan',
+  assets: 'asset',
+  products: 'product',
+  services: 'service',
+  events: 'event',
+  groups: 'group',
+  circles: 'circle',
+  wishlists: 'wishlist',
+  research: 'research',
+  ai_assistants: 'ai_assistant',
+};
+
+/** Entity-backed tabs shown after "All" in the discover nav (order matters). */
+export const DISCOVER_ENTITY_TAB_IDS = [
+  'projects',
+  'causes',
+  'investments',
+  'loans',
+  'assets',
+  'products',
+  'services',
+  'events',
+  'groups',
+  'circles',
+  'wishlists',
+  'research',
+  'ai_assistants',
+] as const satisfies readonly DiscoverTabType[];
+
+export interface DiscoverTabFilterConfig {
+  projectStatus: boolean;
+  projectCategories: boolean;
+}
+
+const PROJECT_SEARCH_TABS = new Set<DiscoverTabType>(['all', 'projects']);
+
+/** Which sidebar filter blocks apply per tab. */
+export const DISCOVER_TAB_FILTERS: Record<DiscoverTabType, DiscoverTabFilterConfig> =
+  Object.fromEntries(
+    VALID_TAB_TYPES.map(tab => [
+      tab,
+      {
+        projectStatus: PROJECT_SEARCH_TABS.has(tab),
+        projectCategories: PROJECT_SEARCH_TABS.has(tab),
+      },
+    ])
+  ) as Record<DiscoverTabType, DiscoverTabFilterConfig>;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,24 @@
+/**
+ * Environment SSOT — canonical URLs and runtime mode flags.
+ *
+ * Prefer importing from here over raw `process.env` for values that must stay
+ * consistent across auth redirects, emails, and OG metadata.
+ */
+
+function normalizeUrl(value: string | undefined, fallback: string): string {
+  return (value?.trim() || fallback).replace(/\/$/, '');
+}
+
+const defaultOrigin = 'https://orangecat.ch';
+
+/** Public site origin (marketing, auth redirects). */
+export const SITE_URL = normalizeUrl(process.env.NEXT_PUBLIC_SITE_URL, defaultOrigin);
+
+/** App origin (API callbacks, emails). Falls back to SITE_URL when unset. */
+export const APP_URL = normalizeUrl(process.env.NEXT_PUBLIC_APP_URL, SITE_URL);
+
+export const RUNTIME = {
+  isDev: process.env.NODE_ENV === 'development',
+  isProd: process.env.NODE_ENV === 'production',
+  isTest: process.env.NODE_ENV === 'test',
+} as const;

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,15 @@
+/**
+ * Product feature flags — SSOT for env-gated UI behavior.
+ *
+ * Read flags from here instead of scattering `process.env.NEXT_PUBLIC_*`
+ * checks across components.
+ */
+
+function envFlag(name: string): boolean {
+  return process.env[name] === 'true';
+}
+
+export const FEATURES = {
+  /** Voice input on create forms and onboarding (requires browser speech APIs). */
+  voiceInput: envFlag('NEXT_PUBLIC_FEATURE_VOICE_INPUT'),
+} as const;

--- a/src/config/payment-presets.ts
+++ b/src/config/payment-presets.ts
@@ -1,0 +1,20 @@
+/**
+ * Payment amount presets — SSOT for BTC quick-pick buttons across the app.
+ *
+ * Different surfaces need different scales:
+ * - Micro picks for in-app contribution dialogs (~$1–$100 at $100k/BTC)
+ * - Labeled tiers for public/project support (Small/Medium/Large)
+ */
+
+/** Quick-select amounts for ContributionAmountInput and similar pickers. */
+export const CONTRIBUTION_QUICK_AMOUNTS_BTC = [0.00001, 0.00005, 0.0001, 0.0005, 0.001] as const;
+
+/** Default contribution when the payer hasn't chosen an amount yet. */
+export const DEFAULT_CONTRIBUTION_BTC = 0.0001;
+
+/** Labeled support tiers for public pay panels and project donation sections. */
+export const LABELED_SUPPORT_AMOUNTS_BTC = [
+  { btc: 0.001, label: 'Small' },
+  { btc: 0.005, label: 'Medium' },
+  { btc: 0.01, label: 'Large' },
+] as const;

--- a/src/config/public-api.ts
+++ b/src/config/public-api.ts
@@ -7,8 +7,8 @@
  * non-versioned internal handlers that the OrangeCat web app talks to.
  *
  * Created: 2026-06-03
- * Last Modified: 2026-06-03
- * Last Modified Summary: Initial — names v1, lists the endpoints that are part of the contract.
+ * Last Modified: 2026-07-09
+ * Last Modified Summary: Added stakeholders + integration endpoint registry for v1 discovery.
  */
 
 import type { EntityType } from '@/config/entity-registry';
@@ -43,7 +43,25 @@ export function publicApiEndpoint(type: PublicApiEntityType, basePath?: string):
   return `${base}${PUBLIC_API_BASE}/${segment}`;
 }
 
-export const PUBLIC_API_INTEGRATION_SCOPE_TOKENS = ['timeline.write'] as const;
+export const PUBLIC_API_INTEGRATION_SCOPE_TOKENS = [
+  'timeline.write',
+  'stakeholders.read',
+  'stakeholders.write',
+] as const;
+
+/** Non-entity v1 endpoints (publish bus, stakeholder graph, …). */
+export const PUBLIC_API_INTEGRATION_ENDPOINTS = [
+  {
+    name: 'timeline.publish',
+    methods: ['POST'] as const,
+    endpoint: `${PUBLIC_API_BASE}/timeline/publish`,
+  },
+  {
+    name: 'stakeholders',
+    methods: ['GET', 'POST'] as const,
+    endpoint: `${PUBLIC_API_BASE}/stakeholders`,
+  },
+] as const;
 
 /**
  * All scope tokens minting UIs can offer. Format mirrors hasScope:

--- a/src/config/public-api.ts
+++ b/src/config/public-api.ts
@@ -43,15 +43,17 @@ export function publicApiEndpoint(type: PublicApiEntityType, basePath?: string):
   return `${base}${PUBLIC_API_BASE}/${segment}`;
 }
 
+export const PUBLIC_API_INTEGRATION_SCOPE_TOKENS = ['timeline.write'] as const;
+
 /**
  * All scope tokens minting UIs can offer. Format mirrors hasScope:
  * `<entity>.<read|write>`. Wildcard `'*'` is the everything-token and
  * is never enumerated here — it's a separate user choice.
  */
-export const PUBLIC_API_SCOPE_TOKENS: readonly string[] = PUBLIC_API_ENTITY_TYPES.flatMap(t => [
-  `${t}.read`,
-  `${t}.write`,
-]);
+export const PUBLIC_API_SCOPE_TOKENS: readonly string[] = [
+  ...PUBLIC_API_ENTITY_TYPES.flatMap(t => [`${t}.read`, `${t}.write`]),
+  ...PUBLIC_API_INTEGRATION_SCOPE_TOKENS,
+];
 
 /**
  * Webhook event types that endpoints can subscribe to. Format mirrors

--- a/src/config/stakeholders.ts
+++ b/src/config/stakeholders.ts
@@ -1,0 +1,57 @@
+/**
+ * Stakeholder relationship contract SSOT.
+ *
+ * Typed edges between a project and competitors, collaborators, investors,
+ * customers, employees, acquirers, acquisition targets, or in-house dev
+ * projects. OrangeCat stores the graph; FleetCrown and other clients read it
+ * via /api/v1/stakeholders or the internal /api/stakeholders session route.
+ *
+ * Created: 2026-07-09
+ * Last Modified: 2026-07-09
+ * Last Modified Summary: Initial — kinds enum + create schema extracted from route handler.
+ */
+
+import { z } from 'zod';
+
+/** Stakeholder categories — mirrors stakeholder_relationships.kind CHECK constraint. */
+export const STAKEHOLDER_KINDS = [
+  'competitor',
+  'collaborator',
+  'investor',
+  'customer',
+  'employee',
+  'acquirer',
+  'acquisition_target',
+  'in_house_dev',
+] as const;
+
+export type StakeholderKind = (typeof STAKEHOLDER_KINDS)[number];
+
+export const createStakeholderSchema = z
+  .object({
+    fromProjectId: z.string().uuid('fromProjectId must be a UUID'),
+    kind: z.enum(STAKEHOLDER_KINDS),
+    toActorId: z.string().uuid().optional(),
+    toProjectId: z.string().uuid().optional(),
+    toExternalUrl: z.string().url().optional(),
+    toExternalName: z.string().min(1).max(200).optional(),
+    status: z.string().max(50).optional(),
+    confidence: z.number().int().min(0).max(100).optional(),
+    notes: z.string().max(5000).optional(),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .refine(
+    data => {
+      const set = [data.toActorId, data.toProjectId, data.toExternalUrl].filter(Boolean).length;
+      return set === 1;
+    },
+    {
+      message: 'Exactly one of toActorId, toProjectId, or toExternalUrl must be set',
+    }
+  );
+
+export type CreateStakeholderInput = z.infer<typeof createStakeholderSchema>;
+
+export function isStakeholderKind(value: string): value is StakeholderKind {
+  return (STAKEHOLDER_KINDS as readonly string[]).includes(value);
+}

--- a/src/data/aiProviders.ts
+++ b/src/data/aiProviders.ts
@@ -21,6 +21,21 @@
 
 export type AIProviderCategory = 'direct' | 'aggregator' | 'local';
 
+/**
+ * Providers Cat's chat route can route through today (server-reachable).
+ * SSOT for AIKeyAddForm filter and CAT_WIRED_PROVIDERS on /pricing.
+ */
+export const WIRED_PROVIDER_IDS = [
+  'groq',
+  'openrouter',
+  'openai',
+  'together',
+  'deepseek',
+  'xai',
+] as const;
+
+export type WiredProviderId = (typeof WIRED_PROVIDER_IDS)[number];
+
 export interface AIProvider {
   id: string;
   name: string;
@@ -153,6 +168,14 @@ export const aiProviders: AIProvider[] = [
     apiKeyExample: 'http://localhost:1234/v1',
   },
 ];
+
+const wiredIdSet = new Set<string>(WIRED_PROVIDER_IDS);
+
+/** Subset of aiProviders that Cat routes through on the platform key path. */
+export const wiredProviders = aiProviders.filter(p => wiredIdSet.has(p.id));
+
+/** Display names for marketing copy — derived from the provider registry. */
+export const WIRED_PROVIDER_DISPLAY_NAMES = wiredProviders.map(p => p.name);
 
 // ==================== UTILITY FUNCTIONS ====================
 

--- a/src/lib/oauth/config.ts
+++ b/src/lib/oauth/config.ts
@@ -59,6 +59,8 @@ export const OAUTH_SCOPES: readonly OAuthScope[] = [
   { name: 'project.read', description: 'See your projects' },
   { name: 'project.write', description: 'Create and update projects on your behalf' },
   { name: 'timeline.write', description: 'Post updates to your wall on your behalf' },
+  { name: 'stakeholders.read', description: 'Read stakeholder relationships on your projects' },
+  { name: 'stakeholders.write', description: 'Add stakeholder relationships on your projects' },
   { name: 'wallet.read', description: 'See your wallet balances and payment methods' },
   { name: 'messages.read', description: 'Read your messages' },
   { name: 'messages.write', description: 'Send messages on your behalf' },

--- a/src/lib/openapi/registerV1Routes.ts
+++ b/src/lib/openapi/registerV1Routes.ts
@@ -23,6 +23,7 @@ import {
 } from '@/config/public-api';
 import { getEntityMetadata } from '@/config/entity-registry';
 import { externalPublishSchema } from '@/config/external-publish';
+import { createStakeholderSchema } from '@/config/stakeholders';
 import {
   userProductSchema,
   userServiceSchema,
@@ -264,11 +265,9 @@ export function registerV1Routes(): void {
   const publishResponseSchema = z
     .object({
       id: z.string().uuid().openapi({ description: 'OrangeCat timeline event id.' }),
-      status: z
-        .enum(['created', 'updated'])
-        .openapi({
-          description: '`created` on first publish, `updated` on a reconciling re-publish.',
-        }),
+      status: z.enum(['created', 'updated']).openapi({
+        description: '`created` on first publish, `updated` on a reconciling re-publish.',
+      }),
     })
     .openapi('TimelinePublishResponse');
 
@@ -310,6 +309,102 @@ export function registerV1Routes(): void {
       404: COMMON_ERROR_RESPONSES[404],
       422: {
         description: 'Validation error — body did not match the schema, or url origin not allowed.',
+        content: { 'application/json': { schema: apiErrorSchema } },
+      },
+      429: COMMON_ERROR_RESPONSES[429],
+      500: COMMON_ERROR_RESPONSES[500],
+    },
+  });
+
+  const stakeholderRowSchema = z
+    .object({
+      id: z.string().uuid(),
+      from_project_id: z.string().uuid(),
+      kind: z.string(),
+      owner_actor_id: z.string().uuid(),
+    })
+    .catchall(z.unknown())
+    .openapi('StakeholderRelationship');
+
+  const stakeholderListSchema = z
+    .object({
+      relationships: z.array(stakeholderRowSchema),
+    })
+    .openapi('StakeholderListResponse');
+
+  const stakeholderCreateSchema = z
+    .object({
+      relationship: stakeholderRowSchema,
+    })
+    .openapi('StakeholderCreateResponse');
+
+  openApiRegistry.registerPath({
+    method: 'get',
+    path: `${PUBLIC_API_BASE}/stakeholders`,
+    summary: 'List stakeholder relationships for a project',
+    description:
+      'Returns typed edges from a project to competitors, collaborators, investors, and other stakeholder categories. Requires `stakeholders.read` and ownership of the project.',
+    tags: ['Stakeholders'],
+    security: [{ IntegrationKey: [] }],
+    request: {
+      query: z.object({
+        fromProjectId: z.string().uuid().openapi({ description: 'Project whose edges to list.' }),
+        kind: z.string().optional().openapi({ description: 'Optional kind filter.' }),
+      }),
+    },
+    responses: {
+      200: {
+        description: 'Relationships for the project.',
+        content: {
+          'application/json': {
+            schema: apiSuccessSchema(stakeholderListSchema, 'StakeholderListSuccess'),
+          },
+        },
+      },
+      401: COMMON_ERROR_RESPONSES[401],
+      403: COMMON_ERROR_RESPONSES[403],
+      404: COMMON_ERROR_RESPONSES[404],
+      422: {
+        description: 'Validation error — invalid kind filter.',
+        content: { 'application/json': { schema: apiErrorSchema } },
+      },
+      429: COMMON_ERROR_RESPONSES[429],
+      500: COMMON_ERROR_RESPONSES[500],
+    },
+  });
+
+  openApiRegistry.registerPath({
+    method: 'post',
+    path: `${PUBLIC_API_BASE}/stakeholders`,
+    summary: 'Create a stakeholder relationship',
+    description:
+      'Adds a typed edge from a project to an actor, another project, or an external URL. Requires `stakeholders.write` and ownership of the source project.',
+    tags: ['Stakeholders'],
+    security: [{ IntegrationKey: [] }],
+    request: {
+      body: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: createStakeholderSchema.openapi('StakeholderCreate'),
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: 'Relationship created.',
+        content: {
+          'application/json': {
+            schema: apiSuccessSchema(stakeholderCreateSchema, 'StakeholderCreateSuccess'),
+          },
+        },
+      },
+      401: COMMON_ERROR_RESPONSES[401],
+      403: COMMON_ERROR_RESPONSES[403],
+      404: COMMON_ERROR_RESPONSES[404],
+      422: {
+        description: 'Validation error — body did not match the schema.',
         content: { 'application/json': { schema: apiErrorSchema } },
       },
       429: COMMON_ERROR_RESPONSES[429],

--- a/src/lib/validation/social.ts
+++ b/src/lib/validation/social.ts
@@ -133,5 +133,14 @@ export const eventSchema = z
     }
   );
 
+/** Channel / marketing waitlist sign-up (shared by API route and channel page). */
+export const waitlistSchema = z.object({
+  email: z.string().email('Please enter a valid email address'),
+  source: z.string().max(100).optional(),
+  referrer: z.string().max(500).optional(),
+});
+
+export type WaitlistFormData = z.infer<typeof waitlistSchema>;
+
 // Types
 export type EventFormData = z.infer<typeof eventSchema>;

--- a/src/services/ai/api-key-service.ts
+++ b/src/services/ai/api-key-service.ts
@@ -10,6 +10,7 @@
  * Created: 2026-01-08
  */
 
+import { CAT_FREE_DAILY_LIMIT } from '@/config/cat-plans';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
@@ -459,8 +460,8 @@ export class ApiKeyService {
     if (error || !data || data.length === 0) {
       return {
         daily_requests: 0,
-        daily_limit: 10,
-        requests_remaining: 10,
+        daily_limit: CAT_FREE_DAILY_LIMIT,
+        requests_remaining: CAT_FREE_DAILY_LIMIT,
         can_use_platform: true,
       };
     }

--- a/src/services/billing/getUserPlan.ts
+++ b/src/services/billing/getUserPlan.ts
@@ -15,13 +15,14 @@
 
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { DATABASE_TABLES } from '@/config/database-tables';
+import { CAT_FREE_DAILY_LIMIT } from '@/config/cat-plans';
 import { logger } from '@/utils/logger';
 
 export type PaidTier = 'free' | 'pro';
 
 export interface UserPlan {
   tier: PaidTier;
-  /** Resolved daily message cap. Free=10. Pro plans set their own. */
+  /** Resolved daily message cap. Free uses CAT_FREE_DAILY_LIMIT; Pro sets its own. */
   dailyLimit: number;
   /** ISO timestamp of Pro renewal deadline; null on Free. */
   expiresAt: string | null;
@@ -31,7 +32,7 @@ export interface UserPlan {
 
 const FREE_PLAN: UserPlan = {
   tier: 'free',
-  dailyLimit: 10,
+  dailyLimit: CAT_FREE_DAILY_LIMIT,
   expiresAt: null,
   isExpired: false,
 };
@@ -69,7 +70,7 @@ export async function getUserPlan(supabase: AnySupabaseClient, userId: string): 
 
   return {
     tier,
-    dailyLimit: (data.daily_limit as number | null) ?? 10,
+    dailyLimit: (data.daily_limit as number | null) ?? CAT_FREE_DAILY_LIMIT,
     expiresAt,
     isExpired,
   };

--- a/src/services/loans/api-client.ts
+++ b/src/services/loans/api-client.ts
@@ -1,0 +1,167 @@
+/**
+ * Loans API client — browser-side calls to /api/loans (no direct Supabase writes).
+ *
+ * UI and hooks must use this (via loansService) so creation, updates, and deletes
+ * go through the same validation, rate limits, and domain logic as integrations.
+ */
+
+import { API_ROUTES } from '@/config/api-routes';
+import { logger } from '@/utils/logger';
+import type { Loan, CreateLoanRequest, UpdateLoanRequest, LoanResponse } from '@/types/loans';
+import type { ServiceResult } from '@/types/common';
+
+interface ApiEnvelope<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+/** API loanSchema requires min 10 chars — pad short descriptions safely. */
+export function ensureLoanDescription(description?: string, title?: string): string {
+  const text = (description?.trim() || title?.trim() || 'Loan listing').slice(0, 1000);
+  if (text.length >= 10) {
+    return text;
+  }
+  return `${text} on OrangeCat`.slice(0, 1000);
+}
+
+/** Map a loan record or form payload to the API contract (lib/validation/finance loanSchema). */
+export function loanToApiPayload(
+  loan: Partial<Loan> & Pick<Loan, 'title' | 'original_amount' | 'remaining_balance'>
+): Record<string, unknown> {
+  const fulfillment = loan.fulfillment_type as string | undefined;
+  const fulfillmentType =
+    fulfillment === 'manual' || fulfillment === 'automatic' ? fulfillment : 'manual';
+
+  return {
+    loan_type: 'new_request',
+    title: loan.title,
+    description: ensureLoanDescription(loan.description, loan.title),
+    loan_category_id: loan.loan_category_id ?? null,
+    original_amount: loan.original_amount,
+    remaining_balance: loan.remaining_balance,
+    interest_rate: loan.interest_rate ?? null,
+    bitcoin_address: loan.bitcoin_address ?? null,
+    lightning_address: loan.lightning_address ?? null,
+    fulfillment_type: fulfillmentType,
+    currency: loan.currency,
+    current_lender: loan.current_lender ?? loan.lender_name ?? null,
+    current_interest_rate: loan.current_interest_rate ?? null,
+    monthly_payment: loan.monthly_payment ?? null,
+    desired_rate: loan.desired_rate ?? null,
+    lender_name: loan.lender_name ?? null,
+    loan_number: loan.loan_number ?? null,
+    origination_date: loan.origination_date ?? null,
+    maturity_date: loan.maturity_date ?? null,
+    is_public: loan.is_public ?? false,
+    is_negotiable: loan.is_negotiable ?? true,
+    minimum_offer_amount: loan.minimum_offer_amount ?? null,
+    preferred_terms: loan.preferred_terms ?? null,
+    contact_method: loan.contact_method ?? 'platform',
+    collateral: [],
+  };
+}
+
+export function createLoanRequestToApiPayload(request: CreateLoanRequest): Record<string, unknown> {
+  return loanToApiPayload(request as unknown as Loan);
+}
+
+async function parseLoanEnvelope(res: Response): Promise<LoanResponse> {
+  const json = (await res.json().catch(() => ({}))) as ApiEnvelope<Loan>;
+  if (!res.ok || json.success === false) {
+    return { success: false, error: json.error || `Request failed (${res.status})` };
+  }
+  if (!json.data) {
+    return { success: false, error: 'Empty response from server' };
+  }
+  return { success: true, loan: json.data };
+}
+
+export async function getLoanViaApi(loanId: string): Promise<LoanResponse> {
+  try {
+    const res = await fetch(API_ROUTES.LOANS.BY_ID(loanId), { credentials: 'include' });
+    return parseLoanEnvelope(res);
+  } catch (error) {
+    logger.error('getLoanViaApi failed', error, 'Loans');
+    return { success: false, error: 'Failed to load loan' };
+  }
+}
+
+export async function createLoanViaApi(request: CreateLoanRequest): Promise<LoanResponse> {
+  try {
+    const res = await fetch(API_ROUTES.LOANS.BASE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(createLoanRequestToApiPayload(request)),
+    });
+    const result = await parseLoanEnvelope(res);
+    if (result.success) {
+      logger.info('Loan created via API', { loanId: result.loan?.id }, 'Loans');
+    }
+    return result;
+  } catch (error) {
+    logger.error('createLoanViaApi failed', error, 'Loans');
+    return { success: false, error: 'Failed to create loan' };
+  }
+}
+
+export async function updateLoanViaApi(
+  loanId: string,
+  patch: UpdateLoanRequest
+): Promise<LoanResponse> {
+  try {
+    // PUT validates the full loan schema — merge partial patches onto the current row.
+    const isFullFormPatch =
+      Boolean(patch.title) &&
+      patch.original_amount !== undefined &&
+      patch.original_amount !== null &&
+      patch.remaining_balance !== undefined &&
+      patch.remaining_balance !== null &&
+      ensureLoanDescription(patch.description, patch.title).length >= 10;
+
+    let payload: Record<string, unknown>;
+    if (isFullFormPatch) {
+      payload = loanToApiPayload(patch as Loan);
+    } else {
+      const current = await getLoanViaApi(loanId);
+      if (!current.success || !current.loan) {
+        return current;
+      }
+      payload = loanToApiPayload({ ...current.loan, ...patch });
+    }
+
+    const res = await fetch(API_ROUTES.LOANS.BY_ID(loanId), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload),
+    });
+    const result = await parseLoanEnvelope(res);
+    if (result.success) {
+      logger.info('Loan updated via API', { loanId }, 'Loans');
+    }
+    return result;
+  } catch (error) {
+    logger.error('updateLoanViaApi failed', error, 'Loans');
+    return { success: false, error: 'Failed to update loan' };
+  }
+}
+
+export async function deleteLoanViaApi(loanId: string): Promise<ServiceResult> {
+  try {
+    const res = await fetch(API_ROUTES.LOANS.BY_ID(loanId), {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    const json = (await res.json().catch(() => ({}))) as ApiEnvelope<unknown>;
+    if (!res.ok || json.success === false) {
+      return { success: false, error: json.error || `Request failed (${res.status})` };
+    }
+    logger.info('Loan deleted via API', { loanId }, 'Loans');
+    return { success: true };
+  } catch (error) {
+    logger.error('deleteLoanViaApi failed', error, 'Loans');
+    return { success: false, error: 'Failed to delete loan' };
+  }
+}

--- a/src/services/loans/mutations/loans.ts
+++ b/src/services/loans/mutations/loans.ts
@@ -1,9 +1,8 @@
 /**
  * LOANS SERVICE - Loan Mutations
  *
- * Created: 2025-01-30
- * Last Modified: 2025-01-30
- * Last Modified Summary: Extracted from loans/index.ts for modularity
+ * User-facing create/update/delete route through /api/loans (domain layer + RLS).
+ * createObligationLoan remains a server-adjacent path for offer acceptance flows.
  */
 
 import supabase from '@/lib/supabase/browser';
@@ -12,14 +11,37 @@ import { isSupportedCurrency, PLATFORM_DEFAULT_CURRENCY } from '@/config/currenc
 import { getTableName } from '@/config/entity-registry';
 import type { CreateLoanRequest, UpdateLoanRequest, LoanResponse, Loan } from '@/types/loans';
 import { STATUS } from '@/config/database-constants';
-import { getCurrentUserId } from '../utils/auth';
-import { validateCreateLoanRequest } from '../utils/validation';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import type { ServiceResult } from '@/types/common';
+import { createLoanViaApi, updateLoanViaApi, deleteLoanViaApi } from '@/services/loans/api-client';
+
+/**
+ * Create a new loan listing (via POST /api/loans).
+ */
+export async function createLoan(request: CreateLoanRequest): Promise<LoanResponse> {
+  return createLoanViaApi(request);
+}
+
+/**
+ * Update an existing loan (via PUT /api/loans/:id).
+ */
+export async function updateLoan(
+  loanId: string,
+  request: UpdateLoanRequest
+): Promise<LoanResponse> {
+  return updateLoanViaApi(loanId, request);
+}
+
+/**
+ * Delete a loan (via DELETE /api/loans/:id).
+ */
+export async function deleteLoan(loanId: string): Promise<ServiceResult> {
+  return deleteLoanViaApi(loanId);
+}
 
 /**
  * Resolve a user_id to an actor_id via the browser Supabase client.
- * Returns null if no actor exists.
+ * Used only by createObligationLoan until that flow moves server-side.
  */
 async function resolveActorId(userId: string): Promise<string | null> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,138 +54,9 @@ async function resolveActorId(userId: string): Promise<string | null> {
 }
 
 /**
- * Create a new loan listing
- */
-export async function createLoan(request: CreateLoanRequest): Promise<LoanResponse> {
-  try {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
-      return { success: false, error: 'Authentication required' };
-    }
-
-    // Validate request
-    const validation = validateCreateLoanRequest(request);
-    if (!validation.valid) {
-      return { success: false, error: validation.errors[0]?.message || 'Invalid request' };
-    }
-
-    const actorId = await resolveActorId(user.id);
-    if (!actorId) {
-      return { success: false, error: 'User actor not found' };
-    }
-
-    const { data, error } = await (
-      supabase
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .from(getTableName('loan')) as any
-    )
-      .insert({
-        ...request,
-        currency: isSupportedCurrency(request.currency)
-          ? request.currency
-          : PLATFORM_DEFAULT_CURRENCY,
-        user_id: user.id,
-        actor_id: actorId,
-      })
-      .select()
-      .single();
-
-    if (error) {
-      logger.error('Failed to create loan', error, 'Loans');
-      return { success: false, error: error.message };
-    }
-
-    logger.info('Loan created successfully', { loanId: data.id }, 'Loans');
-    return { success: true, loan: data };
-  } catch (error) {
-    logger.error('Exception creating loan', error, 'Loans');
-    return { success: false, error: 'Failed to create loan' };
-  }
-}
-
-/**
- * Update an existing loan
- */
-export async function updateLoan(
-  loanId: string,
-  request: UpdateLoanRequest
-): Promise<LoanResponse> {
-  try {
-    const userId = await getCurrentUserId();
-    if (!userId) {
-      return { success: false, error: 'Authentication required' };
-    }
-
-    const actorId = await resolveActorId(userId);
-    if (!actorId) {
-      return { success: false, error: 'User actor not found' };
-    }
-
-    const { data, error } = await (
-      supabase
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .from(getTableName('loan')) as any
-    )
-      .update(request)
-      .eq('id', loanId)
-      .eq('actor_id', actorId)
-      .select()
-      .single();
-
-    if (error) {
-      logger.error('Failed to update loan', error, 'Loans');
-      return { success: false, error: error.message };
-    }
-
-    logger.info('Loan updated successfully', { loanId }, 'Loans');
-    return { success: true, loan: data };
-  } catch (error) {
-    logger.error('Exception updating loan', error, 'Loans');
-    return { success: false, error: 'Failed to update loan' };
-  }
-}
-
-/**
- * Delete a loan
- */
-export async function deleteLoan(loanId: string): Promise<ServiceResult> {
-  try {
-    const userId = await getCurrentUserId();
-    if (!userId) {
-      return { success: false, error: 'Authentication required' };
-    }
-
-    const actorId = await resolveActorId(userId);
-    if (!actorId) {
-      return { success: false, error: 'User actor not found' };
-    }
-
-    const { error } = await (
-      supabase
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .from(getTableName('loan')) as any
-    )
-      .delete()
-      .eq('id', loanId)
-      .eq('actor_id', actorId);
-
-    if (error) {
-      logger.error('Failed to delete loan', error, 'Loans');
-      return { success: false, error: error.message };
-    }
-
-    logger.info('Loan deleted successfully', { loanId }, 'Loans');
-    return { success: true };
-  } catch (error) {
-    logger.error('Exception deleting loan', error, 'Loans');
-    return { success: false, error: 'Failed to delete loan' };
-  }
-}
-
-/**
- * Create a new obligation loan after payoff/refinance
+ * Create a new obligation loan after payoff/refinance.
+ *
+ * TODO(phase-E): move to a server route so browser Supabase writes are eliminated.
  */
 export async function createObligationLoan(params: {
   borrowerId: string;

--- a/src/services/loans/mutations/loans.ts
+++ b/src/services/loans/mutations/loans.ts
@@ -56,7 +56,8 @@ async function resolveActorId(userId: string): Promise<string | null> {
 /**
  * Create a new obligation loan after payoff/refinance.
  *
- * TODO(phase-E): move to a server route so browser Supabase writes are eliminated.
+ * Offer-accept flow still uses browser Supabase until a server route exists
+ * (AUDIT_REPORT Phase E).
  */
 export async function createObligationLoan(params: {
   borrowerId: string;

--- a/src/services/platform/stakeholderRelationships.ts
+++ b/src/services/platform/stakeholderRelationships.ts
@@ -1,0 +1,266 @@
+/**
+ * Stakeholder relationship domain service.
+ *
+ * Session callers use their Supabase client (RLS enforces ownership).
+ * v1 integration-key callers use the admin client with explicit app-layer
+ * authz — same pattern as externalPublish.ts (OIDC keys are not a session).
+ */
+import { createAdminClient } from '@/lib/supabase/admin';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { getTableName } from '@/config/entity-registry';
+import {
+  STAKEHOLDER_KINDS,
+  type CreateStakeholderInput,
+  isStakeholderKind,
+} from '@/config/stakeholders';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { logger } from '@/utils/logger';
+
+export type StakeholderRow = Record<string, unknown> & { id: string };
+
+type ListResult =
+  | { ok: true; relationships: StakeholderRow[] }
+  | {
+      ok: false;
+      reason: 'bad_kind' | 'project_not_found' | 'forbidden' | 'error';
+      message: string;
+    };
+
+type CreateResult =
+  | { ok: true; relationship: StakeholderRow }
+  | {
+      ok: false;
+      reason: 'project_not_found' | 'forbidden' | 'no_actor' | 'error';
+      message: string;
+    };
+
+function adminDb(): AnySupabaseClient {
+  return createAdminClient() as unknown as AnySupabaseClient;
+}
+
+async function assertOwnsProject(
+  db: AnySupabaseClient,
+  projectId: string,
+  userId: string
+): Promise<'ok' | 'project_not_found' | 'forbidden'> {
+  const { data } = await db
+    .from(getTableName('project'))
+    .select('user_id')
+    .eq('id', projectId)
+    .maybeSingle();
+  if (!data) {
+    return 'project_not_found';
+  }
+  return (data as { user_id: string | null }).user_id === userId ? 'ok' : 'forbidden';
+}
+
+async function resolveOwnerActorId(db: AnySupabaseClient, userId: string): Promise<string | null> {
+  const { data, error } = await db
+    .from(DATABASE_TABLES.ACTORS)
+    .select('id')
+    .eq('user_id', userId)
+    .eq('actor_type', 'user')
+    .maybeSingle();
+  if (error) {
+    logger.error('Failed to resolve owner actor', error, 'StakeholderRelationships');
+    return null;
+  }
+  return (data as { id: string } | null)?.id ?? null;
+}
+
+function buildInsertRow(ownerActorId: string, input: CreateStakeholderInput) {
+  return {
+    owner_actor_id: ownerActorId,
+    from_project_id: input.fromProjectId,
+    kind: input.kind,
+    to_actor_id: input.toActorId ?? null,
+    to_project_id: input.toProjectId ?? null,
+    to_external_url: input.toExternalUrl ?? null,
+    to_external_name: input.toExternalName ?? null,
+    status: input.status ?? null,
+    confidence: input.confidence ?? null,
+    notes: input.notes ?? null,
+    metadata: input.metadata ?? {},
+  };
+}
+
+/** List relationships for a project (session path — RLS is authoritative). */
+export async function listStakeholderRelationships(
+  supabase: AnySupabaseClient,
+  fromProjectId: string,
+  kindFilter?: string
+): Promise<ListResult> {
+  if (kindFilter && !isStakeholderKind(kindFilter)) {
+    return {
+      ok: false,
+      reason: 'bad_kind',
+      message: `kind must be one of: ${STAKEHOLDER_KINDS.join(', ')}`,
+    };
+  }
+
+  let query = supabase
+    .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
+    .select('*')
+    .eq('from_project_id', fromProjectId)
+    .order('updated_at', { ascending: false });
+
+  if (kindFilter) {
+    query = query.eq('kind', kindFilter);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    logger.error('Failed to list stakeholder relationships', error, 'StakeholderRelationships');
+    return { ok: false, reason: 'error', message: 'Failed to load stakeholders' };
+  }
+
+  return { ok: true, relationships: (data ?? []) as StakeholderRow[] };
+}
+
+/** Create a relationship (session path — caller's supabase + explicit project check). */
+export async function createStakeholderRelationship(
+  supabase: AnySupabaseClient,
+  ownerActorId: string,
+  input: CreateStakeholderInput
+): Promise<CreateResult> {
+  const { data: projectRow, error: projectErr } = await supabase
+    .from(getTableName('project'))
+    .select('id, actor_id')
+    .eq('id', input.fromProjectId)
+    .maybeSingle();
+  if (projectErr) {
+    logger.error('Failed to verify project ownership', projectErr, 'StakeholderRelationships');
+    return { ok: false, reason: 'error', message: 'Failed to verify project' };
+  }
+  if (!projectRow) {
+    return { ok: false, reason: 'project_not_found', message: 'Project not found' };
+  }
+  if ((projectRow as { actor_id: string }).actor_id !== ownerActorId) {
+    return {
+      ok: false,
+      reason: 'forbidden',
+      message: 'You can only add stakeholders to your own projects',
+    };
+  }
+
+  const { data: inserted, error: insertErr } = await supabase
+    .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
+    .insert(buildInsertRow(ownerActorId, input))
+    .select('*')
+    .single();
+
+  if (insertErr) {
+    logger.error(
+      'Failed to insert stakeholder relationship',
+      insertErr,
+      'StakeholderRelationships'
+    );
+    return { ok: false, reason: 'error', message: 'Failed to create stakeholder relationship' };
+  }
+
+  return { ok: true, relationship: inserted as StakeholderRow };
+}
+
+/** List relationships for a v1 caller (admin client + ownership check). */
+export async function listStakeholderRelationshipsForUser(
+  userId: string,
+  fromProjectId: string,
+  kindFilter?: string
+): Promise<ListResult> {
+  if (kindFilter && !isStakeholderKind(kindFilter)) {
+    return {
+      ok: false,
+      reason: 'bad_kind',
+      message: `kind must be one of: ${STAKEHOLDER_KINDS.join(', ')}`,
+    };
+  }
+
+  const db = adminDb();
+  const ownership = await assertOwnsProject(db, fromProjectId, userId);
+  if (ownership === 'project_not_found') {
+    return { ok: false, reason: 'project_not_found', message: 'Project not found' };
+  }
+  if (ownership === 'forbidden') {
+    return {
+      ok: false,
+      reason: 'forbidden',
+      message: 'You can only list stakeholders for your own projects',
+    };
+  }
+
+  let query = db
+    .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
+    .select('*')
+    .eq('from_project_id', fromProjectId)
+    .order('updated_at', { ascending: false });
+
+  if (kindFilter) {
+    query = query.eq('kind', kindFilter);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    logger.error(
+      'Failed to list stakeholder relationships (v1)',
+      error,
+      'StakeholderRelationships'
+    );
+    return { ok: false, reason: 'error', message: 'Failed to load stakeholders' };
+  }
+
+  return { ok: true, relationships: (data ?? []) as StakeholderRow[] };
+}
+
+/** Create a relationship for a v1 caller (admin client + ownership check). */
+export async function createStakeholderRelationshipForUser(
+  userId: string,
+  input: CreateStakeholderInput
+): Promise<CreateResult> {
+  const db = adminDb();
+  const ownerActorId = await resolveOwnerActorId(db, userId);
+  if (!ownerActorId) {
+    return { ok: false, reason: 'no_actor', message: 'No actor associated with this user' };
+  }
+
+  const ownership = await assertOwnsProject(db, input.fromProjectId, userId);
+  if (ownership === 'project_not_found') {
+    return { ok: false, reason: 'project_not_found', message: 'Project not found' };
+  }
+  if (ownership === 'forbidden') {
+    return {
+      ok: false,
+      reason: 'forbidden',
+      message: 'You can only add stakeholders to your own projects',
+    };
+  }
+
+  const { data: projectRow } = await db
+    .from(getTableName('project'))
+    .select('actor_id')
+    .eq('id', input.fromProjectId)
+    .maybeSingle();
+  if ((projectRow as { actor_id: string } | null)?.actor_id !== ownerActorId) {
+    return {
+      ok: false,
+      reason: 'forbidden',
+      message: 'You can only add stakeholders to your own projects',
+    };
+  }
+
+  const { data: inserted, error: insertErr } = await db
+    .from(DATABASE_TABLES.STAKEHOLDER_RELATIONSHIPS)
+    .insert(buildInsertRow(ownerActorId, input))
+    .select('*')
+    .single();
+
+  if (insertErr) {
+    logger.error(
+      'Failed to insert stakeholder relationship (v1)',
+      insertErr,
+      'StakeholderRelationships'
+    );
+    return { ok: false, reason: 'error', message: 'Failed to create stakeholder relationship' };
+  }
+
+  return { ok: true, relationship: inserted as StakeholderRow };
+}


### PR DESCRIPTION
## Summary
- **SSOT pass**: discover tabs, payment presets, feature/env config, wired AI providers, semantic Card/Badge, phantom route cleanup, `timeline.write` scope, audit roadmap
- **Loan dual-path fix**: `createLoan` / `updateLoan` / `deleteLoan` now call `/api/loans` through `services/loans/api-client.ts` — no more browser Supabase inserts for user-facing loan CRUD

## Why
Eliminates validation/RLS drift between UI and API, and continues the config-driven SSOT work from the deep audit.

## Test plan
- [x] `npm run type-check`
- [x] `npm test -- --runTestsByPath __tests__/unit/services/loans/api-client.test.ts`
- [x] `npm test -- --runTestsByPath __tests__/unit/domain/entity-create-financial.test.ts`
- [x] Full unit suite: 723/723 passed at push time
- [ ] Manual: create loan from dashboard → lands as draft via API; toggle visibility on loans list

Made with [Cursor](https://cursor.com)