### PR TITLE
feat(profile): Articles tab — an author's long-form writing on their profile

### DIFF
--- a/src/app/(public)/articles/page.tsx
+++ b/src/app/(public)/articles/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { Clock, PenLine } from 'lucide-react';
+import { PenLine } from 'lucide-react';
 import { listPublishedArticles } from '@/services/articles/get-article';
+import ArticleList from '@/components/articles/ArticleList';
 import { ARTICLE_COPY } from '@/config/articles';
 import { ROUTES } from '@/config/routes';
 
@@ -13,14 +14,6 @@ export const metadata: Metadata = {
   title: 'Articles',
   description: 'Long-form thinking from the OrangeCat community — Bitcoin-native, free to read.',
 };
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-}
 
 export default async function ArticlesIndexPage() {
   const articles = await listPublishedArticles();
@@ -56,42 +49,7 @@ export default async function ArticlesIndexPage() {
             </Link>
           </div>
         ) : (
-          <ul className="divide-y divide-subtle">
-            {articles.map(article => (
-              <li key={article.id}>
-                <Link
-                  href={ROUTES.ARTICLE(article.slug)}
-                  className="group flex gap-4 py-6 transition-opacity hover:opacity-90"
-                >
-                  <div className="min-w-0 flex-1">
-                    <h2 className="text-xl font-semibold leading-snug text-fg-primary group-hover:text-accent-warm">
-                      {article.title}
-                    </h2>
-                    {article.excerpt && (
-                      <p className="mt-1.5 line-clamp-2 text-fg-secondary">{article.excerpt}</p>
-                    )}
-                    <div className="mt-3 flex items-center gap-3 text-sm text-fg-tertiary">
-                      <span className="font-medium text-fg-secondary">{article.author.name}</span>
-                      <span aria-hidden>·</span>
-                      <time dateTime={article.publishedAt}>{formatDate(article.publishedAt)}</time>
-                      <span className="inline-flex items-center gap-1">
-                        <Clock className="h-3.5 w-3.5" />
-                        {article.readingTime} min
-                      </span>
-                    </div>
-                  </div>
-                  {article.coverImage && (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={article.coverImage}
-                      alt=""
-                      className="h-20 w-28 flex-shrink-0 rounded-lg border border-subtle object-cover"
-                    />
-                  )}
-                </Link>
-              </li>
-            ))}
-          </ul>
+          <ArticleList articles={articles} />
         )}
       </div>
     </div>

--- a/src/app/profiles/[username]/page.tsx
+++ b/src/app/profiles/[username]/page.tsx
@@ -6,6 +6,7 @@ import ProfilePageClient from '@/components/profile/ProfilePageClient';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { getTableName } from '@/config/entity-registry';
 import { fetchProfileListingCounts } from '@/services/profile/listingCounts';
+import { listArticlesByAuthor } from '@/services/articles/get-article';
 import { safeJsonLdString } from '@/lib/seo/structured-data';
 import type { ScalableProfile } from '@/services/profile/types';
 import { mapProjectRow } from '@/types/project';
