### PR TITLE
fix(projects): show REAL funding raised, not a column nothing writes

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -8,6 +8,8 @@ import { getTableName } from '@/config/entity-registry';
 import { safeJsonLdString } from '@/lib/seo/structured-data';
 import { APP_NAME, SITE_URL } from '@/config/brand';
 import { resolveSellerReceiveInfo } from '@/domain/payments';
+import { getEntityFundingStats } from '@/services/wallets/funding-stats';
+import { computeAmountRaised } from '@/lib/projectGoal';
 
 const ProjectPageClient = dynamic(() => import('@/components/project/ProjectPageClient'), {
   loading: () => (
@@ -181,12 +183,22 @@ export default async function PublicProjectPage({ params }: PageProps) {
     }
   }
 
+  // Honest funding total: the settled `contributions` ledger via
+  // get_entity_funding_stats — NOT the `raised_amount` column, which no code
+  // ever writes. Converted to the goal currency so the figure and progress bar
+  // are real. Returns 0 for a private fundraise or one with no verified
+  // contributions (better than showing a fabricated number).
+  const fundingStats = await getEntityFundingStats(supabase, 'project', id);
+  const settledRaisedBtc = fundingStats?.totalBtc ?? 0;
+  const settledRaised = await computeAmountRaised(settledRaisedBtc, project.currency ?? 'BTC');
+
   // Ensure non-nullable fields match ProjectPageClient's Project interface
   const projectWithProfile = {
     ...project,
     description: project.description ?? '',
     currency: project.currency ?? 'BTC',
-    raised_amount: project.raised_amount ?? 0,
+    raised_amount: settledRaised,
+    settled_raised_btc: settledRaisedBtc,
     profiles: profile ?? undefined,
   };
   const sellerReceive = await resolveSellerReceiveInfo(supabase, 'project', id);
@@ -194,7 +206,7 @@ export default async function PublicProjectPage({ params }: PageProps) {
   // Generate JSON-LD structured data for SEO
   const creatorName = profile?.name || profile?.username || 'Creator';
   const _progress = project.goal_amount
-    ? Math.round((Number(project.raised_amount || 0) / Number(project.goal_amount)) * 100)
+    ? Math.round((Number(settledRaised) / Number(project.goal_amount)) * 100)
     : 0;
 
   const structuredData = {
@@ -216,10 +228,10 @@ export default async function PublicProjectPage({ params }: PageProps) {
           value: project.goal_amount,
           currency: project.currency || 'BTC',
         },
-        ...(project.raised_amount && {
+        ...(settledRaised > 0 && {
           amountRaised: {
             '@type': 'MonetaryAmount',
-            value: project.raised_amount,
+            value: settledRaised,
             currency: project.currency || 'BTC',
           },
         }),

--- a/src/components/project/ProjectPageClient.tsx
+++ b/src/components/project/ProjectPageClient.tsx
@@ -40,6 +40,8 @@ interface Project {
   created_at: string;
   updated_at: string;
   // Extended fields that may be present
+  /** Honest settled-contributions total in BTC (from get_entity_funding_stats). */
+  settled_raised_btc?: number | null;
   bitcoin_balance_btc?: number | null;
   bitcoin_balance_updated_at?: string | null;
   supporters_count?: number | null;
@@ -181,6 +183,7 @@ export default function ProjectPageClient({ project, sellerReceive }: ProjectPag
                 last_support_at: project.last_support_at || null,
                 user_id: project.user_id,
               }}
+              settledRaisedBtc={project.settled_raised_btc || 0}
               isOwner={isOwner}
             />
 

--- a/src/components/project/ProjectSummaryRail.tsx
+++ b/src/components/project/ProjectSummaryRail.tsx
@@ -26,10 +26,13 @@ interface Props {
     last_support_at?: string | null;
     user_id?: string;
   };
+  /** Honest settled-contributions total in BTC (get_entity_funding_stats). Drives
+   *  "amount raised" — NOT the cached on-chain balance, which is Lightning-blind. */
+  settledRaisedBtc?: number;
   isOwner?: boolean;
 }
 
-export default function ProjectSummaryRail({ project, isOwner }: Props) {
+export default function ProjectSummaryRail({ project, settledRaisedBtc = 0, isOwner }: Props) {
   const { formatAmountBtc } = useDisplayCurrency();
   const goalCurrency = project.goal_currency || project.currency || PLATFORM_DEFAULT_CURRENCY;
   const [amountRaised, setAmountRaised] = useState<number>(0);
@@ -41,14 +44,17 @@ export default function ProjectSummaryRail({ project, isOwner }: Props) {
     project.bitcoin_balance_updated_at || null
   );
 
+  // "Amount raised" comes from the settled-contributions ledger (includes
+  // Lightning), converted to the goal currency — NOT the cached on-chain
+  // balance below (which misses Lightning and can be stale). Refreshing the
+  // balance updates the balance line only, never this figure.
   useEffect(() => {
     const init = async () => {
-      const btc = bitcoinBalanceBtc;
-      const amt = await computeAmountRaised(btc, goalCurrency);
+      const amt = await computeAmountRaised(settledRaisedBtc, goalCurrency);
       setAmountRaised(amt);
     };
     init();
-  }, [bitcoinBalanceBtc, goalCurrency]);
+  }, [settledRaisedBtc, goalCurrency]);
 
   const progress = useMemo(() => {
     const goal = project.goal_amount || 0;


### PR DESCRIPTION
The #1 functional lie from the payments audit: project detail pages show a funding figure + progress bar driven by `projects.raised_amount` — **a column no code in the app ever writes** (verified: 0 inserts/updates). A project can take real Lightning funding and still display "0 raised." A second surface (summary rail) derived "raised" from the cached **on-chain** balance — Lightning-blind and stale. Two rails, two wrong numbers.

## Fix — re-point to the honest settled ledger

Both now read the settled-`contributions` total via `get_entity_funding_stats` (the same source cause/research pages already use):

- **page.tsx** computes the settled total (BTC), converts it to the goal currency, and overrides `raised_amount` at the single data source — so ProjectContent's "Funding Progress", the progress %, and the JSON-LD `amountRaised` all become real at once. Returns **0 for a private fundraise** (honest) instead of a fabricated number.
- **ProjectSummaryRail** drives "amount raised" from the settled total (new `settledRaisedBtc` prop) and keeps the cached on-chain figure only for its separate, correctly-labeled **"Bitcoin Balance"** line. Refreshing the balance no longer moves the raised figure. **Both surfaces now agree.**

## Follow-ups (flagged, not here)
- Project cards in **search / discover / trending** still `SELECT` the dead `raised_amount` column (list surfaces need a batch stats approach, not N RPCs).
- `supporters_count` still counts reactions/comments/unverified self-reports — a separate fix.

type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)