### PR TITLE
feat(articles): edit and delete your own articles

### DIFF
--- a/__tests__/unit/services/articles/write-shared.test.ts
+++ b/__tests__/unit/services/articles/write-shared.test.ts
@@ -1,0 +1,115 @@
+/**
+ * write-shared — the single source of truth for article write validation and the
+ * `timeline_events.metadata` shape. Both publish (create) and edit (update) go
+ * through these, so the invariants here (is_article discriminator present, slug
+ * preserved, limits enforced) protect the whole article write path.
+ */
+import { validateArticleInput, buildArticleMetadata } from '@/services/articles/write-shared';
+import { ARTICLE_LIMITS } from '@/config/articles';
+import type { CreateArticleInput } from '@/services/articles/types';
+
+const base: CreateArticleInput = {
+  title: 'A real headline',
+  body: 'Some genuine long-form body content.',
+  visibility: 'public',
+};
+
+describe('validateArticleInput', () => {
+  it('accepts and trims valid input', () => {
+    const result = validateArticleInput(
+      { ...base, title: '  Trim me  ', body: '  Hi there  ' },
+      'publish'
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value.title).toBe('Trim me');
+      expect(result.value.body).toBe('Hi there');
+    }
+  });
+
+  it('rejects an empty/whitespace title', () => {
+    const result = validateArticleInput({ ...base, title: '   ' }, 'publish');
+    expect(result).toEqual({ success: false, error: 'Give your article a title.' });
+  });
+
+  it('rejects a title over the limit', () => {
+    const result = validateArticleInput(
+      { ...base, title: 'x'.repeat(ARTICLE_LIMITS.title + 1) },
+      'save'
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a body under the minimum', () => {
+    const result = validateArticleInput({ ...base, body: '   ' }, 'save');
+    expect(result).toEqual({ success: false, error: 'Write something before saving.' });
+  });
+
+  it('rejects a body over the limit', () => {
+    const result = validateArticleInput(
+      { ...base, body: 'x'.repeat(ARTICLE_LIMITS.body + 1) },
+      'publish'
+    );
+    expect(result).toEqual({ success: false, error: 'This article is too long to publish.' });
+  });
+
+  it('uses action-specific copy for publish vs save', () => {
+    const publish = validateArticleInput({ ...base, body: '' }, 'publish');
+    const save = validateArticleInput({ ...base, body: '' }, 'save');
+    expect(publish.success).toBe(false);
+    expect(save.success).toBe(false);
+    if (!publish.success && !save.success) {
+      expect(publish.error).toContain('publishing');
+      expect(save.error).toContain('saving');
+    }
+  });
+
+  it('derives an excerpt from the body when none is given, capped at the limit', () => {
+    const result = validateArticleInput(
+      { ...base, excerpt: undefined, body: 'y'.repeat(500) },
+      'publish'
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value.excerpt.length).toBeLessThanOrEqual(ARTICLE_LIMITS.excerpt);
+    }
+  });
+
+  it('normalizes a blank cover image to undefined', () => {
+    const result = validateArticleInput({ ...base, coverImage: '   ' }, 'publish');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value.coverImage).toBeUndefined();
+    }
+  });
+});
+
+describe('buildArticleMetadata', () => {
+  const normalized = {
+    title: 'Headline',
+    body: 'Body text that is long enough.',
+    excerpt: 'Body text',
+    coverImage: 'https://example.com/cover.jpg',
+    slug: 'headline-ab12cd',
+  };
+
+  it('always carries the article discriminators', () => {
+    const meta = buildArticleMetadata(normalized) as Record<string, unknown>;
+    expect(meta.is_user_post).toBe(true);
+    expect(meta.is_article).toBe(true);
+  });
+
+  it('preserves the provided slug verbatim (edit must never break the URL)', () => {
+    const meta = buildArticleMetadata(normalized) as { article: { slug: string } };
+    expect(meta.article.slug).toBe('headline-ab12cd');
+  });
+
+  it('embeds the body, cover image, and a computed reading time', () => {
+    const meta = buildArticleMetadata(normalized) as {
+      article: { body: string; cover_image?: string; reading_time: number };
+    };
+    expect(meta.article.body).toBe(normalized.body);
+    expect(meta.article.cover_image).toBe(normalized.coverImage);
+    expect(meta.article.reading_time).toBeGreaterThan(0);
+  });
+});

