### PR TITLE
fix(deps): force @hono/node-server 2.x tree-wide via override (clears Dependabot high)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",
         "@google/generative-ai": "^0.24.1",
-        "@hono/node-server": "^1.19.10",
+        "@hono/node-server": "^2.0.5",
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.4.1",
         "@mdx-js/loader": "^3.1.0",
@@ -75,6 +75,7 @@
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "resend": "^6.9.3",
+        "sharp": "^0.34.5",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^3.3.0",
@@ -1376,12 +1377,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@google/generative-ai": "^0.24.1",
-    "@hono/node-server": "^1.19.10",
+    "@hono/node-server": "^2.0.5",
     "@hookform/resolvers": "^5.2.2",
     "@marsidev/react-turnstile": "^1.4.1",
     "@mdx-js/loader": "^3.1.0",
@@ -220,6 +220,7 @@
     "@isaacs/brace-expansion": "^5.0.1",
     "@babel/core": "^7.29.6",
     "hono": "^4.12.27",
+    "@hono/node-server": "^2.0.5",
     "js-yaml": "^4.1.1",
     "tar": "^7.5.8",
     "postcss": "^8.5.10",


### PR DESCRIPTION
## What

Forces `@hono/node-server` to **2.x across the whole dependency tree** (single copy `2.0.11`), clearing the Dependabot high.

## Why an override (not just a direct bump)

`@hono/node-server` is **not imported anywhere in orangecat** — it's a transitive dep of `@modelcontextprotocol/sdk` (which pins `^1.19.9`), and orangecat's own MCP servers use the **stdio** transport, so `getRequestListener` (the only thing the SDK imports from it) is never invoked.

Bumping only the root direct dep to `^2.0.5` would leave the SDK's nested vulnerable `1.19.x` copy (and split into two copies). So this bumps the direct dep **and** adds an `overrides` entry forcing v2 tree-wide.

**Supersedes Dependabot PR #416** (direct-bump-only — leaves the nested 1.19.x, doesn't clear the alert).

## v2 breaking changes don't apply

- Node ≥20: already required (`engines`, `.nvmrc`, runtime v22).
- Removed `@hono/node-server/vercel` adapter: unused.
- Public API unchanged (incl. `getRequestListener`).
- `hono` core `^4` peer: already satisfied (`^4.12.27`).

## Verification

- ✅ Single `@hono/node-server@2.0.11` in the tree (no nested 1.19.x); `npm audit` clears it
- ✅ **Pre-push gate green**: `type-check`, route audit, and unit tests all passed
- ✅ webpack compile green (the full local build's only failure was `/sitemap.xml` timing out against placeholder Supabase env — unrelated; CI builds it with real env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)