### PR TITLE
feat(tips): Bitcoin tipping — non-custodial, zero-fee gifts to writers

### DIFF
--- a/__tests__/unit/tips/tip-service.test.ts
+++ b/__tests__/unit/tips/tip-service.test.ts
@@ -1,0 +1,118 @@
+/**
+ * tip-service — recipient resolution + non-custodial invoice generation. Mocks
+ * the reused payment primitives so we test the tip orchestration in isolation:
+ * unknown person, person without a wallet, and the happy path invoice shape.
+ */
+
+import { generateTipInvoice, getTipReceiveInfo } from '@/domain/tips/tip-service';
+import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
+import { generateInvoice } from '@/domain/payments/invoiceGenerationService';
+
+jest.mock('@/domain/payments/walletResolutionService', () => ({
+  resolveUserWallet: jest.fn(),
+}));
+jest.mock('@/domain/payments/invoiceGenerationService', () => ({
+  generateInvoice: jest.fn(),
+}));
+
+const mockResolveWallet = resolveUserWallet as jest.MockedFunction<typeof resolveUserWallet>;
+const mockGenerateInvoice = generateInvoice as jest.MockedFunction<typeof generateInvoice>;
+
+/** Minimal supabase stub whose profiles lookup resolves to `profile`. */
+function supabaseWith(profile: Record<string, unknown> | null) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: profile, error: null }),
+        }),
+      }),
+    }),
+  } as never;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getTipReceiveInfo', () => {
+  it('returns null for an unknown username', async () => {
+    expect(await getTipReceiveInfo(supabaseWith(null), 'ghost')).toBeNull();
+    expect(mockResolveWallet).not.toHaveBeenCalled();
+  });
+
+  it('reports canReceive=false when the person has no wallet', async () => {
+    mockResolveWallet.mockResolvedValue(null);
+    const info = await getTipReceiveInfo(
+      supabaseWith({ id: 'u1', username: 'alice', display_name: 'Alice' }),
+      'alice'
+    );
+    expect(info).toEqual({ canReceive: false, recipientName: 'Alice', methodLabel: undefined });
+  });
+
+  it('reports the rail label when a wallet exists', async () => {
+    mockResolveWallet.mockResolvedValue({ method: 'onchain', wallet_id: 'w1', onchain_address: 'bc1x' });
+    const info = await getTipReceiveInfo(
+      supabaseWith({ id: 'u1', username: 'bob', display_name: 'Bob' }),
+      'bob'
+    );
+    expect(info).toEqual({ canReceive: true, recipientName: 'Bob', methodLabel: 'On-chain Bitcoin' });
+  });
+});
+
+describe('generateTipInvoice', () => {
+  it('errors when the person cannot be found', async () => {
+    const r = await generateTipInvoice(supabaseWith(null), 'ghost', 0.0001);
+    expect(r).toEqual({ ok: false, error: 'That person could not be found.' });
+  });
+
+  it('errors (no throw) when the recipient has no wallet', async () => {
+    mockResolveWallet.mockResolvedValue(null);
+    const r = await generateTipInvoice(
+      supabaseWith({ id: 'u1', username: 'alice', display_name: 'Alice' }),
+      'alice',
+      0.0001
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/hasn't set up a wallet/);
+  });
+
+  it('returns a non-custodial invoice for the recipient wallet', async () => {
+    mockResolveWallet.mockResolvedValue({
+      method: 'lightning_address',
+      wallet_id: 'w1',
+      lightning_address: 'bob@ln.tld',
+    });
+    mockGenerateInvoice.mockResolvedValue({
+      bolt11: 'lnbc1...',
+      payment_hash: 'hash',
+      onchain_address: null,
+      lnurl_verify_url: null,
+      qr_data: 'LNBC1...',
+      expires_at: null,
+    });
+
+    const r = await generateTipInvoice(
+      supabaseWith({ id: 'u1', username: 'bob', display_name: 'Bob' }),
+      'bob',
+      0.0005
+    );
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.invoice).toMatchObject({
+        qrData: 'LNBC1...',
+        bolt11: 'lnbc1...',
+        methodLabel: 'Lightning',
+        recipientName: 'Bob',
+        amountBtc: 0.0005,
+      });
+    }
+    // The invoice is built against the recipient's own wallet — never a platform wallet.
+    expect(mockGenerateInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({ lightning_address: 'bob@ln.tld' }),
+      0.0005,
+      expect.stringContaining('Tip for Bob')
+    );
+  });
+});