--- a/src/app/(public)/articles/[slug]/ArticleOwnerActions.tsx
+++ b/src/app/(public)/articles/[slug]/ArticleOwnerActions.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Pencil, Trash2, Loader2 } from 'lucide-react';
+import { ROUTES } from '@/config/routes';
+import { ARTICLE_COPY } from '@/config/articles';
+import { deleteArticle } from '@/services/articles/update';
+
+/**
+ * Owner-only edit/delete controls on the article reader. Delete uses an inline
+ * two-step confirm (no jarring native dialog). Server gates visibility to the
+ * author; the delete mutation is independently RLS-protected.
+ */
+export default function ArticleOwnerActions({
+  articleId,
+  slug,
+}: {
+  articleId: string;
+  slug: string;
+}) {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    setDeleting(true);
+    setError(null);
+    const result = await deleteArticle(articleId);
+    if (!result.success) {
+      setError(result.error);
+      setDeleting(false);
+      setConfirming(false);
+      return;
+    }
+    router.push(ROUTES.ARTICLES);
+    router.refresh();
+  }
+
+  const linkClass =
+    'inline-flex items-center gap-1.5 rounded-md border border-default px-3 py-1.5 text-sm font-medium text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary';
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Link href={ROUTES.ARTICLE_EDIT(slug)} className={linkClass}>
+        <Pencil className="h-4 w-4" />
+        {ARTICLE_COPY.reader.edit}
+      </Link>
+
+      {confirming ? (
+        <span className="inline-flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting}
+            className="inline-flex items-center gap-1.5 rounded-md bg-status-negative px-3 py-1.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {deleting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="h-4 w-4" />
+            )}
+            {deleting ? ARTICLE_COPY.reader.deleting : 'Confirm delete'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            disabled={deleting}
+            className="text-sm text-fg-secondary hover:text-fg-primary"
+          >
+            {ARTICLE_COPY.new.cancel}
+          </button>
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className={linkClass}
+          title={ARTICLE_COPY.reader.deleteConfirm}
+        >
+          <Trash2 className="h-4 w-4" />
+          {ARTICLE_COPY.reader.delete}
+        </button>
+      )}
+
+      {error && <span className="text-sm text-status-negative">{error}</span>}
+    </div>
+  );
+}

--- a/src/app/(public)/articles/[slug]/edit/page.tsx
+++ b/src/app/(public)/articles/[slug]/edit/page.tsx
@@ -1,0 +1,49 @@
+import { notFound, redirect } from 'next/navigation';
+import { createServerClient } from '@/lib/supabase/server';
+import { getUserActorId } from '@/domain/actors';
+import { getArticleBySlug } from '@/services/articles/get-article';
+import { ROUTES } from '@/config/routes';
+import ArticleComposer from '../../new/ArticleComposer';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function EditArticlePage({ params }: PageProps) {
+  const { slug } = await params;
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`${ROUTES.AUTH}?mode=login&from=${encodeURIComponent(`/articles/${slug}/edit`)}`);
+  }
+
+  const [article, actorId] = await Promise.all([
+    getArticleBySlug(slug),
+    getUserActorId(supabase, user.id),
+  ]);
+
+  // Only the author may edit (mutations are RLS-protected regardless).
+  if (!article || !actorId || actorId !== article.authorActorId) {
+    notFound();
+  }
+
+  return (
+    <ArticleComposer
+      user={{ id: user.id }}
+      initial={{
+        id: article.id,
+        slug: article.slug,
+        title: article.title,
+        excerpt: article.excerpt,
+        coverImage: article.coverImage,
+        body: article.body,
+        visibility: article.visibility,
+      }}
+    />
+  );
+}

