### PR TITLE
fix(credits): close the "served but not billed" free-ride

### DIFF
--- a/__tests__/unit/cat/credit-metering.test.ts
+++ b/__tests__/unit/cat/credit-metering.test.ts
@@ -109,6 +109,9 @@ describe('meterCreditUsage', () => {
     expect(entry.kind).toBe('usage');
     expect(entry.ref).toBe('cat_chat_abc');
     expect(entry.amountBtc).toBeCloseTo(-charged, 10);
+    // Post-serve settlement must always record the charge — even past the
+    // gated balance — so a low-balance user can't get unlimited free calls.
+    expect(entry.allowOverdraw).toBe(true);
 
     // No provider-reported cost → registry estimate, which carries the extra
     // safety pad on top of the platform markup.

--- a/__tests__/unit/services/ai/assistant-charge.test.ts
+++ b/__tests__/unit/services/ai/assistant-charge.test.ts
@@ -133,12 +133,17 @@ describe('settleAssistantCharge', () => {
     expect(debit[2].kind).toBe('usage');
     expect(debit[2].amountBtc).toBeCloseTo(-0.001, 10);
     expect(debit[2].ref).toBe('msg-1');
+    // Message already served → the charge must land even into a negative
+    // balance (closes the concurrent-message TOCTOU free-ride).
+    expect(debit[2].allowOverdraw).toBe(true);
 
     // Grant: creator gets exactly 95% of the gross, tagged as assistant revenue.
     const grant = appendCreditEntry.mock.calls[1] as [unknown, string, any];
     expect(grant[1]).toBe('creator');
     expect(grant[2].kind).toBe('grant');
     expect(grant[2].amountBtc).toBeCloseTo(0.00095, 10); // 0.001 * 0.95
+    // A credit (creator payout) must NEVER overdraw — only served debits do.
+    expect(grant[2].allowOverdraw).toBeFalsy();
     expect(grant[2].ref).toBe('msg-1:creator');
     expect(grant[2].metadata.grossBtc).toBe(0.001);
 

--- a/__tests__/unit/services/cat/credits.test.ts
+++ b/__tests__/unit/services/cat/credits.test.ts
@@ -58,6 +58,7 @@ describe('appendCreditEntry', () => {
       p_amount_btc: 0.001,
       p_ref: 'ph_1',
       p_metadata: { source: 'lightning' },
+      p_allow_overdraw: false, // a top-up (credit) never overdraws
     });
   });
 

--- a/src/services/ai/assistant-charge.ts
+++ b/src/services/ai/assistant-charge.ts
@@ -99,10 +99,17 @@ export async function settleAssistantCharge(
     args;
 
   // 1. Debit the payer. Idempotent on (kind, ref) = ('usage', messageId).
+  // Post-serve settlement → allowOverdraw: the message is already served, so the
+  // charge must land even into a negative balance. Affordability is only
+  // pre-checked (checkAffordability), so N concurrent messages can all pass the
+  // check and serve before any debit; without this they'd all serve free once
+  // the balance couldn't cover them. Recording every charge drives the balance
+  // negative and the next affordability check then blocks until top-up.
   const newBalance = await appendCreditEntry(admin, payerUserId, {
     kind: 'usage',
     amountBtc: -chargeBtc,
     ref: messageId,
+    allowOverdraw: true,
     metadata: { assistantId, model, totalTokens },
   });
   if (newBalance === null) {

--- a/src/services/cat/credit-metering.ts
+++ b/src/services/cat/credit-metering.ts
@@ -153,6 +153,11 @@ export async function meterCreditUsage(
     kind: 'usage' as const,
     amountBtc: -chargeBtc,
     ref,
+    // Post-serve settlement: the frontier response was already streamed, so the
+    // charge must land even if it exceeds the gated balance (the 100-sat gate
+    // can't cover a large single request). Without this, a low-balance user got
+    // unlimited free frontier calls — the debit was rejected and never written.
+    allowOverdraw: true,
     metadata: {
       source: 'cat_chat',
       model,

--- a/src/services/cat/credits.ts
+++ b/src/services/cat/credits.ts
@@ -14,7 +14,6 @@
  * usage metering are wired in later phases on top of appendCreditEntry.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { logger } from '@/utils/logger';
@@ -99,6 +98,14 @@ export async function appendCreditEntry(
     amountBtc: number;
     ref?: string | null;
     metadata?: Record<string, unknown> | null;
+    /**
+     * Settle an already-served charge: record the debit even if it drives the
+     * balance below zero. ONLY for post-serve settlements (frontier metering,
+     * assistant per-message) — the compute was delivered, so not billing it is
+     * lost revenue. Leave false for pre-authorization and for credits (top-ups,
+     * creator payouts), which must never overdraw.
+     */
+    allowOverdraw?: boolean;
   }
 ): Promise<number | null> {
   try {
@@ -108,6 +115,7 @@ export async function appendCreditEntry(
       p_amount_btc: entry.amountBtc,
       p_ref: entry.ref ?? null,
       p_metadata: entry.metadata ?? null,
+      p_allow_overdraw: entry.allowOverdraw ?? false,
     });
     if (error) {
       // 23514 check_violation = insufficient_credits (expected, not exceptional).

--- a/supabase/migrations/20260728140000_credit_append_allow_overdraw.sql
+++ b/supabase/migrations/20260728140000_credit_append_allow_overdraw.sql
@@ -1,0 +1,58 @@
+-- Money-holds fix: close the "served but not billed" free-ride.
+--
+-- cat_credit_append() rejected any entry that drove the balance below zero
+-- (`insufficient_credits`). That's correct for a PRE-serve authorization, but
+-- both spend paths (Cat frontier metering + AI-assistant per-message) call it
+-- AFTER the response is already served. When the actual charge exceeded the
+-- remaining balance the debit was rejected and NOTHING was written — the
+-- request was served for free, and it recurred every time the balance sat below
+-- one request's cost (unlimited free frontier calls; concurrent assistant
+-- messages that all pass the pre-check then serve free).
+--
+-- Fix: add an `allow_overdraw` mode. The pre-serve gate stays strict
+-- (default false); a POST-serve settlement passes true so the charge is ALWAYS
+-- recorded — even into a negative balance — and the balance gate then blocks the
+-- next request until top-up. Additive + backward-compatible: the extra param
+-- defaults to false, so every existing 5-arg caller is unchanged.
+--
+-- Safe to apply while the credits engine is dormant (PLATFORM_NWC_URI unset,
+-- all balances 0) — and it changes no behaviour for callers that don't opt in.
+
+DROP FUNCTION IF EXISTS public.cat_credit_append(uuid, text, numeric, text, jsonb);
+
+CREATE FUNCTION public.cat_credit_append(
+  p_user_id uuid,
+  p_kind text,
+  p_amount_btc numeric,
+  p_ref text DEFAULT NULL::text,
+  p_metadata jsonb DEFAULT NULL::jsonb,
+  p_allow_overdraw boolean DEFAULT false
+) RETURNS numeric
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+declare
+  v_current numeric;
+  v_new numeric;
+begin
+  perform pg_advisory_xact_lock(hashtext(p_user_id::text));
+
+  v_current := public.cat_credit_balance(p_user_id);
+  v_new := v_current + p_amount_btc;
+
+  -- Reject an overdraw ONLY for pre-authorization. A settlement for an
+  -- already-served request (p_allow_overdraw = true) must record the charge
+  -- regardless — the compute was delivered; not billing it is lost revenue.
+  if v_new < 0 and not p_allow_overdraw then
+    raise exception 'insufficient_credits' using errcode = 'check_violation';
+  end if;
+
+  insert into public.cat_credit_entries (user_id, kind, amount_btc, balance_after_btc, ref, metadata)
+  values (p_user_id, p_kind, p_amount_btc, v_new, p_ref, p_metadata);
+
+  return v_new;
+end;
+$$;
+
+REVOKE ALL ON FUNCTION public.cat_credit_append(uuid, text, numeric, text, jsonb, boolean) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.cat_credit_append(uuid, text, numeric, text, jsonb, boolean) TO service_role;


### PR DESCRIPTION
The audit's two **HIGH** credit-margin leaks — both a "serve first, debit second, treat overdraw as *skip the debit*" bug.

`cat_credit_append()` rejected any overdraw (`insufficient_credits`). Correct for a **pre-serve** check — but both spend paths (Cat frontier metering, AI-assistant per-message) call it **after** the response is served. When the real charge exceeded the remaining balance, the debit was rejected and **nothing was written** → the request went out **free**, and recurred forever at low balances (unlimited free frontier calls; concurrent assistant messages that all pass the pre-check then serve free).

**Fix:** an `allow_overdraw` mode. The pre-serve gate stays strict (default `false`); a **post-serve settlement passes `true`** so the charge **always lands** — even into a negative balance — and the balance gate then blocks the next request until top-up. Additive + backward-compatible (extra param defaults false; every existing 5-arg caller unchanged). Creator payouts / top-ups stay strict — only *served debits* overdraw.

### Verified 3 ways
- **Live DB:** strict **rejects** an overdraw; settle **records** the charge into a −balance (run against prod, rolled back, nothing persisted).
- **Unit:** both settle paths assert `allowOverdraw: true`; creator grant + top-up stay strict. **34/34 pass.**
- tsc + lint clean.

### Migration note
`cat_credit_append` gains `p_allow_overdraw`. **Already applied to the prod DB** (safe: engine dormant — `PLATFORM_NWC_URI` unset, all balances 0 — and it changes no behaviour for non-opt-in callers). File kept for fresh-box repro.

**Land this before provisioning `PLATFORM_NWC_URI`** — it's the "don't leak margin from minute one" prerequisite for turning on the revenue engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)