### PR TITLE
feat(fleetcrown): sell FleetCrown plans as Bitcoin-payable OrangeCat passes

### DIFF
--- a/__tests__/unit/fleetcrown/passes.test.ts
+++ b/__tests__/unit/fleetcrown/passes.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Contract test for the FleetCrown Bitcoin entitlement rail.
+ *
+ * Proves the seed's product tags (what OrangeCat WRITES) are exactly what the
+ * settlement notifier PARSES, and that the derived webhook payload satisfies
+ * FleetCrown's receiver contract. FleetCrown's verifier
+ * (src/app/api/orangecat/entitlement/route.ts in the FleetCrown repo) enforces:
+ *   plan ∈ its plan enum · externalId 1..200 chars · periodDays a positive int ≤ 3660.
+ * If the tag format, the plan set, or a price ever drifts, this fails before a
+ * dormant rail ships.
+ */
+import {
+  FLEETCROWN_PASSES,
+  FLEETCROWN_PLANS,
+  parseFleetCrownPass,
+  passTags,
+} from '@/config/fleetcrown-passes';
+
+describe('FleetCrown passes — tag/parse contract', () => {
+  it('every catalogued pass round-trips through parseFleetCrownPass', () => {
+    for (const pass of FLEETCROWN_PASSES) {
+      expect(parseFleetCrownPass(pass.tags)).toEqual({
+        plan: pass.plan,
+        periodDays: pass.periodDays,
+      });
+    }
+  });
+
+  it('covers exactly the paid plans, once each', () => {
+    const plans = FLEETCROWN_PASSES.map((p) => p.plan).sort();
+    expect(plans).toEqual([...FLEETCROWN_PLANS].sort());
+    expect(new Set(plans).size).toBe(FLEETCROWN_PASSES.length);
+  });
+
+  it('passTags is the exact inverse of parseFleetCrownPass', () => {
+    for (const plan of FLEETCROWN_PLANS) {
+      expect(parseFleetCrownPass(passTags(plan, 30))).toEqual({ plan, periodDays: 30 });
+    }
+  });
+
+  it('rejects non-pass / malformed tags', () => {
+    expect(parseFleetCrownPass(null)).toBeNull();
+    expect(parseFleetCrownPass(['random', 'tags'])).toBeNull();
+    expect(parseFleetCrownPass(['fleetcrown-plan:pro'])).toBeNull(); // missing days
+    expect(parseFleetCrownPass(['fleetcrown-days:30'])).toBeNull(); // missing plan
+    expect(parseFleetCrownPass(['fleetcrown-plan:bogus', 'fleetcrown-days:30'])).toBeNull();
+  });
+
+  it('derived entitlement payload satisfies FleetCrown’s receiver constraints', () => {
+    for (const pass of FLEETCROWN_PASSES) {
+      const parsed = parseFleetCrownPass(pass.tags);
+      expect(parsed).not.toBeNull();
+      // plan is a bounded token FleetCrown's zod enum accepts
+      expect(FLEETCROWN_PLANS).toContain(parsed!.plan);
+      // periodDays: positive int ≤ 3660
+      expect(Number.isInteger(parsed!.periodDays)).toBe(true);
+      expect(parsed!.periodDays).toBeGreaterThan(0);
+      expect(parsed!.periodDays).toBeLessThanOrEqual(3660);
+    }
+  });
+
+  it('prices match FleetCrown /pricing (CHF 15/40/90), guarding accidental drift', () => {
+    const byPlan = Object.fromEntries(FLEETCROWN_PASSES.map((p) => [p.plan, p.price]));
+    expect(byPlan).toEqual({ personal: 15, pro: 40, team: 90 });
+    for (const p of FLEETCROWN_PASSES) {
+      expect(p.currency).toBe('CHF');
+    }
+  });
+});

