### PR TITLE
fix(search): guard command palette against shadow-DOM keystroke hijack

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -114,6 +114,18 @@ const eslintConfig = [
           message:
             "Arbitrary text-[10px] — use the text-2xs token (10px, defined in tailwind.config.ts). It exists for exactly this; don't bypass it.",
         },
+        {
+          // Close the keystroke-hijack class (2026-07 dogfood): a global keyboard
+          // shortcut's "is the user typing?" guard must inspect the COMPOSED path
+          // leaf, not e.target. When a keystroke crosses a shadow-DOM boundary
+          // (e.g. the embedded FleetCrown feedback widget), e.target is retargeted
+          // to the shadow host, so the guard misreads a text field as "not typing"
+          // and the shortcut fires and eats the keystroke. Pass e.composedPath()[0].
+          selector:
+            "CallExpression[callee.name='isTypingTarget'] > MemberExpression.arguments[property.name='target']",
+          message:
+            'Pass the composed-path leaf to isTypingTarget (e.composedPath()[0] ?? e.target), not a bare e.target — a bare .target is shadow-DOM-blind and reintroduces the keystroke-hijack bug.',
+        },
       ],
       // Lock @deprecated count at 0.
       'no-warning-comments': ['error', { terms: ['@deprecated'], location: 'anywhere' }],

--- a/src/components/search/SearchTrigger.tsx
+++ b/src/components/search/SearchTrigger.tsx
@@ -39,8 +39,12 @@ export function SearchTrigger({ compact = false, className }: SearchTriggerProps
         setOpen(prev => !prev);
         return;
       }
-      // "/" hotkey when focus isn't already in an input.
-      if (e.key === '/' && !isTypingTarget(e.target)) {
+      // "/" hotkey when focus isn't already in an input. Read the composed-path
+      // leaf, not e.target: when the keystroke originates inside a shadow root
+      // (e.g. the embedded FleetCrown feedback widget's textarea) the event
+      // retargets to the shadow host, so e.target misreads a text field as
+      // "not typing" and the palette steals the keystroke mid-sentence.
+      if (e.key === '/' && !isTypingTarget(e.composedPath()[0] ?? e.target)) {
         e.preventDefault();
         setOpen(true);
       }


### PR DESCRIPTION
## The bug

The global `/` hotkey opened the command palette **even while the user was typing** into the embedded FleetCrown feedback widget — stealing the keystroke mid-sentence. (Surfaced in a live cross-product dogfood.)

**Mechanism:** the widget's input lives in a shadow root. When the keystroke crosses the shadow boundary it retargets to the shadow **host** element, so `isTypingTarget(e.target)` reads the host `<div>` (not the `<textarea>`), misreads it as "not typing", and fires the palette.

## The fix

`SearchTrigger.tsx` now reads the composed-path leaf — `isTypingTarget(e.composedPath()[0] ?? e.target)` — the true innermost target even across shadow boundaries.

### Close the class (Never-Twice)
A `no-restricted-syntax` rule bans passing a bare `.target` to `isTypingTarget`, so this exact regression fails lint. Verified: the rule flags `isTypingTarget(e.target)` and passes the `composedPath` form.

## Context

The **primary** cross-product fix lives in the widget itself (FleetCrown `widget/main.ts`, PR maonakamoto/fleetcrown#109) — it traps all keystrokes at the shadow boundary while its panel is open, fixing every embedding host at once. This OrangeCat PR is defense-in-depth for OrangeCat's own palette against any shadow-DOM input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)