### PR TITLE
fix(honesty): stop claiming payment capabilities the code can't deliver

### DIFF
--- a/src/app/(public)/bitcoin-wallet-guide/config.ts
+++ b/src/app/(public)/bitcoin-wallet-guide/config.ts
@@ -17,23 +17,44 @@ export interface WalletOption {
 
 export const walletOptions: WalletOption[] = [
   {
+    id: 'primal',
+    name: 'Primal',
+    type: 'mobile',
+    description:
+      'The fastest way to start receiving on OrangeCat. Install it and you get a Lightning address (like name@primal.net) in about a minute — exactly what OrangeCat needs to receive tips and funding.',
+    pros: [
+      'Gives you a Lightning address in ~1 minute',
+      'Instant, near-zero-fee receiving',
+      'Beautiful, genuinely beginner-friendly app',
+      'Works directly with your OrangeCat address',
+    ],
+    cons: ['Mobile only', 'Starts custodial — you can move to self-custody later'],
+    difficulty: 'beginner',
+    downloadUrl: 'https://primal.net/downloads',
+    supportedPlatforms: ['iOS', 'Android'],
+    features: ['Lightning address', 'Instant receiving', 'Beginner-friendly'],
+    recommended: true,
+  },
+  {
     id: 'brave',
     name: 'Brave Wallet',
     type: 'browser',
-    description: 'Built-in wallet in the Brave browser. Simple, secure, and perfect for beginners.',
+    description:
+      'Built-in wallet in the Brave browser. Good for holding on-chain Bitcoin, but it has no Lightning support — so it cannot receive Lightning tips or back a name@orangecat.ch address.',
     pros: [
       'Already built into Brave browser',
       'No additional downloads needed',
       'Self-custody - you control your keys',
       'Multi-chain support (Bitcoin, Ethereum, Solana)',
-      'Easy to use interface',
     ],
-    cons: ['Only available in Brave browser', 'Relatively new compared to other wallets'],
+    cons: [
+      'No Lightning support — cannot receive Lightning tips or a Lightning address',
+      'Only available in Brave browser',
+    ],
     difficulty: 'beginner',
     downloadUrl: 'https://brave.com/',
     supportedPlatforms: ['Windows', 'macOS', 'Linux', 'iOS', 'Android'],
     features: ['Self-custody', 'Multi-chain', 'Browser integrated', 'Open source'],
-    recommended: true,
   },
   {
     id: 'blue-wallet',

--- a/src/app/(public)/docs/page.tsx
+++ b/src/app/(public)/docs/page.tsx
@@ -119,12 +119,12 @@ export default function DocsPage() {
           </div>
           <div className="bg-surface-base rounded-lg border border-default p-6 space-y-4">
             <p className="text-fg-secondary leading-relaxed">
-              Bitcoin and Lightning Network are the native and preferred payment rails. OrangeCat
-              supports Lightning addresses (e.g.{' '}
+              Bitcoin and Lightning Network are the native and preferred payment rails. Once you
+              connect a Lightning-capable wallet, your username becomes a Lightning address (e.g.{' '}
               <code className="bg-surface-raised px-1 py-0.5 rounded text-sm font-mono">
                 yourname@orangecat.ch
               </code>
-              ) for instant, near-zero-fee payments. On-chain Bitcoin is also supported.
+              ) anyone can pay at instantly, near-zero-fee. On-chain Bitcoin is also supported.
             </p>
             <p className="text-fg-secondary leading-relaxed">
               Other rails are intentionally unavailable today. Fiat methods such as Twint rely on

--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -152,7 +152,7 @@ const FAQ_SECTIONS: FaqSection[] = [
       {
         question: 'What is the Lightning Network?',
         answer:
-          "The Lightning Network is a payment layer built on top of Bitcoin. It enables near-instant transactions with fees of a fraction of a cent — far cheaper and faster than on-chain Bitcoin. Think of it as Bitcoin's payment rails for everyday transactions. OrangeCat supports Lightning addresses (e.g. yourname@orangecat.ch) for easy receiving.",
+          "The Lightning Network is a payment layer built on top of Bitcoin. It enables near-instant transactions with fees of a fraction of a cent — far cheaper and faster than on-chain Bitcoin. Think of it as Bitcoin's payment rails for everyday transactions. Once you connect a Lightning-capable wallet, your username becomes a Lightning address (e.g. yourname@orangecat.ch) people can pay you at.",
       },
       {
         question: 'Does OrangeCat hold my Bitcoin?',

--- a/src/app/auth/AuthHeroPanel.tsx
+++ b/src/app/auth/AuthHeroPanel.tsx
@@ -20,7 +20,7 @@ import { ROUTES } from '@/config/routes';
 
 const HIGHLIGHTS = [
   { icon: TrendingUp, label: 'Full economic spectrum — exchange, fund, lend, invest, govern' },
-  { icon: Globe, label: 'Any currency, any identity — Bitcoin native, fiat where it makes sense' },
+  { icon: Globe, label: 'Bitcoin & Lightning native — instant, near-zero-fee, non-custodial' },
   { icon: Shield, label: 'Pseudonymous by default — real identity opt-in, never required' },
 ] as const;
 
@@ -53,8 +53,8 @@ export function AuthHeroPanel() {
         </h1>
 
         <p className="mb-10 text-lg leading-relaxed text-fg-secondary">
-          Fund, lend, invest, trade, and govern — with any identity, any currency, any counterparty.
-          No gatekeepers.
+          Fund, lend, invest, trade, and govern — with any identity, any counterparty, settled in
+          Bitcoin. No gatekeepers.
         </p>
 
         <ul className="space-y-3">

--- a/src/app/discover/layout.tsx
+++ b/src/app/discover/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Discover',
   description:
-    'Explore projects, causes, products, services, and more on OrangeCat — the open platform for economic participation with any identity, any currency.',
+    'Explore projects, causes, products, services, and more on OrangeCat — the open platform for economic participation with any identity, in Bitcoin.',
 };
 
 export default function DiscoverLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,7 +71,7 @@ export const metadata: Metadata = {
   },
   description: APP_DESCRIPTION,
   keywords:
-    'AI economic agent, bitcoin, finance, community, fund, invest, lend, products, services, lightning network, peer-to-peer, pseudonymous, any currency',
+    'AI economic agent, bitcoin, finance, community, fund, invest, lend, products, services, lightning network, peer-to-peer, pseudonymous, non-custodial',
   metadataBase: new URL(SITE_URL),
   openGraph: {
     type: 'website',
@@ -84,7 +84,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'OrangeCat - Your AI Economic Agent',
-    description: 'Fund, lend, invest, trade, and govern with any identity, any currency.',
+    description: 'Fund, lend, invest, trade, and govern with any identity, settled in Bitcoin.',
   },
   manifest: '/manifest.json',
   icons: {
@@ -121,7 +121,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   url: SITE_URL,
                   logo: `${SITE_URL}/images/orange-cat-logo.svg`,
                   description:
-                    'Fund, lend, invest, trade, and govern with any identity, any currency.',
+                    'Fund, lend, invest, trade, and govern with any identity, settled in Bitcoin.',
                   sameAs: [],
                 },
                 {

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: `${siteName} - Your AI Economic Agent`,
-    description: 'Exchange, fund, lend, invest, and govern — with any identity, in any currency.',
+    description: 'Exchange, fund, lend, invest, and govern — with any identity, settled in Bitcoin.',
     type: 'website',
     locale: 'en_US',
     siteName: siteName,
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: `${siteName} - Your AI Economic Agent`,
-    description: 'Exchange, fund, lend, invest, and govern — with any identity, in any currency.',
+    description: 'Exchange, fund, lend, invest, and govern — with any identity, settled in Bitcoin.',
   },
   robots: {
     index: true,


### PR DESCRIPTION
From the payments/wallets honesty audit. The money path itself is truthful (0%, non-custodial, verified settlement) — but several surfaces promise things the code can't do. Copy/config only, no logic change.

## Fixes

- **docs + FAQ** implied every user already has a working `yourname@orangecat.ch`. Reality: it resolves only once the user connects a **Lightning-capable** wallet (on-chain-only / no-wallet users get an LNURL error). Reworded to *"once you connect a Lightning-capable wallet, your username becomes a Lightning address."*
- **bitcoin-wallet-guide** recommended **Brave Wallet** to beginners — but Brave has **no Lightning support**, so the recommended path *guaranteed* the user couldn't receive tips or back a `@orangecat.ch` address. Un-recommended Brave (now honest about the limitation) and added **Primal** as the recommended beginner wallet (gives a Lightning address in ~1 min).
- **auth hero + SEO metadata** (layout, metadata, discover) still said *"any currency / fiat where it makes sense"* — fiat isn't implemented. Replaced with accurate Bitcoin/Lightning framing, matching the already-scrubbed landing-page config.

## Context: the audit's bottom line

**Real:** the payment stack, user NWC (persisted + AES-256-GCM encrypted), `<username>@orangecat.ch`, 0%/non-custodial. The feared `MockPaymentProvider` (fake invoices) is **dead code nothing calls**.

**Still to fix (separate, flagged):**
- 🔴 **Project funding numbers are fake** — the progress bar reads `raised_amount`, a column no code ever writes; the honest `get_entity_funding_stats` ledger (settled contributions) is only wired to cause/research pages. (Biggest functional lie — its own PR.)
- 🟡 Delete dead `MockPaymentProvider` + `btcpayProvider`.
- ⚙️ Cat Credits top-up is gated off until `PLATFORM_NWC_URI` is provisioned (needs founder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)