### PR TITLE
fix(projects): honest settled-ledger funding on ALL list surfaces + real supporter counts

### DIFF
--- a/__tests__/unit/domain/projects-list-workflow.test.ts
+++ b/__tests__/unit/domain/projects-list-workflow.test.ts
@@ -8,6 +8,13 @@ jest.mock('@/services/actors/getOrCreateUserActor', () => ({
   getOrCreateUserActor: jest.fn().mockResolvedValue({ id: 'a1' }),
 }));
 
+// Funding enrichment converts settled BTC totals via the currency service —
+// keep the test deterministic (identity conversion, no rate fetch).
+jest.mock('@/services/currency', () => ({
+  currencyConverter: { getRates: jest.fn().mockResolvedValue({}) },
+  convertBtcTo: (amountBtc: number) => amountBtc,
+}));
+
 import { createServerClient } from '@/lib/supabase/server';
 
 describe('Project list workflow', () => {
@@ -58,13 +65,19 @@ describe('Project list workflow', () => {
     jest.clearAllMocks();
   });
 
-  it('lists active projects and maps profile info', async () => {
+  it('lists active projects and maps funding from the settled ledger, not the dead column', async () => {
     const dataQuery = makeChainableQuery({ data: dataRows, error: null });
     const countQuery = makeChainableQuery({ count: 2, error: null });
 
     const from = jest.fn().mockReturnValueOnce(dataQuery).mockReturnValueOnce(countQuery);
+    // Settled funding stats: only p2 has real contributions. The raised_amount
+    // column value (1200 on p2) must be IGNORED — nothing ever writes it.
+    const rpc = jest.fn().mockResolvedValue({
+      data: [{ entity_id: 'p2', total_btc: 0.01, contributor_count: 2, named_supporter_count: 1 }],
+      error: null,
+    });
 
-    (createServerClient as jest.Mock).mockResolvedValue({ from });
+    (createServerClient as jest.Mock).mockResolvedValue({ from, rpc });
 
     const result = await listProjectsPage(20, 0);
 
@@ -72,7 +85,11 @@ describe('Project list workflow', () => {
     expect(result.items).toHaveLength(2);
     expect(result.items[0].profiles?.username).toBe('alice');
     expect(result.items[0].raised_amount).toBe(0);
-    expect(result.items[1].raised_amount).toBe(1200);
+    expect(result.items[0].supporters_count).toBe(0);
+    // p2: settled ledger total (0.01 BTC, identity-converted) — NOT the dead 1200.
+    expect(result.items[1].raised_amount).toBe(0.01);
+    expect(result.items[1].settled_raised_btc).toBe(0.01);
+    expect(result.items[1].supporters_count).toBe(2);
   });
 
   it('applies user filter when userId is provided', async () => {

--- a/__tests__/unit/services/project-funding-enrichment.test.ts
+++ b/__tests__/unit/services/project-funding-enrichment.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Settled-funding enrichment — the honest numbers for project list surfaces.
+ *
+ * Guards the core money-honesty invariants:
+ *  - raised_amount comes from the settled ledger (batch RPC), NOT the dead
+ *    raised_amount column;
+ *  - conversion into the project's own currency (BTC projects pass through);
+ *  - entities absent from the RPC result (private / unfunded) get zeros;
+ *  - failures degrade to zeros, never to fabricated numbers, never throw.
+ */
+
+import { enrichProjectsWithSettledFunding } from '@/services/wallets/project-funding';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+
+jest.mock('@/services/currency', () => ({
+  currencyConverter: { getRates: jest.fn().mockResolvedValue({}) },
+  convertBtcTo: (amountBtc: number, currency: string) =>
+    currency === 'BTC' ? amountBtc : amountBtc * 100_000,
+}));
+
+function clientWithRpc(rows: unknown, error: unknown = null): AnySupabaseClient {
+  return {
+    rpc: jest.fn().mockResolvedValue({ data: rows, error }),
+  } as unknown as AnySupabaseClient;
+}
+
+describe('enrichProjectsWithSettledFunding', () => {
+  it('returns [] for an empty list without calling the RPC', async () => {
+    const client = clientWithRpc([]);
+    await expect(enrichProjectsWithSettledFunding(client, [])).resolves.toEqual([]);
+    expect(client.rpc).not.toHaveBeenCalled();
+  });
+
+  it('attaches settled totals in BTC + project currency + supporter count', async () => {
+    const client = clientWithRpc([
+      { entity_id: 'btc-project', total_btc: 0.5, contributor_count: 3, named_supporter_count: 2 },
+      { entity_id: 'chf-project', total_btc: 0.001, contributor_count: 1, named_supporter_count: 1 },
+    ]);
+
+    const result = await enrichProjectsWithSettledFunding(client, [
+      { id: 'btc-project', currency: 'BTC' },
+      { id: 'chf-project', currency: 'CHF' },
+    ]);
+
+    expect(result[0]).toMatchObject({
+      raised_amount: 0.5,
+      settled_raised_btc: 0.5,
+      supporters_count: 3,
+    });
+    expect(result[1]).toMatchObject({
+      raised_amount: 100, // 0.001 BTC * mocked 100k rate
+      settled_raised_btc: 0.001,
+      supporters_count: 1,
+    });
+  });
+
+  it('zeros projects the RPC did not return (private or unfunded)', async () => {
+    const client = clientWithRpc([]);
+    const [project] = await enrichProjectsWithSettledFunding(client, [
+      { id: 'unfunded', currency: 'CHF' },
+    ]);
+    expect(project).toMatchObject({
+      raised_amount: 0,
+      settled_raised_btc: 0,
+      supporters_count: 0,
+    });
+  });
+
+  it('degrades to zeros on RPC error — never fabricates, never throws', async () => {
+    const errClient = clientWithRpc(null, { message: 'boom' });
+    const [a] = await enrichProjectsWithSettledFunding(errClient, [{ id: 'x', currency: 'BTC' }]);
+    expect(a).toMatchObject({ raised_amount: 0, settled_raised_btc: 0, supporters_count: 0 });
+
+    const throwingClient = {
+      rpc: jest.fn().mockRejectedValue(new Error('network down')),
+    } as unknown as AnySupabaseClient;
+    const [b] = await enrichProjectsWithSettledFunding(throwingClient, [
+      { id: 'y', currency: 'BTC' },
+    ]);
+    expect(b).toMatchObject({ raised_amount: 0, settled_raised_btc: 0, supporters_count: 0 });
+  });
+});

--- a/src/app/api/profiles/[userId]/entities/[entityType]/route.ts
+++ b/src/app/api/profiles/[userId]/entities/[entityType]/route.ts
@@ -20,6 +20,7 @@ import {
 } from '@/config/entity-registry';
 import { getOrCreateUserActor } from '@/services/actors/getOrCreateUserActor';
 import { ENTITY_STATUS } from '@/config/database-constants';
+import { enrichProjectsWithSettledFunding } from '@/services/wallets/project-funding';
 
 // Entity-specific column selections for optimal queries
 const ENTITY_COLUMNS: Record<EntityType, string> = {
@@ -118,11 +119,21 @@ export const GET = withOptionalAuth(async (request, context: RouteContext) => {
       return apiInternalError(`Failed to fetch ${entityType}s`);
     }
 
+    // Projects: replace the dead raised_amount column with the settled-ledger
+    // total so profile tabs show honest funding figures.
+    const entities =
+      entityType === 'project'
+        ? await enrichProjectsWithSettledFunding(
+            supabase,
+            (data || []) as unknown as Array<{ id: string; currency?: string | null }>
+          )
+        : data || [];
+
     const metadata = getEntityMetadata(entityType as EntityType);
 
     return apiSuccess(
       {
-        data: data || [],
+        data: entities,
         entityType,
         metadata: {
           name: metadata.name,

--- a/src/app/api/profiles/[userId]/projects/route.ts
+++ b/src/app/api/profiles/[userId]/projects/route.ts
@@ -6,6 +6,7 @@ import { getTableName } from '@/config/entity-registry';
 import { getOrCreateUserActor } from '@/services/actors/getOrCreateUserActor';
 import { STORAGE_BUCKETS } from '@/config/database-tables';
 import { ENTITY_STATUS } from '@/config/database-constants';
+import { enrichProjectsWithSettledFunding } from '@/services/wallets/project-funding';
 
 interface RouteContext {
   params: Promise<{ userId: string }>;
@@ -76,8 +77,15 @@ export const GET = withOptionalAuth(async (request, context: RouteContext) => {
       updated_at: string;
       project_media: { id: string; storage_path: string; position: number }[] | null;
     };
+    // Honest funding figures from the settled ledger — raised_amount is a dead
+    // column nothing writes, so cards fed by this route would otherwise show 0.
+    const enrichedProjects = await enrichProjectsWithSettledFunding(
+      supabase,
+      (projects || []) as ProjectWithMedia[]
+    );
+
     // Process projects to get first media URL
-    const projectsWithMedia = (projects || []).map((project: ProjectWithMedia) => {
+    const projectsWithMedia = enrichedProjects.map((project: ProjectWithMedia) => {
       if (project.project_media && project.project_media.length > 0) {
         // Get first media item (sorted by position)
         const firstMedia = project.project_media.sort(

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/api/buildUpdatePayload';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { DATABASE_TABLES } from '@/config/database-tables';
+import { enrichProjectsWithSettledFunding } from '@/services/wallets/project-funding';
 
 // Post-process GET: Fetch profile and add to response
 async function postProcessProjectGet(
@@ -69,9 +70,14 @@ async function postProcessProjectGet(
     }
   }
 
+  // Honest funding figures from the settled ledger — the raised_amount column
+  // is dead, so API consumers would otherwise see 0 regardless of funding.
+  const [enriched] = await enrichProjectsWithSettledFunding(supabase, [
+    project as { id: string; currency?: string | null },
+  ]);
+
   return {
-    ...project,
-    raised_amount: (project.raised_amount as number) ?? 0,
+    ...(enriched ?? project),
     profiles: profile,
   };
 }

--- a/src/app/api/projects/[id]/stats/route.ts
+++ b/src/app/api/projects/[id]/stats/route.ts
@@ -3,8 +3,9 @@ import { withOptionalAuth } from '@/lib/api/withAuth';
 import { apiSuccess, apiNotFound, handleApiError } from '@/lib/api/standardResponse';
 import { getTableName } from '@/config/entity-registry';
 import { validateUUID, getValidationError } from '@/lib/api/validation';
-import { DATABASE_TABLES } from '@/config/database-tables';
 import { ENTITY_STATUS } from '@/config/database-constants';
+import { getEntityFundingStats } from '@/services/wallets/funding-stats';
+import { convertBtcTo, currencyConverter } from '@/services/currency';
 
 const DEFAULT_CAMPAIGN_DURATION_DAYS = 30;
 
@@ -27,7 +28,7 @@ export const GET = withOptionalAuth(
         title,
         description,
         goal_amount,
-        raised_amount,
+        currency,
         bitcoin_address,
         status,
         created_at,
@@ -44,18 +45,21 @@ export const GET = withOptionalAuth(
         return apiNotFound('Project not found');
       }
 
-      // Get real supporter count from project_support table
-      const { count: supportCount } = await supabase
-        .from(DATABASE_TABLES.PROJECT_SUPPORT)
-        .select('*', { count: 'exact', head: true })
-        .eq('project_id', projectId);
-      const supporterCount = supportCount ?? 0;
+      // Honest funding figures: the settled `contributions` ledger is the only
+      // source of raised/supporter numbers. (The raised_amount column is dead,
+      // and project_support rows are unverified self-reports — neither is money.)
+      const fundingStats = await getEntityFundingStats(supabase, 'project', projectId);
+      const raisedBtc = fundingStats?.totalBtc ?? 0;
+      const supporterCount = fundingStats?.contributorCount ?? 0;
+      const goalCurrency = ((project.currency as string) || 'BTC').toUpperCase();
+      if (raisedBtc > 0 && goalCurrency !== 'BTC') {
+        await currencyConverter.getRates().catch(() => undefined);
+      }
+      const raisedAmount = raisedBtc > 0 ? convertBtcTo(raisedBtc, goalCurrency) : 0;
 
       // Calculate progress
       const progressPercent =
-        project.goal_amount > 0
-          ? Math.min((project.raised_amount / project.goal_amount) * 100, 100)
-          : 0;
+        project.goal_amount > 0 ? Math.min((raisedAmount / project.goal_amount) * 100, 100) : 0;
 
       // Calculate days remaining (default campaign duration from creation date)
       const createdDate = new Date(project.created_at);
@@ -73,12 +77,12 @@ export const GET = withOptionalAuth(
         1,
         Math.ceil((now.getTime() - createdDate.getTime()) / (24 * 60 * 60 * 1000))
       );
-      const dailyFundingRate = project.raised_amount / daysSinceCreation;
+      const dailyFundingRate = raisedAmount / daysSinceCreation;
 
       // Get project category and related projects
       const { data: relatedProjectsData, error: _relatedError } = await supabase
         .from(getTableName('project'))
-        .select('id, title, raised_amount')
+        .select('id, title')
         .eq('category', project.category || '')
         .neq('id', projectId)
         .limit(5);
@@ -91,12 +95,12 @@ export const GET = withOptionalAuth(
         title: project.title,
         fundingMetrics: {
           goalAmount: project.goal_amount,
-          raisedAmount: project.raised_amount,
+          raisedAmount,
+          raisedBtc,
           progressPercent: Math.round(progressPercent * 100) / 100,
-          remaining: Math.max(0, project.goal_amount - project.raised_amount),
+          remaining: Math.max(0, project.goal_amount - raisedAmount),
           supporterCount,
-          averageContribution:
-            supporterCount > 0 ? Math.round(project.raised_amount / supporterCount) : 0,
+          averageContribution: supporterCount > 0 ? Math.round(raisedAmount / supporterCount) : 0,
         },
         timeMetrics: {
           createdAt: project.created_at,
@@ -110,9 +114,8 @@ export const GET = withOptionalAuth(
         },
         performanceMetrics: {
           dailyFundingRate: Math.round(dailyFundingRate),
-          projectedTotal: Math.round(project.raised_amount + dailyFundingRate * daysRemaining),
-          willReachGoal:
-            project.raised_amount + dailyFundingRate * daysRemaining >= project.goal_amount,
+          projectedTotal: Math.round(raisedAmount + dailyFundingRate * daysRemaining),
+          willReachGoal: raisedAmount + dailyFundingRate * daysRemaining >= project.goal_amount,
           category: project.category || 'uncategorized',
           categoryRank,
         },

--- a/src/app/api/projects/favorites/route.ts
+++ b/src/app/api/projects/favorites/route.ts
@@ -3,6 +3,7 @@ import { apiSuccess, apiInternalError } from '@/lib/api/standardResponse';
 import { logger } from '@/utils/logger';
 import { getTableName } from '@/config/entity-registry';
 import { DATABASE_TABLES } from '@/config/database-tables';
+import { enrichProjectsWithSettledFunding } from '@/services/wallets/project-funding';
 
 type ProjectRow = {
   id: string;
@@ -106,8 +107,15 @@ async function handleGetFavorites(request: AuthenticatedRequest) {
       }
     }
 
+    // Honest funding figures from the settled ledger (raised_amount is a dead
+    // column — favorites cards would otherwise show 0 regardless of funding).
+    const enrichedProjects = await enrichProjectsWithSettledFunding(
+      supabase,
+      (projects || []) as unknown as Array<ProjectRow & { currency?: string | null }>
+    );
+
     // Map projects with favorite metadata and profiles
-    const projectsWithFavorite = (projects || []).map((project: ProjectRow) => ({
+    const projectsWithFavorite = enrichedProjects.map((project: ProjectRow) => ({
       ...project,
       favorited_at: (favorites as FavoriteRow[]).find(f => f.project_id === project.id)?.created_at,
       profiles: project.user_id ? profilesMap.get(project.user_id) : null,

--- a/src/app/profiles/[username]/page.tsx
+++ b/src/app/profiles/[username]/page.tsx
@@ -11,6 +11,7 @@ import { listArticlesByAuthor } from '@/services/articles/get-article';
 import { safeJsonLdString } from '@/lib/seo/structured-data';
 import type { ScalableProfile } from '@/services/profile/types';
 import { mapProjectRow } from '@/types/project';
+import { enrichProjectsWithSettledFunding } from '@/services/wallets/project-funding';
 import { ROUTES } from '@/config/routes';
 import { APP_NAME, APP_KICKER, SITE_URL } from '@/config/brand';
 import { applyProfilePrivacy } from '@/config/profile-privacy';
@@ -188,7 +189,15 @@ export default async function PublicProfilePage({ params }: PageProps) {
     .neq('status', 'draft') // Exclude drafts from public profile
     .neq('show_on_profile', false) // Respect user's visibility preference (null = true by default)
     .order('created_at', { ascending: false });
-  const projects = (projectsData || []).map(mapProjectRow);
+  // Honest funding figures from the settled ledger — the raised_amount column
+  // is dead (never written), so profile stats would otherwise always read 0.
+  const enrichedProjects = await enrichProjectsWithSettledFunding(
+    supabase,
+    (projectsData || []) as unknown as Array<
+      Parameters<typeof mapProjectRow>[0] & { id: string; currency?: string | null }
+    >
+  );
+  const projects = enrichedProjects.map(mapProjectRow);
 
   // Fetch follower count
   const { count: followerCount } = await supabase
@@ -236,7 +245,9 @@ export default async function PublicProfilePage({ params }: PageProps) {
 
   // Calculate statistics
   const projectCount = projects?.length || 0;
-  const totalRaised = projects?.reduce((sum, p) => sum + (Number(p.raised_amount) || 0), 0) || 0;
+  // Sum in BTC (the canonical unit) — the overview tab formats this figure with
+  // formatAmountBtc. Summing per-project raised_amount would mix currencies.
+  const totalRaised = enrichedProjects.reduce((sum, p) => sum + (p.settled_raised_btc || 0), 0);
 
   // Check if viewing own profile (server-side, avoids hydration flash)
   const {

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -199,6 +199,9 @@ export default async function PublicProjectPage({ params }: PageProps) {
     currency: project.currency ?? 'BTC',
     raised_amount: settledRaised,
     settled_raised_btc: settledRaisedBtc,
+    // Honest supporters figure: settled contributions only — never emoji
+    // reactions, comments, or self-reported support rows.
+    supporters_count: fundingStats?.contributorCount ?? 0,
     profiles: profile ?? undefined,
   };
   const sellerReceive = await resolveSellerReceiveInfo(supabase, 'project', id);

--- a/src/components/entity/variants/ProjectCard.tsx
+++ b/src/components/entity/variants/ProjectCard.tsx
@@ -24,11 +24,11 @@ interface ProjectCardProps extends Omit<
   EntityCardProps,
   'id' | 'title' | 'headerSlot' | 'progressSlot' | 'metricsSlot' | 'footerSlot'
 > {
+  // currency + supporters_count now live on SearchFundingPage itself (settled
+  // funding enrichment); only card-local extras remain here.
   project: SearchFundingPage & {
-    currency?: string;
     tags?: string[] | null;
     cover_image_url?: string | null;
-    supporters_count?: number;
   };
   showProgress?: boolean;
   showMetrics?: boolean;
@@ -56,7 +56,9 @@ export function ProjectCard({
   const { formatAmountBtc, displayCurrency } = useDisplayCurrency();
   const { convertToBTC } = useCurrencyConversion();
   const goalBtc = convertToBTC(goalAmount, projectCurrency);
-  const currentBtc = convertToBTC(currentAmount, projectCurrency);
+  // Prefer the settled-ledger BTC figure (canonical unit) over converting the
+  // project-currency amount back — avoids a lossy round-trip through rates.
+  const currentBtc = project.settled_raised_btc ?? convertToBTC(currentAmount, projectCurrency);
   const formattedCurrent = formatAmountBtc(currentBtc);
   const formattedGoal = formatAmountBtc(goalBtc);
   const amountColorClass =

--- a/src/domain/projects/service.ts
+++ b/src/domain/projects/service.ts
@@ -4,6 +4,8 @@ import { STATUS } from '@/config/database-constants';
 import type { ProjectData } from '@/lib/validation';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
+import { createServerClient } from '@/lib/supabase/server';
+import { enrichProjectsWithSettledFunding } from '@/services/wallets/project-funding';
 
 export async function listProjectsPage(
   limit: number,
@@ -29,11 +31,14 @@ export async function listProjectsPage(
     publicStatuses: [PROJECT_STATUS.ACTIVE],
   });
 
-  // Ensure raised_amount defaults to 0
-  const items = result.items.map((project: Record<string, unknown>) => ({
-    ...project,
-    raised_amount: project.raised_amount ?? 0,
-  }));
+  // Honest funding figures from the settled ledger — the raised_amount column
+  // is dead (nothing writes it), so lists fed by this service would show 0
+  // regardless of real funding.
+  const supabase = (await createServerClient()) as unknown as AnySupabaseClient;
+  const items = await enrichProjectsWithSettledFunding(
+    supabase,
+    result.items as Array<{ id: string; currency?: string | null }>
+  );
 
   return { items, total: result.total };
 }

--- a/src/services/search/queries/projects.ts
+++ b/src/services/search/queries/projects.ts
@@ -9,6 +9,10 @@ import supabase from '@/lib/supabase/browser';
 import { logger } from '@/utils/logger';
 import { PROJECT_STATUS, PUBLIC_SEARCH_STATUSES } from '@/config/project-statuses';
 import { getTableName } from '@/config/entity-registry';
+import {
+  enrichProjectsWithSettledFunding,
+  type SettledProjectFunding,
+} from '@/services/wallets/project-funding';
 import type { SearchFundingPage, SearchFilters, RawSearchProject } from '../types';
 import { sanitizeQuery, buildProfileMap } from './helpers';
 
@@ -45,11 +49,7 @@ export async function searchFundingPages(
       if (!error && data) {
         let results = data as RawSearchProject[];
         results = applyProjectFilters(results, filters);
-
-        const userIds = [...new Set(results.map(p => p.user_id))];
-        const profileMap = await buildProfileMap(userIds);
-
-        return results.map(project => transformProject(project, profileMap));
+        return finishProjects(results, filters);
       }
     } catch (rpcError) {
       logger.warn('PostGIS RPC not available, using application filtering', rpcError, 'Search');
@@ -76,10 +76,7 @@ export async function searchFundingPages(
           );
         }
 
-        const userIds = [...new Set(results.map(p => p.user_id))];
-        const profileMap = await buildProfileMap(userIds);
-
-        return results.map(project => transformProject(project, profileMap));
+        return finishProjects(results, filters);
       }
     } catch (rpcError) {
       logger.warn('Full-text search RPC not available, using ILIKE', rpcError, 'Search');
@@ -112,11 +109,34 @@ export async function searchFundingPages(
     return [];
   }
 
-  const filteredProjects = rawProjects as RawSearchProject[];
-  const userIds = [...new Set(filteredProjects.map(p => p.user_id))];
+  return finishProjects(rawProjects as RawSearchProject[], filters);
+}
+
+/**
+ * Shared tail for every search path: enrich with settled-ledger funding
+ * (raised_amount is a dead DB column — the honest figure comes from the batch
+ * funding-stats RPC), apply funding-range filters against the REAL totals,
+ * then attach creator profiles and shape the result.
+ */
+async function finishProjects(
+  results: RawSearchProject[],
+  filters?: SearchFilters
+): Promise<SearchFundingPage[]> {
+  let enriched = await enrichProjectsWithSettledFunding(supabase, results);
+
+  // Funding filters must run AFTER enrichment — the DB column is never written,
+  // so filtering on it at the SQL layer matched nothing (or everything).
+  if (filters?.minFunding !== undefined) {
+    enriched = enriched.filter(p => p.raised_amount >= filters.minFunding!);
+  }
+  if (filters?.maxFunding !== undefined) {
+    enriched = enriched.filter(p => p.raised_amount <= filters.maxFunding!);
+  }
+
+  const userIds = [...new Set(enriched.map(p => p.user_id))];
   const profileMap = await buildProfileMap(userIds);
 
-  return filteredProjects.map(project => transformProject(project, profileMap));
+  return enriched.map(project => transformProject(project, profileMap));
 }
 
 /**
@@ -151,12 +171,8 @@ function applyProjectFilters(
   if (filters.hasGoal) {
     filtered = filtered.filter(p => p.goal_amount !== null);
   }
-  if (filters.minFunding !== undefined) {
-    filtered = filtered.filter(p => (p.raised_amount || 0) >= filters.minFunding!);
-  }
-  if (filters.maxFunding !== undefined) {
-    filtered = filtered.filter(p => (p.raised_amount || 0) <= filters.maxFunding!);
-  }
+  // minFunding/maxFunding are applied post-enrichment in finishProjects — the
+  // raw raised_amount column is dead and would filter dishonestly here.
   if (filters.dateRange) {
     filtered = filtered.filter(
       p => p.created_at >= filters.dateRange!.start && p.created_at <= filters.dateRange!.end
@@ -194,13 +210,8 @@ function applyProjectQueryFilters(
     projectQuery = projectQuery.not('goal_amount', 'is', null);
   }
 
-  if (filters.minFunding !== undefined) {
-    projectQuery = projectQuery.gte('raised_amount', filters.minFunding);
-  }
-
-  if (filters.maxFunding !== undefined) {
-    projectQuery = projectQuery.lte('raised_amount', filters.maxFunding);
-  }
+  // minFunding/maxFunding are applied post-enrichment in finishProjects — the
+  // raised_amount column is dead, so a SQL-level gte/lte lies.
 
   if (filters.dateRange) {
     projectQuery = projectQuery
@@ -215,7 +226,7 @@ function applyProjectQueryFilters(
  * Transform a raw project row into a SearchFundingPage.
  */
 function transformProject(
-  project: RawSearchProject,
+  project: RawSearchProject & SettledProjectFunding,
   profileMap: Map<
     string,
     { id: string; username: string | null; name: string | null; avatar_url: string | null }
@@ -226,7 +237,6 @@ function transformProject(
   const { cover_image_url: _coverImg, ...rest } = project;
   return {
     ...rest,
-    raised_amount: project.raised_amount || 0,
     banner_url: coverImageUrl,
     featured_image_url: coverImageUrl,
     profiles: profileMap.get(project.user_id),

--- a/src/services/search/queries/trending.ts
+++ b/src/services/search/queries/trending.ts
@@ -9,6 +9,7 @@ import { logger } from '@/utils/logger';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { PUBLIC_SEARCH_STATUSES } from '@/config/project-statuses';
 import { getTableName } from '@/config/entity-registry';
+import { enrichProjectsWithSettledFunding } from '@/services/wallets/project-funding';
 import type {
   SearchProfile,
   SearchFundingPage,
@@ -31,7 +32,7 @@ export async function getTrending(): Promise<{
         .select(
           `
           id, user_id, title, description, bitcoin_address,
-          created_at, updated_at, category, status, goal_amount, raised_amount,
+          created_at, updated_at, category, status, goal_amount, currency,
           cover_image_url
         `
         )
@@ -50,15 +51,17 @@ export async function getTrending(): Promise<{
     let projects: SearchFundingPage[] = [];
     if (!projectsData.error && projectsData.data) {
       const projectResults = projectsData.data as RawSearchProject[];
-      const userIds = [...new Set(projectResults.map(p => p.user_id))];
+      // Honest funding figures come from the settled ledger, not the dead
+      // raised_amount column — one batch RPC for all trending cards.
+      const enriched = await enrichProjectsWithSettledFunding(supabase, projectResults);
+      const userIds = [...new Set(enriched.map(p => p.user_id))];
       const profileMap = await buildProfileMap(userIds);
 
-      projects = projectResults.map(project => {
+      projects = enriched.map(project => {
         const coverImageUrl = project.cover_image_url;
         const { cover_image_url: _coverImg, ...rest } = project;
         return {
           ...rest,
-          raised_amount: project.raised_amount || 0,
           banner_url: coverImageUrl,
           featured_image_url: coverImageUrl,
           profiles: profileMap.get(project.user_id),

--- a/src/services/search/types.ts
+++ b/src/services/search/types.ts
@@ -29,7 +29,13 @@ export interface SearchFundingPage {
   category: string | null;
   status: string;
   goal_amount: number | null;
+  /** Settled-ledger total in the project's own currency (never the dead DB column). */
   raised_amount: number;
+  /** Settled-ledger total in BTC — canonical unit for viewer-currency display. */
+  settled_raised_btc?: number;
+  /** Settled contributions count — the honest supporters figure. */
+  supporters_count?: number;
+  currency?: string | null;
   created_at: string;
   updated_at: string;
   banner_url?: string | null;
@@ -92,7 +98,8 @@ export interface RawSearchProject {
   category: string | null;
   status: string;
   goal_amount: number | null;
-  raised_amount: number | null;
+  /** Dead DB column — never written; real totals come from funding enrichment. */
+  raised_amount?: number | null;
   currency?: string | null;
   created_at: string;
   updated_at: string;

--- a/src/services/wallets/funding-stats.ts
+++ b/src/services/wallets/funding-stats.ts
@@ -57,3 +57,43 @@ export async function getEntityFundingStats(
     namedSupporterCount: Number(row.named_supporter_count ?? 0),
   };
 }
+
+/**
+ * Batch variant for list surfaces: settled funding stats for many entities in
+ * ONE RPC (`get_entities_funding_stats`) — no N+1 per card. Entities that are
+ * private or have no settled contributions are simply absent from the map.
+ * Never throws — logs and returns an empty map so lists degrade to zeros.
+ */
+export async function getEntitiesFundingStats(
+  supabase: AnySupabaseClient,
+  entityType: EntityType,
+  entityIds: string[]
+): Promise<Map<string, EntityFundingStats>> {
+  const map = new Map<string, EntityFundingStats>();
+  if (entityIds.length === 0) {
+    return map;
+  }
+
+  const { data, error } = await supabase.rpc('get_entities_funding_stats', {
+    p_entity_type: entityType,
+    p_entity_ids: entityIds,
+  });
+
+  if (error) {
+    logger.warn(
+      'Failed to load batch entity funding stats',
+      { entityType, count: entityIds.length, error },
+      'Wallets'
+    );
+    return map;
+  }
+
+  for (const row of (data as Array<Record<string, unknown>> | null) ?? []) {
+    map.set(String(row.entity_id), {
+      totalBtc: Number(row.total_btc ?? 0),
+      contributorCount: Number(row.contributor_count ?? 0),
+      namedSupporterCount: Number(row.named_supporter_count ?? 0),
+    });
+  }
+  return map;
+}

--- a/src/services/wallets/project-funding.ts
+++ b/src/services/wallets/project-funding.ts
@@ -1,0 +1,76 @@
+/**
+ * Project funding enrichment — attach HONEST settled-ledger funding figures to
+ * project rows on list surfaces (search, trending, profile tabs, favorites,
+ * dashboards).
+ *
+ * `projects.raised_amount` is a dead column no code ever writes: any UI reading
+ * it shows 0 regardless of real funding. This helper overwrites it with the
+ * settled `contributions` total converted into the project's own currency (the
+ * unit every consumer already assumes for progress math), and adds the BTC
+ * figure plus the settled contributor count — all from ONE batch RPC.
+ *
+ * Isomorphic: safe from both server routes and the browser search client (the
+ * RPC is granted to anon, and the currency converter caches rates in-process).
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { currencyConverter, convertBtcTo } from '@/services/currency';
+import { logger } from '@/utils/logger';
+import { getEntitiesFundingStats } from './funding-stats';
+
+export interface SettledProjectFunding {
+  /** Settled total in the project's own currency — replaces the dead column. */
+  raised_amount: number;
+  /** Settled total in BTC, the canonical unit, for viewer-currency display. */
+  settled_raised_btc: number;
+  /** Number of settled contributions — the honest "supporters" figure. */
+  supporters_count: number;
+}
+
+/**
+ * Enrich a list of project rows with settled funding figures. Never throws —
+ * on any failure the projects come back with zeros (honest default: we never
+ * show a number we couldn't derive from the ledger).
+ */
+export async function enrichProjectsWithSettledFunding<
+  T extends { id: string; currency?: string | null },
+>(supabase: AnySupabaseClient, projects: T[]): Promise<Array<T & SettledProjectFunding>> {
+  if (projects.length === 0) {
+    return [];
+  }
+
+  let stats: Awaited<ReturnType<typeof getEntitiesFundingStats>>;
+  try {
+    stats = await getEntitiesFundingStats(
+      supabase,
+      'project',
+      projects.map(p => p.id)
+    );
+  } catch (error) {
+    logger.warn('Funding enrichment failed; defaulting to zeros', { error }, 'Wallets');
+    stats = new Map();
+  }
+
+  // Warm the rate cache once so per-project conversion is synchronous. If rates
+  // are unavailable, fiat-denominated projects convert to 0 (never a made-up
+  // number); BTC-denominated projects are unaffected.
+  if (stats.size > 0) {
+    try {
+      await currencyConverter.getRates();
+    } catch (error) {
+      logger.warn('Rates unavailable for funding enrichment', { error }, 'Wallets');
+    }
+  }
+
+  return projects.map(project => {
+    const projectStats = stats.get(project.id);
+    const totalBtc = projectStats?.totalBtc ?? 0;
+    return {
+      ...project,
+      raised_amount:
+        totalBtc > 0 ? convertBtcTo(totalBtc, (project.currency || 'BTC').toUpperCase()) : 0,
+      settled_raised_btc: totalBtc,
+      supporters_count: projectStats?.contributorCount ?? 0,
+    };
+  });
+}

--- a/supabase/migrations/20260729000000_batch_entity_funding_stats.sql
+++ b/supabase/migrations/20260729000000_batch_entity_funding_stats.sql
@@ -1,0 +1,49 @@
+-- Batch variant of get_entity_funding_stats (20260723000000): settled funding
+-- totals for MANY entities in one call, so list surfaces (search cards,
+-- trending, profile tabs, favorites) can show honest ledger-derived figures
+-- without an N+1 RPC per card.
+--
+-- Identical visibility semantics to the single-entity function: an entity
+-- contributes rows ONLY if its primary wallet link exists and is not private
+-- (the scalar subquery yields NULL when there is no primary link, and
+-- NULL <> 'private' is NULL, which excludes the row). Totals come exclusively
+-- from the settled `contributions` ledger — never from cached balances.
+
+CREATE OR REPLACE FUNCTION get_entities_funding_stats(
+  p_entity_type text,
+  p_entity_ids uuid[]
+)
+RETURNS TABLE (
+  entity_id uuid,
+  total_btc numeric,
+  contributor_count bigint,
+  named_supporter_count bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    c.entity_id,
+    COALESCE(SUM(c.amount_btc), 0)::numeric AS total_btc,
+    COUNT(*)::bigint AS contributor_count,
+    COUNT(*) FILTER (WHERE c.is_anonymous = false)::bigint AS named_supporter_count
+  FROM contributions c
+  JOIN payment_intents pi ON pi.id = c.payment_intent_id
+  WHERE c.entity_type = p_entity_type
+    AND c.entity_id = ANY(p_entity_ids)
+    AND pi.status = 'paid'
+    AND (
+      SELECT ew.visibility
+      FROM entity_wallets ew
+      WHERE ew.entity_type = c.entity_type
+        AND ew.entity_id = c.entity_id
+        AND ew.is_primary = true
+      ORDER BY ew.created_at
+      LIMIT 1
+    ) <> 'private'
+  GROUP BY c.entity_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_entities_funding_stats(text, uuid[]) TO anon, authenticated;


### PR DESCRIPTION
## What

Completes the funding-honesty work started in #489. The detail page was fixed to read the settled `contributions` ledger, but **every list surface still read the dead `raised_amount` column** (which no code ever writes), and `supporters_count` counted emoji reactions / comments / unverified self-reports instead of settled payments.

## Changes

- **New batch RPC** `get_entities_funding_stats(text, uuid[])` — settled totals for N entities in one call, identical visibility semantics to the single-entity function. **Already applied to the prod box** (expand-before-deploy; verified executing).
- **New `enrichProjectsWithSettledFunding()`** (`src/services/wallets/project-funding.ts`) — overwrites `raised_amount` with the settled total in the project's own currency, adds `settled_raised_btc` (canonical BTC) and `supporters_count` (settled contributors). Never throws; degrades to zeros — never fabricates.
- **Wired through every list surface**: search (PostGIS / FTS / ILIKE paths), trending, profile projects route, generic profile entities route, favorites, single-project API, dashboard list (domain service), profile-page `totalRaised`.
- `totalRaised` on profiles is now summed **in BTC** — it is displayed via `formatAmountBtc`; the old code summed mixed per-project currencies (latent unit bug masked by the always-0 column).
- Funding min/max search filters moved post-enrichment (SQL `gte/lte` on the dead column silently broke them).
- **Stats route**: raised / supporterCount / averageContribution now from the ledger; the `project_support` self-report count no longer masquerades as paying supporters.
- Detail page threads `supporters_count` (settled contributors) into the summary rail.
- Unit tests for the enrichment invariants (currency conversion, zeros for private/unfunded, never-throw).

## Honest consequence

Projects with no settled contributions show 0 raised / 0 supporters everywhere — consistently with the detail page, instead of fake or contradictory numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)