### PR TITLE
feat(loans): borrower payoff handoff UI flow

### DIFF
--- a/__tests__/unit/domain/loans/payments.test.ts
+++ b/__tests__/unit/domain/loans/payments.test.ts
@@ -99,6 +99,23 @@ describe('createLoanPayment domain', () => {
       message: 'Payer and recipient must be different users',
     });
   });
+
+  it('allows the recipient to record a pending payment with an explicit payer', async () => {
+    const result = await createLoanPayment(
+      recipientId,
+      {
+        loan_id: loanId,
+        amount: 1000,
+        currency: 'CHF',
+        payment_type: 'payoff',
+        payer_id: payerId,
+        recipient_id: recipientId,
+      },
+      mockSupabaseForCreate() as never
+    );
+
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe('completeLoanPayment domain', () => {

--- a/docs/development/loans-flow.md
+++ b/docs/development/loans-flow.md
@@ -1,6 +1,6 @@
 created_date: 2025-12-04
 last_modified_date: 2026-07-09
-last_modified_summary: Loan offer writes now route through /api/loans/offers; the loans vertical is API-first for create/respond/payment flows.
+last_modified_summary: Borrower dashboard now wires incoming offers through accept -> payment -> obligation flow with mobile-first offer management UI.
 
 # OrangeCat Loans Flow (Refinance & Payoff)
 
@@ -27,6 +27,7 @@ last_modified_summary: Loan offer writes now route through /api/loans/offers; th
 ## Implementation notes
 
 - Frontend now loads “My Offers” and borrower offer lists; borrower can accept/reject offers per loan.
+- Borrower dashboard surfaces incoming offers under `My Loans`, with responsive cards and an accept dialog that records payment details on all screen sizes.
 - Service layer includes `getUserOffers` and typed offer mutations routed via `/api/loans/offers`; UI uses service calls with toasts for feedback.
 - RLS and backend validations remain the source of truth; loan mutations use `/api/loans`, `/api/loans/offers`, `/api/loans/obligation`, and `/api/loans/payments` (no direct DB access from UI).
 - Currency source of truth lives in `src/config/currencies.ts` and is reused by UI, validation, services, and DB constraints (CHF included).
@@ -61,6 +62,7 @@ last_modified_summary: Loan offer writes now route through /api/loans/offers; th
 ## Implemented now
 
 - Borrower can accept an offer and immediately open “Record Payoff” to create and complete a payment record (payer = offerer, recipient = borrower for now).
+- Incoming offer acceptance now calls `respondToOffer` -> `createPayment` -> `completePayment`, and refinance completion also creates the obligation loan in the same flow.
 - Offer creation / update / accept / reject route through `/api/loans/offers` handlers instead of browser Supabase writes.
 - Service layer: `createPayment` / `completePayment` call `/api/loans/payments`; `completePayment` accepts optional `createObligation` to create the refinance obligation loan in one step.
 - UI uses typed forms with validation, toasts for feedback, and disables controls while processing.

--- a/src/app/(authenticated)/dashboard/loans/page.tsx
+++ b/src/app/(authenticated)/dashboard/loans/page.tsx
@@ -12,6 +12,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Coins, DollarSign, Target, TrendingUp } from 'lucide-react';
 import EmptyState from '@/components/ui/EmptyState';
 import { AvailableLoans } from '@/components/loans/AvailableLoans';
+import { IncomingLoanOffersList } from '@/components/loans/IncomingLoanOffersList';
 import { LoanOffersList } from '@/components/loans/LoanOffersList';
 import { CreateLoanDialog } from '@/components/loans/CreateLoanDialog';
 import { useLoanList } from './useLoanList';
@@ -33,6 +34,7 @@ export default function LoansPage() {
     switchTab,
     myLoans,
     myOffers,
+    incomingOffers,
     availableLoans,
     availablePage,
     setAvailablePage,
@@ -45,7 +47,9 @@ export default function LoansPage() {
     page,
     total,
     setPage,
+    refresh,
     loadOffers,
+    loadIncomingOffers,
     loadAvailableLoans,
     handleBulkDelete,
     executeBulkDelete,
@@ -62,7 +66,7 @@ export default function LoansPage() {
   }
 
   const headerActions = (
-    <div className="flex items-center gap-2">
+    <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
       {activeTab === 'my-loans' && myLoans.length > 0 && (
         <Button onClick={() => setShowSelection(!showSelection)} variant="outline" size="sm">
           {showSelection ? 'Cancel' : 'Select'}
@@ -115,7 +119,7 @@ export default function LoansPage() {
             ) : (
               <>
                 {showSelection && myLoans.length > 0 && (
-                  <div className="mb-4 flex items-center justify-between">
+                  <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <label className="flex items-center gap-2 text-sm text-fg-primary">
                       <input
                         type="checkbox"
@@ -139,6 +143,15 @@ export default function LoansPage() {
                   showSelection={showSelection}
                 />
                 <CommercePagination page={page} limit={12} total={total} onPageChange={setPage} />
+                <IncomingLoanOffersList
+                  offers={incomingOffers}
+                  borrowerId={user.id}
+                  onOfferUpdated={() => {
+                    loadIncomingOffers();
+                    refresh?.();
+                    loadOffers();
+                  }}
+                />
               </>
             )}
           </TabsContent>

--- a/src/app/(authenticated)/dashboard/loans/useLoanList.ts
+++ b/src/app/(authenticated)/dashboard/loans/useLoanList.ts
@@ -20,6 +20,7 @@ export function useLoanList() {
   const [showSelection, setShowSelection] = useState(false);
   const [activeTab, setActiveTab] = useState<ActiveTab>('my-loans');
   const [myOffers, setMyOffers] = useState<LoanOffer[]>([]);
+  const [incomingOffers, setIncomingOffers] = useState<LoanOffer[]>([]);
   const [availableLoans, setAvailableLoans] = useState<Loan[]>([]);
   const [availablePage, setAvailablePage] = useState(1);
   const [availableTotal, setAvailableTotal] = useState(0);
@@ -53,6 +54,17 @@ export function useLoanList() {
     }
   }, []);
 
+  const loadIncomingOffers = useCallback(async () => {
+    try {
+      const result = await loansService.getIncomingOffers();
+      if (result.success) {
+        setIncomingOffers(result.offers || []);
+      }
+    } catch (err) {
+      logger.error('Failed to load incoming offers', { error: err }, 'LoansPage');
+    }
+  }, []);
+
   const loadAvailableLoans = useCallback(async () => {
     try {
       const result = await loansService.getAvailableLoans(undefined, {
@@ -75,10 +87,13 @@ export function useLoanList() {
     if (activeTab === 'offers') {
       loadOffers();
     }
+    if (activeTab === 'my-loans') {
+      loadIncomingOffers();
+    }
     if (activeTab === 'available') {
       loadAvailableLoans();
     }
-  }, [activeTab, user?.id, loadOffers, loadAvailableLoans]);
+  }, [activeTab, user?.id, loadIncomingOffers, loadOffers, loadAvailableLoans]);
 
   const switchTab = (tab: ActiveTab) => {
     setActiveTab(tab);
@@ -107,6 +122,7 @@ export function useLoanList() {
     setCreateDialogOpen(false);
     refresh();
     loadOffers();
+    loadIncomingOffers();
     loadAvailableLoans();
     toast.success('Loan created successfully!');
   };
@@ -127,6 +143,7 @@ export function useLoanList() {
     switchTab,
     myLoans: memoizedLoans,
     myOffers,
+    incomingOffers,
     availableLoans,
     availablePage,
     setAvailablePage,
@@ -140,7 +157,9 @@ export function useLoanList() {
     total,
     setPage,
     loadOffers,
+    loadIncomingOffers,
     loadAvailableLoans,
+    refresh,
     handleBulkDelete,
     executeBulkDelete,
     handleLoanCreated,

--- a/src/components/loans/AvailableLoans.tsx
+++ b/src/components/loans/AvailableLoans.tsx
@@ -106,12 +106,16 @@ export function AvailableLoans({ loans, onOfferMade }: AvailableLoansProps) {
                 )}
 
                 {/* Action Buttons */}
-                <div className="flex gap-2 pt-2">
-                  <Button size="sm" className="flex-1 gap-1" onClick={() => handleMakeOffer(loan)}>
+                <div className="flex flex-col gap-2 pt-2 sm:flex-row">
+                  <Button
+                    size="sm"
+                    className="w-full flex-1 gap-1"
+                    onClick={() => handleMakeOffer(loan)}
+                  >
                     <Target className="h-3 w-3" />
                     Make Offer
                   </Button>
-                  <Button variant="outline" size="sm" className="gap-1">
+                  <Button variant="outline" size="sm" className="w-full gap-1 sm:w-auto">
                     <MessageSquare className="h-3 w-3" />
                     Details
                   </Button>

--- a/src/components/loans/IncomingLoanOffersList.tsx
+++ b/src/components/loans/IncomingLoanOffersList.tsx
@@ -1,0 +1,384 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { LoanOffer } from '@/types/loans';
+import loansService from '@/services/loans';
+import { toast } from 'sonner';
+import { logger } from '@/utils/logger';
+import { STATUS } from '@/config/database-constants';
+import { formatRelativeTime } from '@/utils/dates';
+import { getLoanOfferStatusColor } from '@/config/loans';
+import { formatLoanAmount } from './useLoanList';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/badge';
+import Button from '@/components/ui/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/Input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { CURRENCY_CODES, PLATFORM_DEFAULT_CURRENCY, type CurrencyCode } from '@/config/currencies';
+import { CheckCircle, Clock, Loader2, XCircle } from 'lucide-react';
+
+const acceptOfferSchema = z.object({
+  payment_method: z.enum(['bitcoin', 'lightning', 'bank_transfer', 'card', 'other']),
+  transaction_id: z.string().max(200).optional(),
+  notes: z.string().max(500).optional(),
+});
+
+type AcceptOfferForm = z.infer<typeof acceptOfferSchema>;
+
+interface IncomingLoanOffersListProps {
+  offers: LoanOffer[];
+  borrowerId: string;
+  onOfferUpdated?: () => void;
+}
+
+function getStatusIcon(status: string) {
+  switch (status) {
+    case STATUS.LOAN_OFFERS.ACCEPTED:
+      return <CheckCircle className="h-4 w-4" />;
+    case STATUS.LOAN_OFFERS.REJECTED:
+      return <XCircle className="h-4 w-4" />;
+    default:
+      return <Clock className="h-4 w-4" />;
+  }
+}
+
+export function IncomingLoanOffersList({
+  offers,
+  borrowerId,
+  onOfferUpdated,
+}: IncomingLoanOffersListProps) {
+  const [activeOffer, setActiveOffer] = useState<LoanOffer | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const pendingOffers = useMemo(
+    () => offers.filter(offer => offer.status === STATUS.LOAN_OFFERS.PENDING),
+    [offers]
+  );
+
+  const form = useForm<AcceptOfferForm>({
+    resolver: zodResolver(acceptOfferSchema),
+    defaultValues: {
+      payment_method: 'bank_transfer',
+      transaction_id: '',
+      notes: '',
+    },
+  });
+
+  const handleReject = async (offer: LoanOffer) => {
+    setSubmitting(true);
+    try {
+      const result = await loansService.respondToOffer(offer.id, false);
+      if (!result.success) {
+        toast.error(result.error || 'Failed to reject offer');
+        return;
+      }
+      toast.success('Offer rejected');
+      onOfferUpdated?.();
+    } catch (error) {
+      logger.error('Failed to reject loan offer', error, 'IncomingLoanOffers');
+      toast.error('Failed to reject offer');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleAccept = async (values: AcceptOfferForm) => {
+    if (!activeOffer) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const respond = await loansService.respondToOffer(activeOffer.id, true, values.notes);
+      if (!respond.success) {
+        toast.error(respond.error || 'Failed to accept offer');
+        return;
+      }
+
+      const loanCurrency =
+        (activeOffer.loans?.currency as CurrencyCode | undefined) ?? PLATFORM_DEFAULT_CURRENCY;
+      const payment = await loansService.createPayment({
+        loan_id: activeOffer.loan_id,
+        offer_id: activeOffer.id,
+        amount: activeOffer.offer_amount,
+        currency: CURRENCY_CODES.includes(loanCurrency) ? loanCurrency : PLATFORM_DEFAULT_CURRENCY,
+        payment_type: activeOffer.offer_type === 'refinance' ? 'refinance' : 'payoff',
+        payer_id: activeOffer.offerer_id,
+        recipient_id: borrowerId,
+        payment_method: values.payment_method,
+        transaction_id: values.transaction_id || undefined,
+        notes: values.notes || undefined,
+      });
+      if (!payment.success || !payment.payment) {
+        toast.error(payment.error || 'Offer accepted, but payment record failed');
+        onOfferUpdated?.();
+        return;
+      }
+
+      const complete = await loansService.completePayment(payment.payment.id, {
+        ...(activeOffer.offer_type === 'refinance'
+          ? {
+              createObligation: {
+                lenderProfileName:
+                  activeOffer.profiles?.display_name ||
+                  activeOffer.profiles?.username ||
+                  'New lender',
+              },
+            }
+          : {}),
+      });
+      if (!complete.success) {
+        toast.error(complete.error || 'Payment created, but completion failed');
+        onOfferUpdated?.();
+        return;
+      }
+
+      toast.success(
+        activeOffer.offer_type === 'refinance'
+          ? 'Offer accepted and refinance handoff completed'
+          : 'Offer accepted and payoff recorded'
+      );
+      form.reset();
+      setActiveOffer(null);
+      onOfferUpdated?.();
+    } catch (error) {
+      logger.error('Failed to accept loan offer', error, 'IncomingLoanOffers');
+      toast.error('Failed to accept offer');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (offers.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold text-fg-primary">Incoming Offers</h3>
+          <p className="text-sm text-fg-secondary">
+            Review lender proposals on your loans and complete the payoff/refinance handoff.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          {offers.map(offer => {
+            const offererLabel =
+              offer.profiles?.display_name || offer.profiles?.username || 'Community lender';
+            const loanTitle = offer.loans?.title || 'Loan';
+
+            return (
+              <Card key={offer.id}>
+                <CardHeader className="pb-3">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <CardTitle className="text-base sm:text-lg">
+                        {offer.offer_type === 'refinance' ? 'Refinance Offer' : 'Payoff Offer'}
+                      </CardTitle>
+                      <CardDescription className="mt-1">
+                        {offererLabel} on {loanTitle} • {formatRelativeTime(offer.created_at)}
+                      </CardDescription>
+                    </div>
+                    <Badge className={`${getLoanOfferStatusColor(offer.status)} w-fit gap-1`}>
+                      {getStatusIcon(offer.status)}
+                      {offer.status}
+                    </Badge>
+                  </div>
+                </CardHeader>
+
+                <CardContent className="space-y-4">
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                    <div className="rounded-md bg-surface-raised p-3">
+                      <p className="text-xs text-fg-secondary">Offer Amount</p>
+                      <p className="mt-1 text-base font-semibold text-status-positive">
+                        {formatLoanAmount(offer.offer_amount, offer.loans?.currency || undefined)}
+                      </p>
+                    </div>
+                    {offer.interest_rate !== undefined && offer.interest_rate !== null && (
+                      <div className="rounded-md bg-surface-raised p-3">
+                        <p className="text-xs text-fg-secondary">Interest Rate</p>
+                        <p className="mt-1 text-base font-semibold">{offer.interest_rate}%</p>
+                      </div>
+                    )}
+                    {offer.term_months !== undefined && offer.term_months !== null && (
+                      <div className="rounded-md bg-surface-raised p-3">
+                        <p className="text-xs text-fg-secondary">Term</p>
+                        <p className="mt-1 text-base font-semibold">{offer.term_months} months</p>
+                      </div>
+                    )}
+                    <div className="rounded-md bg-surface-raised p-3">
+                      <p className="text-xs text-fg-secondary">Loan Balance</p>
+                      <p className="mt-1 text-base font-semibold">
+                        {formatLoanAmount(
+                          offer.loans?.remaining_balance || 0,
+                          offer.loans?.currency || undefined
+                        )}
+                      </p>
+                    </div>
+                  </div>
+
+                  {offer.terms && (
+                    <div className="rounded-md bg-surface-raised/60 p-3">
+                      <p className="text-sm font-medium text-fg-primary">Terms</p>
+                      <p className="mt-1 text-sm text-fg-secondary whitespace-pre-wrap">
+                        {offer.terms}
+                      </p>
+                    </div>
+                  )}
+
+                  {offer.conditions && (
+                    <div className="rounded-md bg-surface-raised/60 p-3">
+                      <p className="text-sm font-medium text-fg-primary">Conditions</p>
+                      <p className="mt-1 text-sm text-fg-secondary whitespace-pre-wrap">
+                        {offer.conditions}
+                      </p>
+                    </div>
+                  )}
+
+                  {offer.status === STATUS.LOAN_OFFERS.PENDING && (
+                    <div className="flex flex-col gap-2 border-t border-default pt-3 sm:flex-row sm:justify-end">
+                      <Button
+                        variant="outline"
+                        className="w-full sm:w-auto text-status-negative hover:text-status-negative/80"
+                        onClick={() => handleReject(offer)}
+                        disabled={submitting}
+                      >
+                        Reject
+                      </Button>
+                      <Button
+                        className="w-full sm:w-auto"
+                        onClick={() => setActiveOffer(offer)}
+                        disabled={submitting}
+                      >
+                        Accept and Record Payment
+                      </Button>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+
+        {pendingOffers.length === 0 && (
+          <p className="text-sm text-fg-secondary">All current offers have been processed.</p>
+        )}
+      </div>
+
+      <Dialog open={Boolean(activeOffer)} onOpenChange={open => !open && setActiveOffer(null)}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Accept Offer and Record Payment</DialogTitle>
+            <DialogDescription>
+              Confirm the payment handoff details. Refinance offers will also create the new
+              obligation loan when the payment is marked completed.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(handleAccept)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="payment_method"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Payment Method</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select a payment method" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="bank_transfer">Bank transfer</SelectItem>
+                        <SelectItem value="bitcoin">Bitcoin</SelectItem>
+                        <SelectItem value="lightning">Lightning</SelectItem>
+                        <SelectItem value="card">Card</SelectItem>
+                        <SelectItem value="other">Other</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="transaction_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Transaction Reference</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Optional reference or invoice id" {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Optional, but helpful if you want to trace the transfer later.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="notes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Notes</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Optional settlement note" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex flex-col gap-2 border-t border-default pt-4 sm:flex-row sm:justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full sm:w-auto"
+                  onClick={() => setActiveOffer(null)}
+                  disabled={submitting}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" className="w-full sm:w-auto" disabled={submitting}>
+                  {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Confirm
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/loans/LoanOffersList.tsx
+++ b/src/components/loans/LoanOffersList.tsx
@@ -44,9 +44,9 @@ export function LoanOffersList({ offers, onOfferUpdated: _onOfferUpdated }: Loan
       {offers.map(offer => (
         <Card key={offer.id} className="oc-card-link">
           <CardHeader className="pb-3">
-            <div className="flex items-start justify-between">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex-1">
-                <div className="flex items-center gap-3 mb-2">
+                <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
                   <CardTitle className="text-lg">
                     {offer.offer_type === 'refinance' ? 'Refinance Offer' : 'Payoff Offer'}
                   </CardTitle>
@@ -57,7 +57,7 @@ export function LoanOffersList({ offers, onOfferUpdated: _onOfferUpdated }: Loan
                 </div>
                 <CardDescription>Made {formatRelativeTime(offer.created_at)}</CardDescription>
               </div>
-              <div className="flex gap-1">
+              <div className="flex gap-1 self-start">
                 {offer.status === STATUS.LOAN_OFFERS.PENDING && (
                   <Button variant="ghost" size="sm">
                     <Edit className="h-4 w-4" />
@@ -69,7 +69,7 @@ export function LoanOffersList({ offers, onOfferUpdated: _onOfferUpdated }: Loan
 
           <CardContent className="space-y-4">
             {/* Offer Details */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
               <div className="space-y-1">
                 <p className="text-sm text-fg-secondary">Offer Amount</p>
                 <p className="text-lg font-semibold text-status-positive">
@@ -103,14 +103,14 @@ export function LoanOffersList({ offers, onOfferUpdated: _onOfferUpdated }: Loan
             {offer.terms && (
               <div className="space-y-2">
                 <p className="text-sm font-medium">Terms & Conditions</p>
-                <p className="text-sm text-fg-secondary bg-surface-raised p-3 rounded">
+                <p className="rounded bg-surface-raised p-3 text-sm text-fg-secondary">
                   {offer.terms}
                 </p>
               </div>
             )}
 
             {/* Status-specific info */}
-            <div className="flex items-center justify-between pt-2 border-t">
+            <div className="flex flex-col gap-3 border-t pt-2 sm:flex-row sm:items-center sm:justify-between">
               <div className="text-sm text-fg-secondary">
                 {offer.status === STATUS.LOAN_OFFERS.PENDING && offer.expires_at && (
                   <span>Expires {formatRelativeTime(offer.expires_at)}</span>
@@ -123,24 +123,24 @@ export function LoanOffersList({ offers, onOfferUpdated: _onOfferUpdated }: Loan
                 )}
               </div>
 
-              <div className="flex gap-2">
+              <div className="flex flex-col gap-2 sm:flex-row">
                 {offer.status === STATUS.LOAN_OFFERS.PENDING && (
                   <>
-                    <Button variant="outline" size="sm" className="gap-1">
+                    <Button variant="outline" size="sm" className="w-full gap-1 sm:w-auto">
                       <MessageSquare className="h-3 w-3" />
                       Message
                     </Button>
                     <Button
                       variant="outline"
                       size="sm"
-                      className="text-status-negative hover:text-status-negative/80"
+                      className="w-full text-status-negative hover:text-status-negative/80 sm:w-auto"
                     >
                       Cancel Offer
                     </Button>
                   </>
                 )}
                 {offer.status === STATUS.LOAN_OFFERS.ACCEPTED && (
-                  <Button variant="outline" size="sm" className="gap-1">
+                  <Button variant="outline" size="sm" className="w-full gap-1 sm:w-auto">
                     <TrendingUp className="h-3 w-3" />
                     View Agreement
                   </Button>

--- a/src/components/loans/MakeOfferDialog.tsx
+++ b/src/components/loans/MakeOfferDialog.tsx
@@ -68,14 +68,14 @@ export function MakeOfferDialog({
             <CardDescription>{loan.description}</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="rounded-md bg-surface-raised/60 p-3">
                 <p className="text-sm text-fg-secondary">Remaining Balance</p>
                 <p className="text-lg font-semibold text-status-negative">
                   {formatLoanCurrency(loan.remaining_balance, loan.currency)}
                 </p>
               </div>
-              <div>
+              <div className="rounded-md bg-surface-raised/60 p-3">
                 <p className="text-sm text-fg-secondary">Current Rate</p>
                 <p className="text-lg font-semibold">
                   {loan.interest_rate ? `${loan.interest_rate}%` : 'N/A'}
@@ -145,7 +145,7 @@ export function MakeOfferDialog({
             />
 
             {watchOfferType === 'refinance' && (
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <FormField
                   control={form.control}
                   name="interest_rate"
@@ -195,7 +195,7 @@ export function MakeOfferDialog({
               </div>
             )}
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <FormField
                 control={form.control}
                 name="terms"
@@ -231,16 +231,17 @@ export function MakeOfferDialog({
               />
             </div>
 
-            <div className="flex justify-end gap-3 pt-6 border-t">
+            <div className="flex flex-col gap-3 border-t pt-6 sm:flex-row sm:justify-end">
               <Button
                 type="button"
                 variant="outline"
+                className="w-full sm:w-auto"
                 onClick={() => handleOpenChange(false)}
                 disabled={loading}
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={loading}>
+              <Button type="submit" className="w-full sm:w-auto" disabled={loading}>
                 {loading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
                 Submit Offer
               </Button>

--- a/src/config/loan-payments.ts
+++ b/src/config/loan-payments.ts
@@ -29,6 +29,7 @@ export const createLoanPaymentSchema = z.object({
   amount: z.number().positive('amount must be greater than 0'),
   currency: z.enum(CURRENCY_CODES),
   payment_type: z.enum(LOAN_PAYMENT_TYPES),
+  payer_id: z.string().uuid().optional(),
   recipient_id: z.string().uuid('recipient_id must be a UUID'),
   transaction_id: z.string().max(200).optional(),
   payment_method: z.enum(LOAN_PAYMENT_METHODS).optional(),

--- a/src/domain/loans/payments.ts
+++ b/src/domain/loans/payments.ts
@@ -21,15 +21,24 @@ type PaymentResult =
     };
 
 export async function createLoanPayment(
-  payerUserId: string,
+  userId: string,
   input: CreateLoanPaymentBody,
   supabase: AnySupabaseClient
 ): Promise<PaymentResult> {
-  if (payerUserId === input.recipient_id) {
+  const payerId = input.payer_id ?? userId;
+
+  if (payerId === input.recipient_id) {
     return {
       ok: false,
       reason: 'forbidden',
       message: 'Payer and recipient must be different users',
+    };
+  }
+  if (userId !== payerId && userId !== input.recipient_id) {
+    return {
+      ok: false,
+      reason: 'forbidden',
+      message: 'You must be a party to the payment',
     };
   }
 
@@ -55,7 +64,7 @@ export async function createLoanPayment(
       amount: input.amount,
       currency: input.currency,
       payment_type: input.payment_type,
-      payer_id: payerUserId,
+      payer_id: payerId,
       recipient_id: input.recipient_id,
       transaction_id: input.transaction_id ?? null,
       payment_method: input.payment_method ?? null,

--- a/src/services/loans/index.ts
+++ b/src/services/loans/index.ts
@@ -19,7 +19,7 @@ import type {
 
 // Import modular functions
 import { getLoan, getUserLoans, getAvailableLoans, getLoanCategories } from './queries/loans';
-import { getLoanOffers, getUserOffers } from './queries/offers';
+import { getIncomingOffers, getLoanOffers, getUserOffers } from './queries/offers';
 import { createLoan, updateLoan, deleteLoan, createObligationLoan } from './mutations/loans';
 import { createLoanOffer, updateLoanOffer, respondToOffer } from './mutations/offers';
 import { createPayment, completePayment } from './mutations/payments';
@@ -99,6 +99,13 @@ class LoansService {
     pagination?: Pagination
   ): Promise<LoanOffersListResponse> {
     return getUserOffers(query, pagination);
+  }
+
+  async getIncomingOffers(
+    query?: LoanOffersQuery,
+    pagination?: Pagination
+  ): Promise<LoanOffersListResponse> {
+    return getIncomingOffers(query, pagination);
   }
 
   async respondToOffer(

--- a/src/services/loans/queries/offers.ts
+++ b/src/services/loans/queries/offers.ts
@@ -134,3 +134,70 @@ export async function getUserOffers(
     return { success: false, error: 'Failed to get offers' };
   }
 }
+
+/**
+ * Get offers received on the current user's loans.
+ */
+export async function getIncomingOffers(
+  query?: LoanOffersQuery,
+  pagination?: Pagination
+): Promise<LoanOffersListResponse> {
+  try {
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      return { success: false, error: 'Authentication required' };
+    }
+
+    let dbQuery = supabase
+      .from(DATABASE_TABLES.LOAN_OFFERS)
+      .select(
+        `
+        *,
+        profiles!loan_offers_offerer_id_fkey (
+          username,
+          display_name,
+          avatar_url
+        ),
+        loans!loan_offers_loan_id_fkey (
+          id,
+          title,
+          remaining_balance,
+          interest_rate,
+          currency,
+          status,
+          user_id
+        )
+      `,
+        { count: 'exact' }
+      )
+      .eq('loans.user_id', userId);
+
+    if (query?.status) {
+      dbQuery = dbQuery.eq('status', query.status);
+    }
+    if (query?.offer_type) {
+      dbQuery = dbQuery.eq('offer_type', query.offer_type);
+    }
+
+    const sortBy = query?.sort_by || 'created_at';
+    const sortOrder = query?.sort_order || 'desc';
+    dbQuery = dbQuery.order(sortBy, { ascending: sortOrder === 'asc' });
+
+    const pageSize = Math.min(pagination?.pageSize || DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
+    const page = pagination?.page || 1;
+    const offset = (page - 1) * pageSize;
+    dbQuery = dbQuery.range(offset, offset + pageSize - 1);
+
+    const { data, error, count } = await dbQuery;
+
+    if (error) {
+      logger.error('Failed to get incoming offers', error, 'Loans');
+      return { success: false, error: error.message };
+    }
+
+    return { success: true, offers: data || [], total: count || 0 };
+  } catch (error) {
+    logger.error('Exception getting incoming offers', error, 'Loans');
+    return { success: false, error: 'Failed to get incoming offers' };
+  }
+}

--- a/src/types/loans.ts
+++ b/src/types/loans.ts
@@ -96,6 +96,20 @@ export interface LoanOffer {
   updated_at: string;
   accepted_at?: string;
   rejected_at?: string;
+  profiles?: {
+    username?: string | null;
+    display_name?: string | null;
+    avatar_url?: string | null;
+  } | null;
+  loans?: {
+    id: string;
+    title?: string | null;
+    remaining_balance?: number | null;
+    interest_rate?: number | null;
+    currency?: CurrencyCode | string | null;
+    status?: string | null;
+    user_id?: string | null;
+  } | null;
 }
 
 interface LoanPayment {
@@ -162,6 +176,7 @@ export interface CreateLoanPaymentRequest {
   amount: number;
   currency: CurrencyCode;
   payment_type: PaymentType;
+  payer_id?: string;
   recipient_id: string;
   transaction_id?: string;
   payment_method?: PaymentMethod;


### PR DESCRIPTION
## Summary
- wire incoming loan offers into the borrower dashboard with accept/reject actions
- connect accept flow to payment creation, payment completion, and refinance obligation creation
- improve touched loan cards and dialogs for mobile-first responsiveness

## Test plan
- [x] `node scripts/docs-slop-scan.js`
- [x] `npm run type-check`
- [x] `npm run audit:routes`
- [x] `npm test -- --testPathPatterns=__tests__/unit`


Made with [Cursor](https://cursor.com)