--- a/src/app/(public)/articles/[slug]/page.tsx
+++ b/src/app/(public)/articles/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { APP_NAME, SITE_URL } from '@/config/brand';
 import ArticleMarkdown from './ArticleMarkdown';
 import ReadingProgress from './ReadingProgress';
 import ShareButton from './ShareButton';
+import TipButton from '@/components/tips/TipButton';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -180,7 +181,15 @@ export default async function ArticlePage({ params }: PageProps) {
                   <span className="block font-semibold text-fg-primary">{article.author.name}</span>
                 </span>
               </Link>
-              <ShareButton title={article.title} url={shareUrl} />
+              <div className="flex flex-wrap items-center gap-2">
+                {article.author.username && (
+                  <TipButton
+                    username={article.author.username}
+                    recipientName={article.author.name}
+                  />
+                )}
+                <ShareButton title={article.title} url={shareUrl} />
+              </div>
             </div>
 
             <div className="mt-8 flex flex-col items-start gap-3 rounded-xl border border-subtle bg-surface-raised/25 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">

--- a/src/app/api/tips/invoice/route.ts
+++ b/src/app/api/tips/invoice/route.ts
@@ -1,0 +1,46 @@
+/**
+ * POST /api/tips/invoice { username, amountBtc } — generate a non-custodial
+ * Bitcoin payment request to the recipient's own wallet. Anonymous tippers are
+ * allowed (easy UX); IP rate-limited to protect recipients' NWC relays from
+ * invoice-generation abuse. Nothing is written to the DB and OrangeCat never
+ * touches the funds.
+ */
+
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { createServerClient } from '@/lib/supabase/server';
+import { rateLimit, createRateLimitResponse } from '@/lib/rate-limit';
+import { apiBadRequest, apiError, apiInternalError, apiSuccess } from '@/lib/api/standardResponse';
+import { TIP_MAX_BTC, TIP_MIN_BTC } from '@/config/tips';
+import { generateTipInvoice } from '@/domain/tips/tip-service';
+import { logger } from '@/utils/logger';
+
+const bodySchema = z.object({
+  username: z.string().trim().min(1).max(60),
+  amountBtc: z.number().positive().min(TIP_MIN_BTC).max(TIP_MAX_BTC),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const rl = await rateLimit(request);
+    if (!rl.success) {
+      return createRateLimitResponse(rl);
+    }
+
+    const parsed = bodySchema.safeParse(await request.json().catch(() => ({})));
+    if (!parsed.success) {
+      return apiBadRequest('Invalid request', parsed.error.flatten());
+    }
+
+    const supabase = await createServerClient();
+    const result = await generateTipInvoice(supabase, parsed.data.username, parsed.data.amountBtc);
+    if (!result.ok) {
+      return apiError(result.error, 'TIP_UNAVAILABLE', 400);
+    }
+
+    return apiSuccess({ invoice: result.invoice });
+  } catch (error) {
+    logger.error('tips/invoice failed', error, 'TipsAPI');
+    return apiInternalError('Could not create a tip request.');
+  }
+}

--- a/src/app/api/tips/receive-info/route.ts
+++ b/src/app/api/tips/receive-info/route.ts
@@ -1,0 +1,36 @@
+/**
+ * GET /api/tips/receive-info?username=X — public, secret-free check of whether a
+ * person can receive Bitcoin tips and via what rail. Powers the tip dialog's
+ * empty state without exposing any wallet details.
+ */
+
+import type { NextRequest } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
+import {
+  apiBadRequest,
+  apiInternalError,
+  apiNotFound,
+  apiSuccess,
+} from '@/lib/api/standardResponse';
+import { getTipReceiveInfo } from '@/domain/tips/tip-service';
+import { logger } from '@/utils/logger';
+
+export async function GET(request: NextRequest) {
+  try {
+    const username = new URL(request.url).searchParams.get('username')?.trim();
+    if (!username) {
+      return apiBadRequest('Missing username');
+    }
+
+    const supabase = await createServerClient();
+    const info = await getTipReceiveInfo(supabase, username);
+    if (!info) {
+      return apiNotFound('Person');
+    }
+
+    return apiSuccess(info);
+  } catch (error) {
+    logger.error('tips/receive-info failed', error, 'TipsAPI');
+    return apiInternalError('Could not load tip info.');
+  }
+}

--- a/src/components/tips/TipButton.tsx
+++ b/src/components/tips/TipButton.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+import { Zap } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { TIP_COPY } from '@/config/tips';
+import TipDialog from './TipDialog';
+
+/**
+ * Opens the tip dialog for a given person. The Zap uses Bitcoin Orange — this is
+ * genuinely Bitcoin-specific UI (a Bitcoin gift), the one place that color rule
+ * permits it. Reusable on articles, posts, and profiles.
+ */
+export default function TipButton({
+  username,
+  recipientName,
+  className,
+}: {
+  username: string;
+  recipientName: string;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-md border border-default px-3 py-1.5 text-sm font-medium text-fg-primary transition-colors hover:bg-surface-raised',
+          className
+        )}
+      >
+        <Zap className="h-4 w-4 text-bitcoinOrange" />
+        {TIP_COPY.button}
+      </button>
+      <TipDialog
+        open={open}
+        onOpenChange={setOpen}
+        username={username}
+        recipientName={recipientName}
+      />
+    </>
+  );
+}

