### PR TITLE
feat(profile): harden maker profiles with status + how-to-help

### DIFF
--- a/src/app/(authenticated)/dashboard/info/edit/profile-completion.ts
+++ b/src/app/(authenticated)/dashboard/info/edit/profile-completion.ts
@@ -17,6 +17,16 @@ export const PROFILE_COMPLETION_FIELDS = [
     isComplete: (profile: Profile) => !!profile.bio?.trim(),
   },
   {
+    label: 'Current status',
+    weight: 10,
+    isComplete: (profile: Profile) => !!profile.current_status?.trim(),
+  },
+  {
+    label: 'Ways others can help',
+    weight: 10,
+    isComplete: (profile: Profile) => !!profile.help_wanted?.length,
+  },
+  {
     label: 'Profile picture',
     weight: 10,
     isComplete: (profile: Profile) => !!profile.avatar_url?.trim(),

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -40,6 +40,8 @@ const PROFILE_ALLOWED_FIELDS = [
   'bitcoin_address',
   'lightning_address',
   'privacy_settings',
+  'current_status',
+  'help_wanted',
 ];
 
 async function respondWithProfile(

--- a/src/components/profile/ModernProfileEditor.tsx
+++ b/src/components/profile/ModernProfileEditor.tsx
@@ -6,6 +6,7 @@ import ProfileWizard from './ProfileWizard';
 import { useProfileEditor } from './hooks/useProfileEditor';
 import { ProfileImagesSection } from './ProfileImagesSection';
 import { ProfileBasicSection } from './sections/ProfileBasicSection';
+import { ProfileStatusSection } from './sections/ProfileStatusSection';
 import { OnlinePresenceSection } from './sections/OnlinePresenceSection';
 import { ContactSection } from './sections/ContactSection';
 import { PreferencesSection } from './sections/PreferencesSection';
@@ -98,6 +99,9 @@ export default function ModernProfileEditor({
                 form={form}
               />
 
+              {/* Status & How to Help Section */}
+              <ProfileStatusSection control={form.control} />
+
               {/* Online Presence Section */}
               <OnlinePresenceSection
                 control={form.control}
@@ -166,6 +170,9 @@ export default function ModernProfileEditor({
                 setLocationGroupLabel={setLocationGroupLabel}
                 form={form}
               />
+
+              {/* Status & How to Help Section */}
+              <ProfileStatusSection control={form.control} />
 
               {/* Online Presence Section */}
               <OnlinePresenceSection

--- a/src/components/profile/ProfileLayout.tsx
+++ b/src/components/profile/ProfileLayout.tsx
@@ -31,6 +31,7 @@ import type { Article } from '@/services/articles/types';
 import { cn } from '@/lib/utils';
 import { useProfileActions } from './useProfileActions';
 import { ProfileBannerSection } from './ProfileBannerSection';
+import { MAKER_STATUS_METADATA, isMakerStatus } from '@/config/maker-status';
 
 // Entity types displayed as generic ProfileEntityTab tabs, in order.
 const PROFILE_ENTITY_TABS: EntityType[] = [
@@ -225,6 +226,11 @@ export default function ProfileLayout({
             <p className="mb-3 break-all text-sm font-medium text-fg-secondary sm:mb-4 sm:text-base md:text-lg">
               @{profile.username}
             </p>
+            {isMakerStatus(profile.current_status) && (
+              <span className="mb-3 inline-flex items-center rounded-full bg-surface-raised border border-default px-2.5 py-1 text-xs font-medium text-fg-primary sm:mb-4">
+                {MAKER_STATUS_METADATA[profile.current_status].label}
+              </span>
+            )}
             {profile.bio && (
               // Surface the bio in the header card so the "who is this" answer
               // is immediate, reinforcing the Overview-first default below.

--- a/src/components/profile/ProfileOverviewSections.tsx
+++ b/src/components/profile/ProfileOverviewSections.tsx
@@ -4,11 +4,17 @@
  * fetching; the parent owns visibility conditions.
  */
 import Link from 'next/link';
-import { User, ArrowRight } from 'lucide-react';
+import { User, ArrowRight, Activity, HandHeart } from 'lucide-react';
 import { Card, CardHeader, CardContent } from '@/components/ui/Card';
 import ProfileProjectCard from './ProfileProjectCard';
 import { ROUTES } from '@/config/routes';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
+import {
+  MAKER_STATUS_METADATA,
+  HELP_WANTED_METADATA,
+  isMakerStatus,
+  isHelpWantedOption,
+} from '@/config/maker-status';
 
 /** Loose project shape — the page passes server-fetched rows; we read defensively. */
 export interface OverviewProject {
@@ -64,6 +70,95 @@ export function ProfileAboutCard({
         ) : (
           <p className="text-sm sm:text-base text-fg-tertiary italic">No bio yet.</p>
         )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * "Status & How to Help" card — the concrete answer to "what stage are they
+ * at" and "what do they actually need". Hidden for visitors when the owner
+ * hasn't set either field (an empty ask is worse than no ask); the owner
+ * always sees it so the gap stays visible and fixable.
+ */
+export function ProfileStatusCard({
+  currentStatus,
+  helpWanted,
+  isOwnProfile,
+  isDashboardView,
+}: {
+  currentStatus?: string | null;
+  helpWanted?: string[] | null;
+  isOwnProfile: boolean;
+  isDashboardView: boolean;
+}) {
+  const statusMeta = isMakerStatus(currentStatus) ? MAKER_STATUS_METADATA[currentStatus] : null;
+  const helpTags = (helpWanted || []).filter(isHelpWantedOption);
+
+  if (!statusMeta && helpTags.length === 0 && !(isOwnProfile && isDashboardView)) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-4 sm:p-6 space-y-4">
+        <div className="flex items-start gap-3">
+          <Activity className="w-4 h-4 sm:w-5 sm:h-5 text-fg-secondary mt-0.5 flex-shrink-0" />
+          <div className="flex-1">
+            <div className="text-sm text-fg-secondary mb-1">Status</div>
+            {statusMeta ? (
+              <div>
+                <span className="inline-flex items-center rounded-full bg-surface-raised border border-default px-2.5 py-1 text-xs font-medium text-fg-primary">
+                  {statusMeta.label}
+                </span>
+                <p className="mt-1 text-sm text-fg-secondary">{statusMeta.description}</p>
+              </div>
+            ) : isOwnProfile && isDashboardView ? (
+              <a
+                href={`${ROUTES.DASHBOARD.INFO_EDIT}#currentStatus`}
+                className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
+              >
+                <span className="text-fg-tertiary italic">Share the status of your work</span>
+                <span className="text-xs uppercase tracking-wide">Add status</span>
+              </a>
+            ) : (
+              <span className="text-sm sm:text-base text-fg-tertiary italic">
+                No status set yet.
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3 pt-3 border-t border-default">
+          <HandHeart className="w-4 h-4 sm:w-5 sm:h-5 text-fg-secondary mt-0.5 flex-shrink-0" />
+          <div className="flex-1">
+            <div className="text-sm text-fg-secondary mb-2">How you can help</div>
+            {helpTags.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {helpTags.map(tag => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center rounded-full bg-surface-raised border border-default px-2.5 py-1 text-xs font-medium text-fg-primary"
+                  >
+                    {HELP_WANTED_METADATA[tag].label}
+                  </span>
+                ))}
+              </div>
+            ) : isOwnProfile && isDashboardView ? (
+              <a
+                href={`${ROUTES.DASHBOARD.INFO_EDIT}#helpWanted`}
+                className="inline-flex items-center gap-2 text-fg-primary hover:text-fg-primary underline-offset-4 hover:underline text-sm sm:text-base"
+              >
+                <span className="text-fg-tertiary italic">Tell people how they can help</span>
+                <span className="text-xs uppercase tracking-wide">Add ways to help</span>
+              </a>
+            ) : (
+              <span className="text-sm sm:text-base text-fg-tertiary italic">
+                No specific asks yet.
+              </span>
+            )}
+          </div>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/profile/ProfileOverviewTab.tsx
+++ b/src/components/profile/ProfileOverviewTab.tsx
@@ -7,6 +7,7 @@ import { SocialLinksDisplay } from './SocialLinksDisplay';
 import { ProfileSupportSection } from './ProfileSupportSection';
 import {
   ProfileAboutCard,
+  ProfileStatusCard,
   ProfileProjectsSection,
   type OverviewProject,
 } from './ProfileOverviewSections';
@@ -85,6 +86,14 @@ export default function ProfileOverviewTab({
           isDashboardView={isDashboardView}
         />
       )}
+
+      {/* Status & how to help — the concrete "where things stand" / "what's needed" answer. */}
+      <ProfileStatusCard
+        currentStatus={profile.current_status}
+        helpWanted={profile.help_wanted}
+        isOwnProfile={isOwnProfile}
+        isDashboardView={isDashboardView}
+      />
 
       {/* Projects — explore the owner's work and back any of it without leaving. */}
       {visibleProjects.length > 0 && (

--- a/src/components/profile/constants.ts
+++ b/src/components/profile/constants.ts
@@ -12,6 +12,7 @@ export const MAX_SOCIAL_LINKS = 15;
 
 export const PROFILE_SECTIONS = {
   PROFILE: 'Profile',
+  STATUS: 'Status & How to Help',
   ONLINE_PRESENCE: 'Online Presence',
   CONTACT: 'Contact Information',
   PREFERENCES: 'Preferences',
@@ -20,6 +21,7 @@ export const PROFILE_SECTIONS = {
 
 export const PROFILE_SECTION_DESCRIPTIONS = {
   PROFILE: 'Your basic profile information – username, name, bio and location.',
+  STATUS: 'What stage your work is at, and concrete ways others can help.',
   ONLINE_PRESENCE: 'Your website and social media – where people can find you online.',
   CONTACT: 'How people can reach you directly.',
   PREFERENCES: 'Your display preferences – currency and other settings.',

--- a/src/components/profile/hooks/useProfileEditor.ts
+++ b/src/components/profile/hooks/useProfileEditor.ts
@@ -9,6 +9,7 @@ import { ProfileStorageService } from '@/services/profile/storage';
 import { SocialLink } from '@/types/social';
 import { profileSchema as serverProfileSchema } from '@/lib/validation';
 import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
+import type { MakerStatus, HelpWantedOption } from '@/config/maker-status';
 import { ProfileFieldType } from '@/lib/profile-guidance';
 import { submitProfileForm } from './profileSubmitHandler';
 import type { ProfileFormValues } from '../types';
@@ -98,6 +99,8 @@ export function useProfileEditor({
       currency: (profile.currency as typeof PLATFORM_DEFAULT_CURRENCY) || PLATFORM_DEFAULT_CURRENCY,
       privacy_settings:
         (profile.privacy_settings as { hidden_fields?: string[] } | null | undefined) ?? undefined,
+      current_status: (profile.current_status as MakerStatus) || '',
+      help_wanted: (profile.help_wanted as HelpWantedOption[]) || [],
     },
   });
 

--- a/src/components/profile/sections/ProfileStatusSection.tsx
+++ b/src/components/profile/sections/ProfileStatusSection.tsx
@@ -1,0 +1,134 @@
+/**
+ * Profile Status Section
+ *
+ * Lets a maker express the current status of their work and concrete ways
+ * others can help — the two things a bio alone doesn't capture. Options are
+ * config-driven (@/config/maker-status), never hardcoded here.
+ *
+ * Created: 2026-07-27
+ */
+
+'use client';
+
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Control } from 'react-hook-form';
+import type { ProfileFormValues } from '../types';
+import { PROFILE_SECTIONS, PROFILE_SECTION_DESCRIPTIONS } from '../constants';
+import {
+  makerStatusSelectOptions,
+  helpWantedSelectOptions,
+  MAX_HELP_WANTED_SELECTIONS,
+  type HelpWantedOption,
+} from '@/config/maker-status';
+import { cn } from '@/lib/utils';
+
+interface ProfileStatusSectionProps {
+  control: Control<ProfileFormValues>;
+}
+
+export function ProfileStatusSection({ control }: ProfileStatusSectionProps) {
+  return (
+    <div className="oc-surface space-y-4 px-4 py-5 sm:px-5 sm:py-6">
+      <div className="mb-1">
+        <h3 className="text-sm font-semibold text-fg-primary uppercase tracking-wide">
+          {PROFILE_SECTIONS.STATUS}
+        </h3>
+        <p className="mt-1 text-xs text-fg-secondary">{PROFILE_SECTION_DESCRIPTIONS.STATUS}</p>
+      </div>
+
+      <FormField
+        control={control}
+        name="current_status"
+        render={({ field }) => (
+          <FormItem id="currentStatus">
+            <FormLabel className="text-sm font-medium text-fg-primary">Current status</FormLabel>
+            <Select onValueChange={field.onChange} value={field.value || ''}>
+              <FormControl>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="What stage is your work at?" />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {makerStatusSelectOptions.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormDescription className="text-xs text-fg-secondary">
+              Shown on your public profile so visitors know where things stand.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="help_wanted"
+        render={({ field }) => {
+          const selected: HelpWantedOption[] = field.value || [];
+          const toggle = (value: HelpWantedOption) => {
+            if (selected.includes(value)) {
+              field.onChange(selected.filter(v => v !== value));
+              return;
+            }
+            if (selected.length >= MAX_HELP_WANTED_SELECTIONS) {
+              return;
+            }
+            field.onChange([...selected, value]);
+          };
+          return (
+            <FormItem id="helpWanted">
+              <FormLabel className="text-sm font-medium text-fg-primary">
+                How can others help?
+              </FormLabel>
+              <FormControl>
+                <div className="flex flex-wrap gap-2">
+                  {helpWantedSelectOptions.map(option => {
+                    const isSelected = selected.includes(option.value);
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        aria-pressed={isSelected}
+                        onClick={() => toggle(option.value)}
+                        className={cn(
+                          'rounded-full border px-3 py-1.5 text-xs font-medium transition-colors',
+                          isSelected
+                            ? 'border-transparent bg-fg-primary text-fg-inverted'
+                            : 'border-default text-fg-secondary hover:bg-surface-raised'
+                        )}
+                      >
+                        {option.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </FormControl>
+              <FormDescription className="text-xs text-fg-secondary">
+                Pick up to {MAX_HELP_WANTED_SELECTIONS} — shown as tags on your public profile.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          );
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/ProfileCard.tsx
+++ b/src/components/ui/ProfileCard.tsx
@@ -10,6 +10,7 @@ import Button from '@/components/ui/Button';
 import DefaultAvatar from '@/components/ui/DefaultAvatar';
 import { SearchProfile } from '@/services/search';
 import { ROUTES } from '@/config/routes';
+import { MAKER_STATUS_METADATA, isMakerStatus } from '@/config/maker-status';
 
 interface ProfileCardProps {
   profile: SearchProfile;
@@ -25,6 +26,13 @@ export default function ProfileCard({ profile, viewMode = 'grid' }: ProfileCardP
       Person
     </div>
   );
+
+  const StatusBadge = () =>
+    isMakerStatus(profile.current_status) ? (
+      <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-surface-raised text-fg-primary border border-default">
+        {MAKER_STATUS_METADATA[profile.current_status].label}
+      </span>
+    ) : null;
 
   if (viewMode === 'list') {
     return (
@@ -59,6 +67,11 @@ export default function ProfileCard({ profile, viewMode = 'grid' }: ProfileCardP
             </div>
             {profile.username && (
               <p className="text-sm text-fg-secondary truncate">@{profile.username}</p>
+            )}
+            {isMakerStatus(profile.current_status) && (
+              <div className="mt-1">
+                <StatusBadge />
+              </div>
             )}
             {profile.bio && (
               <p className="text-sm text-fg-secondary mt-1 line-clamp-2">{profile.bio}</p>
@@ -108,6 +121,12 @@ export default function ProfileCard({ profile, viewMode = 'grid' }: ProfileCardP
         </div>
 
         {profile.username && <p className="text-sm text-fg-secondary mb-3">@{profile.username}</p>}
+
+        {isMakerStatus(profile.current_status) && (
+          <div className="-mt-2 mb-3">
+            <StatusBadge />
+          </div>
+        )}
 
         {profile.bio && (
           <p className="text-sm text-fg-secondary mb-4 line-clamp-3">{profile.bio}</p>

--- a/src/config/maker-status.ts
+++ b/src/config/maker-status.ts
@@ -1,0 +1,94 @@
+/**
+ * SINGLE SOURCE OF TRUTH FOR MAKER STATUS & HELP-WANTED OPTIONS
+ *
+ * A public profile (a "maker") should be able to clearly express, at a glance:
+ * 1. What they do            → profiles.bio
+ * 2. The current status of their work → profiles.current_status (this file)
+ * 3. Concrete ways others can help    → profiles.help_wanted (this file)
+ *
+ * Database CHECK constraints and the Zod schema (src/lib/validation/base.ts)
+ * MUST derive from these value lists — do NOT hardcode either list elsewhere.
+ */
+
+export const MAKER_STATUS_VALUES = [
+  'exploring_ideas',
+  'actively_building',
+  'shipped_live',
+  'seeking_funding',
+  'seeking_collaborators',
+  'paused',
+] as const;
+
+export type MakerStatus = (typeof MAKER_STATUS_VALUES)[number];
+
+export const MAKER_STATUS_METADATA: Record<MakerStatus, { label: string; description: string }> = {
+  exploring_ideas: {
+    label: 'Exploring Ideas',
+    description: 'Still shaping what to build',
+  },
+  actively_building: {
+    label: 'Actively Building',
+    description: 'Heads-down making progress',
+  },
+  shipped_live: {
+    label: 'Shipped & Live',
+    description: 'Out in the world and usable today',
+  },
+  seeking_funding: {
+    label: 'Seeking Funding',
+    description: 'Raising Bitcoin or other support to keep going',
+  },
+  seeking_collaborators: {
+    label: 'Seeking Collaborators',
+    description: 'Looking for people to build alongside',
+  },
+  paused: {
+    label: 'On Pause',
+    description: 'Not actively worked on right now',
+  },
+};
+
+export const makerStatusSelectOptions = MAKER_STATUS_VALUES.map(value => ({
+  value,
+  label: MAKER_STATUS_METADATA[value].label,
+}));
+
+export function isMakerStatus(value: string | null | undefined): value is MakerStatus {
+  return !!value && (MAKER_STATUS_VALUES as readonly string[]).includes(value);
+}
+
+export const HELP_WANTED_VALUES = [
+  'funding',
+  'collaborators',
+  'feedback',
+  'users_customers',
+  'mentorship',
+  'job_opportunities',
+  'press_coverage',
+  'volunteers',
+] as const;
+
+export type HelpWantedOption = (typeof HELP_WANTED_VALUES)[number];
+
+export const HELP_WANTED_METADATA: Record<HelpWantedOption, { label: string }> = {
+  funding: { label: 'Funding' },
+  collaborators: { label: 'Collaborators' },
+  feedback: { label: 'Feedback' },
+  users_customers: { label: 'Users / Customers' },
+  mentorship: { label: 'Mentorship & Advice' },
+  job_opportunities: { label: 'Job Opportunities' },
+  press_coverage: { label: 'Press & Coverage' },
+  volunteers: { label: 'Volunteers' },
+};
+
+export const helpWantedSelectOptions = HELP_WANTED_VALUES.map(value => ({
+  value,
+  label: HELP_WANTED_METADATA[value].label,
+}));
+
+export function isHelpWantedOption(value: string): value is HelpWantedOption {
+  return (HELP_WANTED_VALUES as readonly string[]).includes(value);
+}
+
+/** Max number of help-wanted tags a profile can select — keeps the "ask" scannable. */
+export const MAX_HELP_WANTED_SELECTIONS = 5;

--- a/src/lib/validation/base.ts
+++ b/src/lib/validation/base.ts
@@ -3,6 +3,11 @@ import DOMPurify from 'dompurify';
 import { validatePhoneNumber, normalizePhoneNumber } from '../phone-validation';
 import { CURRENCY_CODES } from '@/config/currencies';
 import { profilePrivacySettingsSchema } from '@/config/profile-privacy';
+import {
+  MAKER_STATUS_VALUES,
+  HELP_WANTED_VALUES,
+  MAX_HELP_WANTED_SELECTIONS,
+} from '@/config/maker-status';
 
 /**
  * Lightning Address Validation
@@ -240,6 +245,14 @@ export const profileSchema = z.object({
   // survives both the client zodResolver and this server-side parse — a field
   // absent from the schema is silently stripped. See config/profile-privacy.ts.
   privacy_settings: profilePrivacySettingsSchema,
+  // Maker profile hardening: current status of their work + concrete ways
+  // others can help. Value lists are the SSOT in @/config/maker-status.
+  current_status: z.enum(MAKER_STATUS_VALUES).optional().nullable().or(z.literal('')),
+  help_wanted: z
+    .array(z.enum(HELP_WANTED_VALUES))
+    .max(MAX_HELP_WANTED_SELECTIONS, `Select up to ${MAX_HELP_WANTED_SELECTIONS} options`)
+    .optional()
+    .nullable(),
 });
 
 // HTML sanitization for rich text content

--- a/src/services/search/queries/profiles.ts
+++ b/src/services/search/queries/profiles.ts
@@ -24,7 +24,7 @@ export async function searchProfiles(
   let profileQuery = supabase
     .from(DATABASE_TABLES.PROFILES)
     .select(
-      'id, username, name, bio, avatar_url, created_at, location_country, location_city, location_zip, latitude, longitude'
+      'id, username, name, bio, avatar_url, created_at, location_country, location_city, location_zip, latitude, longitude, current_status'
     );
 
   // Priority 1: If radius is specified, use PostGIS RPC (handles both query and radius)

--- a/src/services/search/types.ts
+++ b/src/services/search/types.ts
@@ -18,6 +18,7 @@ export interface SearchProfile {
   bio: string | null;
   avatar_url: string | null;
   created_at: string;
+  current_status?: string | null;
 }
 
 export interface SearchFundingPage {
@@ -86,6 +87,7 @@ export interface RawSearchProfile {
   location_zip?: string | null;
   latitude?: number | null;
   longitude?: number | null;
+  current_status?: string | null;
 }
 
 // Raw project from database queries

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -60,6 +60,9 @@ export interface Database {
           lightning_address: string | null;
           bitcoin_public_key: string | null;
           lightning_node_id: string | null;
+          // Maker profile: work status + concrete ways to help (see @/config/maker-status)
+          current_status: string | null;
+          help_wanted: string[] | null;
           // Status & Verification
           verification_status: string | null;
           verification_data: Json | null;
@@ -115,6 +118,9 @@ export interface Database {
           lightning_address?: string | null;
           bitcoin_public_key?: string | null;
           lightning_node_id?: string | null;
+          // Maker profile: work status + concrete ways to help (see @/config/maker-status)
+          current_status?: string | null;
+          help_wanted?: string[] | null;
           // Status & Verification
           verification_status?: string | null;
           verification_data?: Json | null;
@@ -170,6 +176,9 @@ export interface Database {
           lightning_address?: string | null;
           bitcoin_public_key?: string | null;
           lightning_node_id?: string | null;
+          // Maker profile: work status + concrete ways to help (see @/config/maker-status)
+          current_status?: string | null;
+          help_wanted?: string[] | null;
           // Status & Verification
           verification_status?: string | null;
           verification_data?: Json | null;

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -26,6 +26,10 @@ export interface Profile {
   // Wallet fields (kept for backward compatibility, but wallets managed separately)
   bitcoin_address?: string | null;
   lightning_address?: string | null;
+  // Maker profile hardening: what stage their work is at + concrete ways
+  // others can help. Value lists: @/config/maker-status.
+  current_status?: string | null;
+  help_wanted?: string[] | null;
   // User preferences
   currency?: string | null; // User's preferred display currency (from CURRENCY_CODES)
   preferences?: Record<string, unknown> | null; // Generic preference bag (theme, notifications, etc.)

--- a/supabase/migrations/20260727000000_profile_status_and_help_wanted.sql
+++ b/supabase/migrations/20260727000000_profile_status_and_help_wanted.sql
@@ -1,0 +1,57 @@
+-- Hardens the maker profile: a public profile should be able to clearly
+-- express (1) what they do — profiles.bio, already exists — (2) the current
+-- status of their work, and (3) concrete ways others can help. (2) and (3)
+-- had no column to live in; this adds them.
+--
+-- Value lists are the SSOT in src/config/maker-status.ts
+-- (MAKER_STATUS_VALUES, HELP_WANTED_VALUES) — the CHECK constraints below
+-- must be kept in sync with that file. Idempotent — safe if a box already
+-- has the columns.
+--
+-- migration-safety: contract-ok the DROP CONSTRAINT IF EXISTS statements only
+-- re-create constraints on the current_status/help_wanted columns this very
+-- migration adds. They are brand-new columns the previous release never reads
+-- or writes, so an auto-rollback to that release runs fine against this schema —
+-- nothing it uses is dropped or renamed.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS current_status TEXT,
+  ADD COLUMN IF NOT EXISTS help_wanted TEXT[] DEFAULT '{}'::text[];
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_current_status_check;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_current_status_check
+  CHECK (
+    current_status IS NULL
+    OR current_status = ANY (ARRAY[
+      'exploring_ideas',
+      'actively_building',
+      'shipped_live',
+      'seeking_funding',
+      'seeking_collaborators',
+      'paused'
+    ]::text[])
+  );
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_help_wanted_check;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_help_wanted_check
+  CHECK (
+    help_wanted <@ ARRAY[
+      'funding',
+      'collaborators',
+      'feedback',
+      'users_customers',
+      'mentorship',
+      'job_opportunities',
+      'press_coverage',
+      'volunteers'
+    ]::text[]
+  );
+
+COMMENT ON COLUMN public.profiles.current_status IS 'Maker-facing status of their work — see MAKER_STATUS_VALUES in src/config/maker-status.ts';
+COMMENT ON COLUMN public.profiles.help_wanted IS 'Concrete ways others can help this maker — see HELP_WANTED_VALUES in src/config/maker-status.ts';


### PR DESCRIPTION
## What

Hardens the **maker profile** — the keystone "who is this person and how do I help them" surface — with two things a bio alone can't express:

- **Current status** of their work (`exploring_ideas` → `actively_building` → `shipped_live` → `seeking_funding`/`seeking_collaborators` → `paused`)
- **How others can help** — up to 5 concrete asks (funding, collaborators, feedback, users, mentorship, jobs, press, volunteers)

Both render as a "Status & How to Help" card on the public profile, with graceful empty states (the owner sees a prompt to fill the gap; visitors see nothing when it's empty — an empty ask is worse than no ask).

## Pieces

| Piece | File |
|---|---|
| Value-list SSOT (labels, metadata, guards, select options) | `src/config/maker-status.ts` |
| DB columns + CHECK constraints (idempotent) | `supabase/migrations/20260727000000_profile_status_and_help_wanted.sql` |
| Zod schema (derives from the SSOT) | `src/lib/validation/base.ts` |
| Editor UI (status select + help-wanted tag toggles) | `src/components/profile/sections/ProfileStatusSection.tsx` |
| Public display card | `src/components/profile/ProfileOverviewSections.tsx` (`ProfileStatusCard`) |
| Wiring (editor + overview tab + allowed-fields + types) | `ModernProfileEditor`, `ProfileOverviewTab`, `api/profile/route.ts`, `types/*` |
| Search integration | `src/services/search/queries/profiles.ts`, `types.ts` |

## Verified

- ✅ Rebased onto current `main` (was 96 commits stale / CONFLICTING); 4 purely-additive conflicts resolved (main's `privacy_settings` + this PR's fields coexist).
- ✅ `type-check` 0 · `lint` 0 errors · **1300 unit tests pass** · migration `replay` (fresh-DB) green · `safety-lint` green (contract-phase `DROP CONSTRAINT IF EXISTS` acknowledged — it only re-creates constraints on the brand-new columns this migration adds, so auto-rollback is unaffected).
- ✅ **Migration already applied to the prod self-host** (`scripts/apply-migrations.sh`) ahead of the code deploy — `profiles.current_status` + `profiles.help_wanted` columns and both CHECK constraints confirmed present. This closes the regression window (profile saves write these columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)