### PR TITLE
feat(ai): add Opus 5 to registry, derive assistant model options from SSOT, gate sampling params by capability

### DIFF
--- a/__tests__/unit/services/ai/openrouter.test.ts
+++ b/__tests__/unit/services/ai/openrouter.test.ts
@@ -160,3 +160,50 @@ describe('OpenRouterService streamChatCompletion cost', () => {
     expect(finalUsage?.costBtc).toBe(expectedBtc);
   });
 });
+
+describe('OpenRouterService sampling-param gating', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function sentBody(): Record<string, unknown> {
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    return JSON.parse(init.body as string);
+  }
+
+  it('omits temperature for models with supportsTemperature=false', async () => {
+    fetchSpy.mockResolvedValue(
+      mockJsonResponse(completionBody({ prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }))
+    );
+
+    const svc = new OpenRouterService('sk-test', { btcPriceUsd: BTC_PRICE_USD });
+    await svc.chatCompletion({
+      model: 'anthropic/claude-opus-5',
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 0.2,
+    });
+
+    expect(sentBody()).not.toHaveProperty('temperature');
+  });
+
+  it('keeps temperature for models without the flag', async () => {
+    fetchSpy.mockResolvedValue(
+      mockJsonResponse(completionBody({ prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }))
+    );
+
+    const svc = new OpenRouterService('sk-test', { btcPriceUsd: BTC_PRICE_USD });
+    await svc.chatCompletion({
+      model: PAID_MODEL,
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 0.2,
+    });
+
+    expect(sentBody()).toHaveProperty('temperature', 0.2);
+  });
+});

--- a/src/components/ai-chat/ModernChatPanel/components/ModelSelector.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/ModelSelector.tsx
@@ -220,7 +220,7 @@ export function ModelSelector({
                         applyCustom();
                       }
                     }}
-                    placeholder="e.g. anthropic/claude-3.5-sonnet"
+                    placeholder="e.g. anthropic/claude-sonnet-5"
                     className="min-w-0 flex-1 rounded-md border border-subtle bg-surface-base px-2 py-1.5 text-sm text-fg-primary placeholder:text-fg-tertiary"
                     aria-label="Custom model id"
                   />

--- a/src/config/ai-models.ts
+++ b/src/config/ai-models.ts
@@ -48,6 +48,12 @@ export interface AIModelMetadata {
   isFree?: boolean;
   /** Rate limit info for free models */
   rateLimit?: string;
+  /**
+   * Whether the model accepts a non-default `temperature`. Absent = true.
+   * Current Anthropic frontier models (Sonnet 5, Opus 4.8, Opus 5, Fable 5)
+   * reject non-default sampling params, so requests must omit the param.
+   */
+  supportsTemperature?: boolean;
 }
 
 // ==================== MODEL REGISTRY ====================
@@ -204,6 +210,7 @@ export const AI_MODEL_REGISTRY: Record<string, AIModelMetadata> = {
     tier: 'standard',
     recommendedFor: ['coding', 'agents', 'professional writing', 'research'],
     isAvailable: true,
+    supportsTemperature: false,
   },
 
   // ==================== PREMIUM TIER ====================
@@ -222,6 +229,23 @@ export const AI_MODEL_REGISTRY: Record<string, AIModelMetadata> = {
     tier: 'premium',
     recommendedFor: ['complex reasoning', 'research', 'high-stakes coding'],
     isAvailable: true,
+    supportsTemperature: false,
+  },
+
+  'anthropic/claude-opus-5': {
+    id: 'anthropic/claude-opus-5',
+    name: 'Claude Opus 5',
+    provider: 'Anthropic',
+    description: 'Newest Anthropic flagship for the hardest reasoning and agentic work',
+    contextWindow: 1000000,
+    maxOutputTokens: 8192,
+    inputCostPer1M: 5.0,
+    outputCostPer1M: 25.0,
+    capabilities: ['text', 'vision', 'function_calling', 'streaming'],
+    tier: 'premium',
+    recommendedFor: ['complex reasoning', 'agents', 'research', 'high-stakes coding'],
+    isAvailable: true,
+    supportsTemperature: false,
   },
 
   'anthropic/claude-fable-5': {
@@ -237,6 +261,7 @@ export const AI_MODEL_REGISTRY: Record<string, AIModelMetadata> = {
     tier: 'premium',
     recommendedFor: ['autonomous agents', 'long-running tasks', 'deep research'],
     isAvailable: true,
+    supportsTemperature: false,
   },
 };
 

