### PR TITLE
feat(wallets): reframe add-a-wallet so non-technical users don't bounce

### DIFF
--- a/src/components/wallets/WalletManager/components/WalletForm.tsx
+++ b/src/components/wallets/WalletManager/components/WalletForm.tsx
@@ -1,9 +1,15 @@
 /**
  * WALLET FORM COMPONENT
- * Form for adding or editing wallet details
+ * Add or edit a way to get paid. Optimized for a non-technical person: the ONLY
+ * thing required is one payment handle, and the approachable option (a Lightning
+ * address — works like an email) leads. On-chain / xpub and Nostr Wallet Connect
+ * are demoted behind an "advanced" disclosure, and naming/categorizing is
+ * optional (collapsed), so the happy path is "paste your Lightning address → Save".
  */
 
 import { useState } from 'react';
+import { ChevronDown, ChevronRight, Zap } from 'lucide-react';
+import Link from 'next/link';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
@@ -19,7 +25,7 @@ export function WalletForm({
   initialData,
   onSubmit,
   onCancel,
-  submitLabel = 'Add Wallet',
+  submitLabel = 'Save',
   onFieldFocus,
 }: WalletFormProps) {
   const [formData, setFormData] = useState<WalletFormData>({
@@ -37,23 +43,23 @@ export function WalletForm({
   });
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // The advanced (technical) rails — reveal only if the user already has one
+  // saved (editing) or explicitly asks for them.
+  const [showAdvanced, setShowAdvanced] = useState(
+    !!initialData?.address_or_xpub || !!initialData?.nwc_connection_uri
+  );
+  const [showDetails, setShowDetails] = useState(false);
 
   const handleSubmit = async () => {
     setError(null);
 
-    // Comprehensive validation
-    if (!formData.label?.trim()) {
-      setError('Wallet name is required');
-      return;
-    }
-
-    // Require at least one receive method: on-chain, Lightning address, or NWC
+    // The one hard requirement: a way to actually get paid.
     if (
       !formData.address_or_xpub?.trim() &&
       !formData.lightning_address?.trim() &&
       !formData.nwc_connection_uri?.trim()
     ) {
-      setError('Provide a Bitcoin address/xpub, a Lightning address, or an NWC connection');
+      setError('Add a Lightning address (or an on-chain address / NWC) so people can pay you.');
       return;
     }
 
@@ -65,16 +71,6 @@ export function WalletForm({
       return;
     }
 
-    if (!formData.category) {
-      setError('Wallet category is required');
-      return;
-    }
-
-    // Ensure behavior_type is set
-    if (!formData.behavior_type) {
-      setFormData(prev => ({ ...prev, behavior_type: 'general' }));
-    }
-
     if (formData.address_or_xpub?.trim()) {
       const validation = validateAddressOrXpub(formData.address_or_xpub);
       if (!validation.valid) {
@@ -83,9 +79,17 @@ export function WalletForm({
       }
     }
 
+    // Name and category are optional — default them so nothing blocks saving.
+    const payload: WalletFormData = {
+      ...formData,
+      label: formData.label?.trim() || 'My wallet',
+      category: formData.category || 'general',
+      behavior_type: formData.behavior_type || 'general',
+    };
+
     setIsSubmitting(true);
     try {
-      await onSubmit(formData);
+      await onSubmit(payload);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save wallet');
       setIsSubmitting(false);
@@ -95,176 +99,205 @@ export function WalletForm({
   const selectedCategory = WALLET_CATEGORIES[formData.category];
 
   return (
-    <div className="border dark:border-default rounded-lg p-4 bg-surface-raised">
-      <h4 className="font-semibold dark:text-fg-primary mb-4">{submitLabel}</h4>
+    <div className="rounded-lg border border-default bg-surface-raised p-4">
+      <h4 className="mb-1 font-semibold text-fg-primary">
+        {submitLabel === 'Save' ? 'Get paid in Bitcoin' : submitLabel}
+      </h4>
+      <p className="mb-4 text-sm text-fg-secondary">
+        Add where you want the money to land. You can change this anytime.
+      </p>
 
       {error && <div className="oc-error-surface mb-4 px-4 py-2">{error}</div>}
 
-      {/* Category selection */}
+      {/* Primary path: Lightning address (email-like, approachable) */}
       <div className="mb-4">
-        <label className="block text-sm font-medium dark:text-fg-primary mb-2">Category</label>
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-          {(Object.keys(WALLET_CATEGORIES) as WalletCategory[]).map(cat => {
-            const catInfo = WALLET_CATEGORIES[cat];
-            return (
-              <button
-                key={cat}
-                type="button"
-                onClick={() => {
-                  setFormData({ ...formData, category: cat, category_icon: catInfo.icon });
-                  onFieldFocus?.('category');
-                }}
-                className={`p-3 border rounded-lg text-left transition-colors ${
-                  formData.category === cat
-                    ? 'border-bitcoinOrange bg-bitcoinOrange/5'
-                    : 'border-strong hover:border-strong'
-                }`}
-              >
-                <div className="text-2xl mb-1">{catInfo.icon}</div>
-                <div className="text-sm font-medium dark:text-fg-primary">{catInfo.label}</div>
-              </button>
-            );
-          })}
-        </div>
-        <p className="text-xs text-fg-secondary mt-2">{selectedCategory.description}</p>
-      </div>
-
-      {/* Label */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium dark:text-fg-primary mb-2">Wallet Name *</label>
-        <Input
-          value={formData.label}
-          onChange={e => setFormData({ ...formData, label: e.target.value })}
-          onFocus={() => onFieldFocus?.('label')}
-          placeholder="e.g., Monthly Rent, Groceries, Medical Fund"
-          required
-        />
-      </div>
-
-      {/* Description */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium dark:text-fg-primary mb-2">
-          Description (optional)
-        </label>
-        <Textarea
-          value={formData.description ?? ''}
-          onChange={e => setFormData({ ...formData, description: e.target.value })}
-          onFocus={() => onFieldFocus?.('description')}
-          placeholder="Explain how these funds will be used..."
-          rows={2}
-        />
-      </div>
-
-      {/* Address or xpub */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium dark:text-fg-primary mb-2">
-          Bitcoin Address or Extended Public Key
-          <span className="ml-2 text-xs font-normal text-fg-secondary">
-            (optional if Lightning address provided)
-          </span>
-        </label>
-        <Input
-          value={formData.address_or_xpub ?? ''}
-          onChange={e => setFormData({ ...formData, address_or_xpub: e.target.value })}
-          onFocus={() => onFieldFocus?.('addressOrXpub')}
-          placeholder="zpub... (recommended) or bc1q..."
-          required
-        />
-        <p className="text-xs text-fg-secondary mt-1">
-          Extended public keys (xpub/ypub/zpub) automatically track all addresses and transactions.
-          Single addresses work but only track that one address.
-        </p>
-      </div>
-
-      {/* Lightning Address */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium dark:text-fg-primary mb-2">
-          Lightning Address (optional)
+        <label className="mb-2 flex items-center gap-1.5 text-sm font-medium text-fg-primary">
+          <Zap className="h-4 w-4 text-bitcoinOrange" />
+          Your Lightning address
         </label>
         <Input
           value={formData.lightning_address || ''}
           onChange={e => setFormData({ ...formData, lightning_address: e.target.value })}
-          onFocus={() => onFieldFocus?.('label')}
-          placeholder="you@getalby.com"
+          onFocus={() => onFieldFocus?.('lightningAddress')}
+          placeholder="you@primal.net"
+          inputMode="email"
         />
-        <p className="text-xs text-fg-secondary mt-1">
-          Lightning address for instant, low-fee payments (e.g., you@getalby.com)
+        <p className="mt-1.5 text-xs text-fg-secondary">
+          It works like an email address for Bitcoin — instant and near-zero fee.{' '}
+          <Link href="/wallets" className="text-accent-warm underline hover:text-accent-warm-hover">
+            Don&apos;t have one? Get set up in a minute →
+          </Link>
         </p>
       </div>
 
-      {/* Nostr Wallet Connect (optional) */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium dark:text-fg-primary mb-2">
-          Nostr Wallet Connect (optional)
-        </label>
-        <Input
-          type="password"
-          value={formData.nwc_connection_uri || ''}
-          onChange={e => setFormData({ ...formData, nwc_connection_uri: e.target.value })}
-          onFocus={() => onFieldFocus?.('label')}
-          placeholder="nostr+walletconnect://..."
-          autoComplete="off"
-        />
-        <p className="text-xs text-fg-secondary mt-1">
-          Connect a wallet (Alby, Mutiny, …) to receive automatically — the highest-priority payout
-          rail. The connection secret is stored securely and never shown again.
-        </p>
-      </div>
-
-      {/* Goal (optional) */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium dark:text-fg-primary mb-2">
-          Funding Goal (optional)
-        </label>
-        <div className="flex gap-2">
-          <Input
-            type="number"
-            step="0.01"
-            value={formData.goal_amount || ''}
-            onChange={e =>
-              setFormData({ ...formData, goal_amount: parseFloat(e.target.value) || undefined })
-            }
-            onFocus={() => onFieldFocus?.('goalAmount')}
-            placeholder="1000"
-            className="flex-1"
-          />
-          <select
-            value={formData.goal_currency ?? ''}
-            onChange={e => setFormData({ ...formData, goal_currency: e.target.value })}
-            onFocus={() => onFieldFocus?.('goalCurrency')}
-            className="border rounded px-3 py-2"
-          >
-            <option value="CHF">CHF</option>
-            <option value="USD">USD</option>
-            <option value="EUR">EUR</option>
-            <option value="BTC">BTC</option>
-          </select>
-        </div>
-      </div>
-
-      {/* Primary wallet checkbox (only when editing) */}
-      {initialData?.address_or_xpub && (
-        <div className="mb-4">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={formData.is_primary || false}
-              onChange={e => setFormData({ ...formData, is_primary: e.target.checked })}
-              className="w-4 h-4 text-bitcoinOrange border-strong rounded focus:ring-ring"
+      {/* Advanced rails: on-chain address / xpub + Nostr Wallet Connect */}
+      <button
+        type="button"
+        onClick={() => setShowAdvanced(v => !v)}
+        className="mb-2 flex items-center gap-1 text-xs font-medium text-fg-secondary hover:text-fg-primary"
+      >
+        {showAdvanced ? (
+          <ChevronDown className="h-3.5 w-3.5" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5" />
+        )}
+        Other ways to get paid (advanced)
+      </button>
+      {showAdvanced && (
+        <div className="mb-4 space-y-4 border-l-2 border-subtle pl-3">
+          <div>
+            <label className="mb-2 block text-sm font-medium text-fg-primary">
+              On-chain Bitcoin address or extended key
+            </label>
+            <Input
+              value={formData.address_or_xpub ?? ''}
+              onChange={e => setFormData({ ...formData, address_or_xpub: e.target.value })}
+              onFocus={() => onFieldFocus?.('addressOrXpub')}
+              placeholder="bc1q…  or  zpub…"
             />
-            <span className="text-sm font-medium">Set as primary wallet</span>
-          </label>
-          <p className="text-xs text-fg-secondary mt-1 ml-6">
-            The primary wallet is displayed prominently on your profile. Only one wallet can be
-            primary at a time.
-          </p>
+            <p className="mt-1.5 text-xs text-fg-secondary">
+              Slower (~10 min to confirm), better for larger amounts. An extended key
+              (xpub/ypub/zpub) auto-tracks new addresses; a single address also works.
+            </p>
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-fg-primary">
+              Nostr Wallet Connect
+            </label>
+            <Input
+              type="password"
+              value={formData.nwc_connection_uri || ''}
+              onChange={e => setFormData({ ...formData, nwc_connection_uri: e.target.value })}
+              onFocus={() => onFieldFocus?.('addressOrXpub')}
+              placeholder="nostr+walletconnect://…"
+              autoComplete="off"
+            />
+            <p className="mt-1.5 text-xs text-fg-secondary">
+              Connect a wallet (Alby, Coinos, …) so payments settle automatically — the best
+              experience if you have it. The connection secret is stored securely and never shown
+              again.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Optional: name, description, category, goal */}
+      <button
+        type="button"
+        onClick={() => setShowDetails(v => !v)}
+        className="mb-2 flex items-center gap-1 text-xs font-medium text-fg-secondary hover:text-fg-primary"
+      >
+        {showDetails ? (
+          <ChevronDown className="h-3.5 w-3.5" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5" />
+        )}
+        Name &amp; details (optional)
+      </button>
+      {showDetails && (
+        <div className="mb-4 space-y-4 border-l-2 border-subtle pl-3">
+          <div>
+            <label className="mb-2 block text-sm font-medium text-fg-primary">Wallet name</label>
+            <Input
+              value={formData.label}
+              onChange={e => setFormData({ ...formData, label: e.target.value })}
+              onFocus={() => onFieldFocus?.('label')}
+              placeholder="e.g., Tips, Main wallet"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-fg-primary">Description</label>
+            <Textarea
+              value={formData.description ?? ''}
+              onChange={e => setFormData({ ...formData, description: e.target.value })}
+              onFocus={() => onFieldFocus?.('description')}
+              placeholder="What this wallet is for…"
+              rows={2}
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-fg-primary">Category</label>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {(Object.keys(WALLET_CATEGORIES) as WalletCategory[]).map(cat => {
+                const catInfo = WALLET_CATEGORIES[cat];
+                return (
+                  <button
+                    key={cat}
+                    type="button"
+                    onClick={() => {
+                      setFormData({ ...formData, category: cat, category_icon: catInfo.icon });
+                      onFieldFocus?.('category');
+                    }}
+                    className={`rounded-lg border p-3 text-left transition-colors ${
+                      formData.category === cat
+                        ? 'border-bitcoinOrange bg-bitcoinOrange/5'
+                        : 'border-strong hover:border-strong'
+                    }`}
+                  >
+                    <div className="mb-1 text-2xl">{catInfo.icon}</div>
+                    <div className="text-sm font-medium text-fg-primary">{catInfo.label}</div>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="mt-2 text-xs text-fg-secondary">{selectedCategory.description}</p>
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-fg-primary">Funding goal</label>
+            <div className="flex gap-2">
+              <Input
+                type="number"
+                step="0.01"
+                value={formData.goal_amount || ''}
+                onChange={e =>
+                  setFormData({ ...formData, goal_amount: parseFloat(e.target.value) || undefined })
+                }
+                onFocus={() => onFieldFocus?.('goalAmount')}
+                placeholder="1000"
+                className="flex-1"
+              />
+              <select
+                value={formData.goal_currency ?? ''}
+                onChange={e => setFormData({ ...formData, goal_currency: e.target.value })}
+                onFocus={() => onFieldFocus?.('goalCurrency')}
+                className="rounded border px-3 py-2"
+              >
+                <option value="CHF">CHF</option>
+                <option value="USD">USD</option>
+                <option value="EUR">EUR</option>
+                <option value="BTC">BTC</option>
+              </select>
+            </div>
+          </div>
+
+          {/* Primary wallet toggle (only meaningful when more than one exists) */}
+          {initialData?.address_or_xpub && (
+            <div>
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={formData.is_primary || false}
+                  onChange={e => setFormData({ ...formData, is_primary: e.target.checked })}
+                  className="h-4 w-4 rounded border-strong text-bitcoinOrange focus:ring-ring"
+                />
+                <span className="text-sm font-medium">Show this one on my profile</span>
+              </label>
+              <p className="ml-6 mt-1 text-xs text-fg-secondary">
+                The primary wallet is the one shown prominently on your profile.
+              </p>
+            </div>
+          )}
         </div>
       )}
 
       {/* Actions */}
       <div className="flex gap-2">
         <Button type="button" onClick={handleSubmit} disabled={isSubmitting} className="flex-1">
-          {isSubmitting ? 'Saving...' : submitLabel}
+          {isSubmitting ? 'Saving…' : submitLabel}
         </Button>
         <Button type="button" onClick={onCancel} variant="outline">
           Cancel

--- a/src/lib/wallet-guidance.ts
+++ b/src/lib/wallet-guidance.ts
@@ -19,6 +19,7 @@ import {
   Coins,
   PiggyBank,
   RefreshCcw,
+  Zap,
 } from 'lucide-react';
 import type { FieldGuidanceContent, DefaultContent } from '@/lib/project-guidance';
 
@@ -26,6 +27,7 @@ export type WalletFieldType =
   | 'category'
   | 'label'
   | 'description'
+  | 'lightningAddress'
   | 'addressOrXpub'
   | 'goalAmount'
   | 'goalCurrency'
@@ -76,6 +78,19 @@ export const walletGuidanceContent: Record<NonNullable<WalletFieldType>, FieldGu
       'Food and basic groceries while I am between jobs.',
       'Emergency medical costs for ongoing treatment.',
     ],
+  },
+  lightningAddress: {
+    icon: React.createElement(Zap, { className: 'w-5 h-5 text-fg-primary' }),
+    title: 'Your Lightning Address',
+    description:
+      'The easiest way to get paid. A Lightning address looks and works like an email address — people send Bitcoin to it instantly, with almost no fee. This is the recommended option for most people.',
+    tips: [
+      'It looks like an email: name@provider.com',
+      "Don't have one yet? Apps like Primal or Coinos give you one for free in about a minute",
+      'Payments arrive instantly — great for tips and everyday support',
+      'Paste it exactly as your wallet app shows it',
+    ],
+    examples: ['you@primal.net', 'you@coinos.io', 'you@getalby.com'],
   },
   addressOrXpub: {
     icon: React.createElement(KeyRound, { className: 'w-5 h-5 text-fg-primary' }),


### PR DESCRIPTION
First shippable step from the wallet-onboarding deep dive. The audit found the add-wallet form is the **#1 place a normal person quits**: it led with *"Bitcoin Address or Extended Public Key"* recommending `zpub…`, forced a budget-category pick first, and required a name — all before the one thing that matters (a way to get paid).

## Reframe (no data-model / API change)

- **Lightning address leads**, framed as *"works like an email address for Bitcoin — instant and near-zero fee,"* with a **"Don't have one? Get set up in a minute →"** link to `/wallets`.
- **On-chain address/xpub AND Nostr Wallet Connect** are demoted behind an **"Other ways to get paid (advanced)"** disclosure (auto-opens when editing an existing one). The NWC field + validation added upstream are preserved.
- **Name / description / category / goal** move into an optional **"Name & details"** disclosure and both default (`label→"My wallet"`, `category→general`), so **the only hard requirement is now one payment handle.**
- Added plain-English **Lightning-address guidance** to the help sidebar (new `lightningAddress` field type) with real provider examples (Primal/Coinos/Alby).

## Before → after

| | Before | After |
|---|---|---|
| First thing shown | 12-button category grid | "Your Lightning address" |
| Recommended field | `zpub…` (xpub) | Lightning address (email-like) |
| Required to save | name + category + a handle | one payment handle |
| xpub / NWC | prominent / stacked | behind "advanced" |

## Scope

This is the friction fix on the *connect-your-own-wallet* surface. The bigger unlock — **auto-provisioning a hosted `you@orangecat.ch` Lightning address at signup** so receiving needs zero setup — depends on standing up a Lightning backend and is tracked separately (it needs a custody decision + infra).

type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)