### PR TITLE
fix(cat-credits): make top-up crediting exactly-once, never lose a paid invoice

### DIFF
--- a/__tests__/unit/services/cat/credit-topup.test.ts
+++ b/__tests__/unit/services/cat/credit-topup.test.ts
@@ -164,7 +164,8 @@ describe('checkTopUp', () => {
     getPlatformNwcClient.mockResolvedValue(
       nwcClient({ lookupInvoice: jest.fn().mockResolvedValue({ settled_at: 1_700_000_000 }) })
     );
-    getCreditBalance.mockResolvedValue(0.0005);
+    // The new balance comes straight from the atomic append (no extra read).
+    appendCreditEntry.mockResolvedValue(0.0005);
 
     const res = await checkTopUp('owner', 'tp1');
     expect(res).toEqual({ status: 'paid', balanceBtc: 0.0005 });
@@ -175,6 +176,38 @@ describe('checkTopUp', () => {
     expect(entry.kind).toBe('topup');
     expect(entry.amountBtc).toBe(0.0005);
     expect(entry.ref).toBe('ph_abc'); // idempotency key = payment hash
+  });
+
+  it('stays pending (never marks paid) when a settled invoice fails to credit — no lost payment', async () => {
+    // Settlement detected, but the atomic credit append fails (transient DB
+    // error → null). The top-up must NOT be flipped to 'paid', or the next poll
+    // short-circuits and the user's paid sats vanish with no credit. Staying
+    // pending lets the next poll retry the idempotent credit.
+    let paidUpdate = false;
+    adminFrom.mockImplementation(() => ({
+      insert: () => adminFrom(),
+      select: () => adminFrom(),
+      eq: () => adminFrom(),
+      order: () => adminFrom(),
+      limit: () => adminFrom(),
+      maybeSingle: async () => ({ data: pendingRow }),
+      single: async () => ({ data: pendingRow }),
+      update: (patch: { status?: string }) => {
+        if (patch?.status === 'paid') {
+          paidUpdate = true;
+        }
+        return adminFrom();
+      },
+      then: (resolve: (v: unknown) => unknown) => resolve({ data: null, error: null }),
+    }));
+    getPlatformNwcClient.mockResolvedValue(
+      nwcClient({ lookupInvoice: jest.fn().mockResolvedValue({ settled_at: 1_700_000_000 }) })
+    );
+    appendCreditEntry.mockResolvedValue(null); // crediting failed
+
+    await expect(checkTopUp('owner', 'tp1')).resolves.toEqual({ status: 'pending' });
+    expect(appendCreditEntry).toHaveBeenCalledTimes(1);
+    expect(paidUpdate).toBe(false); // critically, never marked paid
   });
 
   it('stays pending on a transient lookup failure (client polls again)', async () => {

--- a/src/services/cat/credit-topup.ts
+++ b/src/services/cat/credit-topup.ts
@@ -14,7 +14,6 @@
  * the rest of Cat Credits is unaffected. See docs/architecture/CAT_CREDITS.md.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { getAdminClient } from '@/lib/supabase/admin';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { DATABASE_TABLES } from '@/config/database-tables';
@@ -159,18 +158,31 @@ export async function checkTopUp(userId: string, topupId: string): Promise<TopUp
   try {
     const invoice = await client.lookupInvoice(topup.payment_hash);
     if (invoice.settled_at) {
-      // Credit the OWNER (idempotent on payment_hash), then mark paid.
-      await appendCreditEntry(admin, topup.user_id, {
+      // Credit the OWNER first — idempotent on payment_hash (unique ref in the
+      // ledger), so a retried settlement never double-credits. Mark paid ONLY if
+      // the credit actually landed: if the append fails (transient DB error), we
+      // must NOT flip status to paid, or the next poll short-circuits on 'paid'
+      // and the user's Lightning payment is lost with no credit. Leaving it
+      // pending lets the next poll retry the (idempotent) credit.
+      const balanceBtc = await appendCreditEntry(admin, topup.user_id, {
         kind: 'topup',
         amountBtc: topup.amount_btc,
         ref: topup.payment_hash,
         metadata: { source: 'lightning', topupId: topup.id },
       });
+      if (balanceBtc === null) {
+        logger.warn(
+          'top-up settled but crediting failed — staying pending for retry',
+          { topupId: topup.id },
+          'CatCredits'
+        );
+        return { status: 'pending' };
+      }
       await admin
         .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
         .update({ status: 'paid', paid_at: new Date().toISOString() })
         .eq('id', topup.id);
-      return { status: 'paid', balanceBtc: await getCreditBalance(admin, topup.user_id) };
+      return { status: 'paid', balanceBtc };
     }
   } catch (err) {
     // Transient relay/lookup failure — report pending; client polls again.

--- a/supabase/migrations/20260729120000_credit_append_idempotent_ref.sql
+++ b/supabase/migrations/20260729120000_credit_append_idempotent_ref.sql
@@ -1,0 +1,79 @@
+-- Cat Credits — make crediting idempotent on `ref` (money-safety, pre-launch).
+--
+-- The top-up settle path (checkTopUp) credits a `topup` entry keyed by the
+-- invoice's payment_hash and calls this a "credit … idempotent on payment_hash".
+-- It never actually was: cat_credit_append did a plain INSERT with NO uniqueness
+-- on ref, so the same settled invoice credited more than once whenever the
+-- crediting ran twice — concurrent pollers, or a retry after a transient error.
+-- With real Bitcoin about to flow, that's a double-credit (money OUT) leak, the
+-- mirror of the overdraw leak the previous migration closed.
+--
+-- Fix: give `ref`-carrying entries true exactly-once semantics.
+--   1. A partial unique index makes (user_id, kind, ref) unique for entries that
+--      carry a ref (top-ups by payment_hash, refunds, etc.). Usage debits carry
+--      no ref and are unaffected — each metered charge is its own row.
+--   2. cat_credit_append short-circuits (under the same per-user advisory lock)
+--      when the ref already exists: it records nothing and returns the CURRENT
+--      balance. So a retried/duplicated settlement is a safe no-op that still
+--      reports success — the caller marks the top-up paid and moves on, and the
+--      user is credited exactly once.
+--
+-- Safe to apply while the engine is dormant (PLATFORM_NWC_URI unset, no ref-
+-- carrying entries exist yet, so the unique index builds cleanly). Fully
+-- backward-compatible: same 6-arg signature, same behaviour for ref = NULL.
+--
+-- Idempotent migration: CREATE INDEX IF NOT EXISTS + CREATE OR REPLACE FUNCTION,
+-- so re-running never collides.
+
+CREATE UNIQUE INDEX IF NOT EXISTS cat_credit_entries_user_kind_ref_uidx
+  ON public.cat_credit_entries (user_id, kind, ref)
+  WHERE ref IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.cat_credit_append(
+  p_user_id uuid,
+  p_kind text,
+  p_amount_btc numeric,
+  p_ref text DEFAULT NULL::text,
+  p_metadata jsonb DEFAULT NULL::jsonb,
+  p_allow_overdraw boolean DEFAULT false
+) RETURNS numeric
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+declare
+  v_current numeric;
+  v_new numeric;
+begin
+  perform pg_advisory_xact_lock(hashtext(p_user_id::text));
+
+  -- Exactly-once for ref-carrying entries. A Lightning top-up is keyed by its
+  -- payment_hash; if this ref is already recorded, credit nothing and return the
+  -- balance unchanged, so a retried settlement is a safe no-op, not a double
+  -- credit. The advisory lock serializes appends per user, so this check plus
+  -- the unique index (as a hard backstop) guarantee the invariant.
+  if p_ref is not null and exists (
+    select 1 from public.cat_credit_entries
+     where user_id = p_user_id and kind = p_kind and ref = p_ref
+  ) then
+    return public.cat_credit_balance(p_user_id);
+  end if;
+
+  v_current := public.cat_credit_balance(p_user_id);
+  v_new := v_current + p_amount_btc;
+
+  -- Reject an overdraw ONLY for pre-authorization. A settlement for an
+  -- already-served request (p_allow_overdraw = true) must record the charge
+  -- regardless — the compute was delivered; not billing it is lost revenue.
+  if v_new < 0 and not p_allow_overdraw then
+    raise exception 'insufficient_credits' using errcode = 'check_violation';
+  end if;
+
+  insert into public.cat_credit_entries (user_id, kind, amount_btc, balance_after_btc, ref, metadata)
+  values (p_user_id, p_kind, p_amount_btc, v_new, p_ref, p_metadata);
+
+  return v_new;
+end;
+$$;
+
+REVOKE ALL ON FUNCTION public.cat_credit_append(uuid, text, numeric, text, jsonb, boolean) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.cat_credit_append(uuid, text, numeric, text, jsonb, boolean) TO service_role;


### PR DESCRIPTION
## Why

Pre-launch money-safety fix for the Cat Credits Lightning top-up path, landing **before** `PLATFORM_NWC_URI` is provisioned and real Bitcoin starts flowing. Two coupled bugs, both in `checkTopUp`'s settle path:

1. **Lost payment.** On a settled invoice the code called `appendCreditEntry(...)` but ignored the result, then unconditionally set `status='paid'`. If the append failed (transient DB error), the top-up was marked paid with **no credits granted** — user paid Lightning, got nothing, and the next poll short-circuits on `status==='paid'`. Money in, nothing out.

2. **Double credit (fake idempotency).** The "idempotent on payment_hash" contract was never real: `cat_credit_append` did a plain INSERT with **no uniqueness on `ref`**. Concurrent pollers or a retry could credit the same invoice twice. Money out.

## Fix

- **New migration** `20260729120000_credit_append_idempotent_ref.sql`: partial unique index on `(user_id, kind, ref) WHERE ref IS NOT NULL`, and `cat_credit_append` short-circuits under the per-user advisory lock when the ref already exists — a retried settlement is a safe no-op that returns the current balance. Usage debits (no ref) are unaffected. Backward-compatible (same 6-arg signature, same behaviour for `ref = NULL`).
- **`checkTopUp`**: capture the append's return; only mark `paid` when the credit actually landed. On failure, stay `pending` so the next poll retries the (now genuinely idempotent) credit — no lost payment.
- **Tests**: +1 regression test ("stays pending, never marks paid, when a settled invoice fails to credit"). 14/14 unit tests pass; typecheck + lint clean.

Fix #2 is what makes the retry in Fix #1 safe: retrying can never double-credit.

## Deploy note

CD auto-applies the migration on merge. Safe to apply while the engine is dormant (no ref-carrying entries exist yet, so the unique index builds cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)