### PR TITLE
feat(fleetcrown): harden the OrangeCat↔FleetCrown integration surface

### DIFF
--- a/__tests__/unit/integration/fleetcrown-hardening.test.ts
+++ b/__tests__/unit/integration/fleetcrown-hardening.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration-hardening contract tests.
+ *
+ * Locks the behaviour added when closing the FleetCrown ↔ OrangeCat gaps:
+ *   1. `payment.settled` is a real, advertised webhook event and its payload
+ *      shape matches what the fan-out emits.
+ *   2. The public v1 `search` + `demand` endpoints are discoverable.
+ *   4. `parseSupporterPass` (previously untested) honours its tag contract.
+ */
+import {
+  PUBLIC_API_WEBHOOK_EVENTS,
+  PUBLIC_API_ECONOMIC_WEBHOOK_EVENTS,
+  PUBLIC_API_INTEGRATION_ENDPOINTS,
+} from '@/config/public-api';
+import {
+  PAYMENT_SETTLED_EVENT,
+  buildPaymentSettledPayload,
+} from '@/services/webhooks/paymentSettledWebhook';
+import { parseSupporterPass } from '@/services/supporter/grant';
+import type { PaymentIntent } from '@/domain/payments/types';
+
+describe('payment.settled webhook event (gap 1)', () => {
+  it('is advertised in the public webhook event registry', () => {
+    expect(PUBLIC_API_WEBHOOK_EVENTS).toContain('payment.settled');
+    expect(PUBLIC_API_ECONOMIC_WEBHOOK_EVENTS).toContain('payment.settled');
+  });
+
+  it('the emitter constant matches the advertised event name', () => {
+    expect(PUBLIC_API_WEBHOOK_EVENTS).toContain(PAYMENT_SETTLED_EVENT);
+  });
+
+  it('does not clobber the entity.created events', () => {
+    expect(PUBLIC_API_WEBHOOK_EVENTS).toContain('product.created');
+    expect(PUBLIC_API_WEBHOOK_EVENTS).toContain('project.created');
+  });
+
+  it('builds a payload with the settlement fields integrators need', () => {
+    const pi = {
+      id: 'pi_123',
+      seller_id: 'user_seller',
+      buyer_id: 'user_buyer',
+      entity_type: 'product',
+      entity_id: 'ent_1',
+      amount_btc: 0.0005,
+      intent_kind: 'purchase',
+      description: 'Widget',
+    } as unknown as PaymentIntent;
+
+    expect(buildPaymentSettledPayload(pi)).toEqual({
+      type: 'payment.settled',
+      intentKind: 'purchase',
+      entityType: 'product',
+      entityId: 'ent_1',
+      amountBtc: '0.0005',
+      title: 'Widget',
+      externalId: 'pi_123',
+    });
+  });
+
+  it('coerces a missing amount to an empty string, never null/NaN', () => {
+    const pi = {
+      id: 'pi_x',
+      seller_id: 's',
+      entity_type: 'project',
+      entity_id: 'e',
+      amount_btc: null,
+      intent_kind: 'support',
+      description: null,
+    } as unknown as PaymentIntent;
+    const payload = buildPaymentSettledPayload(pi);
+    expect(payload.amountBtc).toBe('');
+    expect(payload.title).toBeUndefined();
+  });
+});
+
+describe('v1 search + demand discoverability (gap 2)', () => {
+  const names = PUBLIC_API_INTEGRATION_ENDPOINTS.map(e => e.name);
+
+  it('advertises search and demand alongside the existing endpoints', () => {
+    expect(names).toEqual(
+      expect.arrayContaining(['search', 'demand', 'timeline.publish', 'stakeholders'])
+    );
+  });
+
+  it('points them at the real v1 routes as GET', () => {
+    const search = PUBLIC_API_INTEGRATION_ENDPOINTS.find(e => e.name === 'search');
+    const demand = PUBLIC_API_INTEGRATION_ENDPOINTS.find(e => e.name === 'demand');
+    expect(search).toMatchObject({ endpoint: '/api/v1/search', methods: ['GET'] });
+    expect(demand).toMatchObject({ endpoint: '/api/v1/demand', methods: ['GET'] });
+  });
+});
+
+describe('parseSupporterPass tag contract (gap 4)', () => {
+  it('parses a well-formed supporter pass', () => {
+    expect(parseSupporterPass(['supporter-plan', 'supporter-days:30'])).toEqual({ days: 30 });
+  });
+
+  it('ignores tag order and unrelated tags', () => {
+    expect(parseSupporterPass(['x', 'supporter-days:90', 'y', 'supporter-plan'])).toEqual({
+      days: 90,
+    });
+  });
+
+  it('requires BOTH the marker and a day count', () => {
+    expect(parseSupporterPass(['supporter-plan'])).toBeNull();
+    expect(parseSupporterPass(['supporter-days:30'])).toBeNull();
+  });
+
+  it('rejects non-array and non-string entries', () => {
+    expect(parseSupporterPass(null)).toBeNull();
+    expect(parseSupporterPass('supporter-plan')).toBeNull();
+    expect(parseSupporterPass([123, { supporter: true }])).toBeNull();
+  });
+
+  it('rejects zero days and out-of-range day formats', () => {
+    expect(parseSupporterPass(['supporter-plan', 'supporter-days:0'])).toBeNull();
+    expect(parseSupporterPass(['supporter-plan', 'supporter-days:12345'])).toBeNull();
+    expect(parseSupporterPass(['supporter-plan', 'supporter-days:abc'])).toBeNull();
+  });
+});

