### PR TITLE
feat(profile): expandable bio, desktop tab-scroll affordance, timeline-first

### DIFF
--- a/src/components/profile/ProfileLayout.tsx
+++ b/src/components/profile/ProfileLayout.tsx
@@ -219,9 +219,10 @@ export default function ProfileLayout({
             )}
           </div>
 
-          {/* Overview-first: a shared profile should open on the scannable
-              "who is this / what do they offer" summary, not the timeline feed. */}
-          <ProfileViewTabs tabs={filteredTabs} defaultTab="overview" />
+          {/* Timeline-first: open on the living activity feed so visitors see the
+              latest — new projects, funding, updates — the way an X profile does,
+              rather than a static summary. Overview remains one tap away. */}
+          <ProfileViewTabs tabs={filteredTabs} defaultTab="timeline" />
         </div>
       </div>
     </div>

--- a/src/components/profile/ProfileViewTabs.tsx
+++ b/src/components/profile/ProfileViewTabs.tsx
@@ -126,13 +126,14 @@ export default function ProfileViewTabs({ tabs, defaultTab, className }: Profile
     <div className={cn('w-full', className)}>
       {/* Tab Navigation - X/Twitter-style horizontal scroll on mobile, flex on desktop */}
       <div className="border-b border-default mb-4 sm:mb-6 relative">
-        {/* Left fade indicator - only on mobile when scrolled */}
+        {/* Fade affordances — shown on ALL viewports when the strip overflows, so
+            it's clear there are more tabs to scroll to (many entity tabs overflow
+            on desktop too, where the scrollbar is hidden). */}
         {showLeftFade && (
-          <div className="absolute left-0 top-0 bottom-0 w-8 bg-surface-page/80 pointer-events-none z-10 sm:hidden" />
+          <div className="absolute left-0 top-0 bottom-0 w-8 bg-gradient-to-r from-surface-page to-transparent pointer-events-none z-10" />
         )}
-        {/* Right fade indicator - only on mobile when more tabs available */}
         {showRightFade && (
-          <div className="absolute right-0 top-0 bottom-0 w-8 bg-surface-page/80 pointer-events-none z-10 sm:hidden" />
+          <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-surface-page to-transparent pointer-events-none z-10" />
         )}
         <nav
           ref={navRef}

--- a/src/components/profile/sections/ProfileBasicSection.tsx
+++ b/src/components/profile/sections/ProfileBasicSection.tsx
@@ -122,7 +122,10 @@ export function ProfileBasicSection({
             <FormControl>
               <Textarea
                 placeholder="Tell your story..."
-                className="min-h-20 resize-none"
+                // Auto-grow with the content (no inner scrollbar) where supported,
+                // capped so a very long bio doesn't run away; still hand-resizable
+                // as a fallback for browsers without field-sizing.
+                className="min-h-20 max-h-[60vh] resize-y [field-sizing:content]"
                 {...field}
                 value={field.value || ''}
                 onFocus={() => onFieldFocus?.('bio')}


### PR DESCRIPTION
Three self-contained profile UX fixes (no schema change, no data migration):

- **Expandable bio** — the edit-form bio was a fixed-height `resize-none` textarea that forced you to scroll to read your own bio. Now auto-grows with content (`field-sizing:content`), capped at 60vh, hand-resizable fallback.
- **Tab-strip scroll affordance on desktop** — with ~13 entity tabs the strip overflows horizontally, but the fade indicators were `sm:hidden` and the scrollbar is hidden, so on desktop there was no signal there's more. Fades now show on all viewports when it overflows (state already computed on mount + resize).
- **Timeline-first** — public profiles open on Timeline (the living activity feed) instead of Overview, matching an X-style profile. One-line default change; Overview stays one tap away.

Verified: non-incremental typecheck + lint clean; pre-push gate (type-check + route audit + unit tests) green.

Part of the profile-UX cluster. Follow-ups (own PRs): multiple websites, field-level hide toggles, Overview/Info merge, and migrating the profile entity tiles onto the shared `EntityCard` SSOT (they currently hand-roll divergent, mutually-inconsistent cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)