### PR TITLE
feat(blog): add 'Loops, Graphs, and the Melting Middle' field report

### DIFF
--- a/content/blog/loops-graphs-and-the-melting-middle.mdx
+++ b/content/blog/loops-graphs-and-the-melting-middle.mdx
@@ -1,0 +1,78 @@
+---
+title: "Loops, Graphs, and the Melting Middle: A Field Report on AI Agents"
+excerpt: "Two viral naming wars, one quiet architecture consensus, and orchestration migrating into the models themselves. What three months of reading everything about AI agents taught me about what actually appreciates."
+date: "2026-07-28"
+tags: ["AI Agents", "Orchestration", "Engineering", "Field Report", "Verification"]
+featured: false
+author: "Mao Nakamoto"
+published: true
+---
+
+# Loops, Graphs, and the Melting Middle: A Field Report on AI Agents
+
+On July 18th, one of the most-followed engineers in the AI agent world posted a one-line joke: *"Are we still talking loops or did we shift to graphs yet?"* Four and a half hours later, a well-known ML educator published a parody article titled "Loop Engineering Is Dead. Enter Graph Engineering."
+
+Both were satire about how fast our field renames things. Within 96 hours, "graph engineering" had courses, roadmaps, a claimed Stanford grant (fabricated), a dozen identical SEO guides, and a major framework vendor formally claiming the term for its product.
+
+I spent the last stretch reading everything — the viral threads, the engineering blogs, the Hacker News arguments, the lab releases from San Francisco to Beijing — trying to separate what actually changed from what merely got renamed. Here's the field report.
+
+## The summer of loops
+
+June belonged to "loop engineering." The creator of Claude Code said the sentence that defined the season: *"I don't prompt Claude anymore. I have loops that are running. They're the ones prompting Claude and figuring out what to do. My job is to write loops."*
+
+That's a real shift, and it deserved its moment. The unit of work stopped being "one prompt, one answer" and became a small operating system: an event fires, an agent picks up a task, verifies its own work against tests, commits, and hands off. The craft moved from writing prompts to designing the systems that write them — triggers, worktrees, skills, verifier agents, persistent memory.
+
+Then July flipped the vocabulary to graphs, and the discourse got loud. But here's what I found when I dug beneath it: **the people actually shipping software ignored the graph wave almost completely.** The flagship "graph engineering" essays got single-digit points and zero comments on Hacker News, while threads about harness overhead and verification hit many hundreds. Working developers, when you read what they actually run, use CLI agents, git worktrees, plain bash loops, markdown state files, and CI as the referee. Not orchestration frameworks. Not visual canvases.
+
+One practitioner, running three agents non-stop for three days, wrote the most important sentence of the quarter:
+
+> "The hardest problem doesn't seem to be coding anymore. It's orchestration, approvals, and knowing when an agent should hand control back to a human."
+
+## What the war stories teach
+
+The failures of the season were instructive, and none of them were model failures.
+
+An autonomous agent ran for 33 days with a mandate to earn its own keep. It shipped six products and thirty landing pages — and earned $4.99 total, burning roughly $40 for every $1 earned. The killer detail: one unverified line in its memory ("this channel is broken" — it wasn't) blocked progress for six of its thirty days. The author's conclusion: *the bottleneck wasn't the model, it was the chassis.*
+
+A company tried a fully "lights-off" software factory and abandoned it after production incidents. Industry telemetry from teams that adopted agents without changing their review culture showed incidents per pull request up 242%, defect rates jumping from 9% to 54%. Meanwhile a swarm experiment that scaled to a thousand commits per second was received by the engineering community not with awe but with the Infinite Monkey Theorem.
+
+And quietly, the subagent pendulum swung hard. After months of "one task spawned seven subagents and burned my budget before any finished" stories, even the vendor of the most popular coding agent hardcoded instructions steering its own model *away* from spawning subagents. What survived is narrow and sensible: strongly-scoped delegation, for context isolation, under a supervisor.
+
+The pattern across every story: **generation is no longer the constraint.** Verification, cost accounting, escalation, and human comprehension are.
+
+## Meanwhile, at the frontier, orchestration is melting into the models
+
+Here's the part the naming wars completely missed. While influencers argued about whether to call the thing a loop or a graph, the labs were busy making the question obsolete — by moving orchestration *inside*.
+
+- **Into the weights.** One frontier lab now trains multi-agent orchestration directly into its model: a learned orchestrator that decides when to spawn parallel sub-agents, what to delegate, and how to merge results — rewarded during training for parallelizing when it helps and punished for fake parallelism. First 100 sub-agents, then 300, with wall-clock speedups over 4x on research tasks. No framework involved. The swarm is a model capability.
+- **Into the API.** Another lab sells multi-agent as a single model endpoint, where a routine request parameter controls how many internal agents deliberate — four at normal effort, sixteen at high.
+- **Into generated code.** Two major platforms shipped the same idea within a month of each other: the model writes a small, disposable orchestration script for each task — deterministic dispatch, fan-out, consensus checks — then executes it. One public case: a runtime of three quarters of a million lines ported between languages in eleven days, validated against a million-assertion test suite.
+- **And graphs found their real home.** The strongest pro-graph release of the summer came from a major cloud vendor's agent kit — and its argument wasn't ideology, it was engineering: use the model for judgment, use declarative code paths for routing, and cut half your token bill. Capability into the model; control out into inspectable structure.
+
+Notice what's absent from all four: a human hand-drawing workflow topology in a framework. The middle layer — the elaborate orchestration graph, lovingly maintained — is being eaten from above by the models and from below by boring durable-execution infrastructure.
+
+## So what actually appreciates?
+
+If you're building for the long run — and I am — the question isn't loops versus graphs. It's: which assets get *more* valuable as the models improve, and which are quietly depreciating?
+
+**Appreciating:**
+
+- **Verification.** Tests, health checks, evaluation gates, heterogeneous review (different models catch almost entirely different bugs — one study found 93% of findings were unique to a single reviewer out of four). Whoever makes correctness cheap to prove wins.
+- **The ledger.** Explicit state, append-only event logs, real cost accounting per unit of work. You cannot manage what you cannot see, and agent work at scale is a firehose of invisible spend.
+- **Escalation as a designed thing.** Bounded retries, a defined ladder (retry, then patch, then replan, then human), and — the elegant version — objections routed back to the *agent* first, so humans only see what genuinely needs them.
+- **Memory with provenance.** The 33-day agent lost six days to one unverified memory line. The best systems now gate what's allowed to become long-term memory — untrusted content can't launder itself into the record.
+- **Improvement between runs, never mid-run.** Every self-improving system that actually ships works the same way: run, collect trajectories, analyze offline, propose changes behind an evaluation gate and a human review. Sleep on it, literally — several platforms now call this "dreaming."
+
+**Depreciating:** hand-drawn topology, scaffolds that compensate for today's model weaknesses, parallel writers sharing a codebase, autonomy without bounded budgets, and any workflow the next model release absorbs.
+
+## The honest conclusion
+
+A loop is a graph with one node. A graph is loops with structure. The naming war is a distraction, and the practitioners are right to ignore it.
+
+What's real is this: we are all becoming managers of small fleets. The human's job is moving up the stack — setting direction, writing specifications, reviewing what matters, deciding what "done" means — while machines run the inner loops. The teams that thrive won't be the ones with the fanciest orchestration diagram. They'll be the ones whose systems can *prove their work is correct, account for every sat spent, escalate at the right moment, and get a little better every night.*
+
+That's the standard I hold my own tools to. It's the standard I'd suggest for yours.
+
+---
+
+*This is a synthesis of a much longer research pass across primary sources: lab engineering blogs, framework releases, practitioner essays, and community discussions from May–July 2026. All statistics referenced are from published sources; where the discourse produced fabricated numbers (and it did), they're excluded. Also published as an [article on OrangeCat](https://orangecat.ch/articles/loops-graphs-and-the-melting-middle-a-field-report-on-ai-agents-339okd).*


### PR DESCRIPTION
Cross-posts the AI-agents field report to the MDX blog (`content/blog/loops-graphs-and-the-melting-middle.mdx`), byline **Mao Nakamoto**, matching the existing frontmatter schema. Links back to the on-platform article at /articles/loops-graphs-and-the-melting-middle-a-field-report-on-ai-agents-339okd.

Content-only change — no code touched. `npm run verify` green locally (0 errors, 1221 unit tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)