--- a/src/config/entity-configs/ai-assistant-config.ts
+++ b/src/config/entity-configs/ai-assistant-config.ts
@@ -18,6 +18,7 @@ import { createEntityConfig } from './base-config-factory';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { WalletSelectorField } from '@/components/create/wallet-selector';
 import { AI_COMPUTE_PROVIDER_TYPES } from '@/config/ai-assistants';
+import { getAvailableModels } from '@/config/ai-models';
 
 // ==================== CONSTANTS ====================
 
@@ -37,14 +38,12 @@ const AI_CATEGORIES = [
   'Other',
 ];
 
+// Options derive from the model registry (SSOT) so this dropdown can never
+// drift from what the platform actually serves. 'any' and 'local' are routing
+// sentinels, not models.
 const MODEL_PREFERENCES = [
   { value: 'any', label: 'Any - Let the system choose' },
-  { value: 'gpt-4', label: 'GPT-4' },
-  { value: 'gpt-4-turbo', label: 'GPT-4 Turbo' },
-  { value: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo' },
-  { value: 'claude-3-opus', label: 'Claude 3 Opus' },
-  { value: 'claude-3-sonnet', label: 'Claude 3 Sonnet' },
-  { value: 'claude-3-haiku', label: 'Claude 3 Haiku' },
+  ...getAvailableModels().map(m => ({ value: m.id, label: m.name })),
   { value: 'local', label: 'Local Model' },
 ];
 

--- a/src/services/ai/openrouter.ts
+++ b/src/services/ai/openrouter.ts
@@ -190,7 +190,9 @@ export class OpenRouterService {
     const request: OpenRouterRequest = {
       model,
       messages: fullMessages,
-      temperature,
+      // Some models (registry: supportsTemperature=false) 400 on a non-default
+      // temperature — omit the param entirely for those.
+      ...(modelMeta.supportsTemperature !== false && { temperature }),
       max_tokens: maxTokens || modelMeta.maxOutputTokens,
       stream: false,
     };
@@ -264,7 +266,7 @@ export class OpenRouterService {
       body: JSON.stringify({
         model,
         messages: fullMessages,
-        temperature,
+        ...(modelMeta.supportsTemperature !== false && { temperature }),
         max_tokens: maxTokens || modelMeta.maxOutputTokens,
         stream: true,
       }),


### PR DESCRIPTION
## What

Three SSOT/config-driven model-config changes, minimal diff:

1. **Claude Opus 5 in the model registry** (`src/config/ai-models.ts`)
   Slug verified against the live OpenRouter model list: `anthropic/claude-opus-5` — $5 input / $25 output per MTok, 1,000,000-token context (matches OpenRouter pricing exactly). Premium tier, same schema as the existing Anthropic entries. Opus 4.8 stays (still served).

2. **Assistant model dropdown derived from the registry** (`src/config/entity-configs/ai-assistant-config.ts`)
   The hardcoded `claude-3-opus/sonnet/haiku` + `gpt-4*` options were retired models and an SSOT violation — and their values never matched a registry id, so any selection silently fell back to the default free model. Options now map from `getAvailableModels()`; `any`/`local` remain as routing sentinels. Also updated the stale `anthropic/claude-3.5-sonnet` placeholder example in `ModelSelector.tsx` (cosmetic placeholder text, not a functional default).

3. **Sampling-param gating (latent 400)** (`src/config/ai-models.ts`, `src/services/ai/openrouter.ts`)
   Current Anthropic frontier models (Sonnet 5, Opus 4.8, Opus 5, Fable 5) reject non-default `temperature`, and assistants pass 0.2–0.9 on every request. One flag, one gate: new `supportsTemperature?: boolean` capability on registry entries (absent = true, so no other entry changes), and `OpenRouterService` omits `temperature` from the request body when false — covers both the streaming and non-streaming builders, i.e. every caller (assistants, Cat, BYOK). Anthropic models route exclusively through OpenRouter, so no other provider client needs the gate.

## Verification

- `npm run verify` green: docs checks, type-check, route audit, lint (0 errors), 108 suites / 1212 unit tests passed (before the new tests; 1214 with them)
- New regression tests in `__tests__/unit/services/ai/openrouter.test.ts` assert the request body omits `temperature` for `supportsTemperature: false` models and keeps it otherwise

## Notes

- `src/components/create/templates/ai-assistant-templates.ts` still seeds `model_preference: 'gpt-4'` in ~20 templates; those values resolve through the existing safe fallback in `selectModel` and were left out of scope to keep the diff minimal — happy to sweep them to `'any'` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)