### PR TITLE
feat(profile): consolidate profile tabs behind a "More" overflow menu

### DIFF
--- a/__tests__/unit/profile/profile-tab-layout.test.ts
+++ b/__tests__/unit/profile/profile-tab-layout.test.ts
@@ -1,0 +1,60 @@
+/**
+ * partitionTabs — splits profile tabs into up-front vs. "More" overflow.
+ *
+ * The invariants that keep the tab bar sane: order is preserved on both sides,
+ * only present tabs count (a primary id with no tab just doesn't show), and an
+ * unknown id never lands in primary.
+ */
+
+import { partitionTabs, PRIMARY_PROFILE_TAB_IDS } from '@/components/profile/profileTabLayout';
+
+const tab = (id: string) => ({ id, label: id });
+
+describe('partitionTabs', () => {
+  it('keeps primary tabs and pushes the rest to overflow, preserving order', () => {
+    const tabs = ['overview', 'info', 'timeline', 'projects', 'causes', 'wallets'].map(tab);
+    const { primary, overflow } = partitionTabs(tabs, ['timeline', 'overview', 'projects']);
+    expect(primary.map(t => t.id)).toEqual(['overview', 'timeline', 'projects']);
+    expect(overflow.map(t => t.id)).toEqual(['info', 'causes', 'wallets']);
+  });
+
+  it('ignores primary ids with no matching tab (already-filtered visitor tabs)', () => {
+    const tabs = ['timeline', 'overview'].map(tab);
+    const { primary, overflow } = partitionTabs(tabs, ['timeline', 'overview', 'projects', 'people']);
+    expect(primary.map(t => t.id)).toEqual(['timeline', 'overview']);
+    expect(overflow).toEqual([]);
+  });
+
+  it('puts everything in overflow when nothing is primary', () => {
+    const tabs = ['a', 'b', 'c'].map(tab);
+    const { primary, overflow } = partitionTabs(tabs, []);
+    expect(primary).toEqual([]);
+    expect(overflow.map(t => t.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('defaults to PRIMARY_PROFILE_TAB_IDS', () => {
+    const tabs = ['timeline', 'assets', 'ai-assistants'].map(tab);
+    const { primary, overflow } = partitionTabs(tabs);
+    expect(primary.map(t => t.id)).toEqual(['timeline']);
+    expect(overflow.map(t => t.id)).toEqual(['assets', 'ai-assistants']);
+  });
+
+  it('never loses or duplicates a tab', () => {
+    const tabs = ['timeline', 'overview', 'projects', 'products', 'services', 'people', 'info', 'wallets'].map(tab);
+    const { primary, overflow } = partitionTabs(tabs);
+    expect(primary.length + overflow.length).toBe(tabs.length);
+    const seen = new Set([...primary, ...overflow].map(t => t.id));
+    expect(seen.size).toBe(tabs.length);
+  });
+});
+
+describe('PRIMARY_PROFILE_TAB_IDS', () => {
+  it('is the intended up-front set (default tab included)', () => {
+    expect(PRIMARY_PROFILE_TAB_IDS).toContain('timeline'); // ProfileViewTabs defaultTab
+    expect(PRIMARY_PROFILE_TAB_IDS).toContain('overview');
+    expect(PRIMARY_PROFILE_TAB_IDS).toContain('projects');
+    // Long-tail entity + meta tabs live in the overflow menu.
+    expect(PRIMARY_PROFILE_TAB_IDS).not.toContain('wallets');
+    expect(PRIMARY_PROFILE_TAB_IDS).not.toContain('ai-assistants');
+  });
+});

--- a/src/components/profile/ProfileLayout.tsx
+++ b/src/components/profile/ProfileLayout.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/hooks/useAuth';
 import type { ScalableProfile } from '@/services/profile/types';
 import { ProfileFormData, Project } from '@/types/database';
 import ProfileViewTabs from '@/components/profile/ProfileViewTabs';
+import { PRIMARY_PROFILE_TAB_IDS } from '@/components/profile/profileTabLayout';
 import ProfileOverviewTab from '@/components/profile/ProfileOverviewTab';
 import ProfileTimelineTab from '@/components/profile/ProfileTimelineTab';
 import ProfileProjectsTab from '@/components/profile/ProfileProjectsTab';
@@ -222,7 +223,11 @@ export default function ProfileLayout({
           {/* Timeline-first: open on the living activity feed so visitors see the
               latest — new projects, funding, updates — the way an X profile does,
               rather than a static summary. Overview remains one tap away. */}
-          <ProfileViewTabs tabs={filteredTabs} defaultTab="timeline" />
+          <ProfileViewTabs
+            tabs={filteredTabs}
+            defaultTab="timeline"
+            primaryTabIds={PRIMARY_PROFILE_TAB_IDS}
+          />
         </div>
       </div>
     </div>

--- a/src/components/profile/ProfileViewTabs.tsx
+++ b/src/components/profile/ProfileViewTabs.tsx
@@ -2,7 +2,15 @@
 
 import { useState, ReactNode, useEffect, useRef, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+import { partitionTabs } from './profileTabLayout';
 
 export interface ProfileTab {
   id: string;
@@ -16,6 +24,11 @@ interface ProfileViewTabsProps {
   tabs: ProfileTab[];
   defaultTab?: string;
   className?: string;
+  /**
+   * Tab ids to keep visible up front. Any tab not listed is tucked into a
+   * "More" overflow menu. Omit to render every tab inline (legacy behaviour).
+   */
+  primaryTabIds?: readonly string[];
 }
 
 /**
@@ -27,7 +40,12 @@ interface ProfileViewTabsProps {
  * - Progressive: Lazy loads tab content on first click
  * - Mobile-optimized: X/Twitter-style horizontal scrollable tabs on mobile
  */
-export default function ProfileViewTabs({ tabs, defaultTab, className }: ProfileViewTabsProps) {
+export default function ProfileViewTabs({
+  tabs,
+  defaultTab,
+  className,
+  primaryTabIds,
+}: ProfileViewTabsProps) {
   const searchParams = useSearchParams();
   const tabFromUrl = searchParams?.get('tab');
   const navRef = useRef<HTMLElement>(null);
@@ -122,6 +140,13 @@ export default function ProfileViewTabs({ tabs, defaultTab, className }: Profile
     }
   };
 
+  // Split into up-front tabs and a "More" overflow menu. Without primaryTabIds
+  // every tab stays inline (legacy behaviour, e.g. dashboards with few tabs).
+  const { primary: primaryTabs, overflow: overflowTabs } = primaryTabIds
+    ? partitionTabs(tabs, primaryTabIds)
+    : { primary: tabs, overflow: [] as ProfileTab[] };
+  const activeInOverflow = overflowTabs.some(tab => tab.id === activeTab);
+
   return (
     <div className={cn('w-full', className)}>
       {/* Tab Navigation - X/Twitter-style horizontal scroll on mobile, flex on desktop */}
@@ -146,7 +171,7 @@ export default function ProfileViewTabs({ tabs, defaultTab, className }: Profile
             msOverflowStyle: 'none',
           }}
         >
-          {tabs.map(tab => {
+          {primaryTabs.map(tab => {
             const isActive = activeTab === tab.id;
             return (
               <button
@@ -189,6 +214,53 @@ export default function ProfileViewTabs({ tabs, defaultTab, className }: Profile
               </button>
             );
           })}
+
+          {overflowTabs.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  ref={activeInOverflow ? activeTabRef : null}
+                  className={cn(
+                    'group inline-flex items-center justify-center sm:justify-start py-2.5 sm:py-3 lg:py-4 px-3 sm:px-1 md:px-2 border-b-2 font-medium text-sm transition-colors whitespace-nowrap touch-manipulation min-h-11 flex-shrink-0 focus:outline-none',
+                    activeInOverflow
+                      ? 'border-fg-primary text-fg-primary'
+                      : 'border-transparent text-fg-secondary hover:text-fg-primary hover:border-strong dark:hover:border-default'
+                  )}
+                  aria-label="More profile tabs"
+                  aria-current={activeInOverflow ? 'page' : undefined}
+                >
+                  <span className="truncate">More</span>
+                  <ChevronDown className="ml-1 h-4 w-4 flex-shrink-0" aria-hidden />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[10rem]">
+                {overflowTabs.map(tab => {
+                  const isActive = activeTab === tab.id;
+                  return (
+                    <DropdownMenuItem
+                      key={tab.id}
+                      onSelect={() => handleTabClick(tab.id)}
+                      className={cn(
+                        'cursor-pointer gap-2',
+                        isActive && 'bg-surface-raised text-fg-primary'
+                      )}
+                      aria-current={isActive ? 'page' : undefined}
+                    >
+                      {tab.icon && (
+                        <span className="flex-shrink-0 text-fg-tertiary">{tab.icon}</span>
+                      )}
+                      <span className="flex-1 truncate">{tab.label}</span>
+                      {tab.badge !== undefined && (
+                        <span className="ml-auto py-0.5 px-1.5 rounded-full text-2xs font-medium bg-surface-raised text-fg-secondary flex-shrink-0">
+                          {tab.badge}
+                        </span>
+                      )}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </nav>
       </div>
 

--- a/src/components/profile/profileTabLayout.ts
+++ b/src/components/profile/profileTabLayout.ts
@@ -1,0 +1,51 @@
+/**
+ * Profile tab layout — SSOT for which profile tabs are primary vs. overflow.
+ *
+ * A profile can surface up to ~13 tabs (Overview, Info, Timeline, Projects, and
+ * one per public entity type, plus People and Wallets). Showing all of them at
+ * once is exactly the cognitive overload we want to avoid: keep the few tabs
+ * people actually use up front, and tuck the long tail behind a "More" menu.
+ *
+ * This is the single decision point — change PRIMARY_PROFILE_TAB_IDS to re-rank
+ * what stays visible. `partitionTabs` is pure so it can be unit-tested and reused
+ * by the tab bar without pulling in React.
+ */
+
+/**
+ * Tab ids kept visible up front, in the order they naturally appear. Everything
+ * else falls into the overflow "More" menu. Ids match those built in
+ * ProfileLayout (`overview`, `info`, `timeline`, `projects`, and entity plurals
+ * kebab-cased, e.g. `products`, `ai-assistants`).
+ */
+export const PRIMARY_PROFILE_TAB_IDS: readonly string[] = [
+  'timeline',
+  'overview',
+  'projects',
+  'products',
+  'services',
+  'people',
+];
+
+export interface PartitionedTabs<T> {
+  primary: T[];
+  overflow: T[];
+}
+
+/**
+ * Split tabs into primary (in `primaryIds`) and overflow (the rest), each
+ * preserving the input order. Only ids actually present in `tabs` matter, so a
+ * primary id with no corresponding tab (e.g. a visitor whose empty tabs were
+ * already filtered out) simply doesn't appear.
+ */
+export function partitionTabs<T extends { id: string }>(
+  tabs: T[],
+  primaryIds: readonly string[] = PRIMARY_PROFILE_TAB_IDS
+): PartitionedTabs<T> {
+  const primarySet = new Set(primaryIds);
+  const primary: T[] = [];
+  const overflow: T[] = [];
+  for (const tab of tabs) {
+    (primarySet.has(tab.id) ? primary : overflow).push(tab);
+  }
+  return { primary, overflow };
+}


### PR DESCRIPTION
## What

Profiles can surface up to **~13 tabs** (Overview, Info, Timeline, Projects, one per public entity type, plus People and Wallets). This keeps the few tabs people actually use **up front** — Timeline, Overview, Projects, Products, Services, People — and tucks the long tail (Info, Causes, Events, Loans, Assets, AI Assistants, Wallets) behind a compact **"More ▾"** menu.

## Why

Directly serves the standing UX north-star: minimize cognitive load, fewer tabs. Thirteen tabs in a scrolling strip is exactly the overload to avoid; a "More" overflow is the endorsed pattern (Twitter/LinkedIn do the same).

## How (SSOT, config-driven)

- **One decision point** — `src/components/profile/profileTabLayout.ts` owns `PRIMARY_PROFILE_TAB_IDS` (the primary set) and a **pure** `partitionTabs()` helper. Re-ranking what stays visible is a one-line array change.
- `ProfileViewTabs` gains an **optional** `primaryTabIds` prop. Without it, every tab renders inline (unchanged legacy behaviour) — so the dashboard usage is untouched.
- The overflow menu reuses the existing **radix `dropdown-menu`** primitive, so a11y / keyboard / click-outside are handled. The "More" trigger reflects the **active** state (and the active row is highlighted) when the current tab lives in overflow, and active-tab **scroll-into-view still works** via the trigger.
- All tabs' content still renders (progressive-load unchanged); only the nav strip is partitioned.

## Tests / gates

- 6 new unit tests for `partitionTabs` (order preserved on both sides, absent primary ids ignored, nothing lost/duplicated, default set).
- Green: **796 unit tests**, `type-check` ✓, `lint` ✓, `audit:routes` ✓.

> The primary/overflow split is intentionally config-driven so the exact ranking is trivial to adjust after you eyeball it on deploy. Visual/interaction polish (e.g. a one-item "More" for very sparse visitor profiles) is a cheap follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)