### PR TITLE
feat(auth): add LinkedIn OAuth + fix provider-union SSOT + config runbook

### DIFF
--- a/docs/operations/oauth-social-login.md
+++ b/docs/operations/oauth-social-login.md
@@ -1,0 +1,99 @@
+# OAuth Social Login — enabling providers
+
+**Audience:** whoever operates the self-hosted Supabase on `bitbaum`.
+**TL;DR:** the login buttons are entirely config-driven. A provider's button
+appears **only** when GoTrue has it enabled _and_ its credentials actually work
+(the app probes each provider's `/authorize` and hides broken ones). Adding a
+provider is zero app-code — configure it on the box and the button appears.
+
+## How it works (so you know where to look)
+
+- **App SSOT:** `src/app/auth/oauth-provider-map.ts` maps our ids → GoTrue keys.
+  Supported today: `google`, `github`, `x` (`twitter`), `linkedin`
+  (`linkedin_oidc`), `facebook`, `apple`.
+- **Which buttons render:** `GET /api/auth/oauth-providers` reads
+  `${SUPABASE_URL}/auth/v1/settings` for flagged-enabled providers, then probes
+  each one's `/auth/v1/authorize` and keeps only those that really redirect to
+  the external IdP (a provider flagged on with broken credentials bounces back
+  to the site root and is hidden). Result cached 5 min.
+- **Consequence:** a button that's missing means "not enabled, or enabled with
+  broken/missing credentials." Check the endpoint to see the live truth:
+  ```bash
+  curl -s https://orangecat.ch/api/auth/oauth-providers   # {"data":{"providers":[...]}}
+  ```
+
+## Current state (2026-07-28)
+
+| Provider    | GoTrue flag | Works (probe)                                          | Button shows                                 |
+| ----------- | ----------- | ------------------------------------------------------ | -------------------------------------------- |
+| google      | on          | ✅ yes                                                 | ✅                                           |
+| github      | on          | ✅ yes                                                 | ✅                                           |
+| x (twitter) | on          | ❌ no — bounces to site root (bad/missing credentials) | ❌ hidden                                    |
+| linkedin    | off         | —                                                      | ❌ (configure to enable)                     |
+| facebook    | off         | —                                                      | ❌ (configure to enable)                     |
+| apple       | off         | —                                                      | intentionally not offered (paid dev program) |
+
+So **google + github already work**; **x needs its credentials fixed**;
+**linkedin + facebook need configuring**.
+
+## Enabling / fixing a provider
+
+For each provider you want:
+
+### 1. Register an OAuth app with the provider (free except Apple)
+
+Set the **authorized redirect URI** to the GoTrue callback:
+
+```
+https://supabase.orangecat.ch/auth/v1/callback
+```
+
+- **Google:** console.cloud.google.com → APIs & Services → Credentials → OAuth client ID (Web). Also add your OAuth consent screen.
+- **GitHub:** github.com/settings/developers → New OAuth App. "Authorization callback URL" = the URI above.
+- **X:** developer.x.com → Project/App → User authentication settings → enable OAuth 2.0, set the callback URI above. (This is the one currently broken — most likely a missing/rotated client secret or a callback-URI mismatch.)
+- **LinkedIn:** linkedin.com/developers → create an app → **Products → "Sign In with LinkedIn using OpenID Connect"** (this is why the GoTrue key is `linkedin_oidc`), then Auth tab → add the redirect URL above.
+- **Facebook:** developers.facebook.com → create an app → Facebook Login → Valid OAuth Redirect URIs = the URI above.
+
+### 2. Give the credentials to GoTrue on the box
+
+GoTrue reads them from env (`/opt/orangecat` compose / the GoTrue service env).
+Set per provider (names follow GoTrue's `GOTRUE_EXTERNAL_<P>_*` convention):
+
+```bash
+GOTRUE_EXTERNAL_LINKEDIN_OIDC_ENABLED=true
+GOTRUE_EXTERNAL_LINKEDIN_OIDC_CLIENT_ID=...
+GOTRUE_EXTERNAL_LINKEDIN_OIDC_SECRET=...
+GOTRUE_EXTERNAL_LINKEDIN_OIDC_REDIRECT_URI=https://supabase.orangecat.ch/auth/v1/callback
+
+GOTRUE_EXTERNAL_FACEBOOK_ENABLED=true
+GOTRUE_EXTERNAL_FACEBOOK_CLIENT_ID=...
+GOTRUE_EXTERNAL_FACEBOOK_SECRET=...
+GOTRUE_EXTERNAL_FACEBOOK_REDIRECT_URI=https://supabase.orangecat.ch/auth/v1/callback
+
+# X is already enabled but broken — re-set its secret + confirm the callback:
+GOTRUE_EXTERNAL_TWITTER_CLIENT_ID=...
+GOTRUE_EXTERNAL_TWITTER_SECRET=...
+GOTRUE_EXTERNAL_TWITTER_REDIRECT_URI=https://supabase.orangecat.ch/auth/v1/callback
+```
+
+Restart GoTrue (`docker compose up -d gotrue` / `restart`).
+
+### 3. Verify
+
+```bash
+# GoTrue now flags it:
+curl -s https://supabase.orangecat.ch/auth/v1/settings -H "apikey: <ANON_KEY>" | jq .external
+# The app now shows it (probe passes). Cache is 5 min — wait or redeploy the web app:
+curl -s https://orangecat.ch/api/auth/oauth-providers | jq .data.providers
+```
+
+When the provider appears in that last list, its button renders on `/auth`
+automatically — no app deploy needed for the button itself.
+
+## Note: the "buttons appear a beat late" effect
+
+On a cold cache the probe does live redirects to each IdP, so the "Or continue
+with" row can pop in ~1s after the page. It's cached 5 min after the first hit,
+so in practice only the very first visitor after a deploy/cache-expiry sees it.
+If it ever needs to feel instant, warm the cache on deploy (hit
+`/api/auth/oauth-providers` in the post-deploy smoke).

--- a/src/app/auth/OAuthIcons.tsx
+++ b/src/app/auth/OAuthIcons.tsx
@@ -62,6 +62,19 @@ function FacebookIcon({ className }: { className?: string }) {
   );
 }
 
+function LinkedInIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="#0A66C2"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z" />
+    </svg>
+  );
+}
+
 export const OAUTH_PROVIDERS: {
   id: OAuthProvider;
   name: string;
@@ -69,6 +82,7 @@ export const OAUTH_PROVIDERS: {
 }[] = [
   { id: 'google', name: 'Google', icon: GoogleIcon },
   { id: 'github', name: 'GitHub', icon: GitHubIcon },
-  { id: 'facebook', name: 'Facebook', icon: FacebookIcon },
   { id: 'x', name: 'X', icon: XIcon },
+  { id: 'linkedin', name: 'LinkedIn', icon: LinkedInIcon },
+  { id: 'facebook', name: 'Facebook', icon: FacebookIcon },
 ];

--- a/src/app/auth/oauth-provider-map.ts
+++ b/src/app/auth/oauth-provider-map.ts
@@ -11,10 +11,17 @@ export const OAUTH_TO_SUPABASE = {
   facebook: 'facebook',
   apple: 'apple',
   x: 'twitter',
+  // LinkedIn uses GoTrue's OIDC provider key (`linkedin_oidc`); the legacy
+  // `linkedin` provider was removed upstream.
+  linkedin: 'linkedin_oidc',
 } as const;
 
 /** App-level OAuth provider id — derived from the map (SSOT). */
 export type OAuthProvider = keyof typeof OAUTH_TO_SUPABASE;
+
+/** GoTrue/supabase-js provider key — derived from the map (SSOT), so adding a
+ *  provider above extends every consumer's type instead of a hardcoded union. */
+export type SupabaseOAuthProvider = (typeof OAUTH_TO_SUPABASE)[OAuthProvider];
 
 export const OAUTH_PROVIDER_IDS = Object.keys(OAUTH_TO_SUPABASE) as OAuthProvider[];
 

--- a/src/app/auth/useAuthForm.ts
+++ b/src/app/auth/useAuthForm.ts
@@ -6,6 +6,7 @@ import { signInAnonymously } from '@/services/supabase/auth';
 import { getReadableError } from '@/utils/getReadableError';
 import supabase from '@/lib/supabase/browser';
 import { useAuthSubmission } from './useAuthSubmission';
+import type { Provider } from '@supabase/supabase-js';
 import { OAUTH_TO_SUPABASE, type OAuthProvider } from './oauth-provider-map';
 
 export type { OAuthProvider };
@@ -145,13 +146,10 @@ export function useAuthForm() {
   const handleOAuthSignIn = async (provider: OAuthProvider) => {
     try {
       const { error } = await supabase.auth.signInWithOAuth({
-        // Map app id → GoTrue/supabase key (X is `twitter` upstream).
-        provider: OAUTH_TO_SUPABASE[provider] as
-          | 'google'
-          | 'github'
-          | 'facebook'
-          | 'apple'
-          | 'twitter',
+        // Map app id → GoTrue/supabase key (X is `twitter`, LinkedIn is
+        // `linkedin_oidc`). Cast to supabase-js's own Provider union derived
+        // from the map (SSOT) rather than a hardcoded list.
+        provider: OAUTH_TO_SUPABASE[provider] as Provider,
         options: { redirectTo: `${window.location.origin}/auth/callback` },
       });
       if (error) {


### PR DESCRIPTION
Social login is already config-driven and well-architected — buttons derive from `OAUTH_TO_SUPABASE`, and `/api/auth/oauth-providers` probes each provider's real `/authorize` so only working ones render (a provider flagged-on with broken credentials is hidden, not shown as a dead button). Two gaps closed:

- **LinkedIn added** — `linkedin: 'linkedin_oidc'` in the map (auto-flows through the probe route and the client hook) + a LinkedIn button in `OAuthIcons`, ordered google/github/x/linkedin/facebook.
- **Provider-union SSOT violation fixed** — `handleOAuthSignIn` hardcoded a `'google'|'github'|'facebook'|'apple'|'twitter'` union (a duplicate of the map that rots when a provider is added). Replaced with supabase-js's own `Provider` type; exported `SupabaseOAuthProvider` from the map.

### Diagnosis (why you saw no buttons / Google "failed")
Live probe of the self-hosted GoTrue:
| Provider | Flagged | Works | Button |
|---|---|---|---|
| google | on | ✅ | shows |
| github | on | ✅ | shows |
| x (twitter) | on | ❌ bounces to site root (broken credentials) | hidden |
| linkedin / facebook | off | — | need configuring |

So **google + github already work** (the "no buttons" was cold-cache latency — the probe does live IdP redirects on first load, cached 5 min, so the row pops in ~1s). **X needs its credentials fixed**; **LinkedIn + Facebook need configuring**. All of that is **ops, not code** — `docs/operations/oauth-social-login.md` has the exact per-provider steps (register app → GoTrue redirect URI → `GOTRUE_EXTERNAL_*` env → restart → verify).

tsc + lint clean; the providers endpoint returns cleanly with LinkedIn added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)