### PR TITLE
fix(articles): return a real 404 for missing articles (SEO soft-404)

### DIFF
--- a/src/app/(public)/articles/[slug]/page.tsx
+++ b/src/app/(public)/articles/[slug]/page.tsx
@@ -33,7 +33,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { slug } = await params;
   const article = await getArticleBySlug(slug);
   if (!article) {
-    return { title: 'Article not found' };
+    // generateMetadata resolves before the page's streaming boundary, so a
+    // notFound() here can still send a real 404 status — unlike the same call
+    // inside the (streamed) page body, which the root loading.tsx forces to a
+    // 200 + auto-noindex "soft 404". Falls back to that safe behavior if
+    // metadata itself streams.
+    notFound();
   }
 
   const isIndexable = article.visibility === 'public';


### PR DESCRIPTION
## What

A nonexistent article URL (e.g. `/articles/does-not-exist`) rendered the not-found UI but returned **HTTP 200** — a "soft 404". This makes it return a real **404** where the framework allows.

## Root cause (diagnosed against Next.js docs)

`notFound()` only sets a hard 404 **if triggered before streaming starts**. The root `app/loading.tsx` opens a Suspense boundary that streams immediately, so by the time the page `await`s the DB and calls `notFound()`, Next.js *"cannot alter the HTTP status code and instead injects a `noindex` tag"* (per the streaming docs).

**Important:** that auto-injected `noindex` already protects SEO — Google won't index a soft-404 that carries `noindex`. The remaining issue is HTTP correctness + Search Console "soft 404" warnings, so this is a polish fix, not an indexing bug.

## Fix

Move the not-found decision into `generateMetadata`, which resolves **ahead of** the page's streaming boundary — so `notFound()` there can still emit a real 404 status. If metadata itself streams (Next 16 streaming metadata), it harmlessly falls back to today's 200 + auto-`noindex`. **Strictly better, zero risk** — the missing-article path previously just returned a title.

## Verification

- type-check + lint clean.
- Will confirm the live status code (200 → 404) after deploy; if the framework streams metadata and keeps 200, the `noindex` still fully protects indexing (documented fallback).

## Note

The same one-line pattern applies to other public detail routes (profiles, products, etc.) that also `notFound()` after their DB fetch. Scoped this PR to the article surface (the text-expression SEO target); happy to sweep the rest as a follow-up once the mechanism is confirmed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)