--- a/src/components/tips/TipDialog.tsx
+++ b/src/components/tips/TipDialog.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Loader2, Zap } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/Button';
+import { PaymentQRCode } from '@/components/payment/PaymentQRCode';
+import { ContributionAmountInput } from '@/components/payment/ContributionAmountInput';
+import { fetchTipInvoice, fetchTipReceiveInfo, type TipInvoice } from '@/services/tips/tip-client';
+import { DEFAULT_TIP_BTC, TIP_COPY, TIP_MAX_BTC, TIP_MIN_BTC } from '@/config/tips';
+
+interface TipDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  username: string;
+  recipientName: string;
+}
+
+export default function TipDialog({ open, onOpenChange, username, recipientName }: TipDialogProps) {
+  const [amount, setAmount] = useState(DEFAULT_TIP_BTC);
+  const [checkingWallet, setCheckingWallet] = useState(true);
+  const [canReceive, setCanReceive] = useState<boolean | null>(null);
+  const [invoice, setInvoice] = useState<TipInvoice | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // On open, reset and check whether the recipient can receive tips.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    let active = true;
+    setInvoice(null);
+    setError(null);
+    setAmount(DEFAULT_TIP_BTC);
+    setCheckingWallet(true);
+    setCanReceive(null);
+    fetchTipReceiveInfo(username)
+      .then(info => {
+        if (active) {
+          setCanReceive(info.canReceive);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setCanReceive(false);
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setCheckingWallet(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [open, username]);
+
+  async function handleGenerate() {
+    setGenerating(true);
+    setError(null);
+    try {
+      setInvoice(await fetchTipInvoice(username, amount));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not create a tip request.');
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Zap className="h-5 w-5 text-bitcoinOrange" />
+            {TIP_COPY.title(recipientName)}
+          </DialogTitle>
+          <DialogDescription>{TIP_COPY.subtitle}</DialogDescription>
+        </DialogHeader>
+
+        {checkingWallet ? (
+          <div className="flex items-center justify-center py-10">
+            <Loader2 className="h-6 w-6 animate-spin text-fg-tertiary" />
+          </div>
+        ) : canReceive === false ? (
+          <p className="rounded-md border border-subtle bg-surface-raised/40 px-4 py-6 text-center text-sm text-fg-secondary">
+            {TIP_COPY.noWallet(recipientName)}
+          </p>
+        ) : invoice ? (
+          <div className="space-y-4">
+            <PaymentQRCode
+              qrData={invoice.qrData}
+              methodLabel={invoice.methodLabel}
+              amountBtc={invoice.amountBtc}
+              expiresInSeconds={invoice.expiresInSeconds ?? undefined}
+            />
+            <p className="text-center text-sm text-fg-secondary">{TIP_COPY.scan}</p>
+            <p className="text-center text-xs text-fg-tertiary">{TIP_COPY.disclaimer}</p>
+            <div className="flex justify-center gap-3">
+              <Button variant="outline" onClick={() => setInvoice(null)}>
+                {TIP_COPY.again}
+              </Button>
+              <Button variant="accent" onClick={() => onOpenChange(false)}>
+                {TIP_COPY.done}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <ContributionAmountInput
+              value={amount}
+              onChange={setAmount}
+              minBtc={TIP_MIN_BTC}
+              maxBtc={TIP_MAX_BTC}
+            />
+            {error && <p className="text-sm text-status-negative">{error}</p>}
+            <p className="text-center text-xs text-fg-tertiary">{TIP_COPY.disclaimer}</p>
+            <Button
+              variant="accent"
+              className="w-full"
+              onClick={handleGenerate}
+              disabled={generating || amount <= 0}
+              isLoading={generating}
+            >
+              {generating ? TIP_COPY.generating : TIP_COPY.generate}
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/config/tips.ts
+++ b/src/config/tips.ts
@@ -1,0 +1,39 @@
+/**
+ * Tips — SSOT for the Bitcoin tipping surface.
+ *
+ * A tip is an UNCONDITIONAL Bitcoin gift from one person to another. It settles
+ * NON-CUSTODIALLY: OrangeCat generates a payment request against the recipient's
+ * OWN wallet (NWC / Lightning address / on-chain) and never touches the funds.
+ * Zero platform fee — the tipper pays exactly the amount they choose.
+ *
+ * v1 shows the payment request (QR + copy) so any Bitcoin wallet can pay it; it
+ * does not record the tip server-side (that needs a schema change). Keep the copy
+ * honest: we help you pay the writer directly, we don't hold or take a cut.
+ */
+
+import { CONTRIBUTION_QUICK_AMOUNTS_BTC, DEFAULT_CONTRIBUTION_BTC } from './payment-presets';
+
+/** Quick-pick amounts (BTC). Reuses the contribution presets for consistency. */
+export const TIP_QUICK_AMOUNTS_BTC = CONTRIBUTION_QUICK_AMOUNTS_BTC;
+
+export const DEFAULT_TIP_BTC = DEFAULT_CONTRIBUTION_BTC;
+
+/** Sane bounds — a positive amount, capped to avoid fat-finger disasters. */
+export const TIP_MIN_BTC = 0.000001;
+export const TIP_MAX_BTC = 1;
+
+export const TIP_COPY = {
+  button: 'Tip',
+  title: (name: string) => `Tip ${name}`,
+  subtitle: 'Send a Bitcoin gift, paid straight to their wallet.',
+  amountLabel: 'Amount',
+  custom: 'Custom',
+  generate: 'Show tip QR',
+  generating: 'Preparing…',
+  scan: 'Scan with any Bitcoin wallet to send your tip.',
+  noWallet: (name: string) => `${name} hasn't set up a wallet to receive Bitcoin tips yet.`,
+  /** The honesty line — non-custodial, zero fee. */
+  disclaimer: 'Paid directly to them. OrangeCat takes 0% and never touches your funds.',
+  again: 'Change amount',
+  done: 'Done',
+} as const;

--- a/src/domain/payments/walletResolutionService.ts
+++ b/src/domain/payments/walletResolutionService.ts
@@ -284,7 +284,7 @@ async function resolveLinkedEntityWallet(
  * Priority across wallets: a wallet with NWC > one with a Lightning Address >
  * one with an on-chain address. Primary wallet wins ties (ordered first).
  */
-async function resolveUserWallet(
+export async function resolveUserWallet(
   supabase: SupabaseClient,
   userId: string
 ): Promise<ResolvedWallet | null> {

--- a/src/domain/tips/tip-service.ts
+++ b/src/domain/tips/tip-service.ts
@@ -1,0 +1,125 @@
+/**
+ * Tip service — resolve a person by username and generate a non-custodial
+ * Bitcoin payment request against THEIR own wallet. Reuses the payment stack's
+ * wallet resolution + invoice generation (SSOT) so a tip pays exactly like any
+ * other payment on the platform: NWC > Lightning address > on-chain, zero fee,
+ * OrangeCat never in the money path.
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
+import { generateInvoice } from '@/domain/payments/invoiceGenerationService';
+import type { ResolvedWallet } from '@/domain/payments/types';
+import { logger } from '@/utils/logger';
+
+const METHOD_LABELS: Record<ResolvedWallet['method'], string> = {
+  nwc: 'Lightning',
+  lightning_address: 'Lightning',
+  onchain: 'On-chain Bitcoin',
+};
+
+interface TipRecipient {
+  userId: string;
+  username: string;
+  displayName: string;
+}
+
+async function resolveRecipient(
+  supabase: AnySupabaseClient,
+  username: string
+): Promise<TipRecipient | null> {
+  const { data } = await supabase
+    .from(DATABASE_TABLES.PROFILES)
+    .select('id, username, display_name:name')
+    .eq('username', username)
+    .maybeSingle();
+
+  const row = data as { id?: string; username?: string; display_name?: string } | null;
+  if (!row?.id || !row.username) {
+    return null;
+  }
+  return { userId: row.id, username: row.username, displayName: row.display_name || row.username };
+}
+
+export interface TipReceiveInfo {
+  canReceive: boolean;
+  recipientName: string;
+  methodLabel?: string;
+}
+
+/** Public, secret-free: can this person receive tips, and via what rail. */
+export async function getTipReceiveInfo(
+  supabase: AnySupabaseClient,
+  username: string
+): Promise<TipReceiveInfo | null> {
+  const recipient = await resolveRecipient(supabase, username);
+  if (!recipient) {
+    return null;
+  }
+  const wallet = await resolveUserWallet(supabase, recipient.userId);
+  return {
+    canReceive: !!wallet,
+    recipientName: recipient.displayName,
+    methodLabel: wallet ? METHOD_LABELS[wallet.method] : undefined,
+  };
+}
+
+export interface TipInvoice {
+  qrData: string;
+  bolt11: string | null;
+  onchainAddress: string | null;
+  methodLabel: string;
+  recipientName: string;
+  amountBtc: number;
+  expiresInSeconds: number | null;
+}
+
+type TipInvoiceResult = { ok: true; invoice: TipInvoice } | { ok: false; error: string };
+
+/** Build a payment request for `amountBtc` to the recipient's own wallet. */
+export async function generateTipInvoice(
+  supabase: AnySupabaseClient,
+  username: string,
+  amountBtc: number
+): Promise<TipInvoiceResult> {
+  const recipient = await resolveRecipient(supabase, username);
+  if (!recipient) {
+    return { ok: false, error: 'That person could not be found.' };
+  }
+
+  const wallet = await resolveUserWallet(supabase, recipient.userId);
+  if (!wallet) {
+    return {
+      ok: false,
+      error: `${recipient.displayName} hasn't set up a wallet to receive Bitcoin tips yet.`,
+    };
+  }
+
+  try {
+    const inv = await generateInvoice(
+      wallet,
+      amountBtc,
+      `Tip for ${recipient.displayName} on OrangeCat`
+    );
+    const expiresInSeconds = inv.expires_at
+      ? Math.max(0, Math.floor((new Date(inv.expires_at).getTime() - Date.now()) / 1000))
+      : null;
+
+    return {
+      ok: true,
+      invoice: {
+        qrData: inv.qr_data,
+        bolt11: inv.bolt11,
+        onchainAddress: inv.onchain_address,
+        methodLabel: METHOD_LABELS[wallet.method],
+        recipientName: recipient.displayName,
+        amountBtc,
+        expiresInSeconds,
+      },
+    };
+  } catch (err) {
+    logger.error('Failed to generate tip invoice', { err: String(err), username }, 'Tips');
+    return { ok: false, error: 'Could not create a tip request right now. Please try again.' };
+  }
+}

--- a/src/services/tips/tip-client.ts
+++ b/src/services/tips/tip-client.ts
@@ -1,0 +1,41 @@
+/**
+ * Browser client for the tipping endpoints. Type-only imports of the service
+ * shapes (erased at compile — no server code pulled into the bundle).
+ */
+
+import type { TipInvoice, TipReceiveInfo } from '@/domain/tips/tip-service';
+
+export type { TipInvoice, TipReceiveInfo } from '@/domain/tips/tip-service';
+
+async function readJson(
+  res: Response
+): Promise<{ success?: boolean; data?: unknown; error?: unknown }> {
+  return (await res.json().catch(() => null)) ?? {};
+}
+
+function errorMessage(json: { error?: unknown }, fallback: string): string {
+  const err = json.error;
+  return (typeof err === 'string' ? err : (err as { message?: string })?.message) || fallback;
+}
+
+export async function fetchTipReceiveInfo(username: string): Promise<TipReceiveInfo> {
+  const res = await fetch(`/api/tips/receive-info?username=${encodeURIComponent(username)}`);
+  const json = await readJson(res);
+  if (!res.ok || !json.success) {
+    throw new Error(errorMessage(json, 'Could not load tip info.'));
+  }
+  return json.data as TipReceiveInfo;
+}
+
+export async function fetchTipInvoice(username: string, amountBtc: number): Promise<TipInvoice> {
+  const res = await fetch('/api/tips/invoice', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, amountBtc }),
+  });
+  const json = await readJson(res);
+  if (!res.ok || !json.success) {
+    throw new Error(errorMessage(json, 'Could not create a tip request.'));
+  }
+  return (json.data as { invoice: TipInvoice }).invoice;
+}


### PR DESCRIPTION
A **"Tip" button** on the article reader lets anyone send an unconditional Bitcoin gift **straight to the author's own wallet**. OrangeCat never touches the funds and takes **0%** — it just generates the payment request.

## How it works (reuses the payment stack, SSOT)
- `resolveUserWallet` (NWC → Lightning address → on-chain) + `generateInvoice` + `PaymentQRCode` + `ContributionAmountInput` — the exact primitives the rest of the app pays with. Exported the previously-private `resolveUserWallet`.
- `domain/tips/tip-service` — resolve a person by username → generate a real amount-specific invoice against **their** wallet. Never throws; friendly errors.
- `POST /api/tips/invoice` (anon-friendly for easy UX, IP rate-limited to protect NWC relays) + `GET /api/tips/receive-info` (public, secret-free empty-state check).
- `TipButton` (Bitcoin-Orange ⚡ — genuinely Bitcoin UI, the one place that color rule permits) + `TipDialog` (amount → QR + copy + countdown), in the reader footer.

## Honesty (all satisfied by the reused stack)
- **Non-custodial**: paid directly to the recipient's wallet; OC never in the money path; never routes through `PLATFORM_NWC_URI`.
- **Zero fee**: the tipper pays exactly the chosen amount.
- **No fake settlement**: v1 shows the payment request (like a BTC address QR); it does not claim to track/confirm the payment.

## Scope
No DB migration, no funds held. Recording tips + "you got tipped" notifications is a fast-follow (needs a recipient-bearing schema — `contributions`/`payment_intents` are entity-scoped).

## Verification
type-check + lint clean; prod build green (both `/api/tips/*` routes); **787 unit tests pass** (added 6 for the tip service — recipient resolution, no-wallet, invoice built against the recipient's own wallet). Built in an isolated git worktree to avoid colliding with concurrent work. Live tip-flow verification after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)