### PR TITLE
fix(credits): harden the margin so the Cat Credits rail is actually break-even

### DIFF
--- a/__tests__/unit/cat/credit-metering.test.ts
+++ b/__tests__/unit/cat/credit-metering.test.ts
@@ -13,6 +13,7 @@ import {
   checkFrontierAccess,
   isPlatformMeteredModel,
   CREDIT_USAGE_MARKUP,
+  ESTIMATE_SAFETY_MULTIPLIER,
   MIN_FRONTIER_BALANCE_BTC,
 } from '@/services/cat/credit-metering';
 import { calculateCostBtc, getFreeModels, getAvailableModels } from '@/config/ai-models';
@@ -109,10 +110,14 @@ describe('meterCreditUsage', () => {
     expect(entry.ref).toBe('cat_chat_abc');
     expect(entry.amountBtc).toBeCloseTo(-charged, 10);
 
-    // Charge covers the raw cost plus the platform margin.
+    // No provider-reported cost → registry estimate, which carries the extra
+    // safety pad on top of the platform markup.
     const raw = calculateCostBtc(PAID_MODEL, 100000, 100000, 100000);
-    expect(charged).toBeGreaterThanOrEqual(raw * CREDIT_USAGE_MARKUP - 1e-8);
-    expect(charged).toBeLessThan(raw * CREDIT_USAGE_MARKUP + 1e-7);
+    const expected = raw * CREDIT_USAGE_MARKUP * ESTIMATE_SAFETY_MULTIPLIER;
+    expect(charged).toBeGreaterThanOrEqual(expected - 1e-8);
+    expect(charged).toBeLessThan(expected + 1e-7);
+    expect(entry.metadata.pricingSource).toBe('registry_estimate');
+    expect(entry.metadata.markup).toBeCloseTo(CREDIT_USAGE_MARKUP * ESTIMATE_SAFETY_MULTIPLIER, 10);
   });
 
   it('never bills free or unknown models', async () => {
@@ -162,7 +167,7 @@ describe('meterCreditUsage', () => {
     expect(entry.metadata.pricingSource).toBe('provider_reported');
   });
 
-  it('returns 0 (never throws) when the ledger append fails', async () => {
+  it('returns 0 (never throws) but retries before giving up when the ledger keeps failing', async () => {
     appendCreditEntry.mockResolvedValue(null);
     await expect(
       meterCreditUsage(admin, 'u1', {
@@ -172,5 +177,19 @@ describe('meterCreditUsage', () => {
         ref: 'r3',
       })
     ).resolves.toBe(0);
+    // Retried the idempotent debit rather than handing out a free frontier call.
+    expect(appendCreditEntry.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('recovers from a transient ledger failure and still bills', async () => {
+    appendCreditEntry.mockResolvedValueOnce(null).mockResolvedValueOnce(0.0005);
+    const charged = await meterCreditUsage(admin, 'u1', {
+      model: PAID_MODEL,
+      inputTokens: 100000,
+      outputTokens: 100000,
+      ref: 'retry-ref',
+    });
+    expect(charged).toBeGreaterThan(0);
+    expect(appendCreditEntry).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/services/cat/credit-metering.ts
+++ b/src/services/cat/credit-metering.ts
@@ -22,10 +22,27 @@ import { convertFromBTC } from '@/services/currency/rates';
 import { logger } from '@/utils/logger';
 
 /**
- * Platform margin on raw provider cost. The user's ledger is debited
+ * Platform markup on raw provider cost. The user's ledger is debited
  * cost × markup; the spread is the platform's revenue on intelligence.
+ *
+ * 40% (was a razor-thin 20%). The markup must cover more than margin: Lightning
+ * routing fees on top-up, BTC/USD drift between top-up and spend (a prepaid
+ * float held for days), and the occasional un-debited request. 20% went
+ * negative after fees + volatility; 40% keeps the credit rail actually
+ * break-even. Inference is cents/exchange, so this stays trivial to the user.
  */
-export const CREDIT_USAGE_MARKUP = 1.2;
+export const CREDIT_USAGE_MARKUP = 1.4;
+
+/**
+ * Extra safety applied ONLY to registry-ESTIMATE charges — i.e. when the
+ * provider didn't report a real cost and we fall back to the hand-maintained
+ * price table (`ai-models.ts`), which can lag real prices and silently
+ * under-bill. Provider-reported cost is ground truth and gets no pad.
+ */
+export const ESTIMATE_SAFETY_MULTIPLIER = 1.25;
+
+/** Retries for the post-response debit — idempotent per `ref`, so safe to retry. */
+const DEBIT_MAX_ATTEMPTS = 3;
 
 /**
  * Minimum balance (BTC) required to unlock platform-served frontier models —
@@ -89,27 +106,51 @@ export async function meterCreditUsage(
     return 0;
   }
 
+  const hasProviderCost = Number.isFinite(rawCostBtc) && (rawCostBtc ?? 0) > 0;
+
   let btcPriceUsd = 100000;
+  let liveRate = false;
   try {
     const usdPerBtc = await convertFromBTC(1, 'USD');
     if (Number.isFinite(usdPerBtc) && usdPerBtc > 0) {
       btcPriceUsd = usdPerBtc;
+      liveRate = true;
     }
   } catch {
-    /* keep conservative default */
+    /* fall through to the conservative default + the warning below */
   }
 
-  const meteredRawCostBtc =
-    Number.isFinite(rawCostBtc) && (rawCostBtc ?? 0) > 0
-      ? (rawCostBtc as number)
-      : calculateCostBtc(model, inputTokens, outputTokens, btcPriceUsd);
+  const meteredRawCostBtc = hasProviderCost
+    ? (rawCostBtc as number)
+    : calculateCostBtc(model, inputTokens, outputTokens, btcPriceUsd);
   if (meteredRawCostBtc <= 0) {
     return 0;
   }
-  const chargeBtc = ceilBtc(meteredRawCostBtc * CREDIT_USAGE_MARKUP);
 
-  const newBalance = await appendCreditEntry(admin, userId, {
-    kind: 'usage',
+  // Provider-reported cost is ground truth → charge margin only. A registry
+  // estimate is less reliable (hand-maintained prices lag), and doubly so if
+  // the live BTC/USD rate was unavailable — pad it and record the source so a
+  // low-confidence bill is auditable rather than a silent under-charge.
+  const effectiveMarkup = hasProviderCost
+    ? CREDIT_USAGE_MARKUP
+    : CREDIT_USAGE_MARKUP * ESTIMATE_SAFETY_MULTIPLIER;
+  const pricingSource = hasProviderCost
+    ? 'provider_reported'
+    : liveRate
+      ? 'registry_estimate'
+      : 'registry_estimate_norate';
+  if (!hasProviderCost && !liveRate) {
+    logger.warn(
+      'Cat credit debit priced from a registry estimate with no live BTC rate — used the conservative fallback',
+      { userId, model, ref, btcPriceUsd },
+      'CatCredits'
+    );
+  }
+
+  const chargeBtc = ceilBtc(meteredRawCostBtc * effectiveMarkup);
+
+  const entry = {
+    kind: 'usage' as const,
     amountBtc: -chargeBtc,
     ref,
     metadata: {
@@ -118,20 +159,28 @@ export async function meterCreditUsage(
       inputTokens,
       outputTokens,
       rawCostBtc: meteredRawCostBtc,
-      pricingSource:
-        Number.isFinite(rawCostBtc) && (rawCostBtc ?? 0) > 0
-          ? 'provider_reported'
-          : 'registry_estimate',
-      markup: CREDIT_USAGE_MARKUP,
+      pricingSource,
+      markup: effectiveMarkup,
       conversationId: conversationId ?? null,
     },
-  });
+  };
+
+  // The response is already served; retry the debit (idempotent per `ref`)
+  // before giving up, so a transient ledger blip doesn't hand out a free
+  // frontier call.
+  let newBalance: number | null = null;
+  for (let attempt = 1; attempt <= DEBIT_MAX_ATTEMPTS; attempt++) {
+    newBalance = await appendCreditEntry(admin, userId, entry);
+    if (newBalance !== null) {
+      break;
+    }
+  }
 
   if (newBalance === null) {
-    // Served but not billed (race/duplicate/transient). Reconcilable from logs.
-    logger.warn(
-      'Cat frontier usage debit failed — response served, ledger not debited',
-      { userId, model, chargeBtc, ref },
+    // Served but not billed after retries. Loud — this is lost revenue to reconcile.
+    logger.error(
+      'Cat frontier usage debit failed after retries — response served, ledger NOT debited',
+      { userId, model, chargeBtc, ref, attempts: DEBIT_MAX_ATTEMPTS },
       'CatCredits'
     );
     return 0;


### PR DESCRIPTION
Four leaks the pricing deep-dive found that would make the Cat Credits rail **lose money** once it's live. Fixed *before* activation (you provision `PLATFORM_NWC_URI`; this makes what it collects actually break-even).

1. **Markup 20% → 40%** (`CREDIT_USAGE_MARKUP` 1.2 → 1.4). A flat 20% goes negative after Lightning routing fees + BTC/USD drift on a prepaid float held for days. The pricing-card label derives from the constant, so it auto-updates to **"provider cost + 40%"** — no drift. Inference is cents/exchange, so this stays trivial to users.
2. **Registry estimates padded** (`ESTIMATE_SAFETY_MULTIPLIER` 1.25). Provider-reported cost is ground truth (margin only); the hand-maintained price table lags real prices and silently **under-billed**. Estimate charges now over- rather than under-bill.
3. **Missing live BTC rate is visible + auditable.** When an estimate falls back to the hardcoded BTC price (rate fetch failed), it logs a warning and records `pricingSource='registry_estimate_norate'` instead of billing silently on an arbitrary anchor.
4. **Failed-debit leakage closed.** A single transient ledger failure used to hand out a **free** frontier call. The debit (idempotent per `ref`) now retries up to 3× before giving up, and a real miss logs at **error** level as lost revenue to reconcile.

## Verification
- `tsc` ✅ 0 · `eslint` ✅ 0
- **19 credit/model tests pass** — updated estimate-path expectations, added retry-recovery + retry-exhaustion coverage.

Pairs with the memory note: do this before flipping `CAT_CREDITS_LIVE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)