### PR TITLE
fix(marketing): stop claiming unintegrated payment rails; honest settlement copy

### DIFF
--- a/src/app/(public)/company/about/page.tsx
+++ b/src/app/(public)/company/about/page.tsx
@@ -198,7 +198,8 @@ export default function BitBaumAboutPage() {
                 <div>
                   <h4 className="font-semibold text-fg-primary">Community Growth</h4>
                   <p className="text-fg-secondary text-sm">
-                    Thousands of creators and supporters building with Bitcoin.
+                    An open, censorship-resistant home for creators and supporters building with
+                    Bitcoin.
                   </p>
                 </div>
               </div>

--- a/src/app/(public)/docs/page.tsx
+++ b/src/app/(public)/docs/page.tsx
@@ -90,7 +90,7 @@ export default function DocsPage() {
             <p className="text-fg-secondary leading-relaxed mb-5">
               Everything on OrangeCat is an <strong>entity</strong> — a structured unit of economic
               or governance activity. Entities give the Cat a rich world model to read and operate
-              on. There are 14 entity types covering the full economic spectrum:
+              on. There are {ENTITY_TYPES.length} entity types covering the full economic spectrum:
             </p>
             <div className="grid sm:grid-cols-2 gap-3">
               {ENTITY_TYPES.map(entity => (
@@ -127,9 +127,9 @@ export default function DocsPage() {
               ) for instant, near-zero-fee payments. On-chain Bitcoin is also supported.
             </p>
             <p className="text-fg-secondary leading-relaxed">
-              OrangeCat is not Bitcoin-only. Any payment method — Twint, PayPal, Venmo, bank
-              transfers — can be listed as a receiving option. Users choose the method that works
-              for them. Meet counterparties where they are.
+              Price your listing in any currency — CHF, USD, EUR, or Bitcoin — using your preferred
+              display currency. However it&apos;s priced, payments settle in Bitcoin and Lightning:
+              instant, global, and non-custodial.
             </p>
             <div className="grid sm:grid-cols-3 gap-4">
               {/* Highlight cards — uniform neutral tiles per migration 6/N */}
@@ -144,8 +144,10 @@ export default function DocsPage() {
                 <p className="text-fg-secondary text-xs mt-1">OrangeCat never holds your funds</p>
               </div>
               <div className="p-4 bg-surface-raised/40 border border-subtle rounded-lg text-center">
-                <p className="font-medium text-fg-primary text-sm">Any currency</p>
-                <p className="text-fg-secondary text-xs mt-1">Bitcoin, Lightning, fiat, and more</p>
+                <p className="font-medium text-fg-primary text-sm">Price in any currency</p>
+                <p className="text-fg-secondary text-xs mt-1">
+                  Priced in fiat or BTC, settled in Bitcoin
+                </p>
               </div>
             </div>
           </div>

--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -26,7 +26,7 @@ const FAQ_SECTIONS: FaqSection[] = [
       {
         question: 'What is OrangeCat?',
         answer:
-          'OrangeCat is your AI economic agent — a platform that lets any person, pseudonym, or organization participate in the full spectrum of economic activity: exchange goods and services, fund projects, lend money, invest, and coordinate together. Bitcoin and Lightning Network are the native payment rails, but any payment method is supported.',
+          'OrangeCat is your AI economic agent — a platform that lets any person, pseudonym, or organization participate in the full spectrum of economic activity: exchange goods and services, fund projects, lend money, invest, and coordinate together. Bitcoin and Lightning Network are the native settlement rails, and you can price your work in any currency.',
       },
       {
         question: 'Who is OrangeCat for?',
@@ -130,7 +130,7 @@ const FAQ_SECTIONS: FaqSection[] = [
       {
         question: 'What is the difference between a project and a cause?',
         answer:
-          'Projects have milestones and accountability — backers expect progress reports and deliverables. Causes are no-strings funding for meaningful purposes — community support, education, environment, or any cause where the act of giving is the goal itself. Both can receive Bitcoin, Lightning, or other payment methods.',
+          'Projects have milestones and accountability — backers expect progress reports and deliverables. Causes are no-strings funding for meaningful purposes — community support, education, environment, or any cause where the act of giving is the goal itself. Both can receive Bitcoin and Lightning payments.',
       },
       {
         question: 'How do loans work?',
@@ -147,7 +147,7 @@ const FAQ_SECTIONS: FaqSection[] = [
       {
         question: 'Do I need Bitcoin to use OrangeCat?',
         answer:
-          'No. Bitcoin and Lightning are the native and preferred payment rails because they enable instant, global, permissionless transactions. But OrangeCat supports any payment method — Twint, PayPal, Venmo, bank transfers, and more. You can list whatever receiving options you have and let counterparties choose what works for them.',
+          "You can sign up, publish, and price your work in any currency (CHF, USD, EUR…) without owning any Bitcoin. To receive payments you'll want a Lightning or Bitcoin wallet — that's how OrangeCat settles, instantly and non-custodially — and setting one up is free and takes a minute.",
       },
       {
         question: 'What is the Lightning Network?',

--- a/src/config/landing-page.ts
+++ b/src/config/landing-page.ts
@@ -153,7 +153,7 @@ export const HOW_IT_WORKS_STEPS: HowItWorksStep[] = [
     icon: Wallet,
     title: 'Pick Your Currency',
     description:
-      'Bitcoin and Lightning native — but Twint, PayPal, and local fiat payment methods worldwide are all first-class. Meet your counterparty where they are.',
+      'Price your work in any currency — CHF, USD, EUR, or Bitcoin. Payments settle natively in Bitcoin and Lightning: instant, global, and non-custodial.',
     iconGradient: GRADIENTS.iconOrange,
     bgColor: 'bg-surface-raised',
   },
@@ -210,7 +210,7 @@ export const PLATFORM_COMPARISON: ComparisonRow[] = [
   {
     feature: 'Payment methods',
     traditional: 'One currency, their rules',
-    orangecat: 'Any currency — Bitcoin, Twint, PayPal, fiat…',
+    orangecat: 'Price in any currency, settle in Bitcoin',
     highlight: true,
   },
   { feature: 'Platform fees', traditional: '5–10%', orangecat: '0%' },
@@ -252,7 +252,7 @@ export const PLATFORM_BENEFITS: PlatformBenefit[] = [
     icon: Wallet,
     title: 'Any Currency',
     description:
-      'Bitcoin and Lightning are native, but Twint, PayPal, and local fiat payment methods worldwide are first-class.',
+      'Price your work in any currency — CHF, USD, EUR. Payments settle natively in Bitcoin and Lightning.',
   },
   {
     icon: Lock,
@@ -302,7 +302,7 @@ export const EXAMPLE_USE_CASES: ExampleUseCase[] = [
     category: 'Research',
     title: 'Decentralized Science',
     description:
-      'Fund equipment, studies, and publications. Accept Bitcoin, PayPal, Twint — whatever your supporters use.',
+      'Fund equipment, studies, and publications. Price in any currency; receive support directly in Bitcoin and Lightning.',
     transparencyExample: 'Publish findings, share lab updates, build scientific credibility.',
     gradient: 'bg-surface-base',
   },

--- a/src/lib/ai/prompts/form-prefill.ts
+++ b/src/lib/ai/prompts/form-prefill.ts
@@ -20,7 +20,7 @@ export function getSystemPrompt(entityType: EntityType): string {
 Your task is to extract structured data from a user's natural language description to help them create a ${entityName} listing.
 
 IMPORTANT CONTEXT:
-- OrangeCat supports Bitcoin/Lightning and any fiat payment method (Twint, PayPal, Venmo, bank transfers, etc.)
+- OrangeCat settles payments in Bitcoin/Lightning; fiat currencies (CHF, USD, EUR, etc.) are supported for pricing and display only
 - Express Bitcoin amounts in BTC (e.g., 0.001 BTC) EVERYWHERE — in prices and in any title/description text. NEVER write "sats" or "satoshis"; rephrase to BTC even if the user's description used sats.
 - Keep fiat prices in their original currency (CHF, USD, EUR, etc.)
 - Price examples: "0.001 BTC", "CHF 50", "$25", "€100"

--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -45,7 +45,7 @@ const BASE_SYSTEM_PROMPT = `You are My Cat, the AI economic agent for OrangeCat.
 ## Your Purpose
 You help people find and build what matters to them — whether that's income, connection, meaning, or all three. Not everyone wants to be an entrepreneur. Some people want to earn. Some want to organize. Some want to be seen. Some just want to feel useful again. Your job is to understand which, and help.
 
-OrangeCat is a permissionless platform where any person, pseudonym, or organization can participate in economic and community life: selling, funding, lending, saving, governing, gathering, and giving. No gatekeepers. Any currency — Bitcoin is native and preferred, but any payment method is welcome. Pseudonymous by default.
+OrangeCat is a permissionless platform where any person, pseudonym, or organization can participate in economic and community life: selling, funding, lending, saving, governing, gathering, and giving. No gatekeepers. Price in any currency — Bitcoin and Lightning are the native settlement rails; fiat currencies (CHF, USD, EUR…) are supported for pricing and display. Pseudonymous by default.
 
 ## Current Session Awareness
 The user's context (below) begins with a **Current Session** block: which actor they're acting as right now, their preferred display currency, their locale, and the page they just came from. Use it:


### PR DESCRIPTION
Landing, docs, FAQ, and the AI prompts named **Twint / PayPal / Venmo / bank transfers** as live receiving options and called them "first-class." Those rails have no code path — settlement is Bitcoin and Lightning only; fiat is display/pricing. Reframed every such claim to the true story: *price in any currency, settle in Bitcoin & Lightning*.

Also:
- Removed the fabricated **"Thousands of creators and supporters"** metric on the About page (no data backs it).
- Made the `/docs` entity-type count SSOT (`{ENTITY_TYPES.length}`, was a hardcoded 14).

Generic mission/vision "any currency" language elsewhere is intentionally left as-is — it's positioning, not a false live claim.

Verified: type-check + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)