### PR TITLE
chore(infra): remove Vercel references

### DIFF
--- a/docs/archive/2026-h1/preview-automation.md
+++ b/docs/archive/2026-h1/preview-automation.md
@@ -4,6 +4,12 @@ last_modified_summary: "Initial documentation for automated preview Lighthouse r
 
 # Automated Preview Lighthouse Reporting
 
+> **OBSOLETE (2026-06):** The preview/deploy workflow described below
+> (`.github/workflows/deploy.yml`, `amondnet/vercel-action`, Vercel preview
+> deployments) was removed when OrangeCat migrated off Vercel to self-hosting on
+> Hetzner ("bitbaum"). None of it runs anymore — this file is kept only as a
+> historical record. See `docs/operations/devops/infrastructure.md` for current infra.
+
 > NOTE: This documentation describes the _pull-request_ automation introduced on 2025-06-10. It does not replace the production deployment pipeline; it enhances the developer feedback loop for non-production changes.
 
 ## Overview

--- a/docs/operations/ENVIRONMENT.md
+++ b/docs/operations/ENVIRONMENT.md
@@ -52,7 +52,7 @@ BITCOIN_NETWORK=mainnet
 
 ## Production Setup
 
-Production env lives in the app's `.env` on the Hetzner box (not Vercel). Edit it
+Production env lives in the app's `.env` on the Hetzner box. Edit it
 there directly and restart the `orangecat-app` service after changes. See
 `docs/deployment/DEPLOYMENT_PROCESS.md`.
 


### PR DESCRIPTION
Vercel is decommissioned; every OrangeCat app now runs self-hosted on Hetzner ("bitbaum") behind Caddy.

The 2026-06 self-host migration already removed all **live** Vercel surface — there is no `vercel.json`, no `@vercel/*` dependency, no `process.env.VERCEL_*` read, no `*.vercel.app` URL, and no Vercel CI workflow left in the tree. This PR trims the remaining gratuitous/misleading **textual** mentions:

- `docs/operations/ENVIRONMENT.md` — drop the now-redundant "(not Vercel)" parenthetical (the Hetzner box is already named).
- `docs/archive/2026-h1/preview-automation.md` — add an OBSOLETE banner so nobody reads the present-tense Vercel preview/deploy workflow as still active; body preserved as historical record.

**Deliberately kept** (still-true statements, not dead cruft): the protective "there is no Vercel / no `vercel env pull`" guidance, accurate historical rationale in the current infra/deploy docs, the `/vercel/next.js` Context7 library id (Next.js genuinely lives under the vercel org), and the dated historical snapshots under `docs/archive/**` and `docs/reference/changelog/**`.

`npm run type-check` passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)