### PR TITLE
fix(articles): cap cover upload at 5MB to match the banners bucket

### DIFF
--- a/src/services/articles/cover-storage.ts
+++ b/src/services/articles/cover-storage.ts
@@ -1,9 +1,8 @@
 /**
  * Upload an article cover image. Reuses the public BANNERS bucket with a
- * `${userId}/…` path — a cover is a banner-class hero image, and the userId
- * prefix matches the bucket's existing owner-scoped RLS, so no new bucket or
- * storage-policy change is needed. Returns a public URL to store in
- * `metadata.article.cover_image`.
+ * `${userId}/…` path — a cover is a banner-class hero image, matching the same
+ * upload path avatars/banners already use (no new bucket needed). Returns a
+ * public URL to store in `metadata.article.cover_image`.
  */
 
 import supabase from '@/lib/supabase/browser';
@@ -12,7 +11,9 @@ import { STORAGE_BUCKETS } from '@/config/database-tables';
 import type { FileUploadResult } from '@/types/storage';
 
 const BUCKET = STORAGE_BUCKETS.BANNERS;
-const MAX_SIZE = 8 * 1024 * 1024; // 8MB — covers are large hero images
+// Must not exceed the banners bucket's server-side file_size_limit (5MB) — a
+// larger file passes this check then fails at the bucket with a cryptic error.
+const MAX_SIZE = 5 * 1024 * 1024;
 const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif'];
 
 export const COVER_ACCEPT = ALLOWED_TYPES.join(',');
@@ -36,7 +37,8 @@ export async function uploadArticleCover(userId: string, file: File): Promise<Fi
 
   try {
     const ext = file.name.split('.').pop() || 'jpg';
-    // userId first segment → satisfies the bucket's owner-scoped RLS.
+    // userId first segment namespaces each author's uploads (same convention as
+    // avatars/banners). Timestamp keeps successive covers from colliding.
     const fileName = `${userId}/article-cover_${Date.now()}.${ext}`;
 
     const { error } = await supabase.storage.from(BUCKET).upload(fileName, file, {


### PR DESCRIPTION
## What

The cover-image validator allowed **8MB**, but the `banners` bucket's server-side `file_size_limit` is **5MB** (verified on the box). So a 5–8MB image passed the client check and then failed at the bucket with a cryptic storage error. This caps the client limit at 5MB — the dropzone copy derives from `COVER_MAX_MB`, so it now reads "up to 5MB" automatically.

Also corrects a misleading comment: the `banners` bucket has **no** owner-scoped RLS policy (only `project-files` does), so the `${userId}/` path prefix is a namespacing convention, not an RLS-enforced boundary — same as avatars/banners already operate.

## Context

Found during a post-launch audit of the session's shipped features. The audit also confirmed the cover surface is otherwise sound: the `banners` bucket **is** restricted to image MIME types (no SVG) + 5MB server-side, markdown rendering has no XSS (`react-markdown`, no `rehype-raw`, `rehypeSanitize` applied), and JSON-LD is escaped.

## Flagged separately (not this PR)

`banners`/`avatars` buckets lack owner-scoped write RLS (pre-existing, app-wide — only `project-files` has it). Adding it touches the long-standing avatar/banner upload path, so it needs deliberate testing rather than a drive-by change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)