--- a/src/app/api/integrations/fleetcrown/build-intents/route.ts
+++ b/src/app/api/integrations/fleetcrown/build-intents/route.ts
@@ -1,13 +1,15 @@
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
-import { apiBadRequest, apiForbidden, apiSuccess } from '@/lib/api/standardResponse';
+import {
+  apiBadRequest,
+  apiForbidden,
+  apiServiceUnavailable,
+  apiSuccess,
+} from '@/lib/api/standardResponse';
 import { getEntityMetadata, isValidEntityType } from '@/config/entity-registry';
 import { getAdminClient } from '@/lib/supabase/admin';
 import { getSellerUserId } from '@/domain/payments';
 import { getOrCreateUserActor } from '@/services/actors/getOrCreateUserActor';
-import {
-  signFleetCrownBuildIntent,
-  suggestedHandoffFor,
-} from '@/services/fleetcrown/build-intent';
+import { signFleetCrownBuildIntent, suggestedHandoffFor } from '@/services/fleetcrown/build-intent';
 import { ECOSYSTEM } from '@/config/ecosystem';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 
@@ -51,20 +53,27 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
 
   const row = entity as unknown as Record<string, unknown>;
   const title = String(row[titleColumn] || meta.name);
-  const description =
-    typeof row.description === 'string' ? row.description.slice(0, 1200) : null;
+  const description = typeof row.description === 'string' ? row.description.slice(0, 1200) : null;
   const actor = await getOrCreateUserActor(request.user.id);
-  const token = signFleetCrownBuildIntent({
-    sub: actor.id,
-    entity: {
-      type: entityType,
-      id: body.entity_id,
-      title,
-      description,
-      publicUrl: new URL(body.source_path, ECOSYSTEM.orangeCat.siteUrl).toString(),
-    },
-    suggestedHandoff: suggestedHandoffFor(entityType, title),
-  });
+  let token: string;
+  try {
+    token = signFleetCrownBuildIntent({
+      sub: actor.id,
+      entity: {
+        type: entityType,
+        id: body.entity_id,
+        title,
+        description,
+        publicUrl: new URL(body.source_path, ECOSYSTEM.orangeCat.siteUrl).toString(),
+      },
+      suggestedHandoff: suggestedHandoffFor(entityType, title),
+    });
+  } catch {
+    // FLEETCROWN_BUILD_INTENT_SECRET not set on this deploy — the handoff is
+    // unavailable, not a server fault. Return 503 so the CTA can fall back to
+    // the plain FleetCrown link instead of surfacing a generic 500.
+    return apiServiceUnavailable('FleetCrown build handoff is not configured');
+  }
 
   const url = new URL('/integrations/orangecat/build', ECOSYSTEM.fleetCrown.siteUrl);
   url.searchParams.set('intent', token);

--- a/src/components/integrations/FleetCrownBuildCta.tsx
+++ b/src/components/integrations/FleetCrownBuildCta.tsx
@@ -62,6 +62,13 @@ export default function FleetCrownBuildCta({
           source_path: sourcePath,
         }),
       });