--- a/src/app/(public)/articles/[slug]/page.tsx
+++ b/src/app/(public)/articles/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { ArrowLeft, Clock, Lock, Users } from 'lucide-react';
-import { getArticleBySlug } from '@/services/articles/get-article';
+import { getArticleBySlug, isCurrentUserArticleAuthor } from '@/services/articles/get-article';
 import { ARTICLE_COPY } from '@/config/articles';
 import { ROUTES } from '@/config/routes';
 import { JsonLdScript } from '@/lib/seo/structured-data';
@@ -11,6 +11,7 @@ import ArticleMarkdown from './ArticleMarkdown';
 import ReadingProgress from './ReadingProgress';
 import ShareButton from './ShareButton';
 import TipButton from '@/components/tips/TipButton';
+import ArticleOwnerActions from './ArticleOwnerActions';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -64,6 +65,8 @@ export default async function ArticlePage({ params }: PageProps) {
   if (!article) {
     notFound();
   }
+
+  const isOwner = await isCurrentUserArticleAuthor(article.authorActorId);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -188,6 +191,7 @@ export default async function ArticlePage({ params }: PageProps) {
                     recipientName={article.author.name}
                   />
                 )}
+                {isOwner && <ArticleOwnerActions articleId={article.id} slug={article.slug} />}
                 <ShareButton title={article.title} url={shareUrl} />
               </div>
             </div>

--- a/src/app/(public)/articles/new/ArticleComposer.tsx
+++ b/src/app/(public)/articles/new/ArticleComposer.tsx
@@ -12,6 +12,7 @@ import { TIMELINE_SURFACE, TIMELINE_VISIBILITY_OPTIONS } from '@/config/timeline
 import { ARTICLE_COPY, ARTICLE_LIMITS, estimateReadingTime } from '@/config/articles';
 import { ROUTES } from '@/config/routes';
 import { publishArticle } from '@/services/articles/create';
+import { updateArticle } from '@/services/articles/update';
 import type { TimelineVisibility } from '@/types/timeline';
 import type { ArticleDraft } from '@/services/cat/writing-types';
 import ArticleMarkdown from '../[slug]/ArticleMarkdown';
@@ -30,13 +31,31 @@ interface DraftShape {
   visibility: TimelineVisibility;
 }
 
-export default function ArticleComposer({ user }: { user: { id: string } }) {
+/** Existing article passed when the composer is opened in edit mode. */
+export interface ArticleInitial {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string;
+  coverImage?: string;
+  body: string;
+  visibility: TimelineVisibility;
+}
+
+export default function ArticleComposer({
+  user,
+  initial,
+}: {
+  user: { id: string };
+  initial?: ArticleInitial;
+}) {
   const router = useRouter();
-  const [title, setTitle] = useState('');
-  const [excerpt, setExcerpt] = useState('');
-  const [coverImage, setCoverImage] = useState('');
-  const [body, setBody] = useState('');
-  const [visibility, setVisibility] = useState<TimelineVisibility>('public');
+  const isEditing = !!initial;
+  const [title, setTitle] = useState(initial?.title ?? '');
+  const [excerpt, setExcerpt] = useState(initial?.excerpt ?? '');
+  const [coverImage, setCoverImage] = useState(initial?.coverImage ?? '');
+  const [body, setBody] = useState(initial?.body ?? '');
+  const [visibility, setVisibility] = useState<TimelineVisibility>(initial?.visibility ?? 'public');
   const [tab, setTab] = useState<'write' | 'preview'>('write');
   const [publishing, setPublishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -45,8 +64,12 @@ export default function ArticleComposer({ user }: { user: { id: string } }) {
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const md = useMarkdownTextarea(bodyRef, body, setBody);
 
-  // Restore an in-progress draft once on mount.
+  // Restore an in-progress draft once on mount (new articles only — never clobber
+  // an article being edited with a stale local draft).
   useEffect(() => {
+    if (isEditing) {
+      return;
+    }
     try {
       const raw = localStorage.getItem(DRAFT_KEY);
       if (!raw) {
@@ -66,10 +89,13 @@ export default function ArticleComposer({ user }: { user: { id: string } }) {
     } catch {
       /* ignore corrupt draft */
     }
-  }, []);
+  }, [isEditing]);
 
-  // Autosave (debounced) whenever content changes.
+  // Autosave (debounced) whenever content changes (new articles only).
   useEffect(() => {
+    if (isEditing) {
+      return;
+    }
     if (!title && !body && !excerpt && !coverImage) {
       return;
     }
@@ -84,7 +110,7 @@ export default function ArticleComposer({ user }: { user: { id: string } }) {
       }
     }, 600);
     return () => clearTimeout(id);
-  }, [title, excerpt, coverImage, body, visibility]);
+  }, [isEditing, title, excerpt, coverImage, body, visibility]);
 
   const wordCount = body.trim() ? body.trim().split(/\s+/).length : 0;
   const readingTime = wordCount ? estimateReadingTime(body) : 0;
