### PR TITLE
fix(seo): stop indexing junk/private URLs across public routes

### DIFF
--- a/src/app/(public)/articles/[slug]/page.tsx
+++ b/src/app/(public)/articles/[slug]/page.tsx
@@ -46,6 +46,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     title: article.title,
     description: article.excerpt,
     robots: isIndexable ? undefined : { index: false, follow: false },
+    // Slugs are user-authored (title + random suffix) and duplicate-prone —
+    // pin the canonical URL so near-duplicate titles don't split ranking.
+    alternates: { canonical: `${SITE_URL}/articles/${article.slug}` },
     openGraph: {
       title: article.title,
       description: article.excerpt,

--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -142,6 +142,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: post.title,
     description: post.excerpt,
+    alternates: { canonical: `${SITE_URL}/blog/${slug}` },
     openGraph: {
       title: post.title,
       description: post.excerpt,

--- a/src/app/groups/[slug]/page.tsx
+++ b/src/app/groups/[slug]/page.tsx
@@ -57,6 +57,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title,
     description,
+    // Only public groups are indexable — a private/unlisted group reachable by
+    // direct URL must not be indexed (its name/description would leak into SERPs).
+    robots: g.visibility === 'public' ? undefined : { index: false, follow: false },
     alternates: { canonical: url },
     openGraph: {
       title: `${g.name} — ${APP_NAME}`,

--- a/src/app/groups/[slug]/proposals/[id]/page.tsx
+++ b/src/app/groups/[slug]/proposals/[id]/page.tsx
@@ -8,6 +8,8 @@
  * Last Modified Summary: Initial implementation
  */
 
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { ProposalDetail } from '@/components/groups/proposals/ProposalDetail';
 import { createServerClient } from '@/lib/supabase/server';
 import { checkGroupPermission } from '@/services/groups/permissions';
@@ -16,6 +18,11 @@ import { getGroupBySlug } from '@/services/groups/queries/groups';
 interface PageProps {
   params: Promise<{ slug: string; id: string }>;
 }
+
+// Group governance is member-facing, not search content — never index proposals.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default async function ProposalPage({ params }: PageProps) {
   const { slug, id } = await params;
@@ -27,11 +34,7 @@ export default async function ProposalPage({ params }: PageProps) {
   // Get group
   const groupResult = await getGroupBySlug(slug);
   if (!groupResult.success || !groupResult.group) {
-    return (
-      <div className="text-center py-12">
-        <p className="text-status-negative">Group not found</p>
-      </div>
-    );
+    notFound();
   }
 
   const group = groupResult.group;

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -119,6 +119,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title,
     description,
+    // Only published (active) projects are indexable — a draft/paused/archived
+    // project reachable by direct URL must not be indexed.
+    robots: project.status === 'active' ? undefined : { index: false, follow: false },
     alternates: {
       canonical: url,
     },


### PR DESCRIPTION
## What

Audit of **every public dynamic route** (fanned out from the article soft-404 investigation) turned up real indexation leaks — some worse than cosmetic. Fixes them.

| Route | Before | After |
|---|---|---|
| `groups/[slug]/proposals/[id]` | Rendered "Group not found" at **HTTP 200**, no `notFound()`, **no metadata** → any junk URL a crawlable soft-404 | `notFound()`; proposals (member governance) are `noindex` outright |
| `projects/[id]` | Fetched with **no status filter** → draft/paused/archived projects served to crawlers at 200 with full metadata + JSON-LD, **no noindex** | `robots: noindex` for any non-active project |
| `groups/[slug]` | **No visibility filter** → private/unlisted group name + description indexable | `robots: noindex` for any non-public group |
| `articles/[slug]`, `blog/[slug]` | No canonical | `alternates.canonical` added (user-authored slugs are duplicate-prone) |

## What's verified fine (no change)

Every entity page routed through the shared `PublicEntityDetailPage` already filters `status=active` + owner-previews drafts + `notFound()`s (products, services, causes, events, investments, loans, assets, research, ai-assistants, circles, wishlists). `robots.ts` + `sitemap.ts` are present and correct (sitemap already excludes drafts). Articles were already best-in-class (noindex + author-gated private bodies).

## Scope

**SEO only** — `noindex` + real `404`. This deliberately does **not** change who can *view* a draft project or private group by direct URL; that's an access-control decision flagged separately for @maonakamoto.

## Verification

type-check + lint clean on all 5 files. (The article HTTP status stays 200+noindex by framework streaming design, per the prior investigation — indexing is what's protected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)