### PR TITLE
feat(articles): drag-and-drop cover image upload (replaces URL-only)

### DIFF
--- a/__tests__/unit/articles/cover-validate.test.ts
+++ b/__tests__/unit/articles/cover-validate.test.ts
@@ -1,0 +1,31 @@
+/**
+ * validateCoverFile — guards article cover uploads by type + size before they
+ * ever hit storage.
+ */
+import { validateCoverFile } from '@/services/articles/cover-storage';
+
+function fakeFile(type: string, sizeBytes: number): File {
+  // A File whose reported size we control without allocating real bytes.
+  const f = new File(['x'], 'cover', { type });
+  Object.defineProperty(f, 'size', { value: sizeBytes });
+  return f;
+}
+
+describe('validateCoverFile', () => {
+  it('accepts a normal-sized image of an allowed type', () => {
+    expect(validateCoverFile(fakeFile('image/jpeg', 2 * 1024 * 1024))).toEqual({ valid: true });
+    expect(validateCoverFile(fakeFile('image/webp', 1024)).valid).toBe(true);
+  });
+
+  it('rejects non-image types', () => {
+    const r = validateCoverFile(fakeFile('application/pdf', 1024));
+    expect(r.valid).toBe(false);
+    expect(r.error).toMatch(/JPEG|PNG|WebP/);
+  });
+
+  it('rejects images over the size cap', () => {
+    const r = validateCoverFile(fakeFile('image/png', 9 * 1024 * 1024));
+    expect(r.valid).toBe(false);
+    expect(r.error).toMatch(/under \d+MB/);
+  });
+});

--- a/src/app/(public)/articles/new/ArticleComposer.tsx
+++ b/src/app/(public)/articles/new/ArticleComposer.tsx
@@ -18,6 +18,7 @@ import ArticleMarkdown from '../[slug]/ArticleMarkdown';
 import MarkdownToolbar from '@/components/articles/MarkdownToolbar';
 import { useMarkdownTextarea } from '@/components/articles/useMarkdownTextarea';
 import AiWriterPanel from '@/components/articles/AiWriterPanel';
+import CoverImageUpload from '@/components/articles/CoverImageUpload';
 
 const DRAFT_KEY = 'oc:draft:article';
 