@@ -123,13 +149,27 @@ export default function ArticleComposer({ user }: { user: { id: string } }) {
     }
     setPublishing(true);
     setError(null);
-    const result = await publishArticle(user, {
+    const payload = {
       title,
       body,
       excerpt: excerpt || undefined,
       coverImage: coverImage || undefined,
       visibility,
-    });
+    };
+
+    if (initial) {
+      const result = await updateArticle({ id: initial.id, slug: initial.slug }, payload);
+      if (!result.success) {
+        setError(result.error);
+        setPublishing(false);
+        return;
+      }
+      router.push(ROUTES.ARTICLE(initial.slug));
+      router.refresh();
+      return;
+    }
+
+    const result = await publishArticle(user, payload);
     if (!result.success) {
       setError(result.error);
       setPublishing(false);
@@ -147,23 +187,27 @@ export default function ArticleComposer({ user }: { user: { id: string } }) {
     <div className="min-h-screen bg-surface-page pt-20 pb-24 text-fg-primary">
       <div className="mx-auto w-full max-w-[720px] px-5">
         <Link
-          href={ROUTES.ARTICLES}
+          href={isEditing ? ROUTES.ARTICLE(initial!.slug) : ROUTES.ARTICLES}
           className="mb-6 inline-flex items-center gap-1.5 text-sm text-fg-secondary transition-colors hover:text-fg-primary"
         >
           <ArrowLeft className="h-4 w-4" />
-          {ARTICLE_COPY.reader.back}
+          {isEditing ? 'Back to article' : ARTICLE_COPY.reader.back}
         </Link>
 
         <header className="mb-5">
           <h1 className="text-2xl font-semibold tracking-display text-fg-primary">
-            {ARTICLE_COPY.new.heading}
+            {isEditing ? ARTICLE_COPY.edit.heading : ARTICLE_COPY.new.heading}
           </h1>
-          <p className="mt-1.5 text-sm text-fg-secondary">{ARTICLE_COPY.new.subheading}</p>
+          <p className="mt-1.5 text-sm text-fg-secondary">
+            {isEditing ? ARTICLE_COPY.edit.subheading : ARTICLE_COPY.new.subheading}
+          </p>
         </header>
 
-        <div className="mb-5">
-          <AiWriterPanel title={title} onApplyDraft={applyDraft} disabled={publishing} />
-        </div>
+        {!isEditing && (
+          <div className="mb-5">
+            <AiWriterPanel title={title} onApplyDraft={applyDraft} disabled={publishing} />
+          </div>
+        )}
 
         {restored && (
           <p className="mb-4 rounded-md border border-subtle bg-surface-raised/30 px-3 py-2 text-xs text-fg-secondary">
@@ -291,7 +335,13 @@ export default function ArticleComposer({ user }: { user: { id: string } }) {
             disabled={!canPublish}
             isLoading={publishing}
           >
-            {publishing ? ARTICLE_COPY.new.publishing : ARTICLE_COPY.new.publish}
+            {isEditing
+              ? publishing
+                ? ARTICLE_COPY.edit.saving
+                : ARTICLE_COPY.edit.save
+              : publishing
+                ? ARTICLE_COPY.new.publishing
+                : ARTICLE_COPY.new.publish}
           </Button>
         </div>
       </div>

--- a/src/config/articles.ts
+++ b/src/config/articles.ts
@@ -46,11 +46,21 @@ export const ARTICLE_COPY = {
     publishing: 'Publishing…',
     cancel: 'Cancel',
   },
+  edit: {
+    heading: 'Edit article',
+    subheading: 'Update your article. Changes go live immediately.',
+    save: 'Save changes',
+    saving: 'Saving…',
+  },
   reader: {
     back: 'All articles',
     byUnknown: 'Unknown',
     privateNotice: 'Only you can see this article.',
     followersNotice: 'Visible to your followers.',
+    edit: 'Edit',
+    delete: 'Delete',
+    deleting: 'Deleting…',
+    deleteConfirm: 'Delete this article? This cannot be undone.',
   },
   index: {
     heading: 'Articles',

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -286,6 +286,7 @@ export const ROUTES = {
   ARTICLES: '/articles',
   ARTICLES_NEW: '/articles/new',
   ARTICLE: (slug: string) => `/articles/${slug}`,
+  ARTICLE_EDIT: (slug: string) => `/articles/${slug}/edit`,
   DOCS: '/docs',
   FAQ: '/faq',
   PRICING: '/pricing',

--- a/src/services/articles/create.ts
+++ b/src/services/articles/create.ts
@@ -6,14 +6,8 @@
 
 import { timelineService } from '@/services/timeline';
 import { logger } from '@/utils/logger';
-import {
-  ARTICLE_EVENT_TYPE,
-  ARTICLE_LIMITS,
-  buildArticleSlug,
-  deriveExcerpt,
-  estimateReadingTime,
-  shortToken,
-} from '@/config/articles';
+import { ARTICLE_EVENT_TYPE, buildArticleSlug, shortToken } from '@/config/articles';
+import { buildArticleMetadata, validateArticleInput } from './write-shared';
 import type { CreateArticleInput } from './types';
 
 interface PublishArticleUser {
@@ -26,25 +20,12 @@ export async function publishArticle(
   user: PublishArticleUser,
   input: CreateArticleInput
 ): Promise<PublishArticleResult> {
-  const title = input.title.trim();
-  const body = input.body.trim();
-
-  if (!title) {
-    return { success: false, error: 'Give your article a title.' };
+  const validation = validateArticleInput(input, 'publish');
+  if (!validation.success) {
+    return validation;
   }
-  if (title.length > ARTICLE_LIMITS.title) {
-    return { success: false, error: `Title must be ${ARTICLE_LIMITS.title} characters or fewer.` };
-  }
-  if (body.length < ARTICLE_LIMITS.bodyMin) {
-    return { success: false, error: 'Write something before publishing.' };
-  }
-  if (body.length > ARTICLE_LIMITS.body) {
-    return { success: false, error: 'This article is too long to publish.' };
-  }
-
-  const excerpt = (input.excerpt?.trim() || deriveExcerpt(body)).slice(0, ARTICLE_LIMITS.excerpt);
+  const { title, body, excerpt, coverImage } = validation.value;
   const slug = buildArticleSlug(title, shortToken());
-  const coverImage = input.coverImage?.trim() || undefined;
 
   // Owner (profile) timeline + community feed when public — mirrors the short-post
   // distribution contexts so articles surface everywhere posts do.
@@ -64,16 +45,7 @@ export async function publishArticle(
     title,
     description: excerpt,
     visibility: input.visibility,
-    metadata: {
-      is_user_post: true,
-      is_article: true,
-      article: {
-        slug,
-        cover_image: coverImage,
-        reading_time: estimateReadingTime(body),
-        body,
-      },
-    },
+    metadata: buildArticleMetadata({ title, body, excerpt, coverImage, slug }),
     timelineContexts,
   });
 

--- a/src/services/articles/get-article.ts
+++ b/src/services/articles/get-article.ts
@@ -58,6 +58,7 @@ function rowToArticle(row: EnrichedArticleRow): Article | null {
       username: actor?.username,
       avatarUrl: actor?.avatar_url,
     },
+    authorActorId: row.actor_id,
   };
 }
 
@@ -86,10 +87,16 @@ export async function getArticleBySlug(slug: string): Promise<Article | null> {
     }
 
     if (article.visibility !== 'public') {
+      // Non-public articles are visible only to their author. Compare via actor
+      // id (author.id / user.id are different id spaces).
       const {
         data: { user },
       } = await supabase.auth.getUser();
-      if (!user || user.id !== article.author.id) {
+      if (!user) {
+        return null;
+      }
+      const viewerActorId = await getUserActorId(supabase, user.id);
+      if (!viewerActorId || viewerActorId !== article.authorActorId) {
         return null;
       }
     }
@@ -98,6 +105,27 @@ export async function getArticleBySlug(slug: string): Promise<Article | null> {
   } catch (err) {
     logger.error('Failed to fetch article by slug', { err, slug }, 'Articles');
     return null;
+  }
+}
+
+/**
+ * Whether the current (session) viewer is the article's author. Compares actor
+ * ids (author.id / user.id are different id spaces). Used to gate owner-only
+ * edit/delete affordances — the mutations are independently RLS-protected.
+ */
+export async function isCurrentUserArticleAuthor(authorActorId: string): Promise<boolean> {
+  try {
+    const supabase = await createServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return false;
+    }
+    const viewerActorId = await getUserActorId(supabase, user.id);
+    return !!viewerActorId && viewerActorId === authorActorId;
+  } catch {
+    return false;
   }
 }
 

--- a/src/services/articles/types.ts
+++ b/src/services/articles/types.ts
@@ -24,6 +24,10 @@ export interface Article {
   visibility: 'public' | 'followers' | 'private';
   publishedAt: string;
   author: ArticleAuthor;
+  /** The owning actor id (timeline_events.actor_id) — for ownership checks.
+   *  NOTE: this is an actor id, not an auth user id; resolve the viewer's actor
+   *  via getUserActorId before comparing. */
+  authorActorId: string;
 }
 
 /** The payload persisted at `metadata.article`. */

--- a/src/services/articles/update.ts
+++ b/src/services/articles/update.ts
@@ -1,0 +1,43 @@
+/**
+ * Edit / delete an article. An article is a timeline_events row, so these wrap
+ * the existing timeline mutations (updateEvent / deleteEvent) — RLS enforces
+ * that only the author can change or remove it. The slug is preserved on edit so
+ * the article's URL never breaks.
+ */
+
+import { updateEvent, deleteEvent } from '@/services/timeline/mutations/events';
+import { logger } from '@/utils/logger';
+import { buildArticleMetadata, validateArticleInput } from './write-shared';
+import type { CreateArticleInput } from './types';
+
+type ArticleWriteResult = { success: true } | { success: false; error: string };
+
+export async function updateArticle(
+  article: { id: string; slug: string },
+  input: CreateArticleInput
+): Promise<ArticleWriteResult> {
+  const validation = validateArticleInput(input, 'save');
+  if (!validation.success) {
+    return validation;
+  }
+  const { title, body, excerpt, coverImage } = validation.value;
+
+  const result = await updateEvent(article.id, {
+    title,
+    description: excerpt,
+    visibility: input.visibility,
+    // slug preserved — never regenerate on edit, so the article URL stays stable.
+    metadata: buildArticleMetadata({ title, body, excerpt, coverImage, slug: article.slug }),
+  });
+
+  if (!result.success) {
+    logger.error('Failed to update article', { error: result.error }, 'Articles');
+    return { success: false, error: result.error || 'Failed to save changes.' };
+  }
+  return { success: true };
+}
+
+export async function deleteArticle(articleId: string): Promise<ArticleWriteResult> {
+  const ok = await deleteEvent(articleId);
+  return ok ? { success: true } : { success: false, error: 'Could not delete this article.' };
+}

--- a/src/services/articles/write-shared.ts
+++ b/src/services/articles/write-shared.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared write-path helpers for articles. Both publish (create) and edit
+ * (update) go through these so the limits, error copy, and — critically — the
+ * `timeline_events.metadata` shape live in exactly ONE place. If create and edit
+ * ever built the metadata differently, an edit could drop the `is_article`
+ * discriminator or slug and silently "unpublish" the article; a single builder
+ * makes that impossible.
+ */
+
+import { ARTICLE_LIMITS, deriveExcerpt, estimateReadingTime } from '@/config/articles';
+import type { ArticleMetadataPayload, CreateArticleInput } from './types';
+
+/** Trimmed, length-checked article fields ready to persist. */
+export interface NormalizedArticle {
+  title: string;
+  body: string;
+  excerpt: string;
+  coverImage?: string;
+}
+
+export type ArticleValidation =
+  | { success: true; value: NormalizedArticle }
+  | { success: false; error: string };
+
+/**
+ * Validate + normalize article input. `action` only tweaks the two user-facing
+ * verbs ("publishing" vs "saving") so each flow reads naturally.
+ */
+export function validateArticleInput(
+  input: CreateArticleInput,
+  action: 'publish' | 'save'
+): ArticleValidation {
+  const title = input.title.trim();
+  const body = input.body.trim();
+
+  if (!title) {
+    return { success: false, error: 'Give your article a title.' };
+  }
+  if (title.length > ARTICLE_LIMITS.title) {
+    return { success: false, error: `Title must be ${ARTICLE_LIMITS.title} characters or fewer.` };
+  }
+  if (body.length < ARTICLE_LIMITS.bodyMin) {
+    return {
+      success: false,
+      error:
+        action === 'publish'
+          ? 'Write something before publishing.'
+          : 'Write something before saving.',
+    };
+  }
+  if (body.length > ARTICLE_LIMITS.body) {
+    return {
+      success: false,
+      error:
+        action === 'publish' ? 'This article is too long to publish.' : 'This article is too long.',
+    };
+  }
+
+  const excerpt = (input.excerpt?.trim() || deriveExcerpt(body)).slice(0, ARTICLE_LIMITS.excerpt);
+  const coverImage = input.coverImage?.trim() || undefined;
+  return { success: true, value: { title, body, excerpt, coverImage } };
+}
+
+/**
+ * Assemble the `timeline_events.metadata` for an article row. Used by both
+ * create and edit so the discriminator (`is_article`) and slug are always
+ * present and identical across the write paths.
+ */
+export function buildArticleMetadata(
+  article: NormalizedArticle & { slug: string }
+): Record<string, unknown> {
+  const payload: ArticleMetadataPayload = {
+    slug: article.slug,
+    cover_image: article.coverImage,
+    reading_time: estimateReadingTime(article.body),
+    body: article.body,
+  };
+  return { is_user_post: true, is_article: true, article: payload };
+}


### PR DESCRIPTION
Reopens the work from #434 (auto-closed when its stacked base branch `chore/verify-ssot` was deleted on merge of #428). Rebased onto current main and verified locally: **npm ci 0, tsc 0, build 226/226 pages**.

Author actions on an article now include TipButton (existing) + owner-only edit/delete via `ArticleOwnerActions` + ShareButton (rebase conflict in `articles/[slug]/page.tsx` resolved to keep all three).

🤖 Generated with [Claude Code](https://claude.com/claude-code)