### PR TITLE
ops(uptime): Telegram alert on box-death transition

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -62,13 +62,30 @@ jobs:
           check "https://orangecat.ch/" || fail=1
           echo "down=$fail" >> "$GITHUB_OUTPUT"
 
-      - name: Alert / resolve via GitHub issue
+      - name: Alert / resolve via GitHub issue (+ Telegram on transition)
         uses: actions/github-script@v7
+        env:
+          # Same bot fleetcrown/openclaw use — box-death (orangecat.ch = the box)
+          # reaches the channel George actually watches, not just a GitHub issue.
+          # Optional: absent secrets just skip the Telegram send (issue still fires).
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         with:
           script: |
             const down = '${{ steps.probe.outputs.down }}' === '1';
             const title = '🔴 orangecat.ch is DOWN';
             const { owner, repo } = context.repo;
+            // Fire-and-forget Telegram; never let a notify failure fail the check.
+            const tg = async (text) => {
+              const t = process.env.TELEGRAM_BOT_TOKEN, c = process.env.TELEGRAM_CHAT_ID;
+              if (!t || !c) return;
+              try {
+                await fetch(`https://api.telegram.org/bot${t}/sendMessage`, {
+                  method: 'POST', headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify({ chat_id: c, text }),
+                });
+              } catch (e) { core.warning(`telegram send failed: ${e}`); }
+            };
             const open = (await github.rest.issues.listForRepo({
               owner, repo, state: 'open', labels: 'uptime', per_page: 1,
             })).data[0];
@@ -78,12 +95,16 @@ jobs:
               if (open) {
                 await github.rest.issues.createComment({ owner, repo, issue_number: open.number, body: `Still down at ${now}.` });
               } else {
+                // First DOWN transition → page Telegram (transition-only: the
+                // absence of an open issue is the "was up" state).
                 await github.rest.issues.create({ owner, repo, title, body, labels: ['uptime'] });
+                await tg(`🔴 orangecat.ch (the bitbaum box) is DOWN as of ${now}. On-box alerts are dark when the box is dead — this is the external check.`);
               }
               core.setFailed('Site is DOWN');
             } else if (open) {
               await github.rest.issues.createComment({ owner, repo, issue_number: open.number, body: `✅ Recovered at ${now} — closing.` });
               await github.rest.issues.update({ owner, repo, issue_number: open.number, state: 'closed' });
+              await tg(`✅ orangecat.ch (bitbaum) RECOVERED at ${now}.`);
             }
 
       # Separate, non-fatal alert: the single box is the whole failure domain, so a


### PR DESCRIPTION
The off-box uptime monitor already detects box-death (orangecat.ch is on bitbaum) but only opened a GitHub issue. Now it also pings Telegram on the down/recovery transition — reusing the fleetcrown/openclaw bot via repo secrets — so total box failure (the one case the on-box watchdog cannot report) reaches the channel George actually watches. Fire-and-forget; absent secrets just skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)