### PR TITLE
feat(tips): record tips + notify the recipient (via payment_intents)

### DIFF
--- a/__tests__/unit/domain/payments/handlePaymentConfirmed.test.ts
+++ b/__tests__/unit/domain/payments/handlePaymentConfirmed.test.ts
@@ -11,6 +11,7 @@ import { checkPaymentStatus } from '@/domain/payments/paymentFlowService';
 import { STATUS } from '@/config/database-constants';
 import { logger } from '@/utils/logger';
 import { checkOnchainPaymentStatus } from '@/domain/payments/paymentStatusService';
+import { NotificationDispatcher } from '@/services/notifications/dispatcher';
 
 jest.mock('@/utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
@@ -28,9 +29,11 @@ jest.mock('@/domain/payments/paymentStatusService', () => ({
 
 const errorMock = logger.error as jest.Mock;
 const onchainMock = checkOnchainPaymentStatus as jest.Mock;
+const dispatchMock = NotificationDispatcher.dispatch as jest.Mock;
 
 const PI_ID = 'pi-1';
 const BUYER = 'buyer-1';
+const SELLER = 'seller-1';
 
 const onchainIntent = {
   id: PI_ID,
@@ -65,6 +68,37 @@ function makeSupabase(orderUpdateError: unknown) {
   return { from: jest.fn(() => builder), rpc } as never;
 }
 
+/** A tip intent: entity-less, kind='tip'. Confirming it must NOT touch orders or
+ *  getEntityMetadata (which would throw on a null entity_type). */
+const tipIntent = {
+  id: PI_ID,
+  buyer_id: null,
+  seller_id: SELLER,
+  status: STATUS.PAYMENT_INTENTS.INVOICE_READY,
+  payment_method: 'onchain',
+  intent_kind: 'tip',
+  onchain_address: 'bc1qtip',
+  entity_type: null,
+  entity_id: null,
+  amount_btc: 0.0005,
+  description: 'Tip for Bob',
+  paid_at: null,
+  expires_at: null,
+};
+
+/** Builder returning `intent`; the tip path only awaits ONE update (mark paid). */
+function makeSupabaseReturning(intent: unknown) {
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'update', 'eq', 'in']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
+  builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve({ error: null }).then(resolve, reject);
+  const rpc = jest.fn(() => Promise.resolve({ error: null }));
+  return { from: jest.fn(() => builder), rpc } as never;
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   onchainMock.mockResolvedValue('confirmed');
@@ -87,5 +121,25 @@ describe('handlePaymentConfirmed via checkPaymentStatus (onchain confirmed)', ()
       expect.stringContaining('reconciliation'),
       expect.objectContaining({ paymentIntentId: PI_ID })
     );
+  });
+});
+
+describe('handlePaymentConfirmed — tip branch', () => {
+  it('settles an entity-less tip and notifies the recipient (no entity side-effects)', async () => {
+    const supabase = makeSupabaseReturning(tipIntent);
+    // The recipient (seller) polling their own tip; a null entity_type must not throw.
+    const res = await checkPaymentStatus(supabase, PI_ID, SELLER);
+
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: SELLER,
+        type: 'payment',
+        title: expect.stringContaining('tip'),
+        data: expect.objectContaining({ kind: 'tip', amount_btc: 0.0005 }),
+      })
+    );
+    // No reconciliation error path — a tip has no order to get stuck.
+    expect(errorMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/unit/tips/tip-service.test.ts
+++ b/__tests__/unit/tips/tip-service.test.ts
@@ -1,22 +1,29 @@
 /**
- * tip-service — recipient resolution + non-custodial invoice generation. Mocks
- * the reused payment primitives so we test the tip orchestration in isolation:
- * unknown person, person without a wallet, and the happy path invoice shape.
+ * tip-service — recipient resolution + tip orchestration. Mocks the reused
+ * payment primitives so we test the tip layer in isolation: unknown person,
+ * person without a wallet, the happy-path intent shape, and status mapping.
  */
 
-import { generateTipInvoice, getTipReceiveInfo } from '@/domain/tips/tip-service';
+import { initiateTip, getTipReceiveInfo, getTipStatus } from '@/domain/tips/tip-service';
 import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
-import { generateInvoice } from '@/domain/payments/invoiceGenerationService';
+import {
+  initiateTip as initiateTipPayment,
+  checkPublicPaymentStatus,
+} from '@/domain/payments/paymentFlowService';
 
 jest.mock('@/domain/payments/walletResolutionService', () => ({
   resolveUserWallet: jest.fn(),
 }));
-jest.mock('@/domain/payments/invoiceGenerationService', () => ({
-  generateInvoice: jest.fn(),
+jest.mock('@/domain/payments/paymentFlowService', () => ({
+  initiateTip: jest.fn(),
+  checkPublicPaymentStatus: jest.fn(),
 }));
 
 const mockResolveWallet = resolveUserWallet as jest.MockedFunction<typeof resolveUserWallet>;
-const mockGenerateInvoice = generateInvoice as jest.MockedFunction<typeof generateInvoice>;
+const mockInitiateTipPayment = initiateTipPayment as jest.MockedFunction<typeof initiateTipPayment>;
+const mockCheckStatus = checkPublicPaymentStatus as jest.MockedFunction<
+  typeof checkPublicPaymentStatus
+>;
 
 /** Minimal supabase stub whose profiles lookup resolves to `profile`. */
 function supabaseWith(profile: Record<string, unknown> | null) {
@@ -51,48 +58,64 @@ describe('getTipReceiveInfo', () => {
   });
 
   it('reports the rail label when a wallet exists', async () => {
-    mockResolveWallet.mockResolvedValue({ method: 'onchain', wallet_id: 'w1', onchain_address: 'bc1x' });
+    mockResolveWallet.mockResolvedValue({
+      method: 'onchain',
+      wallet_id: 'w1',
+      onchain_address: 'bc1x',
+    });
     const info = await getTipReceiveInfo(
       supabaseWith({ id: 'u1', username: 'bob', display_name: 'Bob' }),
       'bob'
     );
-    expect(info).toEqual({ canReceive: true, recipientName: 'Bob', methodLabel: 'On-chain Bitcoin' });
+    expect(info).toEqual({
+      canReceive: true,
+      recipientName: 'Bob',
+      methodLabel: 'On-chain Bitcoin',
+    });
   });
 });
 
-describe('generateTipInvoice', () => {
+describe('initiateTip', () => {
   it('errors when the person cannot be found', async () => {
-    const r = await generateTipInvoice(supabaseWith(null), 'ghost', 0.0001);
+    const r = await initiateTip(supabaseWith(null), 'ghost', 0.0001);
     expect(r).toEqual({ ok: false, error: 'That person could not be found.' });
+    expect(mockInitiateTipPayment).not.toHaveBeenCalled();
   });
 
   it('errors (no throw) when the recipient has no wallet', async () => {
     mockResolveWallet.mockResolvedValue(null);
-    const r = await generateTipInvoice(
+    const r = await initiateTip(
       supabaseWith({ id: 'u1', username: 'alice', display_name: 'Alice' }),
       'alice',
       0.0001
     );
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/hasn't set up a wallet/);
+    expect(mockInitiateTipPayment).not.toHaveBeenCalled();
   });
 
-  it('returns a non-custodial invoice for the recipient wallet', async () => {
+  it('mints a tip intent against the recipient wallet and returns the pollable shape', async () => {
     mockResolveWallet.mockResolvedValue({
       method: 'lightning_address',
       wallet_id: 'w1',
       lightning_address: 'bob@ln.tld',
     });
-    mockGenerateInvoice.mockResolvedValue({
-      bolt11: 'lnbc1...',
-      payment_hash: 'hash',
-      onchain_address: null,
-      lnurl_verify_url: null,
+    mockInitiateTipPayment.mockResolvedValue({
+      payment_intent: {
+        id: 'pi_1',
+        amount_btc: 0.0005,
+        payment_method: 'lightning_address',
+        status: 'invoice_ready',
+        expires_at: null,
+        can_acknowledge: false,
+      },
+      status_token: 'tok_abc',
       qr_data: 'LNBC1...',
-      expires_at: null,
+      method_label: 'Lightning Address',
+      expires_in_seconds: 3600,
     });
 
-    const r = await generateTipInvoice(
+    const r = await initiateTip(
       supabaseWith({ id: 'u1', username: 'bob', display_name: 'Bob' }),
       'bob',
       0.0005
@@ -101,18 +124,44 @@ describe('generateTipInvoice', () => {
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.invoice).toMatchObject({
+        intentId: 'pi_1',
+        statusToken: 'tok_abc',
         qrData: 'LNBC1...',
-        bolt11: 'lnbc1...',
-        methodLabel: 'Lightning',
         recipientName: 'Bob',
         amountBtc: 0.0005,
       });
     }
-    // The invoice is built against the recipient's own wallet — never a platform wallet.
-    expect(mockGenerateInvoice).toHaveBeenCalledWith(
-      expect.objectContaining({ lightning_address: 'bob@ln.tld' }),
-      0.0005,
-      expect.stringContaining('Tip for Bob')
+    // The intent is minted against the recipient's own wallet — never a platform wallet.
+    expect(mockInitiateTipPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientUserId: 'u1',
+        recipientName: 'Bob',
+        amountBtc: 0.0005,
+        wallet: expect.objectContaining({ lightning_address: 'bob@ln.tld' }),
+      })
     );
+  });
+});
+
+describe('getTipStatus', () => {
+  it('maps a settled intent to paid', async () => {
+    mockCheckStatus.mockResolvedValue({
+      status: 'paid',
+      paid_at: '2026-07-28T00:00:00Z',
+      requires_recipient_confirmation: false,
+    });
+    expect(await getTipStatus('pi_1', 'tok')).toEqual({
+      status: 'paid',
+      paidAt: '2026-07-28T00:00:00Z',
+    });
+  });
+
+  it('collapses non-terminal statuses to pending', async () => {
+    mockCheckStatus.mockResolvedValue({
+      status: 'invoice_ready',
+      paid_at: null,
+      requires_recipient_confirmation: false,
+    });
+    expect(await getTipStatus('pi_1', 'tok')).toEqual({ status: 'pending', paidAt: null });
   });
 });

--- a/src/app/api/tips/invoice/route.ts
+++ b/src/app/api/tips/invoice/route.ts
@@ -1,9 +1,9 @@
 /**
- * POST /api/tips/invoice { username, amountBtc } — generate a non-custodial
- * Bitcoin payment request to the recipient's own wallet. Anonymous tippers are
- * allowed (easy UX); IP rate-limited to protect recipients' NWC relays from
- * invoice-generation abuse. Nothing is written to the DB and OrangeCat never
- * touches the funds.
+ * POST /api/tips/invoice { username, amountBtc } — mint a non-custodial Bitcoin
+ * tip request against the recipient's own wallet. Anonymous tippers are allowed
+ * (easy UX); IP rate-limited to protect recipients' NWC relays from invoice-
+ * generation abuse. Persists an entity-less payment_intent so the tip can be
+ * tracked + the recipient notified on settlement; OrangeCat never touches funds.
  */
 
 import type { NextRequest } from 'next/server';
@@ -12,7 +12,7 @@ import { createServerClient } from '@/lib/supabase/server';
 import { rateLimit, createRateLimitResponse } from '@/lib/rate-limit';
 import { apiBadRequest, apiError, apiInternalError, apiSuccess } from '@/lib/api/standardResponse';
 import { TIP_MAX_BTC, TIP_MIN_BTC } from '@/config/tips';
-import { generateTipInvoice } from '@/domain/tips/tip-service';
+import { initiateTip } from '@/domain/tips/tip-service';
 import { logger } from '@/utils/logger';
 
 const bodySchema = z.object({
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = await createServerClient();
-    const result = await generateTipInvoice(supabase, parsed.data.username, parsed.data.amountBtc);
+    const result = await initiateTip(supabase, parsed.data.username, parsed.data.amountBtc);
     if (!result.ok) {
       return apiError(result.error, 'TIP_UNAVAILABLE', 400);
     }

--- a/src/app/api/tips/status/route.ts
+++ b/src/app/api/tips/status/route.ts
@@ -1,0 +1,45 @@
+/**
+ * POST /api/tips/status { intentId, token } — poll whether a tip has settled.
+ * Account-free: access is granted by the opaque bearer token minted with the
+ * tip (its SHA-256 hash is stored on the intent), not by a session. Detection
+ * reuses the generic public status check (NWC lookup / LUD-21 verify / on-chain).
+ * On settlement the recipient is notified server-side by the shared settle path.
+ */
+
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { rateLimit, createRateLimitResponse } from '@/lib/rate-limit';
+import { apiBadRequest, apiError, apiInternalError, apiSuccess } from '@/lib/api/standardResponse';
+import { getTipStatus } from '@/domain/tips/tip-service';
+import { logger } from '@/utils/logger';
+
+const bodySchema = z.object({
+  intentId: z.string().uuid(),
+  token: z.string().min(1).max(200),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const rl = await rateLimit(request);
+    if (!rl.success) {
+      return createRateLimitResponse(rl);
+    }
+
+    const parsed = bodySchema.safeParse(await request.json().catch(() => ({})));
+    if (!parsed.success) {
+      return apiBadRequest('Invalid request', parsed.error.flatten());
+    }
+
+    try {
+      const status = await getTipStatus(parsed.data.intentId, parsed.data.token);
+      return apiSuccess(status);
+    } catch {
+      // checkPublicPaymentStatus throws only when the (id, token) pair matches no
+      // intent — treat as not-found without leaking which half was wrong.
+      return apiError('Tip not found', 'TIP_NOT_FOUND', 404);
+    }
+  } catch (error) {
+    logger.error('tips/status failed', error, 'TipsAPI');
+    return apiInternalError('Could not check tip status.');
+  }
+}

--- a/src/components/tips/TipDialog.tsx
+++ b/src/components/tips/TipDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { Loader2, Zap } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, Zap, CheckCircle2, Clock } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -12,8 +12,19 @@ import {
 import { Button } from '@/components/ui/Button';
 import { PaymentQRCode } from '@/components/payment/PaymentQRCode';
 import { ContributionAmountInput } from '@/components/payment/ContributionAmountInput';
-import { fetchTipInvoice, fetchTipReceiveInfo, type TipInvoice } from '@/services/tips/tip-client';
-import { DEFAULT_TIP_BTC, TIP_COPY, TIP_MAX_BTC, TIP_MIN_BTC } from '@/config/tips';
+import {
+  fetchTipInvoice,
+  fetchTipReceiveInfo,
+  fetchTipStatus,
+  type TipInvoice,
+} from '@/services/tips/tip-client';
+import {
+  DEFAULT_TIP_BTC,
+  TIP_COPY,
+  TIP_MAX_BTC,
+  TIP_MIN_BTC,
+  TIP_POLL_INTERVAL_MS,
+} from '@/config/tips';
 
 interface TipDialogProps {
   open: boolean;
@@ -22,11 +33,14 @@ interface TipDialogProps {
   recipientName: string;
 }
 
+type SettleState = 'pending' | 'paid' | 'expired';
+
 export default function TipDialog({ open, onOpenChange, username, recipientName }: TipDialogProps) {
   const [amount, setAmount] = useState(DEFAULT_TIP_BTC);
   const [checkingWallet, setCheckingWallet] = useState(true);
   const [canReceive, setCanReceive] = useState<boolean | null>(null);
   const [invoice, setInvoice] = useState<TipInvoice | null>(null);
+  const [settleState, setSettleState] = useState<SettleState>('pending');
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -37,6 +51,7 @@ export default function TipDialog({ open, onOpenChange, username, recipientName 
     }
     let active = true;
     setInvoice(null);
+    setSettleState('pending');
     setError(null);
     setAmount(DEFAULT_TIP_BTC);
     setCheckingWallet(true);
@@ -62,16 +77,56 @@ export default function TipDialog({ open, onOpenChange, username, recipientName 
     };
   }, [open, username]);
 
+  // While an unpaid invoice is showing, poll for settlement. Any Lightning wallet
+  // pays near-instantly, so the tipper sees "received!" without leaving the modal.
+  const invoiceRef = useRef(invoice);
+  invoiceRef.current = invoice;
+  useEffect(() => {
+    if (!invoice || settleState !== 'pending') {
+      return;
+    }
+    let active = true;
+    const id = setInterval(async () => {
+      const current = invoiceRef.current;
+      if (!current) {
+        return;
+      }
+      try {
+        const { status } = await fetchTipStatus(current.intentId, current.statusToken);
+        if (!active) {
+          return;
+        }
+        if (status === 'paid') {
+          setSettleState('paid');
+        } else if (status === 'expired' || status === 'failed') {
+          setSettleState('expired');
+        }
+      } catch {
+        // Transient — keep polling; the interval clears on close/settle.
+      }
+    }, TIP_POLL_INTERVAL_MS);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [invoice, settleState]);
+
   async function handleGenerate() {
     setGenerating(true);
     setError(null);
     try {
       setInvoice(await fetchTipInvoice(username, amount));
+      setSettleState('pending');
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not create a tip request.');
     } finally {
       setGenerating(false);
     }
+  }
+
+  function resetToAmount() {
+    setInvoice(null);
+    setSettleState('pending');
   }
 
   return (
@@ -93,6 +148,24 @@ export default function TipDialog({ open, onOpenChange, username, recipientName 
           <p className="rounded-md border border-subtle bg-surface-raised/40 px-4 py-6 text-center text-sm text-fg-secondary">
             {TIP_COPY.noWallet(recipientName)}
           </p>
+        ) : invoice && settleState === 'paid' ? (
+          <div className="flex flex-col items-center gap-3 py-6 text-center">
+            <CheckCircle2 className="h-12 w-12 text-status-positive" />
+            <p className="text-lg font-semibold text-fg-primary">{TIP_COPY.paidTitle}</p>
+            <p className="text-sm text-fg-secondary">{TIP_COPY.paidBody(recipientName)}</p>
+            <Button variant="accent" className="mt-2" onClick={() => onOpenChange(false)}>
+              {TIP_COPY.done}
+            </Button>
+          </div>
+        ) : invoice && settleState === 'expired' ? (
+          <div className="flex flex-col items-center gap-3 py-6 text-center">
+            <Clock className="h-12 w-12 text-fg-tertiary" />
+            <p className="text-lg font-semibold text-fg-primary">{TIP_COPY.expiredTitle}</p>
+            <p className="text-sm text-fg-secondary">{TIP_COPY.expiredBody}</p>
+            <Button variant="outline" className="mt-2" onClick={resetToAmount}>
+              {TIP_COPY.again}
+            </Button>
+          </div>
         ) : invoice ? (
           <div className="space-y-4">
             <PaymentQRCode
@@ -101,10 +174,13 @@ export default function TipDialog({ open, onOpenChange, username, recipientName 
               amountBtc={invoice.amountBtc}
               expiresInSeconds={invoice.expiresInSeconds ?? undefined}
             />
-            <p className="text-center text-sm text-fg-secondary">{TIP_COPY.scan}</p>
+            <p className="flex items-center justify-center gap-2 text-center text-sm text-fg-secondary">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              {TIP_COPY.scan}
+            </p>
             <p className="text-center text-xs text-fg-tertiary">{TIP_COPY.disclaimer}</p>
             <div className="flex justify-center gap-3">
-              <Button variant="outline" onClick={() => setInvoice(null)}>
+              <Button variant="outline" onClick={resetToAmount}>
                 {TIP_COPY.again}
               </Button>
               <Button variant="accent" onClick={() => onOpenChange(false)}>

--- a/src/config/tips.ts
+++ b/src/config/tips.ts
@@ -6,9 +6,10 @@
  * OWN wallet (NWC / Lightning address / on-chain) and never touches the funds.
  * Zero platform fee — the tipper pays exactly the amount they choose.
  *
- * v1 shows the payment request (QR + copy) so any Bitcoin wallet can pay it; it
- * does not record the tip server-side (that needs a schema change). Keep the copy
- * honest: we help you pay the writer directly, we don't hold or take a cut.
+ * A tip is minted as an entity-less payment_intent (intent_kind='tip'), so it
+ * rides the shared settle path: the tipper sees live confirmation and the
+ * recipient gets the standard "you got paid" notification. Keep the copy honest:
+ * we help you pay the writer directly, we don't hold or take a cut.
  */
 
 import { CONTRIBUTION_QUICK_AMOUNTS_BTC, DEFAULT_CONTRIBUTION_BTC } from './payment-presets';
@@ -36,4 +37,12 @@ export const TIP_COPY = {
   disclaimer: 'Paid directly to them. OrangeCat takes 0% and never touches your funds.',
   again: 'Change amount',
   done: 'Done',
+  /** Live confirmation once the tip settles on-rail. */
+  paidTitle: 'Tip received!',
+  paidBody: (name: string) => `Paid straight to ${name}'s wallet. Zero fee, zero middleman.`,
+  expiredTitle: 'This tip request expired',
+  expiredBody: 'No Bitcoin was sent. You can start a new tip anytime.',
 } as const;
+
+/** How often the dialog polls for tip settlement, in milliseconds. */
+export const TIP_POLL_INTERVAL_MS = 3000;

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -33,6 +33,7 @@ import type {
   PaymentIntent,
   InitiatePublicSupportInput,
   InitiatePublicSupportResult,
+  InitiateTipInput,
   PublicPaymentStatusResult,
 } from './types';
 import { logger } from '@/utils/logger';
@@ -295,6 +296,83 @@ export async function initiatePublicSupport(
       expires_at: paymentIntent.expires_at,
       can_acknowledge:
         paymentIntent.payment_method === 'lightning_address' && !paymentIntent.lnurl_verify_url,
+    },
+    status_token: token,
+    qr_data: invoice.qr_data,
+    method_label: METHOD_LABELS[wallet.method] || wallet.method,
+    expires_in_seconds: expiresInSeconds,
+  } as InitiatePublicSupportResult;
+}
+
+/**
+ * Initiate a tip — an unconditional, account-free Bitcoin gift to a PERSON.
+ *
+ * Unlike public support, a tip has no entity: it creates an entity-less
+ * payment_intent (intent_kind='tip') against the recipient's OWN wallet, so it
+ * settles non-custodially and rides the exact same status-poll + settle path.
+ * When it settles, {@link handlePaymentConfirmed} notifies the recipient. The
+ * caller (tips domain) resolves the recipient + wallet; this only mints the
+ * intent. Returns the same public shape as support: a bearer status token the
+ * anonymous tipper polls with.
+ */
+export async function initiateTip(
+  input: InitiateTipInput
+): Promise<InitiatePublicSupportResult> {
+  const { recipientUserId, recipientName, wallet, amountBtc } = input;
+  const description = `Tip for ${recipientName}`;
+  const invoice = await generateInvoice(wallet, amountBtc, description);
+  const token = randomBytes(32).toString('base64url');
+  const expiresAt =
+    invoice.expires_at ?? new Date(Date.now() + PUBLIC_SUPPORT_EXPIRY_MS).toISOString();
+  const admin = getAdminClient() as unknown as SupabaseClient;
+
+  const { data: paymentIntent, error: paymentError } = await admin
+    .from(DATABASE_TABLES.PAYMENT_INTENTS)
+    .insert({
+      buyer_id: null,
+      seller_id: recipientUserId,
+      entity_type: null,
+      entity_id: null,
+      amount_btc: amountBtc,
+      payment_method: wallet.method,
+      intent_kind: 'tip',
+      receiving_wallet_id: wallet.wallet_id,
+      bolt11: invoice.bolt11,
+      payment_hash: invoice.payment_hash,
+      onchain_address: invoice.onchain_address,
+      lnurl_verify_url: invoice.lnurl_verify_url,
+      status:
+        invoice.bolt11 || invoice.onchain_address
+          ? STATUS.PAYMENT_INTENTS.INVOICE_READY
+          : STATUS.PAYMENT_INTENTS.CREATED,
+      description,
+      expires_at: expiresAt,
+      public_status_token_hash: hashPublicStatusToken(token),
+    })
+    .select()
+    .single();
+
+  if (paymentError || !paymentIntent) {
+    logger.error('Failed to create tip payment intent', { error: paymentError });
+    throw new Error('Failed to create tip payment intent');
+  }
+
+  const expiresInSeconds = Math.max(
+    0,
+    Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000)
+  );
+
+  return {
+    payment_intent: {
+      id: paymentIntent.id,
+      amount_btc: Number(paymentIntent.amount_btc),
+      payment_method: paymentIntent.payment_method,
+      status: paymentIntent.status,
+      expires_at: paymentIntent.expires_at,
+      // Tips v1 confirm only on auto-detected rails (NWC / LUD-21 verify /
+      // on-chain). A bare Lightning address with no verify URL simply shows the
+      // QR without live confirmation — no manual "I paid" override.
+      can_acknowledge: false,
     },
     status_token: token,
     qr_data: invoice.qr_data,
@@ -636,6 +714,25 @@ async function handlePaymentConfirmed(
 
   // Mark payment intent as paid
   await updatePaymentStatus(supabase, piId, 'paid');
+
+  // A tip is a person-to-person gift with no entity — none of the entity-scoped
+  // side-effects below apply (and getEntityMetadata would throw on a null type).
+  // Notify the recipient and fan the settlement out to their webhooks, then stop.
+  if (paymentIntent.intent_kind === 'tip') {
+    const tipAmount = paymentIntent.amount_btc;
+    void NotificationDispatcher.dispatch({
+      userId: paymentIntent.seller_id,
+      type: 'payment',
+      title: `You received a tip: ${tipAmount} BTC`,
+      message: `Someone sent you a ${tipAmount} BTC tip — paid straight to your wallet.`,
+      data: { paymentIntentId: piId, amount_btc: tipAmount, kind: 'tip' },
+      actionUrl: '/dashboard',
+    });
+    void enqueuePaymentSettledWebhook(paymentIntent).catch(err =>
+      logger.warn('payment.settled webhook enqueue failed (tip)', { err }, 'paymentFlowService')
+    );
+    return;
+  }
 
   const meta = getEntityMetadata(entityType);
 

--- a/src/domain/payments/types.ts
+++ b/src/domain/payments/types.ts
@@ -12,7 +12,7 @@ import { STATUS } from '@/config/database-constants';
 // =====================================================================
 
 export type PaymentMethod = 'nwc' | 'lightning_address' | 'onchain';
-export type PaymentIntentKind = 'purchase' | 'support';
+export type PaymentIntentKind = 'purchase' | 'support' | 'tip';
 
 // =====================================================================
 // PAYMENT INTENT
@@ -143,6 +143,16 @@ export interface InitiatePublicSupportResult {
 
 export interface PublicPaymentStatusResult extends PaymentStatusResult {
   requires_recipient_confirmation: boolean;
+}
+
+export interface InitiateTipInput {
+  /** Auth user id of the person being tipped (the payment intent's seller_id). */
+  recipientUserId: string;
+  /** Display name, for the invoice/description. */
+  recipientName: string;
+  /** The recipient's own resolved wallet — funds go straight here. */
+  wallet: ResolvedWallet;
+  amountBtc: number;
 }
 
 /** Resolved wallet info for a seller */

--- a/src/domain/tips/tip-service.ts
+++ b/src/domain/tips/tip-service.ts
@@ -1,15 +1,20 @@
 /**
- * Tip service — resolve a person by username and generate a non-custodial
- * Bitcoin payment request against THEIR own wallet. Reuses the payment stack's
- * wallet resolution + invoice generation (SSOT) so a tip pays exactly like any
- * other payment on the platform: NWC > Lightning address > on-chain, zero fee,
- * OrangeCat never in the money path.
+ * Tip service — resolve a person by username and mint a non-custodial Bitcoin
+ * tip against THEIR own wallet. A tip is a first-class payment_intent
+ * (intent_kind='tip'): it reuses the payment stack's wallet resolution, invoice
+ * generation, status polling AND settle path (SSOT), so it pays exactly like any
+ * other payment — NWC > Lightning address > on-chain, zero fee, OrangeCat never
+ * in the money path — and the recipient gets the standard "you got paid"
+ * notification for free when it settles.
  */
 
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
-import { generateInvoice } from '@/domain/payments/invoiceGenerationService';
+import {
+  initiateTip as initiateTipPayment,
+  checkPublicPaymentStatus,
+} from '@/domain/payments/paymentFlowService';
 import type { ResolvedWallet } from '@/domain/payments/types';
 import { logger } from '@/utils/logger';
 
@@ -66,9 +71,11 @@ export async function getTipReceiveInfo(
 }
 
 export interface TipInvoice {
+  /** payment_intents row id — the tipper polls status with this + statusToken. */
+  intentId: string;
+  /** Opaque bearer token to poll settlement without an account. */
+  statusToken: string;
   qrData: string;
-  bolt11: string | null;
-  onchainAddress: string | null;
   methodLabel: string;
   recipientName: string;
   amountBtc: number;
@@ -77,8 +84,12 @@ export interface TipInvoice {
 
 type TipInvoiceResult = { ok: true; invoice: TipInvoice } | { ok: false; error: string };
 
-/** Build a payment request for `amountBtc` to the recipient's own wallet. */
-export async function generateTipInvoice(
+/**
+ * Mint a tip payment request for `amountBtc` to the recipient's own wallet.
+ * Persists an entity-less payment_intent so the payment can be tracked, the
+ * tipper shown live confirmation, and the recipient notified on settlement.
+ */
+export async function initiateTip(
   supabase: AnySupabaseClient,
   username: string,
   amountBtc: number
@@ -97,29 +108,51 @@ export async function generateTipInvoice(
   }
 
   try {
-    const inv = await generateInvoice(
+    const res = await initiateTipPayment({
+      recipientUserId: recipient.userId,
+      recipientName: recipient.displayName,
       wallet,
       amountBtc,
-      `Tip for ${recipient.displayName} on OrangeCat`
-    );
-    const expiresInSeconds = inv.expires_at
-      ? Math.max(0, Math.floor((new Date(inv.expires_at).getTime() - Date.now()) / 1000))
-      : null;
-
+    });
     return {
       ok: true,
       invoice: {
-        qrData: inv.qr_data,
-        bolt11: inv.bolt11,
-        onchainAddress: inv.onchain_address,
-        methodLabel: METHOD_LABELS[wallet.method],
+        intentId: res.payment_intent.id,
+        statusToken: res.status_token,
+        qrData: res.qr_data,
+        methodLabel: res.method_label,
         recipientName: recipient.displayName,
         amountBtc,
-        expiresInSeconds,
+        expiresInSeconds: res.expires_in_seconds,
       },
     };
   } catch (err) {
-    logger.error('Failed to generate tip invoice', { err: String(err), username }, 'Tips');
+    logger.error('Failed to initiate tip', { err: String(err), username }, 'Tips');
     return { ok: false, error: 'Could not create a tip request right now. Please try again.' };
   }
+}
+
+export type TipStatus = 'pending' | 'paid' | 'expired' | 'failed';
+
+export interface TipStatusResult {
+  status: TipStatus;
+  paidAt: string | null;
+}
+
+/**
+ * Poll a tip's settlement using its bearer token. Wraps the generic public
+ * payment-status check (NWC lookup / LUD-21 verify / on-chain), collapsing the
+ * intent's status vocabulary to what the tip UI needs.
+ */
+export async function getTipStatus(intentId: string, token: string): Promise<TipStatusResult> {
+  const res = await checkPublicPaymentStatus(intentId, token);
+  const status: TipStatus =
+    res.status === 'paid'
+      ? 'paid'
+      : res.status === 'expired'
+        ? 'expired'
+        : res.status === 'failed'
+          ? 'failed'
+          : 'pending';
+  return { status, paidAt: res.paid_at ?? null };
 }

--- a/src/services/tips/tip-client.ts
+++ b/src/services/tips/tip-client.ts
@@ -3,9 +3,9 @@
  * shapes (erased at compile — no server code pulled into the bundle).
  */
 
-import type { TipInvoice, TipReceiveInfo } from '@/domain/tips/tip-service';
+import type { TipInvoice, TipReceiveInfo, TipStatusResult } from '@/domain/tips/tip-service';
 
-export type { TipInvoice, TipReceiveInfo } from '@/domain/tips/tip-service';
+export type { TipInvoice, TipReceiveInfo, TipStatusResult } from '@/domain/tips/tip-service';
 
 async function readJson(
   res: Response
@@ -38,4 +38,18 @@ export async function fetchTipInvoice(username: string, amountBtc: number): Prom
     throw new Error(errorMessage(json, 'Could not create a tip request.'));
   }
   return (json.data as { invoice: TipInvoice }).invoice;
+}
+
+/** Poll whether a tip has settled, using the intent id + bearer token. */
+export async function fetchTipStatus(intentId: string, token: string): Promise<TipStatusResult> {
+  const res = await fetch('/api/tips/status', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ intentId, token }),
+  });
+  const json = await readJson(res);
+  if (!res.ok || !json.success) {
+    throw new Error(errorMessage(json, 'Could not check tip status.'));
+  }
+  return json.data as TipStatusResult;
 }

--- a/supabase/migrations/20260728000000_tips_as_payment_intents.sql
+++ b/supabase/migrations/20260728000000_tips_as_payment_intents.sql
@@ -1,0 +1,28 @@
+-- Tips as first-class payment intents.
+--
+-- A tip is an unconditional, person-to-person Bitcoin gift. Unlike a purchase or
+-- support contribution, it targets a PERSON, not an entity — so it carries no
+-- entity_type/entity_id. Routing tips through payment_intents (rather than a
+-- parallel table) keeps ONE ledger for "Bitcoin received" and reuses the entire
+-- hardened settle -> notify -> webhook path: the recipient gets the existing
+-- in-app "you got paid" notification for free.
+--
+-- migration-safety: contract-ok — every statement here EXPANDS: it relaxes two
+-- NOT NULL constraints (entity_type/entity_id) and widens a CHECK (adds the
+-- 'tip' intent_kind). The previous release only ever inserts non-null entity ids
+-- and the kinds 'purchase'/'support', so it keeps working unchanged and rollback
+-- stays safe (no tip rows exist under the old code).
+
+ALTER TABLE payment_intents
+  ALTER COLUMN entity_type DROP NOT NULL,
+  ALTER COLUMN entity_id DROP NOT NULL;
+
+ALTER TABLE payment_intents
+  DROP CONSTRAINT IF EXISTS payment_intents_intent_kind_check;
+
+ALTER TABLE payment_intents
+  ADD CONSTRAINT payment_intents_intent_kind_check
+  CHECK (intent_kind IN ('purchase', 'support', 'tip'));
+
+COMMENT ON COLUMN payment_intents.intent_kind IS
+  'purchase creates/settles an order; support = voluntary contribution to an entity; tip = unconditional person-to-person Bitcoin gift (entity_type/entity_id are NULL).';


### PR DESCRIPTION
## What

Turns a tip from a fire-and-forget QR into a **recorded, non-custodial payment that notifies the writer**. A tip is now a first-class `payment_intent` (`intent_kind='tip'`), so:

- 🔔 **The recipient gets "You received a tip: X BTC"** in-app the moment it settles — for free, via the existing `handlePaymentConfirmed` path.
- ✅ **The tipper sees live "Tip received!"** — the dialog polls the intent's bearer status token (NWC lookup / LUD-21 verify / on-chain).
- ₿ **Still non-custodial + zero-fee** — funds go straight to the recipient's own wallet; OrangeCat is never in the money path.

## Why this design (not a separate `tips` table)

One ledger for "Bitcoin received," and it **reuses the most safety-critical code instead of re-deriving it** — payment confirmation (NWC/LUD-21/on-chain), idempotent terminal-status short-circuit, notification + webhook fan-out all already exist and are battle-tested. A parallel table would fork the money path and duplicate confirmation logic. This is also likely OrangeCat's **first-ever recorded payment**, so it should land in the real payments ledger and notification system.

## How

- `paymentFlowService.initiateTip` mints an **entity-less** intent (`entity_type/entity_id = null`, no contribution row — a tip isn't an entity gift).
- `handlePaymentConfirmed` **early-returns on `'tip'`** before any entity-scoped side-effects (which would throw on a null `entity_type`): it notifies the recipient + fans out the `payment.settled` webhook.
- Tips domain: `initiateTip` / `getTipStatus`; new `POST /api/tips/status` (account-free, polls by intent id + token).
- `TipDialog`: live settlement polling + success / expired states.

## Schema — expand-only migration (`20260728000000_tips_as_payment_intents.sql`)

\`\`\`sql
ALTER TABLE payment_intents ALTER COLUMN entity_type DROP NOT NULL,
                            ALTER COLUMN entity_id  DROP NOT NULL;
ALTER TABLE payment_intents DROP CONSTRAINT payment_intents_intent_kind_check;
ALTER TABLE payment_intents ADD  CONSTRAINT payment_intents_intent_kind_check
     CHECK (intent_kind IN ('purchase','support','tip'));
\`\`\`

Same shape as the `20260723` public-support migration (which already relaxed `buyer_id` NOT NULL + widened this exact CHECK). Old code never inserts `'tip'`, so it's **inert until this ships**.

## ⚠️ Rollout ordering (expand-migration-first)

The migration **must be applied to the box BEFORE this deploys** — otherwise `initiateTip` inserts `intent_kind='tip'` + null entity columns and hits the old constraint, breaking tip creation. Do **not** merge until the migration is live on the box.

## Verification

- tip-service tests (8) + a `handlePaymentConfirmed` tip-branch case (entity-less settle notifies recipient, touches no order) — **11/11 green** across the payments+tips suites.
- type-check + lint clean on all touched files.
- Not exercised in-browser end-to-end (needs a real Lightning payment); the settle path itself is covered by the existing payments suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)