+      // 503 = the signed handoff isn't configured on this deploy. That's not a
+      // failure the user should see — fall back to the plain FleetCrown link,
+      // exactly as the banner (no entity id) variant already does.
+      if (response.status === 503) {
+        window.location.assign(FLEETCROWN_BUILD_URL);
+        return;
+      }
       const body = (await response.json()) as {
         data?: { url?: string };
         error?: { message?: string };

--- a/src/config/public-api.ts
+++ b/src/config/public-api.ts
@@ -49,7 +49,7 @@ export const PUBLIC_API_INTEGRATION_SCOPE_TOKENS = [
   'stakeholders.write',
 ] as const;
 
-/** Non-entity v1 endpoints (publish bus, stakeholder graph, …). */
+/** Non-entity v1 endpoints (publish bus, stakeholder graph, discovery, …). */
 export const PUBLIC_API_INTEGRATION_ENDPOINTS = [
   {
     name: 'timeline.publish',
@@ -60,6 +60,16 @@ export const PUBLIC_API_INTEGRATION_ENDPOINTS = [
     name: 'stakeholders',
     methods: ['GET', 'POST'] as const,
     endpoint: `${PUBLIC_API_BASE}/stakeholders`,
+  },
+  {
+    name: 'search',
+    methods: ['GET'] as const,
+    endpoint: `${PUBLIC_API_BASE}/search`,
+  },
+  {
+    name: 'demand',
+    methods: ['GET'] as const,
+    endpoint: `${PUBLIC_API_BASE}/demand`,
   },
 ] as const;
 
@@ -74,12 +84,22 @@ export const PUBLIC_API_SCOPE_TOKENS: readonly string[] = [
 ];
 
 /**
- * Webhook event types that endpoints can subscribe to. Format mirrors
- * how entityPostHandler emits: `<entity>.created`. Future events
- * (`<entity>.updated`, `<entity>.deleted`) will append here. An endpoint
- * with `event_types=null` receives every event for its bound actor —
- * the explicit allowlist only gates the firing fan-out.
+ * Non-entity webhook events that carry an economic signal rather than an
+ * entity lifecycle change. `payment.settled` fires when a Bitcoin payment
+ * for one of the actor's entities settles — the same ground-truth signal
+ * that drives the FleetCrown entitlement rail, now also deliverable to any
+ * integrator's own endpoint via the generic webhook fan-out.
  */
-export const PUBLIC_API_WEBHOOK_EVENTS: readonly string[] = PUBLIC_API_ENTITY_TYPES.map(
-  t => `${t}.created`
-);
+export const PUBLIC_API_ECONOMIC_WEBHOOK_EVENTS = ['payment.settled'] as const;
+
+/**
+ * Webhook event types that endpoints can subscribe to. Entity events mirror
+ * how entityPostHandler emits: `<entity>.created` (future `<entity>.updated`
+ * / `<entity>.deleted` append there); economic events carry settlement
+ * signals. An endpoint with `event_types=null` receives every event for its
+ * bound actor — the explicit allowlist only gates the firing fan-out.
+ */
+export const PUBLIC_API_WEBHOOK_EVENTS: readonly string[] = [
+  ...PUBLIC_API_ENTITY_TYPES.map(t => `${t}.created`),
+  ...PUBLIC_API_ECONOMIC_WEBHOOK_EVENTS,
+];

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -43,6 +43,7 @@ import {
   notifyFleetCrownProjectFunding,
 } from '@/services/fleetcrown/entitlement-notify';
 import { grantSupporterPlan } from '@/services/supporter/grant';
+import { enqueuePaymentSettledWebhook } from '@/services/webhooks/paymentSettledWebhook';
 
 const METHOD_LABELS: Record<string, string> = {
   nwc: 'Lightning (NWC)',
@@ -293,8 +294,7 @@ export async function initiatePublicSupport(
       status: paymentIntent.status,
       expires_at: paymentIntent.expires_at,
       can_acknowledge:
-        paymentIntent.payment_method === 'lightning_address' &&
-        !paymentIntent.lnurl_verify_url,
+        paymentIntent.payment_method === 'lightning_address' && !paymentIntent.lnurl_verify_url,
     },
     status_token: token,
     qr_data: invoice.qr_data,
@@ -349,8 +349,7 @@ export async function checkPublicPaymentStatus(
   const result = await refreshPaymentStatus(admin, pi as PaymentIntent);
   return {
     ...result,
-    requires_recipient_confirmation:
-      result.status === STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
+    requires_recipient_confirmation: result.status === STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
   };
 }
 
@@ -397,11 +396,7 @@ export async function acknowledgePublicPayment(
     };
   }
 
-  await updatePaymentStatus(
-    admin,
-    paymentIntentId,
-    STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED
-  );
+  await updatePaymentStatus(admin, paymentIntentId, STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
   return {
     status: STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
     paid_at: null,
@@ -414,10 +409,10 @@ async function refreshPaymentStatus(
   pi: PaymentIntent
 ): Promise<PaymentStatusResult> {
   const terminalStatuses = new Set<PaymentIntentStatus>([
-      STATUS.PAYMENT_INTENTS.PAID,
-      STATUS.PAYMENT_INTENTS.EXPIRED,
-      STATUS.PAYMENT_INTENTS.FAILED,
-      STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
+    STATUS.PAYMENT_INTENTS.PAID,
+    STATUS.PAYMENT_INTENTS.EXPIRED,
+    STATUS.PAYMENT_INTENTS.FAILED,
+    STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
   ]);
   if (terminalStatuses.has(pi.status)) {
     return { status: pi.status, paid_at: pi.paid_at };
@@ -454,11 +449,7 @@ async function refreshPaymentStatus(
       onchainStatus === 'in_mempool' &&
       pi.status !== STATUS.PAYMENT_INTENTS.PENDING_CONFIRMATION
     ) {
-      await updatePaymentStatus(
-        supabase,
-        pi.id,
-        STATUS.PAYMENT_INTENTS.PENDING_CONFIRMATION
-      );
+      await updatePaymentStatus(supabase, pi.id, STATUS.PAYMENT_INTENTS.PENDING_CONFIRMATION);
       return { status: STATUS.PAYMENT_INTENTS.PENDING_CONFIRMATION, paid_at: null };
     }
   }
@@ -600,11 +591,7 @@ async function getEntityTitle(
   const admin = getAdminClient() as unknown as SupabaseClient;
   const meta = getEntityMetadata(entityType);
   const titleColumn = meta.titleColumn ?? 'title';
-  const { data } = await admin
-    .from(meta.tableName)
-    .select(titleColumn)
-    .eq('id', entityId)
-    .single();
+  const { data } = await admin.from(meta.tableName).select(titleColumn).eq('id', entityId).single();
 
   const row = data as unknown as Record<string, unknown> | null;
   const title = row?.[titleColumn];
@@ -706,6 +693,12 @@ async function handlePaymentConfirmed(
   // Fire-and-forget; the receiver drops events for unlinked entities.
   void notifyFleetCrownProjectFunding(paymentIntent).catch(err =>
     logger.warn('FleetCrown funding notify failed', { err }, 'paymentFlowService')
+  );
+
+  // Fan `payment.settled` out to the seller's own webhook endpoints — the
+  // generic, retried rail any integrator can subscribe to. Fire-and-forget.
+  void enqueuePaymentSettledWebhook(paymentIntent).catch(err =>
+    logger.warn('payment.settled webhook enqueue failed', { err }, 'paymentFlowService')
   );
 
   // Grant an OrangeCat Supporter plan if this product was a Supporter pass —

--- a/src/services/webhooks/paymentSettledWebhook.ts
+++ b/src/services/webhooks/paymentSettledWebhook.ts
@@ -1,0 +1,63 @@
+/**
+ * payment.settled webhook fan-out.
+ *
+ * When a Bitcoin payment settles, deliver a `payment.settled` event to every
+ * active webhook endpoint bound to the seller's actor. This closes the gap
+ * where the mint UI advertised subscription/payment delivery but only
+ * `<entity>.created` ever fired: settlement signals previously reached
+ * FleetCrown only via the out-of-band HMAC POST in entitlement-notify. Now any
+ * integrator (FleetCrown included) can subscribe through the generic,
+ * retried, per-actor webhook machinery.
+ *
+ * Fire-and-forget: never throws, never blocks settlement. The seller's PERSONAL
+ * actor is the fan-out target (the actor an individual seller mints endpoints
+ * against) — group-owned entities that route settlement through a group actor
+ * are not covered here and remain served by the direct FleetCrown rail.
+ */
+import { getAdminClient } from '@/lib/supabase/admin';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { enqueueWebhookEvent } from '@/services/webhooks/deliveryService';
+import { logger } from '@/utils/logger';
+import type { PaymentIntent } from '@/domain/payments/types';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+
+/** Must match the economic event advertised in PUBLIC_API_WEBHOOK_EVENTS. */
+export const PAYMENT_SETTLED_EVENT = 'payment.settled' as const;
+
+export function buildPaymentSettledPayload(pi: PaymentIntent) {
+  return {
+    type: PAYMENT_SETTLED_EVENT,
+    intentKind: pi.intent_kind,
+    entityType: pi.entity_type,
+    entityId: pi.entity_id,
+    amountBtc: String(pi.amount_btc ?? ''),
+    title: pi.description ?? undefined,
+    externalId: pi.id,
+  };
+}
+
+export async function enqueuePaymentSettledWebhook(pi: PaymentIntent): Promise<number> {
+  try {
+    const admin = getAdminClient() as unknown as AnySupabaseClient;
+    const { data: actor } = await admin
+      .from(DATABASE_TABLES.ACTORS)
+      .select('id')
+      .eq('user_id', pi.seller_id)
+      .eq('actor_type', 'user')
+      .maybeSingle();
+    if (!actor?.id) {
+      return 0;
+    }
+    return await enqueueWebhookEvent({
+      actorId: actor.id,
+      eventType: PAYMENT_SETTLED_EVENT,
+      payload: buildPaymentSettledPayload(pi),
+    });
+  } catch (err) {
+    logger.error('[payment-settled-webhook] enqueue failed (non-fatal)', {
+      piId: pi.id,
+      error: (err as Error).message,
+    });
+    return 0;
+  }
+}


### PR DESCRIPTION
Advances the FleetCrown ↔ OrangeCat integration by closing four self-contained gaps found in a full audit. The core plumbing (OIDC SSO, v1 API, entitlement rail, per-actor webhook delivery) is already sound — these fixes complete the edges.

## What changed

**1. `payment.settled` is now a real, subscribable webhook event**
The webhook mint UI advertised subscription/payment delivery, but the only event that ever fired was `<entity>.created` — settlement signals reached FleetCrown *solely* via the out-of-band HMAC POST in `entitlement-notify`. Added a `payment.settled` economic event to the public registry (`public-api.ts`) and a fire-and-forget `enqueuePaymentSettledWebhook` fan-out from `paymentFlowService` to the **seller's actor endpoints**, so any integrator can subscribe through the generic, retried webhook rail (not just FleetCrown's hardcoded URL). Never blocks or throws in the settlement path.

**2. v1 `search` + `demand` are discoverable**
Both routes exist and are public but were missing from `PUBLIC_API_INTEGRATION_ENDPOINTS`, so `GET /api/v1` never advertised the FIND→BUILD wire FleetCrown relies on. Added both.

**3. Build-intent handoff fails gracefully**
When `FLEETCROWN_BUILD_INTENT_SECRET` is unset the route threw a **500**; it now returns **503** and `FleetCrownBuildCta` falls back to the plain FleetCrown link (matching the banner variant), instead of surfacing a generic error.

**4. Tests**
Contract tests for the new `payment.settled` event/payload shape, the `search`+`demand` discovery entries, and `parseSupporterPass` (previously untested).

## Not in scope (deliberately)
- **Surfacing the FleetCrown pass catalogue on `/pricing`** — a product decision (passes may be sold only via direct links); flagged for the owner.
- **Cross-repo items** (FleetCrown's `/api/orangecat/entitlement` + `/events` receivers, OIDC RP config, the build-intent consumer page) — these live in `~/dev/fleetcrown` and can't be done from here.

## Verification
- `type-check` ✅ 0 errors
- `eslint src` ✅ 0 errors
- unit tests ✅ **172 pass** (12 new, `fleetcrown-hardening.test.ts`)
- `next build` ✅ compiles + prerenders **225/226**; the only miss is `/sitemap.xml`, a DB-querying route that times out under placeholder Supabase (unchanged by this PR) — resolves under CI's real fixture secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)