### PR TITLE
fix(tips): harden the anonymous tip endpoints

### DIFF
--- a/__tests__/unit/tips/tip-service.test.ts
+++ b/__tests__/unit/tips/tip-service.test.ts
@@ -14,6 +14,9 @@ import {
 jest.mock('@/domain/payments/walletResolutionService', () => ({
   resolveUserWallet: jest.fn(),
 }));
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: jest.fn(() => ({})),
+}));
 jest.mock('@/domain/payments/paymentFlowService', () => ({
   initiateTip: jest.fn(),
   checkPublicPaymentStatus: jest.fn(),

--- a/src/app/api/tips/invoice/route.ts
+++ b/src/app/api/tips/invoice/route.ts
@@ -1,15 +1,16 @@
 /**
  * POST /api/tips/invoice { username, amountBtc } — mint a non-custodial Bitcoin
  * tip request against the recipient's own wallet. Anonymous tippers are allowed
- * (easy UX); IP rate-limited to protect recipients' NWC relays from invoice-
- * generation abuse. Persists an entity-less payment_intent so the tip can be
- * tracked + the recipient notified on settlement; OrangeCat never touches funds.
+ * (easy UX); rate-limited per-IP AND per-recipient to protect recipients' NWC
+ * relays from invoice-generation abuse (an attacker rotating IPs can't flood one
+ * victim). Persists an entity-less payment_intent so the tip can be tracked + the
+ * recipient notified on settlement; OrangeCat never touches funds.
  */
 
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
 import { createServerClient } from '@/lib/supabase/server';
-import { rateLimit, createRateLimitResponse } from '@/lib/rate-limit';
+import { rateLimit, rateLimitTipRecipient, createRateLimitResponse } from '@/lib/rate-limit';
 import { apiBadRequest, apiError, apiInternalError, apiSuccess } from '@/lib/api/standardResponse';
 import { TIP_MAX_BTC, TIP_MIN_BTC } from '@/config/tips';
 import { initiateTip } from '@/domain/tips/tip-service';
@@ -30,6 +31,13 @@ export async function POST(request: NextRequest) {
     const parsed = bodySchema.safeParse(await request.json().catch(() => ({})));
     if (!parsed.success) {
       return apiBadRequest('Invalid request', parsed.error.flatten());
+    }
+
+    // Per-recipient cap: bounds invoice generation against any one victim's
+    // wallet/relay regardless of the tipper's IP.
+    const recipientRl = await rateLimitTipRecipient(parsed.data.username);
+    if (!recipientRl.success) {
+      return createRateLimitResponse(recipientRl);
     }
 
     const supabase = await createServerClient();

--- a/src/app/api/tips/receive-info/route.ts
+++ b/src/app/api/tips/receive-info/route.ts
@@ -6,6 +6,7 @@
 
 import type { NextRequest } from 'next/server';
 import { createServerClient } from '@/lib/supabase/server';
+import { rateLimit, createRateLimitResponse } from '@/lib/rate-limit';
 import {
   apiBadRequest,
   apiInternalError,
@@ -17,6 +18,12 @@ import { logger } from '@/utils/logger';
 
 export async function GET(request: NextRequest) {
   try {
+    // Rate-limit the enumeration oracle (canReceive + rail per username).
+    const rl = await rateLimit(request);
+    if (!rl.success) {
+      return createRateLimitResponse(rl);
+    }
+
     const username = new URL(request.url).searchParams.get('username')?.trim();
     if (!username) {
       return apiBadRequest('Missing username');

--- a/src/domain/tips/tip-service.ts
+++ b/src/domain/tips/tip-service.ts
@@ -8,8 +8,10 @@
  * notification for free when it settles.
  */
 
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { DATABASE_TABLES } from '@/config/database-tables';
+import { getAdminClient } from '@/lib/supabase/admin';
 import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
 import {
   initiateTip as initiateTipPayment,
@@ -23,6 +25,16 @@ const METHOD_LABELS: Record<ResolvedWallet['method'], string> = {
   lightning_address: 'Lightning',
   onchain: 'On-chain Bitcoin',
 };
+
+/**
+ * Resolve the recipient's receiving wallet with the service-role client — same
+ * as the public-support flow. This keeps tips working WITHOUT depending on
+ * wallet rows being anon-readable (so `wallets_select` RLS can be tightened),
+ * and it decrypts the NWC URI server-side only.
+ */
+function resolveRecipientWallet(userId: string): Promise<ResolvedWallet | null> {
+  return resolveUserWallet(getAdminClient() as unknown as SupabaseClient, userId);
+}
 
 interface TipRecipient {
   userId: string;
@@ -62,7 +74,7 @@ export async function getTipReceiveInfo(
   if (!recipient) {
     return null;
   }
-  const wallet = await resolveUserWallet(supabase, recipient.userId);
+  const wallet = await resolveRecipientWallet(recipient.userId);
   return {
     canReceive: !!wallet,
     recipientName: recipient.displayName,
@@ -99,7 +111,7 @@ export async function initiateTip(
     return { ok: false, error: 'That person could not be found.' };
   }
 
-  const wallet = await resolveUserWallet(supabase, recipient.userId);
+  const wallet = await resolveRecipientWallet(recipient.userId);
   if (!wallet) {
     return {
       ok: false,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -92,6 +92,11 @@ const createUpstashLimiter = (
 const upstashGeneralLimiter = createUpstashLimiter('general', 100, '15 m');
 const upstashSocialLimiter = createUpstashLimiter('social', 10, '1 m');
 const upstashWriteLimiter = createUpstashLimiter('write', 30, '1 m');
+// Caps how often a SINGLE recipient's wallet/relay can be hit by anonymous
+// tip-invoice generation, regardless of the tipper's IP — so one attacker
+// (even rotating IPs) can't flood a victim's NWC relay. Generous enough to
+// absorb a legitimately viral post's concurrent tippers.
+const upstashTipRecipientLimiter = createUpstashLimiter('tip-recipient', 20, '5 m');
 
 // ==================== FALLBACK IN-MEMORY LIMITER ====================
 
@@ -144,6 +149,10 @@ class InMemoryRateLimiter {
 const fallbackGeneralLimiter = new InMemoryRateLimiter();
 const fallbackSocialLimiter = new InMemoryRateLimiter({ windowMs: 60 * 1000, maxRequests: 10 });
 const fallbackWriteLimiter = new InMemoryRateLimiter({ windowMs: 60 * 1000, maxRequests: 30 });
+const fallbackTipRecipientLimiter = new InMemoryRateLimiter({
+  windowMs: 5 * 60 * 1000,
+  maxRequests: 20,
+});
 
 // ==================== RATE LIMIT FUNCTIONS ====================
 
@@ -194,6 +203,23 @@ export async function rateLimitSocialAsync(userId: string): Promise<RateLimitRes
   }
 
   return fallbackSocialLimiter.check(key);
+}
+
+/**
+ * Rate limit anonymous tip-invoice generation PER RECIPIENT (by username).
+ * 20 invoices per 5 minutes against any one recipient — protects a victim's
+ * wallet/relay from invoice-spam even when the attacker rotates IPs. Apply this
+ * IN ADDITION to the per-IP `rateLimit`.
+ */
+export async function rateLimitTipRecipient(username: string): Promise<RateLimitResult> {
+  const key = `tip-recipient:${username.toLowerCase()}`;
+
+  if (upstashTipRecipientLimiter) {
+    const result = await upstashTipRecipientLimiter.limit(key);
+    return toRateLimitResult(result);
+  }
+
+  return fallbackTipRecipientLimiter.check(key);
 }
 
 /**


### PR DESCRIPTION
Follow-ups from a security review of the tipping flow we just shipped (#472). No behavior change for legitimate tippers; the non-custodial, zero-fee invariant is untouched (invoices are always minted against the recipient's own wallet).

## Fixes

**MED — per-recipient invoice rate limit.** Previously only a per-IP limit guarded `POST /api/tips/invoice`, and each call hits the recipient's real wallet (NWC `make_invoice` on their relay, or their LNURL provider). An attacker rotating `X-Forwarded-For` could bypass the per-IP cap and flood **one victim's** relay. Added `rateLimitTipRecipient(username)` — 20 / 5 min per recipient, applied on top of the per-IP limit — so abuse against any single victim is bounded regardless of source IP. Generous enough to absorb a viral post's concurrent tippers.

**MED — resolve recipient wallet via the admin (service-role) client.** Tips previously resolved the recipient's wallet through the *anonymous* request client, which only worked because `wallets_select` RLS makes active wallet rows world-readable. Now tips use the service-role client (like the public-support flow), so tipping no longer depends on that RLS being open — a prerequisite for tightening `wallets_select` (flagged separately). NWC URI stays decrypted server-side only.

**LOW — rate-limit `GET /api/tips/receive-info`.** It was unthrottled and returns `canReceive` + rail per username — a free enumeration oracle. Now per-IP rate-limited like the other tip endpoints.

## Verified solid (no change needed)

The review confirmed the status-token security (256-bit, SHA-256 hashed at rest, scoped to id **and** token), the `handlePaymentConfirmed` tip branch (early-returns before any entity logic; recipient always notified), amount validation (server-side Zod bounds), and migration safety (no non-null-assuming consumers of the now-nullable columns).

## Flagged separately (not in this PR)

XFF-spoofable IP in the shared rate limiter (systemic), `wallets_select` RLS tightening (needs a review of all anon wallet readers), on-chain tip finalizer cron (v1 notification gap), and a theoretical double-notify idempotency guard.

## Verification

tip-service tests 8/8, lint + type-check clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)