### PR TITLE
chore(ci): add `verify` script as the single source of truth for the pre-build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,28 +41,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Docs hygiene checks
-        # Don't swallow failures with `|| echo` — that turned this into a no-op
-        # gate. If docs checks legitimately need to be advisory, mark the step
-        # `continue-on-error: true` so the noise is explicit in the UI.
-        run: npm run ci:docs
-
-      - name: Type check
-        run: npm run type-check
-
-      - name: Route integrity audit
-        # Every declared route (ROUTES/API_ROUTES/entity registry) and every
-        # emitted internal link must resolve to a real route file. Static,
-        # fast — prevents the internal-link → 404 class of bug.
-        run: npm run audit:routes
-
-      - name: Lint
-        # Catches the bug class that landed on main as `IntegrationNote` —
-        # eslint would have flagged the undefined identifier before merge.
-        run: npm run lint
-
-      - name: Unit tests
-        run: npm run test:unit -- --watchAll=false
+      - name: Verify (docs + type-check + routes + lint + unit — same as local)
+        # SSOT for "green": the pre-build gate is defined ONCE as the `verify`
+        # npm script and called verbatim here, so `npm run verify` locally and CI
+        # can never drift. The chain (in order): ci:docs → type-check →
+        # audit:routes → lint → test:unit. Rationale for each check:
+        #   - ci:docs      : docs hygiene (slop scan + frontmatter). Fails hard,
+        #                    never swallowed with `|| echo` (that was a no-op gate).
+        #   - type-check   : tsc --noEmit.
+        #   - audit:routes : every declared route + emitted internal link must
+        #                    resolve to a real route file — kills the internal-link
+        #                    → 404 class of bug. Static, fast.
+        #   - lint         : eslint — catches the undefined-identifier class (e.g.
+        #                    the `IntegrationNote` bug that once landed on main).
+        #   - test:unit    : Jest unit suite (--watchAll=false).
+        # (Playwright/E2E stays a separate post-build gate below — it needs a
+        # running server + secrets, so it isn't part of the static verify bundle.)
+        run: npm run verify
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md
+
+Operational guide for any coding agent working in this repo. Claude Code users:
+`CLAUDE.md` is the fuller source of truth — this file mirrors its key facts.
+
+## What this is
+
+**OrangeCat** — an AI-native platform for universal economic and governance
+participation ("My Cat" AI agent: earn, fund, lend, invest, govern in any
+currency). Bitcoin/Lightning native.
+
+## Stack
+
+| Layer      | Technology                                                              |
+| ---------- | ----------------------------------------------------------------------- |
+| Framework  | Next.js 15 (App Router), TypeScript 5.8                                 |
+| Styling    | Tailwind CSS 3.3 (tokens are CSS vars in `src/app/globals.css`)         |
+| Database   | Self-hosted Supabase (Postgres + Auth + RLS) at `supabase.orangecat.ch` |
+| Bitcoin    | Lightning Network, BTCPay, NWC                                          |
+| Deployment | Self-hosted on Hetzner (`bitbaum`, behind Caddy) — no Vercel            |
+
+## Run it
+
+```bash
+npm ci                 # install
+npm run dev -- -p 3020 # dev server on :3020 (avoids conflicts)
+```
+
+## Verify before you commit (single source of truth)
+
+```bash
+npm run verify
+```
+
+`verify` is the ONE gate. It runs, in order: `ci:docs` → `type-check` →
+`audit:routes` → `lint` → `test:unit`. CI (`.github/workflows/ci.yml`,
+`build-and-smoke` job) calls `npm run verify` verbatim, so green locally ⇒ green
+CI. Add or remove a check in the `verify` script only — never re-list checks
+inline in the workflow. (E2E/Playwright is a separate post-build gate; it needs a
+running server + secrets and is not part of `verify`.)
+
+## Database & migrations
+
+- SSOT is the self-hosted Supabase on Hetzner (`supabase.orangecat.ch`). The
+  managed Supabase Cloud project is **retired** — do NOT use it or the Supabase MCP.
+- Migrations live in `supabase/migrations/*.sql`. **Immutable once applied** —
+  never edit an existing one; always add a new file. Migrations are the schema SSOT.
+
+## Deploy path
+
+`main` → CI (`ci.yml`) must go green → CD (`cd.yml`) ships the exact CI-built
+standalone artifact to `bitbaum` via `scripts/deploy-selfhost.sh` (atomic swap +
+rollback). CD is dormant until `SELFHOST_SSH_KEY` is set. No Vercel.
+
+## Core conventions (don't fight these)
+
+- **Entity registry is SSOT**: `src/config/entity-registry.ts`. Never hardcode
+  table names, API paths, or entity labels — read them from the registry.
+- **Actor ownership**: query by `actor_id`, never `user_id` directly.
+- **Bitcoin**: store amounts as BTC in `NUMERIC(18,8)` (never integer sats).
+  Display via the `useDisplayCurrency()` hook (CHF default).
+- **Design tokens**: CSS custom properties in `src/app/globals.css` are the only
+  SSOT for color/radius/shadow. No hardcoded hex in components or Tailwind config.
+- **Layering**: `config/` (what exists) → `domain/` (business logic, no HTTP/UI)
+  → `app/api/` (thin HTTP) → `components/` (UI) → `hooks/` (data fetching).
+
+## Protected files (back up before touching)
+
+`.env.local`, `supabase/migrations/*`, `src/config/entity-registry.ts`.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint:check": "next lint",
     "lint:umlauts": "grep -rn --include='*.ts' --include='*.tsx' -E '(fuer|koennen|moeglich|muessen|wuerde|aehnlich|aerger|aendern|oeffnen|ueber|ueberall|zurueck|natuerlich|genuegt|Strasse|Gruesse)' src/ || echo 'No umlaut violations found'",
     "type-check": "tsc --noEmit --skipLibCheck --incremental false",
