### PR TITLE
feat(loans): obligation loan API route

### DIFF
--- a/__tests__/unit/domain/loans/obligation.test.ts
+++ b/__tests__/unit/domain/loans/obligation.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Obligation loan schema + domain
+ */
+
+import { createObligationLoanSchema } from '@/config/loan-obligation';
+import { createObligationLoan } from '@/domain/loans/obligation';
+
+jest.mock('@/domain/base/entityService', () => ({
+  createEntity: jest.fn().mockResolvedValue({ id: 'new-loan-id', status: 'active' }),
+}));
+
+describe('createObligationLoanSchema', () => {
+  it('requires borrowerId, lender name, and a single offer payload', () => {
+    const parsed = createObligationLoanSchema.safeParse({
+      borrowerId: '00000000-0000-4000-8000-000000000001',
+      lenderProfileName: 'Alice Lender',
+      offer: {
+        loan_id: '00000000-0000-4000-8000-000000000002',
+        offer_amount: 2500,
+        interest_rate: 4.5,
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects non-positive offer amounts', () => {
+    const parsed = createObligationLoanSchema.safeParse({
+      borrowerId: '00000000-0000-4000-8000-000000000001',
+      lenderProfileName: 'Alice',
+      offer: {
+        loan_id: '00000000-0000-4000-8000-000000000002',
+        offer_amount: 0,
+      },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('createObligationLoan domain', () => {
+  const borrowerId = '00000000-0000-4000-8000-000000000099';
+  const sourceLoanId = '00000000-0000-4000-8000-000000000088';
+
+  function mockSupabase(sourceUserId: string | null) {
+    return {
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: sourceUserId ? { id: sourceLoanId, user_id: sourceUserId } : null,
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    };
+  }
+
+  it('creates an active obligation when the borrower owns the source loan', async () => {
+    const supabase = mockSupabase(borrowerId);
+    const result = await createObligationLoan(
+      borrowerId,
+      {
+        lenderProfileName: 'Bob Bank',
+        offer: { loan_id: sourceLoanId, offer_amount: 1200, currency: 'CHF' },
+      },
+      supabase as never
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.loan.id).toBe('new-loan-id');
+    }
+  });
+
+  it('forbids obligation creation for a loan owned by another user', async () => {
+    const supabase = mockSupabase('00000000-0000-4000-8000-000000000001');
+    const result = await createObligationLoan(
+      borrowerId,
+      {
+        lenderProfileName: 'Bob Bank',
+        offer: { loan_id: sourceLoanId, offer_amount: 1200 },
+      },
+      supabase as never
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'forbidden',
+      message: 'You can only create obligations for your own loans',
+    });
+  });
+});

--- a/docs/AUDIT_REPORT.md
+++ b/docs/AUDIT_REPORT.md
@@ -115,7 +115,7 @@ Config SSOT consolidation, phantom routes, UI primitive migration start, integra
 
 ### Phase B — Correctness (in progress)
 
-- ✅ **Loan dual-path closed** — `createLoan` / `updateLoan` / `deleteLoan` route through `/api/loans` via `services/loans/api-client.ts`; `createObligationLoan` deferred to Phase E (offer-accept server route).
+- ✅ **Loan dual-path closed** — all loan mutations including `createObligationLoan` route through `/api/loans` and `/api/loans/obligation` via `services/loans/api-client.ts`.
 - Regenerate DB types; eliminate `as any` on oauth/cat_credit/stakeholder tables
 - Middleware auth prefixes derived from `routes.ts`
 - `config/env.ts` zod validation + CI `validate-env.js` alignment
@@ -158,4 +158,4 @@ grep -rn '\[#' src/    # design token audit — expect 0
 2. **[B2]** Regenerate `database.generated.ts` and migrate Supabase client imports
 3. ~~**[C1]** Migrate dialog/select/dropdown to semantic tokens~~ — done 2026-07-09
 4. ~~**[D1]** Add stakeholders + timeline to v1 SDK~~ — done 2026-07-09
-5. **[E1]** Inventory browser-supabase write sites; migrate loans first
+5. ~~**[E1]** Inventory browser-supabase write sites; migrate loans first~~ — loan obligation route done 2026-07-09; payments/offers still browser-side

--- a/docs/development/loans-flow.md
+++ b/docs/development/loans-flow.md
@@ -1,15 +1,17 @@
 created_date: 2025-12-04
-last_modified_date: 2025-12-05
-last_modified_summary: Add CHF support + shared currency list; enable real asset CRUD
+last_modified_date: 2026-07-09
+last_modified_summary: Obligation loan creation routes through POST /api/loans/obligation (no browser Supabase writes).
 
 # OrangeCat Loans Flow (Refinance & Payoff)
 
 ## Borrower path
+
 - Create a loan listing with remaining balance, current rate/term, lender mask, minimum acceptable offer, negotiable flag, visibility (public/private), and contact preference.
 - Listing appears under `My Loans`; public listings appear in `Available Loans`.
 - Borrower can view offers per loan, then accept or reject. Acceptance marks the loan as `refinanced` or `paid_off` and triggers payment handoff.
 
 ## Lender path
+
 - Browse `Available Loans`, filter by category/amount/rate, open details to assess risk.
 - Submit an offer:
   - Payoff: propose amount to clear the balance.
@@ -18,17 +20,20 @@ last_modified_summary: Add CHF support + shared currency list; enable real asset
 - Borrower reviews offers and accepts or rejects.
 
 ## Payment handoff (next iteration)
+
 - On accept, record payoff payment (payer, recipient, amount, method). Once completed, the original loan is archived and a new obligation to the offerer is created with the accepted terms.
 - Schedule generation and reminders for refinance terms follow the acceptance.
 
 ## Implementation notes
+
 - Frontend now loads “My Offers” and borrower offer lists; borrower can accept/reject offers per loan.
 - Service layer includes `getUserOffers` and reuses `respondToOffer`; UI uses typed service calls with toasts for feedback.
-- RLS and backend validations remain the source of truth; no direct DB access from UI.
+- RLS and backend validations remain the source of truth; loan mutations use `/api/loans` and `/api/loans/obligation` (no direct DB access from UI).
 - Currency source of truth lives in `src/config/currencies.ts` and is reused by UI, validation, services, and DB constraints (CHF included).
 - Assets now use real Supabase CRUD APIs (`/api/assets` and `/api/assets/[id]`) with edit/delete support; entity form drives both create and edit flows.
 
 ## Payoff / Refinance Payment Handoff (implementation plan)
+
 - Trigger: borrower accepts an offer.
 - Status transitions:
   - Set offer to `accepted` with timestamp.
@@ -54,7 +59,7 @@ last_modified_summary: Add CHF support + shared currency list; enable real asset
   - No console logging; use structured logger on service side.
 
 ## Implemented now
-- Borrower can accept an offer and immediately open “Record Payoff” to create and complete a payment record (payer = offerer, recipient = borrower for now).
-- Service layer adds `completePayment` and `createObligationLoan` scaffolding for new-loan creation post-payoff (not yet invoked).
-- UI uses typed forms with validation, toasts for feedback, and disables controls while processing.
 
+- Borrower can accept an offer and immediately open “Record Payoff” to create and complete a payment record (payer = offerer, recipient = borrower for now).
+- Service layer adds `completePayment` and `createObligationLoan` scaffolding for new-loan creation post-payoff (`createObligationLoan` calls `POST /api/loans/obligation`; wire after payment completion in UI).
+- UI uses typed forms with validation, toasts for feedback, and disables controls while processing.

--- a/src/app/api/loans/obligation/route.ts
+++ b/src/app/api/loans/obligation/route.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/loans/obligation — create an active obligation loan after refinance acceptance.
+ *
+ * Session-authenticated; only the borrower may create an obligation for their own
+ * source loan. Replaces the browser Supabase write in createObligationLoan.
+ */
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import {
+  apiCreated,
+  apiBadRequest,
+  apiValidationError,
+  apiForbidden,
+  apiNotFound,
+  apiInternalError,
+} from '@/lib/api/standardResponse';
+import { createObligationLoanSchema } from '@/config/loan-obligation';
+import { createObligationLoan } from '@/domain/loans/obligation';
+import { logger } from '@/utils/logger';
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  try {
+    const { user, supabase } = request;
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return apiBadRequest('Invalid JSON body');
+    }
+
+    const parsed = createObligationLoanSchema.safeParse(body);
+    if (!parsed.success) {
+      return apiValidationError('Invalid request', parsed.error.flatten());
+    }
+
+    if (parsed.data.borrowerId !== user.id) {
+      return apiForbidden('You can only create obligation loans for yourself');
+    }
+
+    const result = await createObligationLoan(
+      user.id,
+      {
+        lenderProfileName: parsed.data.lenderProfileName,
+        offer: parsed.data.offer,
+      },
+      supabase
+    );
+
+    if (!result.ok) {
+      switch (result.reason) {
+        case 'source_loan_not_found':
+          return apiNotFound(result.message);
+        case 'forbidden':
+          return apiForbidden(result.message);
+        default:
+          logger.error('Obligation loan create failed', { message: result.message }, 'LoansAPI');
+          return apiInternalError(result.message);
+      }
+    }
+
+    return apiCreated(result.loan);
+  } catch (error) {
+    logger.error('Unexpected error in POST /api/loans/obligation', error, 'LoansAPI');
+    return apiInternalError('Internal server error');
+  }
+});

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -137,6 +137,7 @@ export const API_ROUTES = {
   LOANS: {
     BASE: ENTITY_REGISTRY['loan'].apiEndpoint,
     BY_ID: (id: string) => `${ENTITY_REGISTRY['loan'].apiEndpoint}/${id}`,
+    OBLIGATION: `${ENTITY_REGISTRY['loan'].apiEndpoint}/obligation`,
     COLLATERAL: '/api/loan-collateral',
   },
   PROFILE: '/api/profile',

--- a/src/config/loan-obligation.ts
+++ b/src/config/loan-obligation.ts
@@ -1,0 +1,32 @@
+/**
+ * Obligation loan contract SSOT — post-payoff / refinance new loan creation.
+ *
+ * Created when a borrower accepts a refinance offer and payment completes.
+ * See docs/development/loans-flow.md ("New obligation (refinance path)").
+ *
+ * Created: 2026-07-09
+ * Last Modified: 2026-07-09
+ * Last Modified Summary: Initial schema for POST /api/loans/obligation.
+ */
+
+import { z } from 'zod';
+
+export const obligationOfferSchema = z.object({
+  loan_id: z.string().uuid('loan_id must be a UUID'),
+  offer_amount: z.number().positive('offer_amount must be greater than 0'),
+  interest_rate: z.number().min(0).max(100).optional(),
+  term_months: z.number().int().positive().optional(),
+  currency: z.string().optional(),
+});
+
+export const createObligationLoanSchema = z.object({
+  borrowerId: z.string().uuid('borrowerId must be a UUID'),
+  lenderProfileName: z.string().min(1).max(200),
+  offer: obligationOfferSchema,
+});
+
+export type CreateObligationLoanInput = z.infer<typeof createObligationLoanSchema>;
+
+/** Fixed copy for obligation loans — satisfies loan description min length. */
+export const OBLIGATION_LOAN_TITLE = 'Refinanced Loan';
+export const OBLIGATION_LOAN_DESCRIPTION = 'Refinanced via OrangeCat offer';

--- a/src/domain/loans/obligation.ts
+++ b/src/domain/loans/obligation.ts
@@ -1,0 +1,88 @@
+/**
+ * Obligation loan domain — creates an active private loan after offer acceptance.
+ */
+import { getTableName } from '@/config/entity-registry';
+import { isSupportedCurrency, PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
+import { STATUS } from '@/config/database-constants';
+import {
+  OBLIGATION_LOAN_DESCRIPTION,
+  OBLIGATION_LOAN_TITLE,
+  type CreateObligationLoanInput,
+} from '@/config/loan-obligation';
+import { createEntity } from '@/domain/base/entityService';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { logger } from '@/utils/logger';
+
+export type CreateObligationLoanResult =
+  | { ok: true; loan: Record<string, unknown> & { id: string } }
+  | {
+      ok: false;
+      reason: 'source_loan_not_found' | 'forbidden' | 'error';
+      message: string;
+    };
+
+export async function createObligationLoan(
+  borrowerUserId: string,
+  input: Omit<CreateObligationLoanInput, 'borrowerId'>,
+  supabase: AnySupabaseClient
+): Promise<CreateObligationLoanResult> {
+  const { lenderProfileName, offer } = input;
+  const currency = isSupportedCurrency(offer.currency) ? offer.currency : PLATFORM_DEFAULT_CURRENCY;
+
+  const { data: sourceLoan, error: sourceErr } = await supabase
+    .from(getTableName('loan'))
+    .select('id, user_id')
+    .eq('id', offer.loan_id)
+    .maybeSingle();
+
+  if (sourceErr) {
+    logger.error('Failed to verify source loan for obligation', sourceErr, 'LoanObligation');
+    return { ok: false, reason: 'error', message: 'Failed to verify source loan' };
+  }
+  if (!sourceLoan) {
+    return { ok: false, reason: 'source_loan_not_found', message: 'Source loan not found' };
+  }
+  if ((sourceLoan as { user_id: string }).user_id !== borrowerUserId) {
+    return {
+      ok: false,
+      reason: 'forbidden',
+      message: 'You can only create obligations for your own loans',
+    };
+  }
+
+  try {
+    const loan = await createEntity(
+      'loan',
+      borrowerUserId,
+      {
+        user_id: borrowerUserId,
+        title: OBLIGATION_LOAN_TITLE,
+        description: OBLIGATION_LOAN_DESCRIPTION,
+        loan_type: 'existing_refinance',
+        original_amount: offer.offer_amount,
+        remaining_balance: offer.offer_amount,
+        amount: offer.offer_amount,
+        interest_rate: offer.interest_rate ?? null,
+        monthly_payment: null,
+        currency,
+        lender_name: lenderProfileName,
+        loan_number: null,
+        origination_date: new Date().toISOString(),
+        maturity_date: null,
+        status: STATUS.LOANS.ACTIVE,
+        is_public: false,
+        is_negotiable: false,
+        minimum_offer_amount: null,
+        preferred_terms: null,
+        contact_method: 'platform',
+        fulfillment_type: 'manual',
+      },
+      { client: supabase }
+    );
+
+    return { ok: true, loan: loan as Record<string, unknown> & { id: string } };
+  } catch (error) {
+    logger.error('Failed to create obligation loan', error, 'LoanObligation');
+    return { ok: false, reason: 'error', message: 'Failed to create obligation loan' };
+  }
+}

--- a/src/services/loans/api-client.ts
+++ b/src/services/loans/api-client.ts
@@ -148,6 +148,35 @@ export async function updateLoanViaApi(
   }
 }
 
+export async function createObligationLoanViaApi(params: {
+  borrowerId: string;
+  lenderProfileName: string;
+  offer: {
+    loan_id: string;
+    offer_amount: number;
+    interest_rate?: number;
+    term_months?: number;
+    currency?: string;
+  };
+}): Promise<LoanResponse> {
+  try {
+    const res = await fetch(API_ROUTES.LOANS.OBLIGATION, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(params),
+    });
+    const result = await parseLoanEnvelope(res);
+    if (result.success) {
+      logger.info('Obligation loan created via API', { loanId: result.loan?.id }, 'Loans');
+    }
+    return result;
+  } catch (error) {
+    logger.error('createObligationLoanViaApi failed', error, 'Loans');
+    return { success: false, error: 'Failed to create obligation loan' };
+  }
+}
+
 export async function deleteLoanViaApi(loanId: string): Promise<ServiceResult> {
   try {
     const res = await fetch(API_ROUTES.LOANS.BY_ID(loanId), {

--- a/src/services/loans/mutations/loans.ts
+++ b/src/services/loans/mutations/loans.ts
@@ -1,19 +1,17 @@
 /**
  * LOANS SERVICE - Loan Mutations
  *
- * User-facing create/update/delete route through /api/loans (domain layer + RLS).
- * createObligationLoan remains a server-adjacent path for offer acceptance flows.
+ * All user-facing mutations route through /api/loans (domain layer + RLS).
  */
 
-import supabase from '@/lib/supabase/browser';
-import { logger } from '@/utils/logger';
-import { isSupportedCurrency, PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
-import { getTableName } from '@/config/entity-registry';
-import type { CreateLoanRequest, UpdateLoanRequest, LoanResponse, Loan } from '@/types/loans';
-import { STATUS } from '@/config/database-constants';
-import { DATABASE_TABLES } from '@/config/database-tables';
+import type { CreateLoanRequest, UpdateLoanRequest, LoanResponse } from '@/types/loans';
 import type { ServiceResult } from '@/types/common';
-import { createLoanViaApi, updateLoanViaApi, deleteLoanViaApi } from '@/services/loans/api-client';
+import {
+  createLoanViaApi,
+  updateLoanViaApi,
+  deleteLoanViaApi,
+  createObligationLoanViaApi,
+} from '@/services/loans/api-client';
 
 /**
  * Create a new loan listing (via POST /api/loans).
@@ -40,24 +38,7 @@ export async function deleteLoan(loanId: string): Promise<ServiceResult> {
 }
 
 /**
- * Resolve a user_id to an actor_id via the browser Supabase client.
- * Used only by createObligationLoan until that flow moves server-side.
- */
-async function resolveActorId(userId: string): Promise<string | null> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data } = (await (supabase.from(DATABASE_TABLES.ACTORS) as any)
-    .select('id')
-    .eq('user_id', userId)
-    .eq('actor_type', 'user')
-    .maybeSingle()) as { data: { id: string } | null };
-  return data?.id ?? null;
-}
-
-/**
- * Create a new obligation loan after payoff/refinance.
- *
- * Offer-accept flow still uses browser Supabase until a server route exists
- * (AUDIT_REPORT Phase E).
+ * Create a new obligation loan after payoff/refinance (via POST /api/loans/obligation).
  */
 export async function createObligationLoan(params: {
   borrowerId: string;
@@ -70,54 +51,5 @@ export async function createObligationLoan(params: {
     currency?: string;
   };
 }): Promise<LoanResponse> {
-  try {
-    const { borrowerId, lenderProfileName, offer } = params;
-
-    const newLoan: CreateLoanRequest = {
-      title: 'Refinanced Loan',
-      description: 'Refinanced via OrangeCat offer',
-      original_amount: offer.offer_amount,
-      remaining_balance: offer.offer_amount,
-      interest_rate: offer.interest_rate,
-      monthly_payment: undefined,
-      currency: isSupportedCurrency(offer.currency) ? offer.currency : PLATFORM_DEFAULT_CURRENCY,
-      lender_name: lenderProfileName,
-      loan_number: undefined,
-      origination_date: new Date().toISOString(),
-      maturity_date: undefined,
-      is_public: false,
-      is_negotiable: false,
-      minimum_offer_amount: undefined,
-      preferred_terms: undefined,
-      contact_method: 'platform',
-    };
-
-    const borrowerActorId = await resolveActorId(borrowerId);
-    if (!borrowerActorId) {
-      return { success: false, error: 'Borrower actor not found' };
-    }
-
-    const { data, error } = await (
-      supabase
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .from(getTableName('loan')) as any
-    )
-      .insert({
-        ...newLoan,
-        actor_id: borrowerActorId,
-        status: STATUS.LOANS.ACTIVE,
-      })
-      .select()
-      .single();
-
-    if (error) {
-      logger.error('Failed to create obligation loan', error, 'Loans');
-      return { success: false, error: error.message };
-    }
-
-    return { success: true, loan: data as Loan };
-  } catch (error) {
-    logger.error('Exception creating obligation loan', error, 'Loans');
-    return { success: false, error: 'Failed to create obligation loan' };
-  }
+  return createObligationLoanViaApi(params);
 }


### PR DESCRIPTION
## Summary
- Adds `POST /api/loans/obligation` for post-refinance obligation loan creation
- Extracts contract SSOT to `config/loan-obligation.ts` and domain logic to `domain/loans/obligation.ts`
- Removes the last browser Supabase write from `services/loans/mutations/loans.ts`

## Test plan
- [x] `npm run type-check`
- [x] Unit tests (727/727), including new obligation domain tests
- [x] `ci:docs` slop scan clean


Made with [Cursor](https://cursor.com)