### PR TITLE
fix(cat): bookings context query selected a non-existent actors.username

### DIFF
--- a/src/services/ai/social-context-fetcher.ts
+++ b/src/services/ai/social-context-fetcher.ts
@@ -153,7 +153,7 @@ export async function fetchInboundActivityForCat(
               status,
               customer:customer_actor_id(
                 display_name,
-                username
+                slug
               )
             `
             )
@@ -186,8 +186,11 @@ export async function fetchInboundActivityForCat(
         starts_at: string;
         ends_at: string | null;
         status: string;
-        // Supabase returns one-to-one FK joins as arrays; take first element
-        customer: { display_name: string | null; username: string | null }[] | null;
+        // Supabase returns one-to-one FK joins as arrays; take first element.
+        // The actor's handle is `slug` — the actors table has no `username`
+        // column (that lives on profiles), which used to make this whole
+        // sub-query error out on every Cat context build.
+        customer: { display_name: string | null; slug: string | null }[] | null;
       }) => {
         const customer = Array.isArray(b.customer) ? b.customer[0] : b.customer;
         return {
@@ -195,7 +198,7 @@ export async function fetchInboundActivityForCat(
           ends_at: b.ends_at,
           status: b.status,
           customer_display_name: customer?.display_name ?? null,
-          customer_username: customer?.username ?? null,
+          customer_username: customer?.slug ?? null,
         };
       }
     );


### PR DESCRIPTION
The Cat's context builder (`social-context-fetcher.ts`) embedded `customer:customer_actor_id(display_name, username)` on the upcoming-bookings query. But the `actors` table has **no `username` column** — its handle is `slug` (username lives on `profiles`). PostgREST rejected it with *"column actors_1.username does not exist"*, so the entire bookings sub-query errored on **every** Cat context build — offers, nudges, chat — and the Cat silently lost that signal (a `WARN` per call, visible throughout the logs).

Fix: select `slug` (the actor's handle) and map it to `customer_username`.

**Verified against the DB:** the old embedded select returns HTTP 400 (column missing); the fixed one returns HTTP 200. tsc + lint clean.

Found while browser-testing the paste-a-profile → offers flow (PR #474), where this warning fired on every offer generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)