+    "verify": "npm run ci:docs && npm run type-check && npm run audit:routes && npm run lint && npm run test:unit -- --watchAll=false",
     "audit:schema": "node scripts/db/audit-schema-drift.mjs",
     "audit:routes": "node scripts/audit-routes.mjs",
     "gen:types": "bash scripts/db/gen-types.sh",


### PR DESCRIPTION
## What

Adds a single **`verify`** npm script that bundles the exact pre-build check chain CI already runs, and makes CI call it verbatim — so "green locally" and "green CI" can no longer drift.

## Why

Prior state: the pre-build gate lived as five separate inline CI steps (`ci:docs`, `type-check`, `audit:routes`, `lint`, `test:unit`). There was **no one command** a developer could run to reproduce the gate locally → local/CI drift. This satisfies the "one definition of verified" standard.

## Changes (additive, behavior-preserving)

- **`package.json`**: new script
  ```
  "verify": "npm run ci:docs && npm run type-check && npm run audit:routes && npm run lint && npm run test:unit -- --watchAll=false"
  ```
  Same scripts, same order as CI ran them inline. No check added or removed.
- **`.github/workflows/ci.yml`**: the `build-and-smoke` job's five inline steps are replaced by a single step that runs `npm run verify`. The per-check rationale comments are preserved on the new step.
- **`AGENTS.md`** (new): points non-Claude agents at the stack, `dev`/`verify` commands, migrations location (`supabase/migrations/`, immutable once applied), and the self-hosted Hetzner deploy path.

## Scope notes

- **E2E / Playwright is intentionally NOT in `verify`** — it's a post-build gate that needs a running standalone server + secrets. `verify` is the static + unit gate (lint + typecheck + tests), matching the "one definition of verified" convention. The E2E gate in `ci.yml` is untouched.
- No changes to test gating, migration strategy, or deploy logic.

## Verification

- `npm run verify` correctly expands to the exact 5-script chain.
- Confirmed passing locally: `ci:docs` (slop scan + frontmatter), `audit:routes` (clean).
- `type-check` / `lint` / `test:unit` are unchanged from what CI already ran; a full local run was truncated by heavy concurrent load on this host, but CI will run the full chain on this PR.
- Both `ci.yml` and `cd.yml` parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)