@@ -212,12 +213,11 @@ export default function ArticleComposer({ user }: { user: { id: string } }) {
               rows={2}
               aria-label="Excerpt"
             />
-            <Input
+            <CoverImageUpload
               value={coverImage}
-              onChange={e => setCoverImage(e.target.value)}
-              placeholder={ARTICLE_COPY.new.coverLabel}
-              type="url"
-              aria-label="Cover image URL"
+              onChange={setCoverImage}
+              userId={user.id}
+              disabled={publishing}
             />
             <div>
               <MarkdownToolbar actions={md} disabled={publishing} />

--- a/src/components/articles/CoverImageUpload.tsx
+++ b/src/components/articles/CoverImageUpload.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { ImagePlus, Link2, Loader2, X } from 'lucide-react';
+import Input from '@/components/ui/Input';
+import { cn } from '@/lib/utils';
+import { COVER_ACCEPT, COVER_MAX_MB, uploadArticleCover } from '@/services/articles/cover-storage';
+
+/**
+ * Article cover picker: drag-and-drop or click to upload (primary), with a
+ * "paste a URL" fallback. Uploads via the cover-storage service and returns a
+ * public URL through onChange. Design-token styling only.
+ */
+export default function CoverImageUpload({
+  value,
+  onChange,
+  userId,
+  disabled,
+}: {
+  value: string;
+  onChange: (url: string) => void;
+  userId: string;
+  disabled?: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [urlMode, setUrlMode] = useState(false);
+
+  async function handleFile(file: File | undefined) {
+    if (!file || disabled) {
+      return;
+    }
+    setUploading(true);
+    setError(null);
+    const result = await uploadArticleCover(userId, file);
+    if (result.success && result.url) {
+      onChange(result.url);
+    } else {
+      setError(result.error || 'Upload failed. Please try again.');
+    }
+    setUploading(false);
+  }
+
+  // Cover already chosen — show a preview with replace/remove.
+  if (value && !urlMode) {
+    return (
+      <div className="group relative overflow-hidden rounded-xl border border-subtle">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={value} alt="Cover preview" className="aspect-[2/1] w-full object-cover" />
+        <div className="absolute inset-0 flex items-center justify-center gap-2 bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+          <button
+            type="button"
+            disabled={disabled || uploading}
+            onClick={() => inputRef.current?.click()}
+            className="rounded-md bg-white/90 px-3 py-1.5 text-sm font-medium text-black hover:bg-white disabled:opacity-50"
+          >
+            {uploading ? 'Uploading…' : 'Replace'}
+          </button>
+          <button
+            type="button"
+            disabled={disabled || uploading}
+            onClick={() => onChange('')}
+            className="inline-flex items-center gap-1 rounded-md bg-white/90 px-3 py-1.5 text-sm font-medium text-black hover:bg-white disabled:opacity-50"
+          >
+            <X className="h-4 w-4" /> Remove
+          </button>
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={COVER_ACCEPT}
+          className="hidden"
+          onChange={e => handleFile(e.target.files?.[0])}
+        />
+        {error && <p className="px-3 py-2 text-xs text-status-negative">{error}</p>}
+      </div>
+    );
+  }
+
+  if (urlMode) {
+    return (
+      <div className="space-y-2">
+        <Input
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder="Cover image URL"
+          type="url"
+          aria-label="Cover image URL"
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          onClick={() => setUrlMode(false)}
+          className="inline-flex items-center gap-1 text-xs text-fg-secondary hover:text-fg-primary"
+        >
+          <ImagePlus className="h-3.5 w-3.5" /> Upload an image instead
+        </button>
+      </div>
+    );
+  }
+
+  // Empty state — dropzone.
+  return (
+    <div>
+      <button
+        type="button"
+        disabled={disabled || uploading}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={e => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={e => {
+          e.preventDefault();
+          setDragging(false);
+          handleFile(e.dataTransfer.files?.[0]);
+        }}
+        className={cn(
+          'flex w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed px-4 py-8 text-center transition-colors',
+          dragging
+            ? 'border-accent-warm bg-accent-warm/5'
+            : 'border-default hover:bg-surface-raised/40',
+          (disabled || uploading) && 'cursor-not-allowed opacity-60'
+        )}
+      >
+        {uploading ? (
+          <Loader2 className="h-6 w-6 animate-spin text-fg-tertiary" />
+        ) : (
+          <ImagePlus className="h-6 w-6 text-fg-tertiary" />
+        )}
+        <span className="text-sm font-medium text-fg-primary">
+          {uploading ? 'Uploading…' : 'Add a cover image'}
+        </span>
+        <span className="text-xs text-fg-tertiary">
+          Drag & drop or click · JPEG, PNG, WebP up to {COVER_MAX_MB}MB
+        </span>
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={COVER_ACCEPT}
+        className="hidden"
+        onChange={e => handleFile(e.target.files?.[0])}
+      />
+      <div className="mt-2">
+        <button
+          type="button"
+          onClick={() => setUrlMode(true)}
+          className="inline-flex items-center gap-1 text-xs text-fg-secondary hover:text-fg-primary"
+        >
+          <Link2 className="h-3.5 w-3.5" /> Paste a URL instead
+        </button>
+      </div>
+      {error && <p className="mt-2 text-xs text-status-negative">{error}</p>}
+    </div>
+  );
+}

--- a/src/services/articles/cover-storage.ts
+++ b/src/services/articles/cover-storage.ts
@@ -1,0 +1,60 @@
+/**
+ * Upload an article cover image. Reuses the public BANNERS bucket with a
+ * `${userId}/…` path — a cover is a banner-class hero image, and the userId
+ * prefix matches the bucket's existing owner-scoped RLS, so no new bucket or
+ * storage-policy change is needed. Returns a public URL to store in
+ * `metadata.article.cover_image`.
+ */
+
+import supabase from '@/lib/supabase/browser';
+import { logger } from '@/utils/logger';
+import { STORAGE_BUCKETS } from '@/config/database-tables';
+import type { FileUploadResult } from '@/types/storage';
+
+const BUCKET = STORAGE_BUCKETS.BANNERS;
+const MAX_SIZE = 8 * 1024 * 1024; // 8MB — covers are large hero images
+const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif'];
+
+export const COVER_ACCEPT = ALLOWED_TYPES.join(',');
+export const COVER_MAX_MB = MAX_SIZE / 1024 / 1024;
+
+export function validateCoverFile(file: File): { valid: boolean; error?: string } {
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return { valid: false, error: 'Please choose a JPEG, PNG, WebP, or GIF image.' };
+  }
+  if (file.size > MAX_SIZE) {
+    return { valid: false, error: `Image must be under ${COVER_MAX_MB}MB.` };
+  }
+  return { valid: true };
+}
+
+export async function uploadArticleCover(userId: string, file: File): Promise<FileUploadResult> {
+  const validation = validateCoverFile(file);
+  if (!validation.valid) {
+    return { success: false, error: validation.error };
+  }
+
+  try {
+    const ext = file.name.split('.').pop() || 'jpg';
+    // userId first segment → satisfies the bucket's owner-scoped RLS.
+    const fileName = `${userId}/article-cover_${Date.now()}.${ext}`;
+
+    const { error } = await supabase.storage.from(BUCKET).upload(fileName, file, {
+      cacheControl: '31536000',
+      upsert: true,
+    });
+    if (error) {
+      logger.error('Failed to upload article cover', { error: error.message }, 'Articles');
+      return { success: false, error: error.message || 'Upload failed. Please try again.' };
+    }
+
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from(BUCKET).getPublicUrl(fileName);
+    return { success: true, url: publicUrl };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Upload failed. Please try again.';
+    logger.error('Error uploading article cover', { message }, 'Articles');
+    return { success: false, error: message };
+  }
+}


### PR DESCRIPTION
Composing an article no longer means pasting a raw image URL — the biggest UX gap in the article composer.

## What
The cover field is now a **drop-zone**: drag & drop or click to upload (JPEG/PNG/WebP/GIF up to 8MB), with an instant preview + **replace/remove**, and a subtle **"paste a URL instead"** fallback for power users.

## How (no migration, no storage/infra change)
- `services/articles/cover-storage.ts` — `uploadArticleCover` reuses the public **BANNERS** bucket with a `${userId}/…` path. A cover is a banner-class hero image, and the userId prefix matches the bucket's existing **owner-scoped RLS**, so no new bucket or policy is needed. Validates type + 8MB cap.
- `components/articles/CoverImageUpload.tsx` — the dropzone/preview/URL-fallback UI, design-tokens only.
- Swapped into `ArticleComposer`'s cover field (one block).

## Verification
type-check + lint clean; **3/3 unit tests** for the validator. The local prod build is currently blocked by a *concurrent Next.js 15.5.19→15.5.21 upgrade churning the shared `node_modules`* in a parallel session (errors are all inside `next/dist`, not this diff) — CI's clean `npm ci` build is the authoritative gate, and I'll verify the live upload post-deploy. Built in an isolated git worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)