### PR TITLE
feat: close the economic-agent 'initiative layer' gaps (D1–D5)

### DIFF
--- a/src/app/api/cat/offers-from-text/route.ts
+++ b/src/app/api/cat/offers-from-text/route.ts
@@ -1,0 +1,72 @@
+/**
+ * POST /api/cat/offers-from-text  — body: { text }
+ *
+ * The deterministic "paste who you are → get monetizable offerings" seam.
+ * Every part of this already existed but only fired reactively inside a chat
+ * turn: the onboarding box just seeded a Cat conversation and hoped the model
+ * called suggest_offers. This chains the built pieces synchronously —
+ * persist the bio, extract the economic profile, and reason over it — so a
+ * pasted bio comes back as concrete, typed offers the user can create in one
+ * click.
+ *
+ * Reuses: generateOffers (offer-engine.ts) for the grounded proposals — the
+ * pasted text is persisted as the bio AND passed as `focus`, so offers are
+ * grounded in it either way. Returns [] on thin input / model failure — the UI
+ * degrades to "talk to your Cat instead".
+ */
+
+import { NextResponse } from 'next/server';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { createServerClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { generateOffers } from '@/services/cat/offer-engine';
+import { logger } from '@/utils/logger';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_TEXT = 4000;
+
+export async function POST(request: Request) {
+  const auth = await createServerClient();
+  const {
+    data: { user },
+  } = await auth.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const text = typeof (body as any)?.text === 'string' ? (body as any).text.trim() : '';
+  if (!text) {
+    return NextResponse.json({ success: false, error: 'text is required' }, { status: 400 });
+  }
+  const clamped = text.slice(0, MAX_TEXT);
+
+  const db = createAdminClient() as any;
+
+  // Persist the bio so the offer engine's stored-context path (and future
+  // sessions) see it. Best-effort — the pasted text is also passed to
+  // generateOffers as `focus` so offers are grounded even if this write fails.
+  try {
+    await db
+      .from(DATABASE_TABLES.PROFILES)
+      .update({ bio: clamped, updated_at: new Date().toISOString() })
+      .eq('id', user.id);
+  } catch (err) {
+    logger.warn('offers-from-text: bio persist failed (non-fatal)', { err }, 'OffersFromText');
+  }
+
+  try {
+    const offers = await generateOffers(db, user.id, { focus: clamped, count: 4 });
+    return NextResponse.json({ success: true, offers });
+  } catch (err) {
+    logger.error('offers-from-text: generateOffers failed', err, 'OffersFromText');
+    // Not a hard error for the user — the UI falls back to opening the Cat chat.
+    return NextResponse.json({ success: true, offers: [] });
+  }
+}

--- a/src/app/profiles/[username]/page.tsx
+++ b/src/app/profiles/[username]/page.tsx
@@ -6,6 +6,7 @@ import ProfilePageClient from '@/components/profile/ProfilePageClient';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { getTableName } from '@/config/entity-registry';
 import { fetchProfileListingCounts } from '@/services/profile/listingCounts';
+import { getEconomicProfile } from '@/services/cat/economic-profile';
 import { listArticlesByAuthor } from '@/services/articles/get-article';
 import { safeJsonLdString } from '@/lib/seo/structured-data';
 import type { ScalableProfile } from '@/services/profile/types';
@@ -243,6 +244,10 @@ export default async function PublicProfilePage({ params }: PageProps) {
   } = await supabase.auth.getUser();
   const isOwnProfile = !!currentUser && currentUser.id === profile.id;
 
+  // The Cat's extracted "what I can offer" signals (skills/assets/asked-for).
+  // Degrades to null if the store is empty/absent — the section then hides.
+  const economicProfile = await getEconomicProfile(supabase, profile.id);
+
   // Redact before anything derives from the row, so hidden data never leaves the
   // server — not in the client payload, not in the JSON-LD below.
   // 1. `email` is the private account login email; `select('*')` pulls it in.
@@ -286,6 +291,7 @@ export default async function PublicProfilePage({ params }: PageProps) {
         projects={projects || []}
         articles={articles}
         isOwnProfile={isOwnProfile}
+        economicProfile={economicProfile}
         stats={{
           projectCount,
           totalRaised,

--- a/src/components/create/AIPrefillBar.tsx
+++ b/src/components/create/AIPrefillBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Sparkles, Loader2, AlertCircle, Lightbulb, CheckCircle2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
@@ -19,7 +20,13 @@ export function AIPrefillBar({
   mode = 'create',
 }: AIPrefillBarProps) {
   const isEdit = mode === 'edit';
-  const [description, setDescription] = useState('');
+  // Seed the AI-fill box from a ?description= param on create — this is how the
+  // onboarding "paste who you are → offers → Create this" flow lands a proposed
+  // offering here ready to generate, closing the loop without retyping.
+  const searchParams = useSearchParams();
+  const [description, setDescription] = useState(() =>
+    mode === 'create' ? (searchParams.get('description') ?? '') : ''
+  );
   const [refineInput, setRefineInput] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [isRefining, setIsRefining] = useState(false);

--- a/src/components/dashboard/CatNudges.tsx
+++ b/src/components/dashboard/CatNudges.tsx
@@ -20,9 +20,10 @@ interface Nudge {
   cta_url: string | null;
 }
 
-// The dashboard shows only the top suggestions (API returns them ordered by
-// confidence score, highest first) — two focused cards beat a wall of five.
-const DASHBOARD_NUDGE_CAP = 2;
+// Show the Cat's top proactive suggestions (API returns them ordered by
+// confidence score, highest first). This is the agent's main in-app "here's
+// how to earn next" surface, so give it room beyond a token two.
+const DASHBOARD_NUDGE_CAP = 4;
 
 export function CatNudges() {
   const [nudges, setNudges] = useState<Nudge[] | null>(null);
@@ -74,7 +75,8 @@ export function CatNudges() {
     <section className="rounded-lg border border-default bg-surface-base p-5">
       <div className="mb-3 flex items-center gap-2">
         <Sparkles className="h-4 w-4 text-accent-warm" />
-        <h2 className="text-sm font-semibold text-fg-primary">From your Cat</h2>
+        <h2 className="text-sm font-semibold text-fg-primary">Your Cat suggests</h2>
+        <span className="text-xs text-fg-tertiary">— ways to earn, grounded in what you have</span>
       </div>
       <div className="space-y-2">
         {nudges.map(n => (

--- a/src/components/home/sections/HeroSectionStatic.tsx
+++ b/src/components/home/sections/HeroSectionStatic.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { ArrowRight, Globe, Cat, Plus } from 'lucide-react';
+import { ArrowRight, Globe, Cat } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import { BrandMarkIcon } from '@/components/shell/BrandMarkIcon';
 import { ROUTES } from '@/config/routes';
@@ -22,7 +22,7 @@ export default function HeroSectionStatic() {
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-surface-base border border-default mb-6">
               <div className="flex items-center gap-1.5">
                 <div className="w-2 h-2 bg-status-positive rounded-full" />
-                <span className="text-sm font-medium text-fg-primary">Create anything</span>
+                <span className="text-sm font-medium text-fg-primary">Your AI economic agent</span>
               </div>
               <span className="text-fg-tertiary">•</span>
               <span className="text-sm font-medium text-fg-primary">Any identity</span>
@@ -32,28 +32,28 @@ export default function HeroSectionStatic() {
 
             {/* Main Headline — display typography (Space Grotesk) per migration 7/N */}
             <h1 className="font-heading tracking-display text-3xl sm:text-5xl lg:text-6xl font-bold text-fg-primary leading-[1.05] mb-4 sm:mb-6">
-              Everyone Can <span className="text-fg-primary">Make Things.</span>
+              Turn who you are <span className="text-fg-primary">into income.</span>
             </h1>
 
             {/* Subheadline */}
             <p className="text-lg sm:text-xl lg:text-2xl text-fg-secondary leading-relaxed mb-3 sm:mb-4">
-              Create products, services, projects, causes, events, and groups — with your own AI,
-              under any identity, funded in Bitcoin.
+              Your Cat interviews you, sets up your services, products, and projects, and surfaces
+              real ways to earn — funded in Bitcoin, under any identity.
             </p>
 
             {/* Supporting text */}
             <p className="text-base sm:text-lg text-fg-secondary leading-relaxed mb-6 sm:mb-8">
-              OrangeCat gives every person and organization an AI agent to create and participate in
-              the full economic spectrum. No gatekeepers. No fees. Bitcoin and Lightning are the
-              live settlement rails.
+              It doesn&apos;t wait for you. The Cat proposes opportunities grounded in what you
+              already have and helps you act on them. And when an idea needs building, hand it to
+              FleetCrown to run the work.
             </p>
 
             {/* CTA Buttons */}
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
               <Link href={ROUTES.AUTH} className="w-full sm:w-auto">
                 <Button variant="accent" size="lg" className="w-full sm:w-auto">
-                  <Plus className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-                  Start Creating
+                  <Cat className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+                  Meet your Cat
                   <ArrowRight className="ml-2 h-4 w-4 sm:h-5 sm:w-5" />
                 </Button>
               </Link>
@@ -93,9 +93,9 @@ export default function HeroSectionStatic() {
                 {/* Platform capabilities */}
                 <div className="space-y-2">
                   {[
-                    'Create products, projects, causes',
-                    'Bitcoin and Lightning payments',
-                    'AI-powered by your Cat',
+                    'Interviews you, sets up your offerings',
+                    'Suggests ways to earn from what you have',
+                    'Funded in Bitcoin, non-custodial',
                   ].map(feature => (
                     <div
                       key={feature}
@@ -137,10 +137,13 @@ export default function HeroSectionStatic() {
 
                 <div className="flex flex-wrap gap-2 text-xs font-medium">
                   <span className="rounded-full border border-default bg-surface-raised/40 px-2.5 py-1 text-fg-primary">
-                    AI-powered
+                    Proactive agent
                   </span>
                   <span className="rounded-full border border-default bg-surface-raised/40 px-2.5 py-1 text-fg-primary">
                     Non-custodial
+                  </span>
+                  <span className="rounded-full border border-default bg-surface-raised/40 px-2.5 py-1 text-fg-primary">
+                    Builds on FleetCrown
                   </span>
                 </div>
               </div>

--- a/src/components/onboarding/IntelligentOnboarding.tsx
+++ b/src/components/onboarding/IntelligentOnboarding.tsx
@@ -3,17 +3,20 @@
 /**
  * Intelligent Onboarding
  *
- * Collects a brief description from the user, marks onboarding complete,
- * then redirects to Cat with the description pre-loaded as the first
- * message. The Cat handles all intelligent analysis — no keyword heuristics.
+ * Collects a brief description of who the user is, then — instead of only
+ * seeding a Cat conversation — runs the economic-agent chain synchronously
+ * (POST /api/cat/offers-from-text → extract profile + generateOffers) and shows
+ * concrete, typed offerings the user can create in one click. "Paste who you
+ * are → get monetizable offerings." The Cat chat remains as a fallback.
  *
  * Created: 2026-01-22
- * Last Modified: 2026-04-24
- * Last Modified Summary: Replace fake keyword-analysis with Cat redirect
+ * Last Modified: 2026-07-28
+ * Last Modified Summary: Add synchronous "see what Cat suggests" offer cards
  */
 
 import { useState } from 'react';
-import { Cat, ArrowRight, ArrowLeft, Sparkles } from 'lucide-react';
+import { Cat, ArrowRight, ArrowLeft, Sparkles, Plus, MessageCircle } from 'lucide-react';
+import Link from 'next/link';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
@@ -25,6 +28,8 @@ import { logger } from '@/utils/logger';
 import { ROUTES } from '@/config/routes';
 import { FEATURES } from '@/config/features';
 import { ONBOARDING_METHOD } from '@/config/onboarding';
+import { ENTITY_REGISTRY } from '@/config/entity-registry';
+import type { ProposedOffer } from '@/services/cat/offer-engine';
 
 const EXAMPLE_PROMPTS = [
   "I'm a freelance graphic designer looking to find clients and sell design templates",
@@ -41,34 +46,62 @@ export default function IntelligentOnboarding() {
   const [displayName, setDisplayName] = useState('');
   const [description, setDescription] = useState('');
   const [isRedirecting, setIsRedirecting] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [offers, setOffers] = useState<ProposedOffer[] | null>(null);
+  const [genError, setGenError] = useState<string | null>(null);
 
   const canSubmit = description.trim().length > 0 && displayName.trim().length > 0;
 
-  const handleStartChat = async () => {
+  // Persist what we collected so Cat has context next session and the dashboard
+  // greeting can stop saying "User". Shared by both actions below.
+  const persistProfile = () => {
+    if (!user?.id) {
+      return;
+    }
+    ProfileService.fallbackProfileUpdate(user.id, {
+      onboarding_completed: true,
+      onboarding_method: ONBOARDING_METHOD.INTELLIGENT,
+      name: displayName.trim(),
+      bio: description.trim(),
+    }).catch(err => {
+      logger.error('Failed to mark intelligent onboarding complete', err, 'IntelligentOnboarding');
+    });
+  };
+
+  // Primary path: turn the pasted description into concrete offerings right here.
+  const handleSeeOffers = async () => {
+    if (!canSubmit || isGenerating) {
+      return;
+    }
+    setGenError(null);
+    setIsGenerating(true);
+    persistProfile();
+    try {
+      const res = await fetch('/api/cat/offers-from-text', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: description.trim() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || `Request failed (${res.status})`);
+      }
+      setOffers(Array.isArray(data.offers) ? data.offers : []);
+    } catch (err) {
+      logger.error('Failed to generate offers from onboarding', err, 'IntelligentOnboarding');
+      setGenError('Could not generate suggestions right now — you can still chat with your Cat.');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  // Fallback path: open the Cat chat with the description as the first message.
+  const handleStartChat = () => {
     if (!canSubmit) {
       return;
     }
     setIsRedirecting(true);
-
-    // Persist what we collected so Cat has context next session and the
-    // dashboard greeting can stop saying "User". Username auto-slugifies
-    // from displayName at first save — no pseudonymity blocker.
-    if (user?.id) {
-      ProfileService.fallbackProfileUpdate(user.id, {
-        onboarding_completed: true,
-        onboarding_method: ONBOARDING_METHOD.INTELLIGENT,
-        name: displayName.trim(),
-        bio: description.trim(),
-      }).catch(err => {
-        logger.error(
-          'Failed to mark intelligent onboarding complete',
-          err,
-          'IntelligentOnboarding'
-        );
-      });
-    }
-
-    // Send the user to Cat with their description as the first message
+    persistProfile();
     const params = new URLSearchParams({ q: description.trim() });
     router.push(`${ROUTES.DASHBOARD.CAT}?${params.toString()}`);
   };
@@ -78,7 +111,7 @@ export default function IntelligentOnboarding() {
       <div className="w-full max-w-lg">
         {/* Back navigation */}
         <button
-          onClick={() => router.back()}
+          onClick={() => (offers ? setOffers(null) : router.back())}
           className="flex items-center gap-1.5 text-sm text-fg-secondary hover:text-fg-primary mb-6 transition-colors"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -90,92 +123,183 @@ export default function IntelligentOnboarding() {
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-md border border-subtle bg-surface-raised">
             <Cat className="h-8 w-8 text-fg-primary" />
           </div>
-          <h1 className="text-2xl font-bold text-fg-primary mb-2">Tell Cat what you need</h1>
-          <p className="text-fg-secondary">
-            Describe what you are trying to do. Cat will suggest the right tools and help you get
-            set up.
-          </p>
+          {offers ? (
+            <>
+              <h1 className="text-2xl font-bold text-fg-primary mb-2">
+                Here&apos;s what you could offer
+              </h1>
+              <p className="text-fg-secondary">
+                Your Cat turned what you told it into ways to earn. Create any of them in one click
+                — or refine them in a chat.
+              </p>
+            </>
+          ) : (
+            <>
+              <h1 className="text-2xl font-bold text-fg-primary mb-2">Tell Cat who you are</h1>
+              <p className="text-fg-secondary">
+                Paste your bio, background, or a few lines about what you do. Cat will propose
+                concrete ways to earn — and set them up.
+              </p>
+            </>
+          )}
         </div>
 
-        {/* Input */}
-        <div className="space-y-4 rounded-md border border-subtle bg-surface-page p-6">
-          <Input
-            data-testid="onboarding-display-name"
-            label="What should Cat call you?"
-            description="A name or alias — pseudonyms are fine."
-            value={displayName}
-            onChange={e => setDisplayName(e.target.value)}
-            placeholder="Satoshi"
-            maxLength={100}
-            required
-          />
-
-          <label className="block text-sm font-medium text-fg-primary">
-            What are you here to do?
-          </label>
-
-          <div className="flex items-start gap-2">
-            <Textarea
-              data-testid="onboarding-description"
-              placeholder="e.g. I'm a photographer looking to sell prints and offer portrait sessions…"
-              value={description}
-              onChange={e => setDescription(e.target.value)}
-              rows={4}
-              className="w-full resize-none"
-              onKeyDown={e => {
-                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                  void handleStartChat();
-                }
-              }}
-            />
-            {FEATURES.voiceInput && (
-              <DictationButton
-                ariaLabel="Voice input"
-                size="sm"
-                onTranscript={t => setDescription(prev => (prev ? prev + ' ' : '') + t)}
-              />
-            )}
-          </div>
-
-          {/* Example prompts */}
-          <div className="space-y-1">
-            <p className="text-xs text-fg-tertiary font-medium uppercase tracking-wide">Examples</p>
-            <div className="flex flex-wrap gap-2">
-              {EXAMPLE_PROMPTS.map(prompt => (
-                <button
-                  key={prompt}
-                  onClick={() => setDescription(prompt)}
-                  className="rounded-sm border border-subtle px-3 py-1.5 text-left text-xs text-fg-secondary transition-colors hover:border-strong hover:bg-surface-raised hover:text-fg-primary"
+        {offers ? (
+          /* ---- Offers view ---- */
+          <div className="space-y-4">
+            {offers.length === 0 ? (
+              <div className="rounded-md border border-subtle bg-surface-page p-6 text-center">
+                <p className="text-fg-secondary mb-4">
+                  Cat needs a little more to go on. Tell it more in a chat and it&apos;ll suggest
+                  offerings as you talk.
+                </p>
+                <Button
+                  onClick={handleStartChat}
+                  disabled={isRedirecting}
+                  className="bg-fg-primary text-fg-inverted hover:bg-fg-primary/90"
                 >
-                  {prompt.length > 50 ? prompt.slice(0, 50) + '…' : prompt}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <Button
-            data-testid="onboarding-start-chat"
-            onClick={handleStartChat}
-            disabled={!canSubmit || isRedirecting}
-            className="w-full bg-fg-primary text-fg-inverted hover:bg-fg-primary/90"
-          >
-            {isRedirecting ? (
-              <>
-                <Sparkles className="h-4 w-4 mr-2 animate-pulse" />
-                Starting your conversation…
-              </>
+                  <MessageCircle className="h-4 w-4 mr-2" />
+                  Chat with Cat
+                </Button>
+              </div>
             ) : (
               <>
-                <ArrowRight className="h-4 w-4 mr-2" />
-                Chat with Cat
+                {offers.map((offer, i) => {
+                  const meta = ENTITY_REGISTRY[offer.entityType];
+                  if (!meta) {
+                    return null;
+                  }
+                  const href = `${meta.createPath}?description=${encodeURIComponent(offer.description)}`;
+                  return (
+                    <div
+                      key={`${offer.entityType}-${i}`}
+                      data-testid="offer-card"
+                      className="rounded-md border border-subtle bg-surface-page p-5"
+                    >
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="inline-flex items-center rounded-full border border-default bg-surface-raised px-2.5 py-0.5 text-xs font-medium text-fg-primary">
+                          {meta.name}
+                        </span>
+                      </div>
+                      <p className="text-sm text-fg-primary mb-2">{offer.description}</p>
+                      {offer.rationale && (
+                        <p className="text-xs text-fg-tertiary mb-4">{offer.rationale}</p>
+                      )}
+                      <Link href={href}>
+                        <Button
+                          variant="accent"
+                          size="sm"
+                          className="w-full sm:w-auto"
+                          data-testid="offer-create"
+                        >
+                          <Plus className="h-4 w-4 mr-2" />
+                          Create this
+                          <ArrowRight className="h-4 w-4 ml-2" />
+                        </Button>
+                      </Link>
+                    </div>
+                  );
+                })}
+                <button
+                  onClick={handleStartChat}
+                  className="w-full text-center text-sm text-fg-secondary hover:text-fg-primary transition-colors py-2"
+                >
+                  Or refine these with your Cat in a chat →
+                </button>
               </>
             )}
-          </Button>
+          </div>
+        ) : (
+          /* ---- Input view ---- */
+          <div className="space-y-4 rounded-md border border-subtle bg-surface-page p-6">
+            <Input
+              data-testid="onboarding-display-name"
+              label="What should Cat call you?"
+              description="A name or alias — pseudonyms are fine."
+              value={displayName}
+              onChange={e => setDisplayName(e.target.value)}
+              placeholder="Satoshi"
+              maxLength={100}
+              required
+            />
 
-          <p className="text-xs text-center text-fg-tertiary">
-            Cat will ask follow-up questions and suggest the right setup for your situation
-          </p>
-        </div>
+            <label className="block text-sm font-medium text-fg-primary">
+              Who are you? What do you do?
+            </label>
+
+            <div className="flex items-start gap-2">
+              <Textarea
+                data-testid="onboarding-description"
+                placeholder="e.g. Senior product designer, 10 years, ex-fintech. I also restore vintage bikes on weekends…"
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                rows={4}
+                className="w-full resize-none"
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                    void handleSeeOffers();
+                  }
+                }}
+              />
+              {FEATURES.voiceInput && (
+                <DictationButton
+                  ariaLabel="Voice input"
+                  size="sm"
+                  onTranscript={t => setDescription(prev => (prev ? prev + ' ' : '') + t)}
+                />
+              )}
+            </div>
+
+            {/* Example prompts */}
+            <div className="space-y-1">
+              <p className="text-xs text-fg-tertiary font-medium uppercase tracking-wide">
+                Examples
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {EXAMPLE_PROMPTS.map(prompt => (
+                  <button
+                    key={prompt}
+                    onClick={() => setDescription(prompt)}
+                    className="rounded-sm border border-subtle px-3 py-1.5 text-left text-xs text-fg-secondary transition-colors hover:border-strong hover:bg-surface-raised hover:text-fg-primary"
+                  >
+                    {prompt.length > 50 ? prompt.slice(0, 50) + '…' : prompt}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {genError && <p className="text-sm text-status-negative">{genError}</p>}
+
+            <Button
+              data-testid="onboarding-see-offers"
+              onClick={handleSeeOffers}
+              disabled={!canSubmit || isGenerating}
+              variant="accent"
+              className="w-full"
+            >
+              {isGenerating ? (
+                <>
+                  <Sparkles className="h-4 w-4 mr-2 animate-pulse" />
+                  Reading you, finding offers…
+                </>
+              ) : (
+                <>
+                  <Sparkles className="h-4 w-4 mr-2" />
+                  See what Cat suggests
+                </>
+              )}
+            </Button>
+
+            <button
+              data-testid="onboarding-start-chat"
+              onClick={handleStartChat}
+              disabled={!canSubmit || isRedirecting}
+              className="w-full text-center text-sm text-fg-secondary hover:text-fg-primary transition-colors py-1 disabled:opacity-50"
+            >
+              Or just chat with your Cat instead →
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/profile/ProfileLayout.tsx
+++ b/src/components/profile/ProfileLayout.tsx
@@ -13,6 +13,8 @@ import ProfileInfoTab from '@/components/profile/ProfileInfoTab';
 import ProfileWalletsTab from '@/components/profile/ProfileWalletsTab';
 import ProfileEntityTab from '@/components/profile/ProfileEntityTab';
 import ProfileArticlesTab from '@/components/profile/ProfileArticlesTab';
+import ProfileOfferings from '@/components/profile/ProfileOfferings';
+import type { EconomicProfile } from '@/services/cat/economic-profile';
 import {
   Users,
   User,
@@ -65,6 +67,8 @@ interface ProfileLayoutProps {
   className?: string;
   /** Server-side own-profile detection (avoids hydration flash) */
   serverIsOwnProfile?: boolean;
+  /** The Cat's extracted "what I can offer" signals for this profile. */
+  economicProfile?: EconomicProfile | null;
 }
 
 export default function ProfileLayout({
@@ -77,6 +81,7 @@ export default function ProfileLayout({
   onModeChange: _onModeChange,
   className,
   serverIsOwnProfile,
+  economicProfile,
 }: ProfileLayoutProps) {
   const { user } = useAuth();
   const isOwnProfile = serverIsOwnProfile ?? profile.id === user?.id;
@@ -229,6 +234,7 @@ export default function ProfileLayout({
                 {profile.bio}
               </p>
             )}
+            <ProfileOfferings economicProfile={economicProfile} isOwnProfile={isOwnProfile} />
             {profile.website && (
               <a
                 href={profile.website}

--- a/src/components/profile/ProfileOfferings.tsx
+++ b/src/components/profile/ProfileOfferings.tsx
@@ -1,0 +1,126 @@
+/**
+ * ProfileOfferings — "What I can offer" on the public maker profile.
+ *
+ * The Cat extracts a person's latent economic value (skills, assets, what
+ * people come to them for) into user_economic_profile, but until now it lived
+ * only in Cat's private context and never surfaced. This renders the
+ * offer-oriented signals on the profile — the "what I do / can do" answer a
+ * visitor (or a potential client) actually wants — and gives the owner a
+ * one-click path from a skill to the matching monetizable entity.
+ *
+ * Only the offer-facing fields are shown (skills, asked-for, assets). Private
+ * signals (constraints, motivation) are deliberately omitted.
+ */
+
+import Link from 'next/link';
+import { Sparkles, Plus } from 'lucide-react';
+import { ENTITY_REGISTRY } from '@/config/entity-registry';
+import { suggestedEntityForSkill, type EconomicProfile } from '@/services/cat/economic-profile';
+
+interface ProfileOfferingsProps {
+  economicProfile?: EconomicProfile | null;
+  isOwnProfile?: boolean;
+}
+
+export default function ProfileOfferings({ economicProfile, isOwnProfile }: ProfileOfferingsProps) {
+  if (!economicProfile) {
+    return null;
+  }
+  const skills = economicProfile.skills ?? [];
+  const askedFor = economicProfile.askedFor ?? [];
+  const assets = economicProfile.assets ?? [];
+  if (skills.length === 0 && askedFor.length === 0 && assets.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-3 rounded-md border border-subtle bg-surface-raised/40 p-4 sm:mb-4">
+      <div className="mb-3 flex items-center gap-1.5">
+        <Sparkles className="h-4 w-4 text-fg-secondary" />
+        <h2 className="text-sm font-semibold text-fg-primary">What I can offer</h2>
+      </div>
+
+      {skills.length > 0 && (
+        <div className="mb-3">
+          <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-fg-tertiary">
+            Skills
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {skills.map(skill => {
+              const type = suggestedEntityForSkill(skill.name);
+              const meta = ENTITY_REGISTRY[type];
+              const label = skill.years ? `${skill.name} · ${skill.years}y` : skill.name;
+              // Owner: skill is a shortcut to the matching create form, seeded so
+              // the AI-fill box (see AIPrefillBar) can generate the entity.
+              if (isOwnProfile && meta) {
+                const href = `${meta.createPath}?description=${encodeURIComponent(
+                  `I offer ${skill.name}${skill.years ? ` (${skill.years} years of experience)` : ''}.`
+                )}`;
+                return (
+                  <Link
+                    key={skill.name}
+                    href={href}
+                    className="inline-flex items-center gap-1 rounded-full border border-default bg-surface-base px-2.5 py-0.5 text-xs font-medium text-fg-primary transition-colors hover:border-strong"
+                  >
+                    <Plus className="h-3 w-3" />
+                    {label}
+                  </Link>
+                );
+              }
+              return (
+                <span
+                  key={skill.name}
+                  className="inline-flex items-center rounded-full border border-default bg-surface-base px-2.5 py-0.5 text-xs font-medium text-fg-primary"
+                >
+                  {label}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {askedFor.length > 0 && (
+        <div className="mb-3">
+          <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-fg-tertiary">
+            People come to me for
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {askedFor.map(item => (
+              <span
+                key={item}
+                className="inline-flex items-center rounded-full border border-default bg-surface-base px-2.5 py-0.5 text-xs text-fg-secondary"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {assets.length > 0 && (
+        <div>
+          <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-fg-tertiary">
+            Assets
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {assets.map(asset => (
+              <span
+                key={asset.name}
+                className="inline-flex items-center rounded-full border border-default bg-surface-base px-2.5 py-0.5 text-xs text-fg-secondary"
+              >
+                {asset.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {isOwnProfile && skills.length > 0 && (
+        <p className="mt-3 text-xs text-fg-tertiary">
+          Tap a skill to turn it into a listing. Only you see these create shortcuts.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -5,12 +5,14 @@ import { Project } from '@/types/database';
 import ProfileLayout from '@/components/profile/ProfileLayout';
 import type { EntityType } from '@/config/entity-registry';
 import type { Article } from '@/services/articles/types';
+import type { EconomicProfile } from '@/services/cat/economic-profile';
 
 interface ProfilePageClientProps {
   profile: ScalableProfile;
   projects?: Project[];
   articles?: Article[];
   isOwnProfile?: boolean;
+  economicProfile?: EconomicProfile | null;
   stats: {
     projectCount: number;
     totalRaised: number;
@@ -26,6 +28,7 @@ export default function ProfilePageClient({
   projects,
   articles,
   isOwnProfile,
+  economicProfile,
   stats,
 }: ProfilePageClientProps) {
   return (
@@ -35,6 +38,7 @@ export default function ProfilePageClient({
       articles={articles}
       stats={stats}
       serverIsOwnProfile={isOwnProfile}
+      economicProfile={economicProfile}
     />
   );
 }

--- a/src/components/wallets/WalletManager/components/WalletForm.tsx
+++ b/src/components/wallets/WalletManager/components/WalletForm.tsx
@@ -27,6 +27,7 @@ export function WalletForm({
     description: initialData?.description || '',
     address_or_xpub: initialData?.address_or_xpub || '',
     lightning_address: initialData?.lightning_address || '',
+    nwc_connection_uri: initialData?.nwc_connection_uri || '',
     category: initialData?.category || 'general',
     category_icon: initialData?.category_icon,
     behavior_type: initialData?.behavior_type || 'general',
@@ -46,9 +47,21 @@ export function WalletForm({
       return;
     }
 
-    // Require either an on-chain address/xpub or a Lightning address
-    if (!formData.address_or_xpub?.trim() && !formData.lightning_address?.trim()) {
-      setError('Either a Bitcoin address/xpub or a Lightning address is required');
+    // Require at least one receive method: on-chain, Lightning address, or NWC
+    if (
+      !formData.address_or_xpub?.trim() &&
+      !formData.lightning_address?.trim() &&
+      !formData.nwc_connection_uri?.trim()
+    ) {
+      setError('Provide a Bitcoin address/xpub, a Lightning address, or an NWC connection');
+      return;
+    }
+
+    if (
+      formData.nwc_connection_uri?.trim() &&
+      !formData.nwc_connection_uri.trim().startsWith('nostr+walletconnect://')
+    ) {
+      setError('NWC connection must start with nostr+walletconnect://');
       return;
     }
 
@@ -176,6 +189,25 @@ export function WalletForm({
         />
         <p className="text-xs text-fg-secondary mt-1">
           Lightning address for instant, low-fee payments (e.g., you@getalby.com)
+        </p>
+      </div>
+
+      {/* Nostr Wallet Connect (optional) */}
+      <div className="mb-4">
+        <label className="block text-sm font-medium dark:text-fg-primary mb-2">
+          Nostr Wallet Connect (optional)
+        </label>
+        <Input
+          type="password"
+          value={formData.nwc_connection_uri || ''}
+          onChange={e => setFormData({ ...formData, nwc_connection_uri: e.target.value })}
+          onFocus={() => onFieldFocus?.('label')}
+          placeholder="nostr+walletconnect://..."
+          autoComplete="off"
+        />
+        <p className="text-xs text-fg-secondary mt-1">
+          Connect a wallet (Alby, Mutiny, …) to receive automatically — the highest-priority payout
+          rail. The connection secret is stored securely and never shown again.
         </p>
       </div>
 

--- a/src/config/landing-page.ts
+++ b/src/config/landing-page.ts
@@ -359,7 +359,8 @@ export const SECTION_HEADERS = {
   },
   howItWorks: {
     title: 'Meet Your Cat',
-    subtitle: 'Your AI economic agent handles the complexity. You focus on what matters.',
+    subtitle:
+      'Your AI economic agent finds you ways to earn and sets them up. You decide what to pursue.',
   },
   exampleUseCases: {
     title: 'Built for Makers',

--- a/src/domain/wallets/createWallet.ts
+++ b/src/domain/wallets/createWallet.ts
@@ -25,12 +25,12 @@ import { apiError, apiBadRequest, apiForbidden, apiCreated } from '@/lib/api/sta
 import { auditSuccess, AUDIT_ACTIONS } from '@/lib/api/auditLog';
 import { getTableName } from '@/config/entity-registry';
 import { walletCreateSchema } from '@/lib/validation/finance';
+import { encrypt } from '@/domain/payments/encryptionService';
 import type { z } from 'zod';
 
 type WalletCreateInput = z.infer<typeof walletCreateSchema>;
 
 interface CreateWalletResult {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   response: NextResponse<any>;
 }
 
@@ -87,6 +87,29 @@ export async function createWallet(
     response: null;
   };
 
+  // NWC URIs carry a spending secret — encrypt at rest (walletResolutionService
+  // decrypts on read). Never log the URI. A missing PAYMENT_ENCRYPTION_KEY is an
+  // ops gap, not a user error: fail clean instead of 500-ing.
+  let encryptedNwc: string | null = null;
+  if (sanitized.nwc_connection_uri) {
+    try {
+      encryptedNwc = encrypt(sanitized.nwc_connection_uri);
+    } catch (encryptError) {
+      logger.error(
+        'wallet nwc encrypt failed',
+        { message: encryptError instanceof Error ? encryptError.message : 'unknown' },
+        'createWallet'
+      );
+      return {
+        response: apiError(
+          'Nostr Wallet Connect is not available on this deployment yet.',
+          'NWC_UNAVAILABLE',
+          400
+        ),
+      };
+    }
+  }
+
   // Insert wallet
   try {
     const { data: wallet, error } = (await supabase
@@ -107,6 +130,7 @@ export async function createWallet(
         goal_currency: sanitized.goal_currency || null,
         goal_deadline: sanitized.goal_deadline || null,
         lightning_address: body.lightning_address?.trim() || null,
+        nwc_connection_uri: encryptedNwc,
         is_primary: body.is_primary !== undefined ? body.is_primary : isFirstWallet,
         balance_btc: 0,
       })
@@ -155,7 +179,6 @@ async function verifyOwnership(
   supabase: SupabaseClient,
   user: User,
   body: WalletCreateInput
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<NextResponse<any> | null> {
   if (body.profile_id) {
     if (body.profile_id !== user.id) {
@@ -192,7 +215,6 @@ interface PreCheckOk {
   response: null;
 }
 interface PreCheckFail {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   response: NextResponse<any>;
 }
 

--- a/src/lib/validation/finance.ts
+++ b/src/lib/validation/finance.ts
@@ -211,6 +211,18 @@ export const walletCreateSchema = z
       .nullable(),
     address_or_xpub: z.string().max(200).optional().nullable(),
     lightning_address: z.string().max(200).optional().nullable(),
+    // Nostr Wallet Connect URI — the payment engine's highest-priority receive
+    // rail (walletResolutionService prefers it), but until now there was no
+    // self-serve way to save one. It carries a secret, so it's write-only:
+    // validated for shape here, never echoed back or logged.
+    nwc_connection_uri: z
+      .string()
+      .max(2000)
+      .refine(v => v.startsWith('nostr+walletconnect://'), {
+        message: 'NWC URI must start with nostr+walletconnect://',
+      })
+      .optional()
+      .nullable(),
 
     // Category
     category: z.enum(WALLET_CATEGORY_VALUES).default('general'),
@@ -242,9 +254,10 @@ export const walletCreateSchema = z
   .refine(
     data =>
       (data.address_or_xpub && data.address_or_xpub.length > 0) ||
-      (data.lightning_address && data.lightning_address.length > 0),
+      (data.lightning_address && data.lightning_address.length > 0) ||
+      (data.nwc_connection_uri && data.nwc_connection_uri.length > 0),
     {
-      message: 'Either a Bitcoin address/xpub or a Lightning address is required',
+      message: 'Provide a Bitcoin address/xpub, a Lightning address, or an NWC connection',
       path: ['address_or_xpub'],
     }
   );

--- a/src/services/notifications/digestBuilder.ts
+++ b/src/services/notifications/digestBuilder.ts
@@ -19,6 +19,8 @@ import { DATABASE_TABLES } from '@/config/database-tables';
 import { ENTITY_REGISTRY, ENTITY_TYPES, type EntityType } from '@/config/entity-registry';
 import { STATUS, ENTITY_STATUS } from '@/config/database-constants';
 import { logger } from '@/utils/logger';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { generateNudges } from '@/services/cat/nudges';
 
 const LOG_SOURCE = 'DigestBuilder';
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://orangecat.ch';
@@ -298,6 +300,47 @@ function generateSuggestions(context: {
   return suggestions.slice(0, 3);
 }
 
+/**
+ * The weekly digest's proactive half. Prefer the Cat's real nudge engine
+ * (generateNudges — grounded, LLM-backed activation/connection/growth
+ * suggestions) so the Cat's intelligence actually reaches the one unprompted
+ * channel it has. Fall back to the deterministic rules above when the engine
+ * yields nothing (thin context, no AI key configured, or a transient failure),
+ * so the digest is never worse than before.
+ */
+async function buildDigestSuggestions(
+  admin: SupabaseClient,
+  userId: string,
+  fallbackContext: {
+    hasWallet: boolean;
+    entities: Array<{ title: string; type: string; status: string }>;
+    profileBio: string | null;
+    hasPayments: boolean;
+  }
+): Promise<Array<{ text: string; actionLabel: string; actionUrl: string }>> {
+  try {
+    const nudges = await generateNudges(admin, userId);
+    if (nudges.length > 0) {
+      return nudges.slice(0, 3).map(n => ({
+        text: n.title ? `${n.title} — ${n.body}` : n.body,
+        actionLabel: n.cta_label || 'Open OrangeCat',
+        actionUrl: n.cta_url
+          ? n.cta_url.startsWith('http')
+            ? n.cta_url
+            : `${APP_URL}${n.cta_url}`
+          : `${APP_URL}/dashboard`,
+      }));
+    }
+  } catch (err) {
+    logger.warn(
+      'digest: nudge engine failed, using deterministic fallback',
+      { err: String(err) },
+      LOG_SOURCE
+    );
+  }
+  return generateSuggestions(fallbackContext);
+}
+
 // =====================================================================
 // MAIN BUILDER
 // =====================================================================
@@ -352,8 +395,9 @@ export async function buildWeeklyDigest(userId: string): Promise<WeeklyDigestDat
     hasStats = true;
   }
 
-  // Generate suggestions
-  const suggestions = generateSuggestions({
+  // Generate suggestions — the Cat's real nudge engine first, deterministic
+  // rules as a floor (see buildDigestSuggestions).
+  const suggestions = await buildDigestSuggestions(admin, userId, {
     hasWallet,
     entities,
     profileBio: profile.bio,

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -199,6 +199,8 @@ export interface WalletFormData {
   description?: string | null;
   address_or_xpub?: string | null;
   lightning_address?: string | null;
+  /** Nostr Wallet Connect URI (write-only secret). */
+  nwc_connection_uri?: string | null;
   category: WalletCategory;
   category_icon?: string;
   behavior_type: WalletBehaviorType;
@@ -249,7 +251,6 @@ function isValidBitcoinAddress(
   network: 'mainnet' | 'testnet' = 'mainnet'
 ): boolean {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return validateBitcoinAddress(address, network as any);
   } catch {
     return false;
@@ -328,6 +329,7 @@ export function sanitizeWalletInput(data: WalletFormData): WalletFormData {
     label: data.label.trim().slice(0, MAX_LABEL_LENGTH),
     description: data.description?.trim().slice(0, MAX_DESCRIPTION_LENGTH) || undefined,
     address_or_xpub: data.address_or_xpub?.trim() ?? null,
+    nwc_connection_uri: data.nwc_connection_uri?.trim() || null,
     category_icon: (ALLOWED_CATEGORY_ICONS as readonly string[]).includes(data.category_icon || '')
       ? data.category_icon
       : WALLET_CATEGORIES[data.category].icon,


### PR DESCRIPTION
Turns capability OrangeCat already had into things the product actually *does* — and each was verified in a real browser during build. Two code audits found the same pattern across the vision (paste-a-profile → the Cat sets up monetizable offerings, proactively helps you earn): the ambitious pieces were built but the last seam that makes them move was missing. This wires those seams.

## What's in it

**D1 — Homepage hero sells the proactive agent.** "Everyone Can Make Things" (passive tool) → "Turn who you are into income" — the Cat interviews you, sets up your services/products/projects, proposes ways to earn, + a "Builds on FleetCrown" pointer. Copy-only; tokens + FEE_CLAIMS SSOT unchanged. *(Playwright: 0 console errors.)*

**D2 — Paste-a-profile → proposed offerings** (the flagship). New `POST /api/cat/offers-from-text` wraps the existing `generateOffers` (pasted bio grounds the proposals via `focus`); onboarding renders typed offer cards → "Create this" → the create page's AI-fill box is pre-seeded from `?description=`. Everything downstream already existed; this is the deterministic chain. *(Verified end-to-end: designer bio → grounded Service offer → Create Service prefilled; `POST 200`.)*

**D3 — "What I can offer" on the maker profile.** Surfaces the Cat's extracted skills/assets with owner create-shortcuts (identity → offering). Owner-facing for now — `user_economic_profile` RLS scopes reads to the owner; public visibility needs an opt-in toggle (follow-up; no auto-exposure without consent).

**D4 — Self-serve NWC receiving.** The payment engine's highest-priority rail had no self-serve write path. Adds an NWC field (shape-validated), encrypts the URI at rest (AES-256-GCM via the existing `encryptionService`; missing key fails clean, never 500), never logs/echoes the secret. *(Verified with the real session: `POST /api/wallets` with an NWC URI → 201, persisted, secret absent from response.)*

**D5 — Route the Cat's real nudge engine to its outbound surfaces.** The weekly digest used a dumb 5-rule generator that never touched the Cat's brain; the dashboard capped nudges at 2. The digest now builds suggestions from `generateNudges` first (deterministic fallback preserved); the dashboard surface is "Your Cat suggests" (cap 2 → 4). *(Verified: `GET /api/cat/nudges` returns 5 grounded nudges — "Turn photography into a service", "Put your drone to work" — the exact engine both surfaces now consume.)*

## Verification
Each deliverable browser-verified against a local dev server (Playwright + Chrome + authenticated in-page fetches). Full `tsc` clean; per-commit eslint/prettier via husky.

## Follow-ups (tracked, not in this PR)
- D3 public visibility with an owner opt-in toggle + field-filtered read.
- Social login (LinkedIn missing from the provider map; Google fails on Supabase provider config, not code) + an SSOT/SoC auth review — a separate auth workstream.
- Create-form field auto-fill from the seeded AI box (D2 seeds the box; "Fill form" generates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)