@@ -250,6 +251,10 @@ export default async function PublicProfilePage({ params }: PageProps) {
   const emailSafeProfile = isOwnProfile ? profile : { ...profile, email: null };
   const safeProfile = applyProfilePrivacy(emailSafeProfile, { isOwner: isOwnProfile });
 
+  // Author's long-form articles for the Articles tab. The owner also sees their
+  // non-public (followers/private) articles; visitors see only public ones.
+  const articles = await listArticlesByAuthor(profile.id, { includeNonPublic: isOwnProfile });
+
   // Generate JSON-LD structured data for SEO
   // Use actual username in URL, not "me" for better SEO
   const canonicalUsername = safeProfile.username || targetUsername;
@@ -279,6 +284,7 @@ export default async function PublicProfilePage({ params }: PageProps) {
       <ProfilePageClient
         profile={safeProfile}
         projects={projects || []}
+        articles={articles}
         isOwnProfile={isOwnProfile}
         stats={{
           projectCount,

--- a/src/components/articles/ArticleList.tsx
+++ b/src/components/articles/ArticleList.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import { Clock } from 'lucide-react';
+import { ROUTES } from '@/config/routes';
+import type { Article } from '@/services/articles/types';
+
+/** Shared presentational list of article cards — used by the /articles index and
+ *  the profile Articles tab so the card markup lives in exactly one place. */
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export default function ArticleList({
+  articles,
+  showAuthor = true,
+}: {
+  articles: Article[];
+  /** Hide the byline where the surrounding context already names the author
+   *  (e.g. the author's own profile tab). */
+  showAuthor?: boolean;
+}) {
+  return (
+    <ul className="divide-y divide-subtle">
+      {articles.map(article => (
+        <li key={article.id}>
+          <Link
+            href={ROUTES.ARTICLE(article.slug)}
+            className="group flex gap-4 py-6 transition-opacity hover:opacity-90"
+          >
+            <div className="min-w-0 flex-1">
+              <h2 className="text-xl font-semibold leading-snug text-fg-primary group-hover:text-accent-warm">
+                {article.title}
+              </h2>
+              {article.excerpt && (
+                <p className="mt-1.5 line-clamp-2 text-fg-secondary">{article.excerpt}</p>
+              )}
+              <div className="mt-3 flex items-center gap-3 text-sm text-fg-tertiary">
+                {showAuthor && (
+                  <>
+                    <span className="font-medium text-fg-secondary">{article.author.name}</span>
+                    <span aria-hidden>·</span>
+                  </>
+                )}
+                <time dateTime={article.publishedAt}>{formatDate(article.publishedAt)}</time>
+                <span className="inline-flex items-center gap-1">
+                  <Clock className="h-3.5 w-3.5" />
+                  {article.readingTime} min
+                </span>
+              </div>
+            </div>
+            {article.coverImage && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={article.coverImage}
+                alt=""
+                className="h-20 w-28 flex-shrink-0 rounded-lg border border-subtle object-cover"
+              />
+            )}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/profile/ProfileArticlesTab.tsx
+++ b/src/components/profile/ProfileArticlesTab.tsx
@@ -1,0 +1,58 @@
+import Link from 'next/link';
+import { PenLine } from 'lucide-react';
+import ArticleList from '@/components/articles/ArticleList';
+import { ROUTES } from '@/config/routes';
+import { ARTICLE_COPY } from '@/config/articles';
+import type { Article } from '@/services/articles/types';
+
+/**
+ * ProfileArticlesTab — the author's long-form articles on their profile. Data is
+ * fetched server-side (session-aware: the owner also sees their non-public
+ * articles) and passed down, so this is purely presentational. The byline is
+ * hidden since the surrounding profile already names the author.
+ */
+export default function ProfileArticlesTab({
+  articles,
+  isOwnProfile,
+}: {
+  articles: Article[];
+  isOwnProfile?: boolean;
+}) {
+  if (articles.length === 0) {
+    return (
+      <div className="mx-auto w-full max-w-2xl px-0 sm:px-4">
+        <div className="rounded-lg border border-subtle bg-surface-raised/30 px-6 py-16 text-center">
+          <p className="text-fg-secondary">
+            {isOwnProfile ? ARTICLE_COPY.index.empty : 'No articles published yet.'}
+          </p>
+          {isOwnProfile && (
+            <Link
+              href={ROUTES.ARTICLES_NEW}
+              className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-accent-warm hover:underline"
+            >
+              <PenLine className="h-4 w-4" />
+              {ARTICLE_COPY.index.write}
+            </Link>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-0 sm:px-4">
+      {isOwnProfile && (
+        <div className="mb-2 flex justify-end">
+          <Link
+            href={ROUTES.ARTICLES_NEW}
+            className="inline-flex items-center gap-1.5 rounded-md bg-accent-warm px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-accent-warm-hover"
+          >
+            <PenLine className="h-4 w-4" />
+            {ARTICLE_COPY.index.write}
+          </Link>
+        </div>
+      )}
+      <ArticleList articles={articles} showAuthor={false} />
+    </div>
+  );
+}

--- a/src/components/profile/ProfileLayout.tsx
+++ b/src/components/profile/ProfileLayout.tsx
@@ -12,9 +12,20 @@ import ProfilePeopleTab from '@/components/profile/ProfilePeopleTab';
 import ProfileInfoTab from '@/components/profile/ProfileInfoTab';
 import ProfileWalletsTab from '@/components/profile/ProfileWalletsTab';
 import ProfileEntityTab from '@/components/profile/ProfileEntityTab';
-import { Users, User, MessageSquare, Globe, ExternalLink, Info, Wallet } from 'lucide-react';
+import ProfileArticlesTab from '@/components/profile/ProfileArticlesTab';
+import {
+  Users,
+  User,
+  MessageSquare,
+  Globe,
+  ExternalLink,
+  Info,
+  Wallet,
+  FileText,
+} from 'lucide-react';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import type { EntityType } from '@/config/entity-registry';
+import type { Article } from '@/services/articles/types';
 import { cn } from '@/lib/utils';
 import { useProfileActions } from './useProfileActions';
 import { ProfileBannerSection } from './ProfileBannerSection';
@@ -39,6 +50,7 @@ const ENTITY_TAB_IDS = new Set(
 interface ProfileLayoutProps {
   profile: ScalableProfile;
   projects?: Project[];
+  articles?: Article[];
   stats?: {
     projectCount: number;
     totalRaised: number;
@@ -58,6 +70,7 @@ interface ProfileLayoutProps {
 export default function ProfileLayout({
   profile,
   projects,
+  articles,
   stats,
   mode: _mode = 'view',
   onSave,
@@ -115,6 +128,13 @@ export default function ProfileLayout({
       content: <ProfileTimelineTab profile={profile} isOwnProfile={isOwnProfile} />,
     },
     {
+      id: 'articles',
+      label: 'Articles',
+      icon: <FileText className="w-4 h-4" />,
+      badge: articles?.length || undefined,
+      content: <ProfileArticlesTab articles={articles ?? []} isOwnProfile={isOwnProfile} />,
+    },
+    {
       id: 'projects',
       label: ENTITY_REGISTRY['project'].namePlural,
       icon: (() => {
@@ -162,6 +182,9 @@ export default function ProfileLayout({
     }
     if (tab.id === 'projects') {
       return (stats?.projectCount || 0) > 0;
+    }
+    if (tab.id === 'articles') {
+      return (articles?.length || 0) > 0;
     }
     if (tab.id === 'people') {
       return (stats?.followerCount || 0) + (stats?.followingCount || 0) > 0;

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -4,10 +4,12 @@ import type { ScalableProfile } from '@/services/profile/types';
 import { Project } from '@/types/database';
 import ProfileLayout from '@/components/profile/ProfileLayout';
 import type { EntityType } from '@/config/entity-registry';
+import type { Article } from '@/services/articles/types';
 
 interface ProfilePageClientProps {
   profile: ScalableProfile;
   projects?: Project[];
+  articles?: Article[];
   isOwnProfile?: boolean;
   stats: {
     projectCount: number;
@@ -22,6 +24,7 @@ interface ProfilePageClientProps {
 export default function ProfilePageClient({
   profile,
   projects,
+  articles,
   isOwnProfile,
   stats,
 }: ProfilePageClientProps) {
@@ -29,6 +32,7 @@ export default function ProfilePageClient({
     <ProfileLayout
       profile={profile}
       projects={projects}
+      articles={articles}
       stats={stats}
       serverIsOwnProfile={isOwnProfile}
     />

--- a/src/services/articles/get-article.ts
+++ b/src/services/articles/get-article.ts
@@ -5,6 +5,7 @@
  */
 
 import { createServerClient } from '@/lib/supabase/server';
+import { getUserActorId } from '@/domain/actors';
 import { logger } from '@/utils/logger';
 import { ARTICLE_METADATA_FLAG } from '@/config/articles';
 import type { Article, ArticleMetadataPayload } from './types';
@@ -120,6 +121,48 @@ export async function listPublishedArticles(limit = 30): Promise<Article[]> {
     return data.map(rowToArticle).filter((a): a is Article => a !== null);
   } catch (err) {
     logger.error('Failed to list published articles', { err }, 'Articles');
+    return [];
+  }
+}
+
+/**
+ * List one author's articles, newest first. Public articles are visible to
+ * everyone; non-public (followers/private) ones are included only when the
+ * viewer is the author (`includeNonPublic`). `authorUserId` is an auth user id —
+ * resolved to the owning actor id to match the article rows.
+ */
+export async function listArticlesByAuthor(
+  authorUserId: string,
+  options: { includeNonPublic?: boolean; limit?: number } = {}
+): Promise<Article[]> {
+  const { includeNonPublic = false, limit = 50 } = options;
+  try {
+    const supabase = await createServerClient();
+    const actorId = await getUserActorId(supabase, authorUserId);
+    if (!actorId) {
+      return [];
+    }
+
+    let query = supabase
+      .from(ENRICHED_VIEW)
+      .select(ARTICLE_COLUMNS)
+      .eq(`metadata->>${ARTICLE_METADATA_FLAG}`, 'true')
+      .eq('actor_id', actorId)
+      .eq('is_deleted', false)
+      .order('event_timestamp', { ascending: false })
+      .limit(limit);
+
+    if (!includeNonPublic) {
+      query = query.eq('visibility', 'public');
+    }
+
+    const { data, error } = await query.returns<EnrichedArticleRow[]>();
+    if (error || !data) {
+      return [];
+    }
+    return data.map(rowToArticle).filter((a): a is Article => a !== null);
+  } catch (err) {
+    logger.error('Failed to list articles by author', { err, authorUserId }, 'Articles');
     return [];
   }
 }


### PR DESCRIPTION
Adds an **"Articles" tab** to `/profiles/[username]` listing that author's articles, newest first.

- **Session-aware**: the owner also sees their non-public (followers/private) articles; visitors see only public ones (explicit `visibility='public'` filter + RLS). `includeNonPublic` is server-computed from `isOwnProfile`, never client-controllable.
- Follows existing profile conventions — server-fetched like `projects`, a count badge, hidden for visitors when the author has no articles; owner gets a "Write an article" CTA.
- **DRY**: extracts the article-card markup from the `/articles` index into a shared `ArticleList` component, now used by both.
- New read: `listArticlesByAuthor(userId, { includeNonPublic })` resolves the user's actor and queries the enriched view by `actor_id`, mirroring the proven `listPublishedArticles` path.

Verified: type-check + lint green. Live render pending deploy (auth/data flow not exercisable in-sandbox; verified by construction against the in-prod list query).

> Note: adds a profile tab, which pushes against the "fewer tabs" consolidation goal — fold into a More▾ menu when that refactor lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)