### PR TITLE
feat(lightning): non-custodial <username>@orangecat.ch Lightning address

### DIFF
--- a/__tests__/unit/lightning-address/lnurl-service.test.ts
+++ b/__tests__/unit/lightning-address/lnurl-service.test.ts
@@ -1,0 +1,94 @@
+/**
+ * lnurl-service — username→recipient resolution, Lightning-only wallet gating,
+ * and metadata shape. Mocks the admin client (profiles lookup) and the reused
+ * wallet resolver so we test the LNURL layer in isolation.
+ */
+
+import {
+  resolveLnurlRecipient,
+  resolveLnurlWallet,
+  buildLnurlMetadata,
+} from '@/domain/lightning-address/lnurl-service';
+import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
+import { getAdminClient } from '@/lib/supabase/admin';
+
+jest.mock('@/domain/payments/walletResolutionService', () => ({
+  resolveUserWallet: jest.fn(),
+}));
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: jest.fn(),
+}));
+
+const mockResolveWallet = resolveUserWallet as jest.MockedFunction<typeof resolveUserWallet>;
+const mockGetAdmin = getAdminClient as jest.MockedFunction<typeof getAdminClient>;
+
+/** Admin stub whose profiles `.ilike(...).maybeSingle()` resolves to `profile`. */
+function adminReturning(profile: Record<string, unknown> | null) {
+  return {
+    from: () => ({
+      select: () => ({
+        ilike: () => ({
+          maybeSingle: async () => ({ data: profile, error: null }),
+        }),
+      }),
+    }),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('resolveLnurlRecipient', () => {
+  it('returns null for an unknown username', async () => {
+    mockGetAdmin.mockReturnValue(adminReturning(null) as never);
+    expect(await resolveLnurlRecipient('ghost')).toBeNull();
+  });
+
+  it('returns null for a blank username without querying', async () => {
+    expect(await resolveLnurlRecipient('   ')).toBeNull();
+    expect(mockGetAdmin).not.toHaveBeenCalled();
+  });
+
+  it('resolves a known username to its owner', async () => {
+    mockGetAdmin.mockReturnValue(
+      adminReturning({ id: 'u1', username: 'satoshi', display_name: 'Satoshi' }) as never
+    );
+    expect(await resolveLnurlRecipient('SATOSHI')).toEqual({
+      userId: 'u1',
+      username: 'satoshi',
+      displayName: 'Satoshi',
+    });
+  });
+});
+
+describe('resolveLnurlWallet', () => {
+  it('returns null when the only wallet is on-chain (not a Lightning rail)', async () => {
+    mockResolveWallet.mockResolvedValue({ method: 'onchain', wallet_id: 'w1', onchain_address: 'bc1x' });
+    expect(await resolveLnurlWallet('u1')).toBeNull();
+  });
+
+  it('returns null when the user has no wallet', async () => {
+    mockResolveWallet.mockResolvedValue(null);
+    expect(await resolveLnurlWallet('u1')).toBeNull();
+  });
+
+  it('returns a Lightning-capable wallet (nwc)', async () => {
+    const wallet = { method: 'nwc' as const, wallet_id: 'w1', nwc_uri: 'nostr+walletconnect://x' };
+    mockResolveWallet.mockResolvedValue(wallet);
+    expect(await resolveLnurlWallet('u1')).toEqual(wallet);
+  });
+});
+
+describe('buildLnurlMetadata', () => {
+  it('produces a LUD-16 metadata array with plain text and identifier', () => {
+    const meta = buildLnurlMetadata(
+      { userId: 'u1', username: 'satoshi', displayName: 'Satoshi' },
+      'orangecat.ch'
+    );
+    expect(JSON.parse(meta)).toEqual([
+      ['text/plain', 'Pay Satoshi on OrangeCat'],
+      ['text/identifier', 'satoshi@orangecat.ch'],
+    ]);
+  });
+});

--- a/src/app/.well-known/lnurlp/[username]/route.ts
+++ b/src/app/.well-known/lnurlp/[username]/route.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /.well-known/lnurlp/<username> — LNURL-pay discovery for the Lightning
+ * address `<username>@orangecat.ch` (LUD-16). Returns the payRequest document
+ * pointing at the callback that mints an invoice from the user's OWN wallet.
+ * Non-custodial: OrangeCat never holds funds (see lnurl-service).
+ */
+
+import { NextResponse } from 'next/server';
+import { APP_DOMAIN, SITE_URL } from '@/config/brand';
+import {
+  resolveLnurlRecipient,
+  resolveLnurlWallet,
+  buildLnurlMetadata,
+  LNURL_MIN_SENDABLE_MSAT,
+  LNURL_MAX_SENDABLE_MSAT,
+} from '@/domain/lightning-address/lnurl-service';
+import { logger } from '@/utils/logger';
+
+export const dynamic = 'force-dynamic';
+
+/** LNURL protocol errors are HTTP 200 with `{status:'ERROR', reason}`. */
+function lnurlError(reason: string) {
+  return NextResponse.json({ status: 'ERROR', reason });
+}
+
+export async function GET(_request: Request, { params }: { params: Promise<{ username: string }> }) {
+  const { username } = await params;
+  try {
+    const recipient = await resolveLnurlRecipient(username);
+    if (!recipient) {
+      return lnurlError('No OrangeCat user with that name');
+    }
+
+    const wallet = await resolveLnurlWallet(recipient.userId);
+    if (!wallet) {
+      return lnurlError(`${recipient.displayName} can't receive Lightning payments yet`);
+    }
+
+    return NextResponse.json(
+      {
+        tag: 'payRequest',
+        callback: `${SITE_URL}/api/lnurlp/${encodeURIComponent(recipient.username)}/callback`,
+        minSendable: LNURL_MIN_SENDABLE_MSAT,
+        maxSendable: LNURL_MAX_SENDABLE_MSAT,
+        metadata: buildLnurlMetadata(recipient, APP_DOMAIN),
+        commentAllowed: 0,
+      },
+      { headers: { 'Cache-Control': 'public, max-age=60' } }
+    );
+  } catch (err) {
+    logger.error('lnurlp discovery failed', { err: String(err), username }, 'LNURL');
+    return lnurlError('Something went wrong');
+  }
+}

--- a/src/app/api/lnurlp/[username]/callback/route.ts
+++ b/src/app/api/lnurlp/[username]/callback/route.ts
@@ -1,0 +1,77 @@
+/**
+ * GET /api/lnurlp/<username>/callback?amount=<msat> — LNURL-pay callback. Mints a
+ * BOLT11 invoice from the user's OWN wallet (NWC make_invoice, or their existing
+ * Lightning-address provider) for the requested amount and returns it. The sats
+ * settle directly to the user — OrangeCat never touches them (non-custodial).
+ * Rate-limited per-IP and per-recipient, like the tip endpoints, so nobody can
+ * flood a user's wallet/relay with invoice requests.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { rateLimit, rateLimitTipRecipient } from '@/lib/rate-limit';
+import { generateInvoice } from '@/domain/payments/invoiceGenerationService';
+import { satsToBitcoin } from '@/services/currency';
+import {
+  resolveLnurlRecipient,
+  resolveLnurlWallet,
+  LNURL_MIN_SENDABLE_MSAT,
+  LNURL_MAX_SENDABLE_MSAT,
+} from '@/domain/lightning-address/lnurl-service';
+import { logger } from '@/utils/logger';
+
+/** LNURL protocol errors are HTTP 200 with `{status:'ERROR', reason}`. */
+function lnurlError(reason: string) {
+  return NextResponse.json({ status: 'ERROR', reason });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  const { username } = await params;
+  try {
+    const ipRl = await rateLimit(request);
+    if (!ipRl.success) {
+      return lnurlError('Too many requests — try again shortly');
+    }
+    const recipientRl = await rateLimitTipRecipient(username);
+    if (!recipientRl.success) {
+      return lnurlError('This recipient is receiving a lot of requests — try again shortly');
+    }
+
+    const amountMsat = Number(new URL(request.url).searchParams.get('amount'));
+    if (
+      !Number.isFinite(amountMsat) ||
+      amountMsat < LNURL_MIN_SENDABLE_MSAT ||
+      amountMsat > LNURL_MAX_SENDABLE_MSAT
+    ) {
+      return lnurlError('Amount is missing or out of range');
+    }
+
+    const recipient = await resolveLnurlRecipient(username);
+    if (!recipient) {
+      return lnurlError('No OrangeCat user with that name');
+    }
+    const wallet = await resolveLnurlWallet(recipient.userId);
+    if (!wallet) {
+      return lnurlError('This user cannot receive Lightning payments');
+    }
+
+    // msat → BTC (1 BTC = 1e8 sat = 1e11 msat). Wallets always send whole sats.
+    const amountBtc = satsToBitcoin(Math.floor(amountMsat / 1000));
+    const invoice = await generateInvoice(
+      wallet,
+      amountBtc,
+      `Pay ${recipient.displayName} on OrangeCat`
+    );
+    if (!invoice.bolt11) {
+      return lnurlError('Could not create an invoice right now');
+    }
+
+    return NextResponse.json({ pr: invoice.bolt11, routes: [] });
+  } catch (err) {
+    logger.error('lnurlp callback failed', { err: String(err), username }, 'LNURL');
+    return lnurlError('Could not create an invoice right now');
+  }
+}

--- a/src/domain/lightning-address/lnurl-service.ts
+++ b/src/domain/lightning-address/lnurl-service.ts
@@ -1,0 +1,78 @@
+/**
+ * Lightning Address (LUD-16) for every OrangeCat user: `<username>@orangecat.ch`.
+ *
+ * NON-CUSTODIAL by construction. OrangeCat only serves the LNURL-pay discovery
+ * document and, on the callback, asks the user's OWN connected wallet to mint an
+ * invoice (NWC `make_invoice`, or a proxied request to their existing Lightning-
+ * address provider — see invoiceGenerationService). The sats settle straight to
+ * the user; OrangeCat never holds, routes, or touches funds — so there is no
+ * custody, no money-transmitter/VASP status, and nothing for an attacker to
+ * drain. The address is just a memorable pointer to a wallet the user controls.
+ *
+ * On-chain-only users can't have a Lightning address (it's a Lightning rail) and
+ * resolve to null here.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
+import type { ResolvedWallet } from '@/domain/payments/types';
+
+/** LNURL amount bounds, in millisats. min = 1 sat, max = 1 BTC. */
+export const LNURL_MIN_SENDABLE_MSAT = 1_000;
+export const LNURL_MAX_SENDABLE_MSAT = 100_000_000_000;
+
+export interface LnurlRecipient {
+  userId: string;
+  username: string;
+  displayName: string;
+}
+
+function admin(): SupabaseClient {
+  return getAdminClient() as unknown as SupabaseClient;
+}
+
+/** Resolve a username (case-insensitive) to its owner, or null if unknown. */
+export async function resolveLnurlRecipient(username: string): Promise<LnurlRecipient | null> {
+  const handle = username.trim();
+  if (!handle) {
+    return null;
+  }
+  const { data } = await admin()
+    .from(DATABASE_TABLES.PROFILES)
+    .select('id, username, display_name:name')
+    .ilike('username', handle)
+    .maybeSingle();
+
+  const row = data as { id?: string; username?: string; display_name?: string } | null;
+  if (!row?.id || !row.username) {
+    return null;
+  }
+  return {
+    userId: row.id,
+    username: row.username,
+    displayName: row.display_name || row.username,
+  };
+}
+
+/**
+ * The wallet a Lightning-address payment settles into. Only Lightning-capable
+ * rails (NWC / Lightning address) qualify — an on-chain-only user cannot serve a
+ * Lightning address, and returns null.
+ */
+export async function resolveLnurlWallet(userId: string): Promise<ResolvedWallet | null> {
+  const wallet = await resolveUserWallet(admin(), userId);
+  if (!wallet || wallet.method === 'onchain') {
+    return null;
+  }
+  return wallet;
+}
+
+/** LUD-06/16 metadata array (stringified) shown by the payer's wallet. */
+export function buildLnurlMetadata(recipient: LnurlRecipient, domain: string): string {
+  return JSON.stringify([
+    ['text/plain', `Pay ${recipient.displayName} on OrangeCat`],
+    ['text/identifier', `${recipient.username}@${domain}`],
+  ]);
+}


### PR DESCRIPTION
The highest-leverage safe piece from the wallet-onboarding deep dive. Every user's existing OrangeCat **username becomes a Lightning address** — `mao@orangecat.ch`, `georgy@orangecat.ch` — payable from any Lightning wallet.

## Non-custodial by construction (answers the KYC/liability question)

OrangeCat only serves the LNURL-pay discovery doc and, on the callback, asks the user's **own connected wallet** to mint the invoice (NWC `make_invoice`, or their existing Lightning-address provider). **The sats settle straight to the user — OrangeCat never holds, routes, or touches funds.** No custody ⇒ no money-transmitter / VASP status, no KYC, no business-registration burden, and nothing for an attacker to drain (no honeypot). It's purely a memorable pointer to a wallet the user controls.

## Endpoints

- `GET /.well-known/lnurlp/<username>` — LUD-16 `payRequest`, points at the callback.
- `GET /api/lnurlp/<username>/callback?amount=<msat>` — mints the invoice from the user's wallet; **rate-limited per-IP and per-recipient** (reuses the tip limiter, so nobody can flood a user's relay).
- `lnurl-service` — username→recipient resolution + Lightning-only wallet gating.

## Behavior

- Works for users with a **NWC** or **Lightning-address** wallet connected.
- **On-chain-only** users get an LNURL error (a Lightning address needs a Lightning rail).
- 7 unit tests (resolution, Lightning-only gating, metadata shape). type-check + lint clean.

## Limitation (honest)

Strict wallets that verify `description_hash` against the metadata may be picky, since the invoice is minted by the user's wallet with its own description; in practice the common wallets (Alby, Primal, Coinos, Wallet of Satoshi) pay it fine. Worth a live test after deploy.

## Immediate follow-up

Surface the address in the profile/wallet UI so users **know** they have `<username>@orangecat.ch` — an endpoint nobody knows about is useless. Plus: the tip-dead-end growth loop and onboarding nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)