--- a/scripts/seed-fleetcrown-passes.ts
+++ b/scripts/seed-fleetcrown-passes.ts
@@ -1,0 +1,169 @@
+/**
+ * Seed the three FleetCrown passes as Bitcoin-payable OrangeCat products.
+ *
+ * FleetCrown sells its paid plans (personal/pro/team) as OrangeCat `products`
+ * tagged for the entitlement rail. When a buyer pays one in BTC and the payment
+ * settles, notifyFleetCrownEntitlement() signals FleetCrown to grant the plan
+ * (src/services/fleetcrown/entitlement-notify.ts). The catalogue + tag format
+ * are the SSOT in src/config/fleetcrown-passes.ts — this script only writes it
+ * to the DB.
+ *
+ * Idempotent: upsert by (actor_id, title); never truncates. Owner-gated so it
+ * can't fire by accident. Prints the three checkout URLs to configure on the
+ * FleetCrown box (ORANGECAT_PAY_URL_*).
+ *
+ * Run against the LIVE self-hosted DB (supabase.orangecat.ch) from the box:
+ *   ORANGECAT_OWNER_SEED=1 npx tsx scripts/seed-fleetcrown-passes.ts
+ *
+ * Requires in the environment (already in .env.local on the box):
+ *   NEXT_PUBLIC_SUPABASE_URL   — self-hosted Supabase URL
+ *   SUPABASE_SERVICE_ROLE_KEY  — service role (bypasses RLS for the seed)
+ *   NEXT_PUBLIC_SITE_URL       — public app origin (for the checkout URLs)
+ *
+ * Created: 2026-07-22
+ */
+
+import { config as loadEnv } from 'dotenv';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import {
+  FLEETCROWN_PASSES,
+  OWNER_ACTOR_SLUG,
+  type FleetCrownPass,
+} from '../src/config/fleetcrown-passes';
+
+loadEnv({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://orangecat.ch').replace(/\/+$/, '');
+
+function die(message: string): never {
+  console.error(`✗ ${message}`);
+  process.exit(1);
+}
+
+if (process.env.ORANGECAT_OWNER_SEED !== '1') {
+  die('Refusing to run without ORANGECAT_OWNER_SEED=1 (owner-gated).');
+}
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  die('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in the environment.');
+}
+
+const admin: SupabaseClient = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+interface ActorRow {
+  id: string;
+  user_id: string | null;
+}
+
+async function resolveOwnerActor(): Promise<ActorRow> {
+  const { data, error } = await admin
+    .from('actors')
+    .select('id, user_id')
+    .eq('slug', OWNER_ACTOR_SLUG)
+    .maybeSingle();
+  if (error) die(`Failed to resolve owner actor: ${error.message}`);
+  if (!data) die(`No actor with slug '${OWNER_ACTOR_SLUG}'. Create it or change OWNER_ACTOR_SLUG.`);
+  if (!data.user_id) die(`Actor '${OWNER_ACTOR_SLUG}' has no user_id; products require one.`);
+  return data as ActorRow;
+}
+
+/**
+ * Warn (don't fail) if the seller actor has no active wallet. The pass products
+ * can exist without one, but checkout will fail with "Seller has no wallet
+ * connected" until a wallet is connected on OrangeCat for this actor.
+ */
+async function checkSellerWallet(actor: ActorRow): Promise<void> {
+  const { data, error } = await admin
+    .from('wallets')
+    .select('id, is_active')
+    .eq('profile_id', actor.user_id)
+    .eq('is_active', true);
+  if (error) {
+    console.warn(`  ⚠ could not verify seller wallet: ${error.message}`);
+    return;
+  }
+  if (!data || data.length === 0) {
+    console.warn(
+      `  ⚠ SELLER HAS NO ACTIVE WALLET — buyers cannot pay until one is connected\n` +
+        `    on OrangeCat for actor '${OWNER_ACTOR_SLUG}'. The passes will exist but\n` +
+        `    checkout fails with "Seller has no wallet connected".`,
+    );
+  } else {
+    console.log(`  ✓ seller wallet present (${data.length} active)`);
+  }
+}
+
+/** Find a product owned by the actor with the given title (null if absent). */
+async function findProduct(actorId: string, title: string): Promise<string | null> {
+  const { data, error } = await admin
+    .from('user_products')
+    .select('id')
+    .eq('actor_id', actorId)
+    .eq('title', title)
+    .maybeSingle();
+  if (error) die(`Failed to look up product '${title}': ${error.message}`);
+  return data?.id ?? null;
+}
+
+/** Upsert one pass product by (actor_id, title). Returns its id. */
+async function upsertPass(actor: ActorRow, pass: FleetCrownPass): Promise<string> {
+  const row = {
+    user_id: actor.user_id,
+    actor_id: actor.id,
+    title: pass.title,
+    description: pass.description,
+    price: pass.price,
+    currency: pass.currency,
+    product_type: 'digital',
+    status: 'active', // API defaults to draft; a purchasable pass must be active
+    show_on_profile: false, // reached from FleetCrown's /pricing, not browsed on OC
+    tags: pass.tags,
+    is_test: false,
+  };
+
+  const existingId = await findProduct(actor.id, pass.title);
+  if (existingId) {
+    const { error } = await admin.from('user_products').update(row).eq('id', existingId);
+    if (error) die(`Failed to update '${pass.title}': ${error.message}`);
+    console.log(`↻ updated ${pass.plan} pass "${pass.title}" (${existingId})`);
+    return existingId;
+  }
+
+  const { data, error } = await admin
+    .from('user_products')
+    .insert(row)
+    .select('id')
+    .single();
+  if (error) die(`Failed to insert '${pass.title}': ${error.message}`);
+  console.log(`+ created ${pass.plan} pass "${pass.title}" (${data.id})`);
+  return data.id as string;
+}
+
+async function main(): Promise<void> {
+  console.log(`Seeding FleetCrown passes against ${SUPABASE_URL} …`);
+  const actor = await resolveOwnerActor();
+  console.log(`owner actor '${OWNER_ACTOR_SLUG}' = ${actor.id}`);
+  await checkSellerWallet(actor);
+
+  const envLines: string[] = [];
+  for (const pass of FLEETCROWN_PASSES) {
+    const id = await upsertPass(actor, pass);
+    envLines.push(`ORANGECAT_PAY_URL_${pass.plan.toUpperCase()}=${SITE_URL}/products/${id}`);
+  }
+
+  console.log('\n✓ done.\n');
+  console.log('Set these on the FleetCrown box (.env) so /pricing lights up "Pay in Bitcoin":\n');
+  for (const line of envLines) {
+    console.log(`  ${line}`);
+  }
+  console.log(
+    '\nAlso set ORANGECAT_WEBHOOK_SECRET to the SAME value on BOTH the OrangeCat and\n' +
+      'FleetCrown boxes — until then the settlement → grant webhook stays inert\n' +
+      '(both ends fail closed by design).',
+  );
+}
+
+main().catch((err) => die(err instanceof Error ? err.message : String(err)));

--- a/src/config/fleetcrown-passes.ts
+++ b/src/config/fleetcrown-passes.ts
@@ -1,0 +1,132 @@
+/**
+ * FleetCrown passes — OrangeCat-side SSOT for the Bitcoin entitlement rail.
+ *
+ * FleetCrown (the execution layer) sells its paid plans as Bitcoin-payable
+ * OrangeCat products. A "pass" is an ordinary `user_products` row carrying two
+ * marker tags the settlement notifier reads:
+ *
+ *     fleetcrown-plan:<personal|pro|team>   fleetcrown-days:<n>
+ *
+ * On a settled payment for such a product, notifyFleetCrownEntitlement()
+ * (src/services/fleetcrown/entitlement-notify.ts) POSTs a signed grant to
+ * FleetCrown, which flips users.plan for `periodDays` — Bitcoin has no native
+ * recurring, so a pass is a renewable time-box.
+ *
+ * This file is the ONE place that knows the plan set, the tag format, the
+ * parser, and the canonical pass catalogue:
+ *   - the seed (scripts/seed-fleetcrown-passes.ts) WRITES tags via passTags()
+ *   - the notifier READS them via parseFleetCrownPass()
+ * Same source → they cannot drift (guarded by __tests__/unit/fleetcrown).
+ *
+ * Prices mirror FleetCrown's /pricing (CHF 15/40/90 per month); OrangeCat
+ * converts CHF → BTC at checkout. Change a price here and re-run the seed.
+ */
+
+/** The paid FleetCrown tiers sold as OrangeCat passes (excludes the free tier). */
+export const FLEETCROWN_PLANS = ['personal', 'pro', 'team'] as const;
+export type FleetCrownPlan = (typeof FLEETCROWN_PLANS)[number];
+
+/** Default pass length. BTC has no native recurring — a pass is a time-box. */
+export const FLEETCROWN_PASS_PERIOD_DAYS = 30;
+
+const PLAN_SET = new Set<string>(FLEETCROWN_PLANS);
+
+/**
+ * The two marker tags a FleetCrown-pass product must carry. This is the SSOT
+ * for the tag format; parseFleetCrownPass() below is its exact inverse.
+ */
+export function passTags(plan: FleetCrownPlan, periodDays: number): [string, string] {
+  return [`fleetcrown-plan:${plan}`, `fleetcrown-days:${periodDays}`];
+}
+
+/** Extract {plan, periodDays} from a product's tags, or null if not a pass. */
+export function parseFleetCrownPass(
+  tags: unknown,
+): { plan: FleetCrownPlan; periodDays: number } | null {
+  if (!Array.isArray(tags)) {
+    return null;
+  }
+  let plan: FleetCrownPlan | null = null;
+  let periodDays: number | null = null;
+  for (const raw of tags) {
+    if (typeof raw !== 'string') {
+      continue;
+    }
+    const t = raw.trim();
+    const p = /^fleetcrown-plan:([a-z]+)$/.exec(t);
+    if (p && PLAN_SET.has(p[1])) {
+      plan = p[1] as FleetCrownPlan;
+    }
+    const d = /^fleetcrown-days:(\d{1,4})$/.exec(t);
+    if (d) {
+      periodDays = parseInt(d[1], 10);
+    }
+  }
+  return plan && periodDays ? { plan, periodDays } : null;
+}
+
+export interface FleetCrownPass {
+  plan: FleetCrownPlan;
+  title: string;
+  description: string;
+  /** Price in `currency`; OrangeCat converts to BTC at checkout. */
+  price: number;
+  currency: 'CHF';
+  periodDays: number;
+  /** The marker tags stored on the product (built from passTags()). */
+  tags: string[];
+}
+
+/**
+ * Actor that sells the passes. There is no dedicated "FleetCrown" platform
+ * actor — the founder's `mao` actor already owns the OrangeCat and FleetCrown
+ * projects, so it sells the passes too and its wallet receives the BTC. Swap to
+ * a dedicated actor/group later by changing this slug and re-running the seed.
+ */
+export const OWNER_ACTOR_SLUG = 'mao';
+
+interface PassSpec {
+  plan: FleetCrownPlan;
+  title: string;
+  description: string;
+  price: number;
+}
+
+const PASS_SPECS: PassSpec[] = [
+  {
+    plan: 'personal',
+    title: 'FleetCrown Pass — Personal',
+    description:
+      'One month of FleetCrown Personal, paid in Bitcoin. Room for a real ' +
+      'project portfolio, the full captain dashboard, and your own runner and ' +
+      'agent keys. Renewable — pay again to extend.',
+    price: 15,
+  },
+  {
+    plan: 'pro',
+    title: 'FleetCrown Pass — Pro',
+    description:
+      'One month of FleetCrown Pro, paid in Bitcoin. For operators running many ' +
+      'projects at once — no ceiling as your fleet grows. Renewable.',
+    price: 40,
+  },
+  {
+    plan: 'team',
+    title: 'FleetCrown Pass — Team',
+    description:
+      'One month of FleetCrown Team, paid in Bitcoin. Shared projects and fleet ' +
+      'visibility for a studio. Renewable.',
+    price: 90,
+  },
+];
+
+/** The canonical pass catalogue the seed inserts and the notifier honours. */
+export const FLEETCROWN_PASSES: FleetCrownPass[] = PASS_SPECS.map((s) => ({
+  plan: s.plan,
+  title: s.title,
+  description: s.description,
+  price: s.price,
+  currency: 'CHF',
+  periodDays: FLEETCROWN_PASS_PERIOD_DAYS,
+  tags: passTags(s.plan, FLEETCROWN_PASS_PERIOD_DAYS),
+}));

--- a/src/services/fleetcrown/entitlement-notify.ts
+++ b/src/services/fleetcrown/entitlement-notify.ts
@@ -20,36 +20,15 @@ import { DATABASE_TABLES } from '@/config/database-tables';
 import { getEntityMetadata, type EntityType } from '@/config/entity-registry';
 import { logger } from '@/utils/logger';
 import type { PaymentIntent } from '@/domain/payments/types';
+import { parseFleetCrownPass } from '@/config/fleetcrown-passes';
 
 const FLEETCROWN_URL =
   process.env.FLEETCROWN_ENTITLEMENT_URL ||
   'https://fleetcrown.orangecat.ch/api/orangecat/entitlement';
 
-const PLANS = new Set(['personal', 'pro', 'team']);
-
-/** Extract {plan, periodDays} from a product's tags, or null if not a pass. */
-export function parseFleetCrownPass(tags: unknown): { plan: string; periodDays: number } | null {
-  if (!Array.isArray(tags)) {
-    return null;
-  }
-  let plan: string | null = null;
-  let periodDays: number | null = null;
-  for (const raw of tags) {
-    if (typeof raw !== 'string') {
-      continue;
-    }
-    const t = raw.trim();
-    const p = /^fleetcrown-plan:([a-z]+)$/.exec(t);
-    if (p && PLANS.has(p[1])) {
-      plan = p[1];
-    }
-    const d = /^fleetcrown-days:(\d{1,4})$/.exec(t);
-    if (d) {
-      periodDays = parseInt(d[1], 10);
-    }
-  }
-  return plan && periodDays ? { plan, periodDays } : null;
-}
+// parseFleetCrownPass + the plan set live in the config SSOT (the seed writes
+// the very tags this reads), re-exported here for existing importers.
+export { parseFleetCrownPass };
 
 const FLEETCROWN_EVENTS_URL =
   process.env.FLEETCROWN_EVENTS_URL || 'https://fleetcrown.orangecat.ch/api/orangecat/events';


### PR DESCRIPTION
## Why

The OrangeCat→FleetCrown Bitcoin **entitlement rail was already wired end-to-end** — `notifyFleetCrownEntitlement()` fires from `handlePaymentConfirmed` on a settled product payment, signs with the shared `ORANGECAT_WEBHOOK_SECRET`, and FleetCrown's `/api/orangecat/entitlement` verifies the HMAC, maps the actor → user, and grants a time-boxed plan (with an expiry-downgrade cron). FleetCrown's `/pricing` even has a "Pay in Bitcoin" CTA ready to light up.

**The only missing piece was the product a user would buy.** No OrangeCat product carried the `fleetcrown-plan:*` / `fleetcrown-days:*` tags the notifier reads, so the whole wired path sat dormant. This PR adds it.

## What

| File | Purpose |
|---|---|
| `src/config/fleetcrown-passes.ts` | **SSOT** — the three passes (personal/pro/team · 30-day · CHF 15/40/90, matching FleetCrown `/pricing`), the tag format, `passTags()`, and `parseFleetCrownPass()`. |
| `src/services/fleetcrown/entitlement-notify.ts` | Now imports the parser from the config SSOT instead of its own copy — the code that **writes** pass tags (seed) and **reads** them (notifier) can't drift. |
| `scripts/seed-fleetcrown-passes.ts` | Owner-gated, idempotent upsert of the passes into `user_products` (sold by the `mao` actor). Prints the checkout URLs + FleetCrown env wiring; warns if the seller has no active wallet. Mirrors `seed-revive-my-old-ride.ts`. |
| `__tests__/unit/fleetcrown/passes.test.ts` | Contract test — every pass's tags round-trip through the real parser and satisfy FleetCrown's receiver constraints. |

## Verification

- `npm run type-check` → 0 errors
- `npm run test:unit` (fleetcrown/passes) → **6/6**
- `eslint` on changed files → 0 errors
- `tsx` seed smoke → loads and correctly refuses without `ORANGECAT_OWNER_SEED=1`

## Operational follow-ups (NOT in this PR — prod/secret steps)

1. Run on the OC box: `ORANGECAT_OWNER_SEED=1 npx tsx scripts/seed-fleetcrown-passes.ts` → creates the passes, prints the three `ORANGECAT_PAY_URL_*` values.
2. Set `ORANGECAT_WEBHOOK_SECRET` to the **same** value on **both** boxes (until then, both ends stay inert by design).
3. Set the three `ORANGECAT_PAY_URL_*` on the FleetCrown box.
4. Ensure the `mao` actor has an **active wallet** on OrangeCat, or checkout fails with "Seller has no wallet connected."

## Open decision

The passes sell as the **`mao` actor** (already owns both projects), so its wallet collects the BTC. This ties to the bitbaum-AG / legal question flagged in `docs/oc-rail-monetization-scope.md`; swapping to a dedicated actor later is a one-line config change + a re-run of the seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
