### PR TITLE
fix(payments): refuse buyer self-attestation on auto-detected rails

### DIFF
--- a/__tests__/unit/domain/payments/buyerConfirmPayment.test.ts
+++ b/__tests__/unit/domain/payments/buyerConfirmPayment.test.ts
@@ -1,10 +1,16 @@
 /**
- * buyerConfirmPayment — state-transition correctness.
+ * buyerConfirmPayment — state-transition correctness + trust-boundary guard.
  *
  * A buyer confirming a payment flips the intent to BUYER_CONFIRMED and the
  * fixed-price order to PAID. A swallowed DB error used to let this return
  * success while the rows stayed stale; these tests lock in that failures now
  * surface instead of silently diverging money state from reality.
+ *
+ * They also lock the trust boundary: manual self-attestation is refused on any
+ * rail we confirm automatically (NWC, verify-capable Lightning addresses,
+ * on-chain). Only a bare Lightning address with no LUD-21 verify URL may be
+ * self-attested — the buyer's word must never flip an order to paid over a
+ * trustworthy on-rail signal.
  */
 
 import { buyerConfirmPayment } from '@/domain/payments/paymentFlowService';
@@ -57,6 +63,10 @@ const fixedPriceIntent = {
   status: STATUS.PAYMENT_INTENTS.INVOICE_READY,
   entity_type: 'product',
   paid_at: null,
+  // A bare Lightning address (no LUD-21 verify URL) is the ONLY rail eligible for
+  // manual confirmation; every other method is auto-detected and now refused.
+  payment_method: 'lightning_address',
+  lnurl_verify_url: null,
 };
 
 describe('buyerConfirmPayment', () => {
@@ -96,6 +106,21 @@ describe('buyerConfirmPayment', () => {
     });
     await expect(buyerConfirmPayment(supabase, PI_ID, BUYER)).rejects.toThrow(
       'Failed to update order status'
+    );
+  });
+
+  it.each([
+    ['NWC', { payment_method: 'nwc', payment_hash: 'h' }],
+    ['on-chain', { payment_method: 'onchain', onchain_address: 'bc1qxyz' }],
+    [
+      'a verify-capable Lightning address',
+      { payment_method: 'lightning_address', lnurl_verify_url: 'https://ln/verify' },
+    ],
+  ])('refuses manual confirmation for an auto-detected rail: %s', async (_label, rail) => {
+    // Detectable rail → the guard throws before any state change (no write reached).
+    const supabase = makeSupabase({ intent: { ...fixedPriceIntent, ...rail } });
+    await expect(buyerConfirmPayment(supabase, PI_ID, BUYER)).rejects.toThrow(
+      'This payment is confirmed automatically'
     );
   });
 });

--- a/src/components/payment/PaymentDialog.tsx
+++ b/src/components/payment/PaymentDialog.tsx
@@ -203,12 +203,17 @@ export function PaymentDialog({
 
               <PaymentStatusIndicator status="invoice_ready" />
 
-              {/* "I've paid" fallback for all non-NWC methods (no auto-detect) */}
-              {state.data.payment_intent.payment_method !== 'nwc' && (
-                <Button variant="outline" size="sm" onClick={confirmPaid} className="min-h-11">
-                  I&apos;ve paid
-                </Button>
-              )}
+              {/* "I've paid" fallback ONLY for a bare Lightning address (no LUD-21
+                  verify URL) — the single rail we can't auto-detect. NWC,
+                  verify-capable Lightning addresses, and on-chain are confirmed
+                  automatically and the server refuses manual confirmation for them.
+                  Keep in sync with buyerConfirmPayment's guard. */}
+              {state.data.payment_intent.payment_method === 'lightning_address' &&
+                !state.data.payment_intent.lnurl_verify_url && (
+                  <Button variant="outline" size="sm" onClick={confirmPaid} className="min-h-11">
+                    I&apos;ve paid
+                  </Button>
+                )}
             </div>
           )}
 

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -262,7 +262,11 @@ export async function checkPaymentStatus(
 }
 
 /**
- * Buyer confirms "I've paid" (for Lightning Address / on-chain where we can't auto-detect)
+ * Buyer's manual "I've paid" fallback — ONLY for a bare Lightning address with no
+ * LUD-21 verify URL, the single rail we cannot confirm automatically. Every other
+ * method (NWC, verify-capable Lightning addresses, on-chain) is detected by
+ * checkPaymentStatus, so manual confirmation is refused there: the buyer's word
+ * must never override a trustworthy on-rail signal.
  */
 export async function buyerConfirmPayment(
   supabase: SupabaseClient,
@@ -282,6 +286,18 @@ export async function buyerConfirmPayment(
 
   if (pi.status === STATUS.PAYMENT_INTENTS.PAID) {
     return { status: STATUS.PAYMENT_INTENTS.PAID, paid_at: pi.paid_at };
+  }
+
+  // Guard the trust boundary: only a bare Lightning address (no LUD-21 verify
+  // URL) is genuinely undetectable. NWC (relay lookup), verify-capable Lightning
+  // addresses, and on-chain (mempool confirmation) are all confirmed by
+  // checkPaymentStatus — accepting the buyer's self-attestation there would let
+  // the weakest signal flip an order to paid over a trustworthy one. Refuse it.
+  const isUndetectable = pi.payment_method === 'lightning_address' && !pi.lnurl_verify_url;
+  if (!isUndetectable) {
+    throw new Error(
+      'This payment is confirmed automatically — please wait for detection instead of confirming manually.'
+    );
   }
 
   // Mark as buyer_confirmed — seller verifies in their wallet


### PR DESCRIPTION
## What
`buyerConfirmPayment` flipped an order to **paid on the buyer's word alone** — even for rails `checkPaymentStatus` confirms automatically (NWC, verify-capable Lightning addresses, on-chain). This guards the trust boundary: only a **bare Lightning address with no LUD-21 verify URL** may be self-attested; every detectable rail is refused before any state change. The UI "I've paid" button is gated to the same condition so no rail is shown a button that now errors.

## Why
It's the one place OrangeCat trusted the weakest party (the buyer) about money — directly on the P0 "first real payment" path. Non-custodial and on-ethos: money must move on a trustworthy on-rail signal, not a click.

## Verification
- Payments unit suite green (6 suites / 30 tests; +3 guard cases in `buyerConfirmPayment.test.ts`).
- Non-incremental typecheck + lint clean.
- ⚠️ **Not exercised against the live DB / a real Lightning payment** (no box access from the dev agent). Confirm on the box before it handles real money.

🤖 Generated with [Claude Code](https://claude.com/claude-code)