### PR TITLE
feat(profile): field-hide privacy toggles — hide public fields from visitors

### DIFF
--- a/__tests__/unit/profile/profile-privacy.test.ts
+++ b/__tests__/unit/profile/profile-privacy.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Profile field-hide privacy — pure redaction helpers.
+ *
+ * These gate what a visitor sees, so the invariants matter: an owner sees their
+ * whole row; a visitor never receives a hidden field's value NOR the hide-list
+ * itself; unknown/legacy keys in the blob never crash or over-redact.
+ */
+
+import {
+  applyProfilePrivacy,
+  getHiddenProfileFields,
+  buildPrivacySettings,
+  HIDEABLE_PROFILE_FIELD_KEYS,
+} from '@/config/profile-privacy';
+
+const baseProfile = {
+  id: 'u1',
+  username: 'alice',
+  name: 'Alice',
+  website: 'https://alice.example',
+  phone: '+41791234567',
+  contact_email: 'hi@alice.example',
+  social_links: { links: [{ platform: 'x', value: '@alice' }] },
+  privacy_settings: { hidden_fields: ['phone', 'website'] },
+};
+
+describe('getHiddenProfileFields', () => {
+  it('returns the known hidden keys from a blob', () => {
+    expect(getHiddenProfileFields({ hidden_fields: ['phone', 'website'] })).toEqual([
+      'phone',
+      'website',
+    ]);
+  });
+
+  it('drops unknown / non-hideable keys and tolerates junk', () => {
+    expect(getHiddenProfileFields({ hidden_fields: ['phone', 'name', 'bogus', 42] })).toEqual([
+      'phone',
+    ]);
+    expect(getHiddenProfileFields(null)).toEqual([]);
+    expect(getHiddenProfileFields(undefined)).toEqual([]);
+    expect(getHiddenProfileFields({})).toEqual([]);
+    expect(getHiddenProfileFields({ hidden_fields: 'phone' })).toEqual([]);
+  });
+});
+
+describe('applyProfilePrivacy', () => {
+  it('returns the owner their untouched row (same reference)', () => {
+    const result = applyProfilePrivacy(baseProfile, { isOwner: true });
+    expect(result).toBe(baseProfile);
+    expect(result.phone).toBe('+41791234567');
+    expect(result.privacy_settings).toEqual({ hidden_fields: ['phone', 'website'] });
+  });
+
+  it('nulls hidden fields for visitors and never leaks the hide-list', () => {
+    const result = applyProfilePrivacy(baseProfile, { isOwner: false });
+    expect(result.phone).toBeNull();
+    expect(result.website).toBeNull();
+    // Non-hidden public fields survive.
+    expect(result.contact_email).toBe('hi@alice.example');
+    expect(result.social_links).toEqual({ links: [{ platform: 'x', value: '@alice' }] });
+    // The hide-list itself must not ship to visitors.
+    expect(result.privacy_settings).toBeNull();
+    // Original is not mutated.
+    expect(baseProfile.phone).toBe('+41791234567');
+  });
+
+  it('is a no-op redaction when nothing is hidden', () => {
+    const open = { ...baseProfile, privacy_settings: { hidden_fields: [] } };
+    const result = applyProfilePrivacy(open, { isOwner: false });
+    expect(result.phone).toBe('+41791234567');
+    expect(result.website).toBe('https://alice.example');
+    // privacy_settings is still stripped for visitors even when empty.
+    expect(result.privacy_settings).toBeNull();
+  });
+
+  it('handles a missing privacy_settings blob', () => {
+    const noSettings = { id: 'u2', phone: '+123', privacy_settings: null };
+    const result = applyProfilePrivacy(noSettings, { isOwner: false });
+    expect(result.phone).toBe('+123');
+    expect(result.privacy_settings).toBeNull();
+  });
+});
+
+describe('buildPrivacySettings', () => {
+  it('preserves unrelated keys already in the blob', () => {
+    expect(buildPrivacySettings({ theme: 'dark' }, ['phone'])).toEqual({
+      theme: 'dark',
+      hidden_fields: ['phone'],
+    });
+  });
+
+  it('overwrites a prior hidden_fields list', () => {
+    expect(buildPrivacySettings({ hidden_fields: ['website'] }, ['phone'])).toEqual({
+      hidden_fields: ['phone'],
+    });
+  });
+
+  it('tolerates a null/undefined existing blob', () => {
+    expect(buildPrivacySettings(null, ['phone'])).toEqual({ hidden_fields: ['phone'] });
+    expect(buildPrivacySettings(undefined, [])).toEqual({ hidden_fields: [] });
+  });
+});
+
+describe('HIDEABLE_PROFILE_FIELD_KEYS', () => {
+  it('covers only optional public fields (never core identity or location)', () => {
+    expect([...HIDEABLE_PROFILE_FIELD_KEYS].sort()).toEqual(
+      ['contact_email', 'phone', 'social_links', 'website'].sort()
+    );
+    expect(HIDEABLE_PROFILE_FIELD_KEYS).not.toContain('username');
+    expect(HIDEABLE_PROFILE_FIELD_KEYS).not.toContain('name');
+    expect(HIDEABLE_PROFILE_FIELD_KEYS).not.toContain('bio');
+    expect(HIDEABLE_PROFILE_FIELD_KEYS).not.toContain('location');
+  });
+});

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -39,6 +39,7 @@ const PROFILE_ALLOWED_FIELDS = [
   'phone',
   'bitcoin_address',
   'lightning_address',
+  'privacy_settings',
 ];
 
 async function respondWithProfile(

--- a/src/app/profiles/[username]/page.tsx
+++ b/src/app/profiles/[username]/page.tsx
@@ -11,6 +11,7 @@ import type { ScalableProfile } from '@/services/profile/types';
 import { mapProjectRow } from '@/types/project';
 import { ROUTES } from '@/config/routes';
 import { APP_NAME, APP_KICKER, SITE_URL } from '@/config/brand';
+import { applyProfilePrivacy } from '@/config/profile-privacy';
 
 interface PageProps {
   params: Promise<{ username: string }>;
@@ -235,35 +236,37 @@ export default async function PublicProfilePage({ params }: PageProps) {
   const projectCount = projects?.length || 0;
   const totalRaised = projects?.reduce((sum, p) => sum + (Number(p.raised_amount) || 0), 0) || 0;
 
-  // Generate JSON-LD structured data for SEO
-  // Use actual username in URL, not "me" for better SEO
-  const canonicalUsername = profile.username || targetUsername;
-  const structuredData = {
-    '@context': 'https://schema.org',
-    '@type': 'Person',
-    name: profile.name || profile.username || canonicalUsername,
-    alternateName: profile.username || undefined,
-    description: profile.bio || undefined,
-    image: profile.avatar_url || undefined,
-    url: `${SITE_URL}/profiles/${canonicalUsername}`,
-    sameAs: profile.website ? [profile.website] : undefined,
-    ...(profile.bitcoin_address && {
-      paymentAccepted: 'Bitcoin',
-      bitcoinAddress: profile.bitcoin_address,
-    }),
-  };
-
   // Check if viewing own profile (server-side, avoids hydration flash)
   const {
     data: { user: currentUser },
   } = await supabase.auth.getUser();
   const isOwnProfile = !!currentUser && currentUser.id === profile.id;
 
-  // The `email` column is the account login email — private. `select('*')` pulls
-  // it into the row, which would otherwise ship to every visitor's client
-  // payload. Redact it for non-owners so it never leaves the server. (phone /
-  // contact_email are opt-in public fields and stay.)
-  const safeProfile = isOwnProfile ? profile : { ...profile, email: null };
+  // Redact before anything derives from the row, so hidden data never leaves the
+  // server — not in the client payload, not in the JSON-LD below.
+  // 1. `email` is the private account login email; `select('*')` pulls it in.
+  // 2. Owner-hidden public fields (website, phone, contact_email, social_links)
+  //    per profiles.privacy_settings. See config/profile-privacy.ts.
+  const emailSafeProfile = isOwnProfile ? profile : { ...profile, email: null };
+  const safeProfile = applyProfilePrivacy(emailSafeProfile, { isOwner: isOwnProfile });
+
+  // Generate JSON-LD structured data for SEO
+  // Use actual username in URL, not "me" for better SEO
+  const canonicalUsername = safeProfile.username || targetUsername;
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: safeProfile.name || safeProfile.username || canonicalUsername,
+    alternateName: safeProfile.username || undefined,
+    description: safeProfile.bio || undefined,
+    image: safeProfile.avatar_url || undefined,
+    url: `${SITE_URL}/profiles/${canonicalUsername}`,
+    sameAs: safeProfile.website ? [safeProfile.website] : undefined,
+    ...(safeProfile.bitcoin_address && {
+      paymentAccepted: 'Bitcoin',
+      bitcoinAddress: safeProfile.bitcoin_address,
+    }),
+  };
 
   // Pass data to client component for interactivity
   return (

--- a/src/components/profile/ModernProfileEditor.tsx
+++ b/src/components/profile/ModernProfileEditor.tsx
@@ -9,6 +9,7 @@ import { ProfileBasicSection } from './sections/ProfileBasicSection';
 import { OnlinePresenceSection } from './sections/OnlinePresenceSection';
 import { ContactSection } from './sections/ContactSection';
 import { PreferencesSection } from './sections/PreferencesSection';
+import { PrivacySection } from './sections/PrivacySection';
 import { FormErrorDisplay } from './components/FormErrorDisplay';
 import { ProfileFormActions } from './components/ProfileFormActions';
 import type { ModernProfileEditorProps } from './types';
@@ -114,6 +115,9 @@ export default function ModernProfileEditor({
 
               {/* Preferences Section */}
               <PreferencesSection control={form.control} onFieldFocus={onFieldFocus} />
+
+              {/* Privacy Section — per-field visibility to visitors */}
+              <PrivacySection form={form} />
             </div>
 
             {/* Action Buttons */}
@@ -180,6 +184,9 @@ export default function ModernProfileEditor({
 
               {/* Preferences Section */}
               <PreferencesSection control={form.control} onFieldFocus={onFieldFocus} />
+
+              {/* Privacy Section — per-field visibility to visitors */}
+              <PrivacySection form={form} />
             </div>
 
             {/* Action Buttons */}

--- a/src/components/profile/ProfileDetailsCard.tsx
+++ b/src/components/profile/ProfileDetailsCard.tsx
@@ -6,6 +6,7 @@ import { SocialLinksDisplay } from './SocialLinksDisplay';
 import { SocialLink } from '@/types/social';
 import { format } from 'date-fns';
 import { isLocationHidden } from '@/lib/location-privacy';
+import { getHiddenProfileFields } from '@/config/profile-privacy';
 import { ProfileField } from './ProfileField';
 import { ROUTES } from '@/config/routes';
 import type { Profile as DatabaseProfile } from '@/types/database';
@@ -29,6 +30,12 @@ export function ProfileDetailsCard({
   // account login email. The registration email has its own owner-gated field
   // below. See profile email-leak fix.
   const publicContactEmail = profile.contact_email || null;
+
+  // Owner-only cue: which public fields the owner has hidden from visitors, so
+  // the "Hidden" pill can surface their own choice on their own profile view.
+  // (Visitors never receive hidden values, so this set is empty-equivalent for
+  // them — but we still gate the pill on isOwnProfile in ProfileField.)
+  const hiddenFields = new Set(getHiddenProfileFields(profile.privacy_settings));
 
   const locationValue = (() => {
     if (isLocationHidden(profile.location_context || '')) {
@@ -144,6 +151,7 @@ export function ProfileDetailsCard({
               }
               editHref={`${ROUTES.DASHBOARD.INFO_EDIT}#website`}
               isOwnProfile={isOwnProfile}
+              hiddenFromVisitors={hiddenFields.has('website')}
             />
             <ProfileField
               icon={Globe}
@@ -152,6 +160,7 @@ export function ProfileDetailsCard({
               editHref={`${ROUTES.DASHBOARD.INFO_EDIT}#socialLinks`}
               emptyText="No links added yet"
               isOwnProfile={isOwnProfile}
+              hiddenFromVisitors={hiddenFields.has('social_links')}
             />
           </div>
         </section>
@@ -186,7 +195,7 @@ export function ProfileDetailsCard({
             )}
             <ProfileField
               icon={Mail}
-              label={`Contact Email${isOwnProfile ? ' (public)' : ''}`}
+              label={`Contact Email${isOwnProfile && !hiddenFields.has('contact_email') ? ' (public)' : ''}`}
               value={
                 publicContactEmail ? (
                   <a
@@ -199,6 +208,7 @@ export function ProfileDetailsCard({
               }
               editHref={`${ROUTES.DASHBOARD.INFO_EDIT}#contactEmail`}
               isOwnProfile={isOwnProfile}
+              hiddenFromVisitors={hiddenFields.has('contact_email')}
             />
             <ProfileField
               icon={Phone}
@@ -215,6 +225,7 @@ export function ProfileDetailsCard({
               }
               editHref={`${ROUTES.DASHBOARD.INFO_EDIT}#phone`}
               isOwnProfile={isOwnProfile}
+              hiddenFromVisitors={hiddenFields.has('phone')}
             />
           </div>
         </section>

--- a/src/components/profile/ProfileField.tsx
+++ b/src/components/profile/ProfileField.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Link from 'next/link';
-import { Edit as EditIcon } from 'lucide-react';
+import { Edit as EditIcon, EyeOff } from 'lucide-react';
 
 interface ProfileFieldProps {
   icon: React.ComponentType<{ className?: string }>;
@@ -11,6 +11,13 @@ interface ProfileFieldProps {
   editHref?: string;
   emptyText?: string;
   isOwnProfile?: boolean;
+  /**
+   * Owner-only cue: this field is hidden from visitors (per the profile privacy
+   * settings). Renders a small "Hidden" pill next to the label so the owner can
+   * see their own choice without opening the editor. Only meaningful when
+   * isOwnProfile — visitors never receive hidden values in the first place.
+   */
+  hiddenFromVisitors?: boolean;
 }
 
 /**
@@ -26,12 +33,24 @@ export function ProfileField({
   editHref,
   emptyText = 'Not filled out yet',
   isOwnProfile,
+  hiddenFromVisitors,
 }: ProfileFieldProps) {
   return (
     <div className="flex items-start gap-3">
       <Icon className="w-5 h-5 text-fg-tertiary mt-0.5" />
       <div className="flex-1">
-        <div className="text-sm text-fg-secondary">{label}</div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-fg-secondary">{label}</span>
+          {hiddenFromVisitors && isOwnProfile && (
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-surface-raised px-1.5 py-0.5 text-2xs font-medium text-fg-tertiary"
+              title="Hidden from visitors — only you can see this"
+            >
+              <EyeOff className="h-3 w-3" aria-hidden />
+              Hidden
+            </span>
+          )}
+        </div>
         {value ? (
           <>{value}</>
         ) : isOwnProfile && editHref ? (

--- a/src/components/profile/constants.ts
+++ b/src/components/profile/constants.ts
@@ -15,6 +15,7 @@ export const PROFILE_SECTIONS = {
   ONLINE_PRESENCE: 'Online Presence',
   CONTACT: 'Contact Information',
   PREFERENCES: 'Preferences',
+  PRIVACY: 'Privacy',
 } as const;
 
 export const PROFILE_SECTION_DESCRIPTIONS = {
@@ -22,4 +23,5 @@ export const PROFILE_SECTION_DESCRIPTIONS = {
   ONLINE_PRESENCE: 'Your website and social media – where people can find you online.',
   CONTACT: 'How people can reach you directly.',
   PREFERENCES: 'Your display preferences – currency and other settings.',
+  PRIVACY: 'Choose which details stay hidden from visitors. You always see everything.',
 } as const;

--- a/src/components/profile/hooks/useProfileEditor.ts
+++ b/src/components/profile/hooks/useProfileEditor.ts
@@ -96,6 +96,8 @@ export function useProfileEditor({
       bitcoin_address: profile.bitcoin_address || '',
       lightning_address: profile.lightning_address || '',
       currency: (profile.currency as typeof PLATFORM_DEFAULT_CURRENCY) || PLATFORM_DEFAULT_CURRENCY,
+      privacy_settings:
+        (profile.privacy_settings as { hidden_fields?: string[] } | null | undefined) ?? undefined,
     },
   });
 

--- a/src/components/profile/sections/PrivacySection.tsx
+++ b/src/components/profile/sections/PrivacySection.tsx
@@ -1,0 +1,79 @@
+/**
+ * Privacy Section
+ *
+ * Owner control for per-field visibility: which optional public profile fields
+ * are hidden from visitors. Persists into the profiles.privacy_settings jsonb
+ * column via the form's `privacy_settings` value. See config/profile-privacy.ts
+ * (SSOT for the hideable-field list) and the server-side redaction in the public
+ * profile page + /api/profiles lookup.
+ */
+
+'use client';
+
+import { EyeOff } from 'lucide-react';
+import type { UseFormReturn } from 'react-hook-form';
+import { Switch } from '@/components/ui/switch';
+import {
+  HIDEABLE_PROFILE_FIELDS,
+  getHiddenProfileFields,
+  buildPrivacySettings,
+  type HideableProfileField,
+} from '@/config/profile-privacy';
+import { PROFILE_SECTIONS, PROFILE_SECTION_DESCRIPTIONS } from '../constants';
+import type { ProfileFormValues } from '../types';
+
+interface PrivacySectionProps {
+  form: UseFormReturn<ProfileFormValues>;
+}
+
+export function PrivacySection({ form }: PrivacySectionProps) {
+  const privacySettings = form.watch('privacy_settings');
+  const hidden = new Set(getHiddenProfileFields(privacySettings));
+
+  const toggle = (key: HideableProfileField) => {
+    const next = new Set(hidden);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    form.setValue('privacy_settings', buildPrivacySettings(privacySettings, [...next]), {
+      shouldDirty: true,
+    });
+  };
+
+  return (
+    <div className="oc-surface space-y-4 px-4 py-5 sm:px-5 sm:py-6">
+      <div className="mb-1">
+        <h3 className="text-sm font-semibold text-fg-primary uppercase tracking-wide">
+          {PROFILE_SECTIONS.PRIVACY}
+        </h3>
+        <p className="mt-1 text-xs text-fg-secondary">{PROFILE_SECTION_DESCRIPTIONS.PRIVACY}</p>
+      </div>
+
+      <ul className="divide-y divide-subtle">
+        {HIDEABLE_PROFILE_FIELDS.map(({ key, label }) => {
+          const isHidden = hidden.has(key);
+          const switchId = `privacy-hide-${key}`;
+          return (
+            <li key={key} className="flex items-center justify-between gap-4 py-3">
+              <label htmlFor={switchId} className="flex items-center gap-2 cursor-pointer">
+                <EyeOff
+                  className={`w-4 h-4 ${isHidden ? 'text-fg-primary' : 'text-fg-tertiary'}`}
+                  aria-hidden
+                />
+                <span className="text-sm font-medium text-fg-primary">{label}</span>
+              </label>
+              <Switch
+                id={switchId}
+                checked={isHidden}
+                onCheckedChange={() => toggle(key)}
+                aria-label={`Hide ${label} from visitors`}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/config/profile-privacy.ts
+++ b/src/config/profile-privacy.ts
@@ -1,0 +1,98 @@
+/**
+ * Profile field privacy — SSOT
+ *
+ * Which public profile fields an owner may hide from visitors, and the pure
+ * helpers that read/apply that choice. The choice is persisted in the existing
+ * `profiles.privacy_settings` jsonb column as `{ hidden_fields: string[] }`, so
+ * this feature needs no database migration.
+ *
+ * Scope: only genuinely optional public-contact/presence fields are hideable.
+ * Core identity (username, name, bio, avatar) is never hideable — hiding it
+ * would make the profile pointless. Location has its own richer control
+ * (actual / hidden / group) in `location-privacy.ts` and is intentionally not
+ * duplicated here.
+ */
+
+import { z } from 'zod';
+
+/** A public profile field the owner may hide. `key` is the actual profiles column. */
+export const HIDEABLE_PROFILE_FIELDS = [
+  { key: 'website', label: 'Website' },
+  { key: 'social_links', label: 'Social media & links' },
+  { key: 'contact_email', label: 'Contact email' },
+  { key: 'phone', label: 'Phone number' },
+] as const;
+
+export type HideableProfileField = (typeof HIDEABLE_PROFILE_FIELDS)[number]['key'];
+
+export const HIDEABLE_PROFILE_FIELD_KEYS: readonly HideableProfileField[] =
+  HIDEABLE_PROFILE_FIELDS.map(f => f.key);
+
+/**
+ * Shape of the `privacy_settings` blob. Deliberately lenient: `hidden_fields`
+ * is a plain string array (validated against known keys only when applied) and
+ * unknown keys pass through, so a future/legacy blob can never reject a whole
+ * profile save. This schema is spread into the canonical `profileSchema` so the
+ * field survives the client zodResolver AND the server `profileSchema.parse`.
+ */
+export const profilePrivacySettingsSchema = z
+  .object({ hidden_fields: z.array(z.string()).optional() })
+  .passthrough()
+  .optional()
+  .nullable();
+
+export type ProfilePrivacySettings = z.infer<typeof profilePrivacySettingsSchema>;
+
+/** Read the hidden-field list from a raw privacy_settings value, keeping only known keys. */
+export function getHiddenProfileFields(privacySettings: unknown): HideableProfileField[] {
+  if (!privacySettings || typeof privacySettings !== 'object') {
+    return [];
+  }
+  const raw = (privacySettings as { hidden_fields?: unknown }).hidden_fields;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const known = HIDEABLE_PROFILE_FIELD_KEYS as readonly string[];
+  return raw.filter((k): k is HideableProfileField => typeof k === 'string' && known.includes(k));
+}
+
+/**
+ * Merge a new hidden-field selection into an existing privacy_settings blob,
+ * preserving any unrelated keys already stored there.
+ */
+export function buildPrivacySettings(
+  existing: unknown,
+  hiddenFields: HideableProfileField[]
+): Record<string, unknown> {
+  const base =
+    existing && typeof existing === 'object' ? { ...(existing as Record<string, unknown>) } : {};
+  return { ...base, hidden_fields: hiddenFields };
+}
+
+/**
+ * Redact owner-hidden fields from a profile row before it is sent to a visitor.
+ *
+ * - Owner sees everything (their own editor and public view are unredacted).
+ * - Visitors get each hidden field nulled — indistinguishable from "not set",
+ *   so the presence of a hidden value never leaks — plus the hide-list itself
+ *   (`privacy_settings`) stripped.
+ *
+ * Pure and allocation-light: returns the same object untouched for owners.
+ */
+export function applyProfilePrivacy<T extends object>(profile: T, opts: { isOwner: boolean }): T {
+  if (opts.isOwner) {
+    return profile;
+  }
+  // Cast to a record: profile is a DB row (ScalableProfile / plain object) whose
+  // TS interface lacks an index signature, so we widen it to read/write by key.
+  const record = profile as Record<string, unknown>;
+  const clean: Record<string, unknown> = { ...record };
+  for (const key of getHiddenProfileFields(record.privacy_settings)) {
+    clean[key] = null;
+  }
+  // Never expose the hide-list to visitors.
+  if ('privacy_settings' in clean) {
+    clean.privacy_settings = null;
+  }
+  return clean as T;
+}

--- a/src/lib/validation/base.ts
+++ b/src/lib/validation/base.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import DOMPurify from 'dompurify';
 import { validatePhoneNumber, normalizePhoneNumber } from '../phone-validation';
 import { CURRENCY_CODES } from '@/config/currencies';
+import { profilePrivacySettingsSchema } from '@/config/profile-privacy';
 
 /**
  * Lightning Address Validation
@@ -234,6 +235,11 @@ export const profileSchema = z.object({
   lightning_address: optionalText(200),
   // Currency preference for displaying prices
   currency: z.enum(CURRENCY_CODES).optional().nullable(),
+  // Per-field visibility (which public fields the owner hides from visitors).
+  // Stored in the profiles.privacy_settings jsonb column. Included here so it
+  // survives both the client zodResolver and this server-side parse — a field
+  // absent from the schema is silently stripped. See config/profile-privacy.ts.
+  privacy_settings: profilePrivacySettingsSchema,
 });
 
 // HTML sanitization for rich text content

--- a/src/services/profile/publicProfile.server.ts
+++ b/src/services/profile/publicProfile.server.ts
@@ -12,6 +12,7 @@ import { DATABASE_TABLES } from '@/config/database-tables';
 import { getTableName } from '@/config/entity-registry';
 import { ENTITY_STATUS } from '@/config/database-constants';
 import { getOrCreateUserActor } from '@/services/actors/getOrCreateUserActor';
+import { applyProfilePrivacy } from '@/config/profile-privacy';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 
 export type PublicProfileErrorCode = 'not_found';
@@ -56,7 +57,11 @@ const SENSITIVE_PROFILE_FIELDS = [
 ] as const;
 
 function toPublicProfile(profile: Record<string, unknown>): Record<string, unknown> {
-  const clean: Record<string, unknown> = { ...profile };
+  // This endpoint is unauthenticated and serves the public view, so honour the
+  // owner's per-field hide list (privacy_settings.hidden_fields) BEFORE the
+  // denylist below strips privacy_settings itself. isOwner: false — an owner who
+  // wants their full row uses the authenticated GET /api/profile.
+  const clean: Record<string, unknown> = applyProfilePrivacy({ ...profile }, { isOwner: false });
   for (const field of SENSITIVE_PROFILE_FIELDS) {
     delete clean[field];
   }

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -29,6 +29,7 @@ export interface Profile {
   // User preferences
   currency?: string | null; // User's preferred display currency (from CURRENCY_CODES)
   preferences?: Record<string, unknown> | null; // Generic preference bag (theme, notifications, etc.)
+  privacy_settings?: Record<string, unknown> | null; // Per-field visibility, e.g. { hidden_fields: [...] }. See config/profile-privacy.ts
   onboarding_completed?: boolean | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## What

Profile owners can now hide individual optional public fields from visitors — **website, social links, contact email, phone** — while still seeing everything on their own profile. A new **Privacy** section of switches in the profile editor controls it.

## Why

"Field-hide toggles" from the text-expression backlog. Users fill in contact details for their own record or for selected contexts but may not want all of them public. Until now the only per-field privacy control was for location.

## How (first-principles, SSOT)

- **No migration.** Reuses the already-present-but-unused `profiles.privacy_settings` jsonb column, stored as `{ hidden_fields: string[] }`.
- **One SSOT** — `src/config/profile-privacy.ts` owns the hideable-field list, the `privacy_settings` zod schema, and a pure `applyProfilePrivacy(profile, { isOwner })` redaction helper (nulls hidden fields for non-owners; never ships the hide-list itself).
- **Redaction is server-side, before the row reaches the client**, on **both** public render paths:
  - the SSR profile page (`/profiles/[username]`) — also feeds JSON-LD, so hidden fields never leak into structured data either;
  - the unauthenticated `/api/profiles` lookup (`publicProfile.server.ts`).
- **Threaded through the full save pipeline.** `privacy_settings` is added to the canonical `profileSchema` (so it survives the client `zodResolver` **and** the server `profileSchema.parse` — a field absent from the schema is silently stripped, the known form-schema-drift trap) and to `PROFILE_ALLOWED_FIELDS` in the PUT route.
- Visitors see a hidden field as identical to "not set" — the presence of a hidden value never leaks.
- Location keeps its own richer actual/hidden/group control and is intentionally **not** duplicated here.

## Tests / gates

- 10 new unit tests for the pure redaction helpers (owner passthrough, visitor nulling, hide-list never leaked, junk/legacy blobs tolerated).
- Full suite green: **800 unit tests**, `type-check` (tsc) ✓, `lint` ✓, `audit:routes` ✓.

> Note: live end-to-end (toggle → persist → visitor view) needs the box DB, which isn't reachable from the dev sandbox; the wiring is fully type-checked end-to-end and the redaction is proven by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)