### PR TITLE
feat(cat): portable memory — import from & export to another AI

### DIFF
--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -14,6 +14,7 @@
  * right-sidebar guidance (added noise).
  */
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { ArrowLeft, Bot, Check, Server, Terminal, AlertCircle } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
@@ -24,10 +25,12 @@ import Loading from '@/components/Loading';
 import { AIKeyManager } from '@/components/ai/AIKeyManager';
 import { CatCreditsPanel } from '@/components/ai/CatCreditsPanel';
 import { CatMemoryManager } from '@/components/ai/CatMemoryManager';
+import { CatMemoryImport } from '@/components/ai/CatMemoryImport';
 import { getProvidersByCategory } from '@/data/aiProviders';
 
 export default function AISettingsPage() {
   const { user, hydrated, isLoading: authLoading } = useRequireAuth();
+  const [memoryReloadKey, setMemoryReloadKey] = useState(0);
 
   const {
     keys,
@@ -137,7 +140,10 @@ export default function AISettingsPage() {
         </section>
 
         {/* ── Memory ────────────────────────────────────────────────────── */}
-        <CatMemoryManager />
+        <CatMemoryManager reloadKey={memoryReloadKey} />
+
+        {/* ── Import memory from another AI ──────────────────────────────── */}
+        <CatMemoryImport onImported={() => setMemoryReloadKey(k => k + 1)} />
 
         {/* ── Local ─────────────────────────────────────────────────────── */}
         <section className="rounded-lg border border-default bg-surface-base p-6">

--- a/src/app/api/cat/memories/import/route.ts
+++ b/src/app/api/cat/memories/import/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Cat Memory Import API
+ *
+ * POST /api/cat/memories/import  — bring memory from another AI.
+ *   body: { text: string }  (the export the user pasted from ChatGPT/Grok/…)
+ *   → { total, imported, skipped, embeddingsEnabled }
+ *
+ * Thin wrapper: parsing, embedding, dedup and storage live in the memory
+ * service. RLS-scoped to the caller; write rate-limited like other mutations.
+ */
+
+import { importMemories } from '@/services/cat/memory';
+import { apiSuccess, apiError, apiRateLimited, handleApiError } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+
+/** Guard against absurdly large pastes (the parser also caps facts to 200). */
+const MAX_TEXT_CHARS = 100_000;
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
+  try {
+    const body = (await request.json().catch(() => null)) as { text?: unknown } | null;
+    const text = typeof body?.text === 'string' ? body.text : '';
+    if (!text.trim()) {
+      return apiError('Paste the exported memory text to import.', 'BAD_REQUEST', 400);
+    }
+    if (text.length > MAX_TEXT_CHARS) {
+      return apiError('That paste is too large (max 100,000 characters).', 'BAD_REQUEST', 400);
+    }
+
+    const result = await importMemories(supabase, user.id, text);
+    return apiSuccess(result);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/src/components/ai/CatMemoryImport.tsx
+++ b/src/components/ai/CatMemoryImport.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+/**
+ * CatMemoryImport — bring your memory from another AI into Cat.
+ *
+ * Two steps: copy a prompt into your other assistant (ChatGPT, Grok, Gemini…),
+ * then paste what it exports back here. OrangeCat distils it into durable Cat
+ * memories, deduped against what Cat already knows. Portable, user-owned context
+ * — the "right of exit" made real. Talks to /api/cat/memories/import.
+ */
+
+import { useCallback, useState } from 'react';
+import { ArrowDownToLine, Copy, Check, Loader2, ChevronDown, ChevronUp } from 'lucide-react';
+import { toast } from 'sonner';
+import Button from '@/components/ui/Button';
+import { logger } from '@/utils/logger';
+import { API_ROUTES } from '@/config/api-routes';
+import { MEMORY_IMPORT_PROMPT } from '@/config/cat-memory-import';
+
+interface CatMemoryImportProps {
+  /** Called after a successful import so a sibling memory list can refresh. */
+  onImported?: () => void;
+}
+
+export function CatMemoryImport({ onImported }: CatMemoryImportProps) {
+  const [text, setText] = useState('');
+  const [isImporting, setIsImporting] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [showPrompt, setShowPrompt] = useState(false);
+
+  const copyPrompt = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(MEMORY_IMPORT_PROMPT);
+      setCopied(true);
+      toast.success('Prompt copied — paste it into your other AI');
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setShowPrompt(true);
+      toast.error('Could not copy automatically — select the prompt below and copy it');
+    }
+  }, []);
+
+  const handleImport = useCallback(async () => {
+    if (!text.trim()) {
+      toast.error('Paste your exported memory first');
+      return;
+    }
+    setIsImporting(true);
+    try {
+      const res = await fetch(API_ROUTES.CAT.MEMORIES_IMPORT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok || !json?.success) {
+        throw new Error(json?.error ?? 'Import failed');
+      }
+      const {
+        total = 0,
+        imported = 0,
+        skipped = 0,
+        embeddingsEnabled = true,
+      } = (json.data ?? {}) as {
+        total?: number;
+        imported?: number;
+        skipped?: number;
+        embeddingsEnabled?: boolean;
+      };
+
+      if (total === 0) {
+        toast.error("Couldn't find any memories in that text. Paste the whole export.");
+      } else if (imported === 0) {
+        toast.success(`Nothing new — Cat already remembered all ${total}.`);
+      } else {
+        toast.success(
+          `Imported ${imported} ${imported === 1 ? 'memory' : 'memories'}` +
+            (skipped > 0 ? `, skipped ${skipped} already known.` : '.')
+        );
+        setText('');
+        onImported?.();
+        if (!embeddingsEnabled) {
+          toast.message('Stored — but semantic recall is off until an embeddings provider is set.');
+        }
+      }
+    } catch (err) {
+      logger.error('Failed to import memories', err, 'CatMemory');
+      toast.error(err instanceof Error ? err.message : 'Import failed');
+    } finally {
+      setIsImporting(false);
+    }
+  }, [text, onImported]);
+
+  return (
+    <section className="rounded-lg border border-default bg-surface-base p-6">
+      <div className="mb-4 flex items-start gap-3">
+        <div className="rounded-md bg-surface-raised p-2">
+          <ArrowDownToLine className="h-5 w-5 text-fg-primary" />
+        </div>
+        <div className="flex-1">
+          <h2 className="text-lg font-semibold text-fg-primary">Import from another AI</h2>
+          <p className="mt-1 text-sm text-fg-secondary">
+            Already have context in ChatGPT, Grok, Gemini or Claude? Bring it over so Cat starts warm
+            instead of cold. Copy the prompt, run it in your other assistant, and paste the result
+            back — Cat keeps what&apos;s new and skips anything it already knows.
+          </p>
+        </div>
+      </div>
+
+      {/* Step 1 — copy the prompt */}
+      <div className="mb-4 rounded-md border border-subtle bg-surface-raised/30 p-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-sm font-medium text-fg-primary">
+            1 · Copy this prompt into your other AI
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShowPrompt(v => !v)}
+              className="inline-flex items-center gap-1 text-sm text-fg-secondary hover:text-fg-primary"
+            >
+              {showPrompt ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+              {showPrompt ? 'Hide' : 'Show'} prompt
+            </button>
+            <Button
+              variant="outline"
+              onClick={copyPrompt}
+              className="h-11 gap-2 px-3 text-sm"
+              aria-label="Copy the import prompt"
+            >
+              {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+              {copied ? 'Copied' : 'Copy prompt'}
+            </Button>
+          </div>
+        </div>
+        {showPrompt && (
+          <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap rounded-md border border-subtle bg-surface-page p-3 text-xs text-fg-secondary">
+            {MEMORY_IMPORT_PROMPT}
+          </pre>
+        )}
+      </div>
+
+      {/* Step 2 — paste the result */}
+      <div className="rounded-md border border-subtle bg-surface-raised/30 p-3">
+        <label htmlFor="memory-import" className="text-sm font-medium text-fg-primary">
+          2 · Paste the result here
+        </label>
+        <textarea
+          id="memory-import"
+          value={text}
+          onChange={e => setText(e.target.value)}
+          disabled={isImporting}
+          rows={6}
+          placeholder="Paste everything your other AI exported…"
+          className="mt-2 w-full resize-y rounded-md border border-subtle bg-surface-page p-3 text-sm text-fg-primary placeholder:text-fg-tertiary focus:outline-none focus:ring-2 focus:ring-accent-warm disabled:opacity-60"
+        />
+        <div className="mt-3 flex items-center justify-end">
+          <Button
+            variant="accent"
+            onClick={handleImport}
+            disabled={isImporting || !text.trim()}
+            className="h-11 gap-2 px-4 text-sm"
+          >
+            {isImporting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <ArrowDownToLine className="h-4 w-4" />
+            )}
+            Import into Cat
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CatMemoryImport;

--- a/src/components/ai/CatMemoryManager.tsx
+++ b/src/components/ai/CatMemoryManager.tsx
@@ -21,7 +21,12 @@ interface Memory {
   created_at: string;
 }
 
-export function CatMemoryManager() {
+interface CatMemoryManagerProps {
+  /** Bump to force a reload — e.g. after an import adds new memories. */
+  reloadKey?: number;
+}
+
+export function CatMemoryManager({ reloadKey = 0 }: CatMemoryManagerProps = {}) {
   const [memories, setMemories] = useState<Memory[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -49,7 +54,7 @@ export function CatMemoryManager() {
 
   useEffect(() => {
     void load();
-  }, [load]);
+  }, [load, reloadKey]);
 
   const handleDelete = useCallback(async (id: string) => {
     setDeletingId(id);

--- a/src/components/ai/CatMemoryManager.tsx
+++ b/src/components/ai/CatMemoryManager.tsx
@@ -9,11 +9,12 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Brain, Trash2, Loader2, AlertCircle } from 'lucide-react';
+import { Brain, Trash2, Loader2, AlertCircle, Download } from 'lucide-react';
 import { toast } from 'sonner';
 import Button from '@/components/ui/Button';
 import { logger } from '@/utils/logger';
 import { API_ROUTES } from '@/config/api-routes';
+import { formatMemoriesForExport, MEMORY_EXPORT_FILENAME } from '@/config/cat-memory-import';
 
 interface Memory {
   id: string;
@@ -75,6 +76,22 @@ export function CatMemoryManager({ reloadKey = 0 }: CatMemoryManagerProps = {}) 
     }
   }, []);
 
+  const handleExport = useCallback(() => {
+    const text = formatMemoriesForExport(memories.map(m => m.content));
+    // Portable, re-importable: download the exact plain-line shape the importer
+    // accepts, so the user can take their memory anywhere. Their right of exit.
+    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = MEMORY_EXPORT_FILENAME;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+    toast.success(`Exported ${memories.length} ${memories.length === 1 ? 'memory' : 'memories'}`);
+  }, [memories]);
+
   const handleClearAll = useCallback(async () => {
     setIsClearing(true);
     try {
@@ -103,13 +120,22 @@ export function CatMemoryManager({ reloadKey = 0 }: CatMemoryManagerProps = {}) 
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-lg font-semibold text-fg-primary">What Cat remembers</h2>
             {memories.length > 0 && !confirmClear && (
-              <button
-                type="button"
-                onClick={() => setConfirmClear(true)}
-                className="text-sm text-fg-secondary underline hover:text-status-negative"
-              >
-                Forget everything
-              </button>
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={handleExport}
+                  className="inline-flex items-center gap-1 text-sm text-fg-secondary hover:text-fg-primary"
+                >
+                  <Download className="h-4 w-4" /> Export
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmClear(true)}
+                  className="text-sm text-fg-secondary underline hover:text-status-negative"
+                >
+                  Forget everything
+                </button>
+              </div>
             )}
           </div>
           <p className="mt-1 text-sm text-fg-secondary">

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -18,6 +18,7 @@ export const API_ROUTES = {
     CREDITS: '/api/cat/credits',
     CREDITS_TOPUP: '/api/cat/credits/topup',
     MEMORIES: '/api/cat/memories',
+    MEMORIES_IMPORT: '/api/cat/memories/import',
     NUDGES: '/api/cat/nudges',
     CONVERSATIONS: '/api/cat/conversations',
     CONVERSATION: (id: string) => `/api/cat/conversations/${id}`,

--- a/src/config/cat-memory-import.ts
+++ b/src/config/cat-memory-import.ts
@@ -1,0 +1,40 @@
+/**
+ * Cat Memory Import — SSOT for the "bring your memory from another AI" bridge.
+ *
+ * MEMORY_IMPORT_PROMPT is the exact text a user copies into another AI (ChatGPT,
+ * Grok, Gemini, Claude, …) to export what it knows about them. They paste the
+ * result back into OrangeCat, which distils it into durable Cat memories.
+ *
+ * Kept here (not inline in the component) so the prompt is defined once and can
+ * be reused by docs, onboarding, or a future FleetCrown import without drift.
+ * The reciprocal direction (export FROM OrangeCat in this same shape) is the
+ * "right of exit" half — portable, user-owned memory, not a walled garden.
+ */
+
+/** Categories the import parser understands as headings (never stored as facts). */
+export const MEMORY_IMPORT_CATEGORIES = [
+  'Instructions',
+  'Identity',
+  'Career',
+  'Projects',
+  'Preferences',
+] as const;
+
+export const MEMORY_IMPORT_PROMPT = `Export everything you've learned and stored about me from our past conversations, so I can bring it to another AI assistant. Preserve my own words where possible, especially instructions and preferences.
+
+## Categories (output in this order):
+
+1. **Instructions**: Rules I've explicitly asked you to follow going forward — tone, format, style, "always do X", "never do Y", and corrections to your behaviour. Only from stored memory, not one-off requests.
+2. **Identity**: Name, location, languages, background, interests — stable facts about who I am.
+3. **Career**: Current and past roles, companies, and skill areas.
+4. **Projects**: Things I'm meaningfully building or committed to — one entry per project, with what it does and its current status. Lead each entry with the project name.
+5. **Preferences**: Opinions, tastes, and working-style preferences that apply broadly.
+
+## Format:
+- A section header per category.
+- One entry per line. Keep each entry to a single, self-contained sentence.
+- If you know when something was established, prefix it: [YYYY-MM-DD] - entry. Otherwise just write the entry.
+
+## Output:
+- Wrap the whole export in a single code block so it's easy to copy.
+- Only include things you actually have stored — never invent or pad. If a category is empty, write "(none)".`;

--- a/src/config/cat-memory-import.ts
+++ b/src/config/cat-memory-import.ts
@@ -20,6 +20,22 @@ export const MEMORY_IMPORT_CATEGORIES = [
   'Preferences',
 ] as const;
 
+/** Filename for the downloadable memory export. */
+export const MEMORY_EXPORT_FILENAME = 'orangecat-cat-memory.txt';
+
+/**
+ * Format stored memories into the portable, re-importable shape — one fact per
+ * line. This is the "right of exit" half: the output round-trips straight back
+ * through parseImportedMemories(), into another AI, or back into OrangeCat.
+ * Deliberately plain text (no headers/JSON) so it's maximally portable.
+ */
+export function formatMemoriesForExport(contents: string[]): string {
+  return contents
+    .map(c => c.trim())
+    .filter(Boolean)
+    .join('\n');
+}
+
 export const MEMORY_IMPORT_PROMPT = `Export everything you've learned and stored about me from our past conversations, so I can bring it to another AI assistant. Preserve my own words where possible, especially instructions and preferences.
 
 ## Categories (output in this order):

--- a/src/services/cat/memory.ts
+++ b/src/services/cat/memory.ts
@@ -17,9 +17,9 @@
  * users can view/delete everything Cat remembers (Settings → AI).
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { DATABASE_TABLES } from '@/config/database-tables';
+import { MEMORY_IMPORT_CATEGORIES } from '@/config/cat-memory-import';
 import { embeddingsEnabled, embedText, embedTexts } from '@/services/ai/embeddings';
 import { logger } from '@/utils/logger';
 
@@ -324,4 +324,185 @@ export async function deleteAllMemories(
     return false;
   }
   return true;
+}
+
+// ─── Import (bring memory from another AI) ─────────────────────────────────────
+
+/** Cap facts accepted from a single paste — a one-time bulk import, kept sane. */
+const MAX_IMPORT_FACTS = 200;
+/** Imported entries may be a full sentence — allow more than a chat-distilled fact. */
+const MAX_IMPORT_FACT_CHARS = 500;
+/** Batch size for embedding many candidates without oversized requests. */
+const IMPORT_EMBED_BATCH = 100;
+
+const IMPORT_HEADER_SET = new Set<string>(MEMORY_IMPORT_CATEGORIES.map(c => c.toLowerCase()));
+
+export interface MemoryImportResult {
+  /** Candidate facts found in the pasted text. */
+  total: number;
+  /** Newly stored (after dedup). */
+  imported: number;
+  /** Dropped because an equivalent memory already existed. */
+  skipped: number;
+  /** False when no embeddings provider is configured — imported facts are stored
+   *  but won't be recalled semantically until one is set. */
+  embeddingsEnabled: boolean;
+}
+
+/** Some assistants answer with a JSON array of strings — accept that shape too. */
+function tryParseJsonArray(raw: string): string[] {
+  const cleaned = raw.replace(/```(?:json)?/gi, '').trim();
+  const match = cleaned.match(/\[[\s\S]*\]/);
+  if (!match) {
+    return [];
+  }
+  try {
+    const arr = JSON.parse(match[0]);
+    return Array.isArray(arr) ? arr.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Strip list markers, numbering, markdown headings/bold from a line. */
+function stripLineDecorations(line: string): string {
+  return line
+    .replace(/^\s*#{1,6}\s*/, '') // markdown heading
+    .replace(/^\s*[-*•·]\s+/, '') // bullet
+    .replace(/^\s*\d+[.)]\s+/, '') // "1. " / "1) "
+    .replace(/\*\*/g, '') // bold
+    .replace(/^\s*[-–—]\s*/, '') // stray leading dash (e.g. exposed after a date strip)
+    .trim();
+}
+
+/** Remove a leading date tag like "[2026-01-01] - " or "[unknown] - ". */
+function stripDatePrefix(line: string): string {
+  return line.replace(/^\[[^\]]*\]\s*[-–—:]\s*/, '').trim();
+}
+
+/** True when a line is just a category heading (e.g. "Projects", "**Identity**:"). */
+function isImportHeader(line: string): boolean {
+  const normalized = stripLineDecorations(line).replace(/:$/, '').trim().toLowerCase();
+  return IMPORT_HEADER_SET.has(normalized);
+}
+
+/**
+ * Turn a pasted memory export (from any AI) into a clean list of fact strings.
+ * Defensive: accepts a JSON array, or category-grouped markdown/bulleted/dated
+ * lines. Strips headers, bullets, numbering and date tags; dedupes and caps.
+ */
+export function parseImportedMemories(raw: string): string[] {
+  if (!raw || !raw.trim()) {
+    return [];
+  }
+  const jsonFacts = tryParseJsonArray(raw);
+  const isJson = jsonFacts.length > 0;
+  const lines = isJson ? jsonFacts : raw.replace(/```(?:json|markdown)?/gi, '').split('\n');
+
+  const seen = new Set<string>();
+  const facts: string[] = [];
+  for (const rawLine of lines) {
+    let line = (rawLine ?? '').trim();
+    if (!line) {
+      continue;
+    }
+    if (!isJson) {
+      if (isImportHeader(line)) {
+        continue;
+      }
+      line = stripDatePrefix(stripLineDecorations(line));
+      line = stripLineDecorations(line); // a date strip can expose a leading dash
+    }
+    const lower = line.toLowerCase();
+    if (!line || line.length < 3 || lower === '(none)' || lower === 'none') {
+      continue;
+    }
+    const key = lower.slice(0, MAX_IMPORT_FACT_CHARS);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    facts.push(line.slice(0, MAX_IMPORT_FACT_CHARS));
+    if (facts.length >= MAX_IMPORT_FACTS) {
+      break;
+    }
+  }
+  return facts;
+}
+
+/**
+ * Import durable facts from a memory export the user pasted from another AI.
+ * Embeds each (for recall + dedup), skips ones already equivalent to a stored
+ * memory, inserts the rest as `source: 'import'`, and prunes to the per-user cap.
+ * Degrades gracefully: with no embeddings provider, facts are still stored
+ * (embeddingsEnabled=false in the result) but can't be recalled by meaning yet.
+ */
+export async function importMemories(
+  supabase: AnySupabaseClient,
+  userId: string,
+  rawText: string
+): Promise<MemoryImportResult> {
+  const facts = parseImportedMemories(rawText);
+  const useEmbeddings = embeddingsEnabled();
+  const result: MemoryImportResult = {
+    total: facts.length,
+    imported: 0,
+    skipped: 0,
+    embeddingsEnabled: useEmbeddings,
+  };
+  if (facts.length === 0) {
+    return result;
+  }
+
+  const vectors: (number[] | null)[] = [];
+  if (useEmbeddings) {
+    for (let i = 0; i < facts.length; i += IMPORT_EMBED_BATCH) {
+      vectors.push(...(await embedTexts(facts.slice(i, i + IMPORT_EMBED_BATCH))));
+    }
+  } else {
+    for (let i = 0; i < facts.length; i++) {
+      vectors.push(null);
+    }
+  }
+
+  const toInsert: Array<{
+    user_id: string;
+    content: string;
+    embedding: string | null;
+    source: string;
+    source_conversation_id: null;
+  }> = [];
+  for (let i = 0; i < facts.length; i++) {
+    const vec = vectors[i];
+    if (vec) {
+      const { data: near } = await supabase.rpc('match_cat_memories', {
+        p_user_id: userId,
+        query_embedding: JSON.stringify(vec),
+        match_count: 1,
+        min_similarity: DEDUP_SIMILARITY,
+      });
+      if (Array.isArray(near) && near.length > 0) {
+        result.skipped++;
+        continue; // already remember something equivalent
+      }
+    }
+    toInsert.push({
+      user_id: userId,
+      content: facts[i],
+      embedding: vec ? JSON.stringify(vec) : null,
+      source: 'import',
+      source_conversation_id: null,
+    });
+  }
+
+  if (toInsert.length > 0) {
+    const { error } = await supabase.from(DATABASE_TABLES.CAT_MEMORIES).insert(toInsert);
+    if (error) {
+      logger.warn('Failed to insert imported cat memories', { error }, 'CatMemory');
+      return result;
+    }
+    result.imported = toInsert.length;
+    await pruneIfNeeded(supabase, userId);
+  }
+  return result;
 }

--- a/src/services/cat/memory.ts
+++ b/src/services/cat/memory.ts
@@ -454,6 +454,21 @@ export async function importMemories(
     return result;
   }
 
+  // Exact-content dedup against what's already stored. Semantic dedup below
+  // catches near-duplicates, but only when embeddings are on — this keeps the
+  // "skips what it already knows" promise true even with no provider, and makes
+  // re-importing the same paste a safe no-op.
+  const { data: existingRows } = await supabase
+    .from(DATABASE_TABLES.CAT_MEMORIES)
+    .select('content')
+    .eq('user_id', userId)
+    .limit(MAX_MEMORIES_PER_USER);
+  const existing = new Set<string>(
+    ((existingRows as Array<{ content: string }> | null) ?? []).map(r =>
+      r.content.trim().toLowerCase()
+    )
+  );
+
   const vectors: (number[] | null)[] = [];
   if (useEmbeddings) {
     for (let i = 0; i < facts.length; i += IMPORT_EMBED_BATCH) {
@@ -473,6 +488,11 @@ export async function importMemories(
     source_conversation_id: null;
   }> = [];
   for (let i = 0; i < facts.length; i++) {
+    const exactKey = facts[i].trim().toLowerCase();
+    if (existing.has(exactKey)) {
+      result.skipped++;
+      continue; // already stored verbatim
+    }
     const vec = vectors[i];
     if (vec) {
       const { data: near } = await supabase.rpc('match_cat_memories', {
@@ -486,6 +506,8 @@ export async function importMemories(
         continue; // already remember something equivalent
       }
     }
+    // Guard against exact dupes within this same paste when embeddings are off.
+    existing.add(exactKey);
     toInsert.push({
       user_id: userId,
       content: facts[i],

--- a/tests/unit/cat-memory-import.test.ts
+++ b/tests/unit/cat-memory-import.test.ts
@@ -1,4 +1,5 @@
 import { parseImportedMemories } from '@/services/cat/memory';
+import { formatMemoriesForExport } from '@/config/cat-memory-import';
 
 /**
  * Parser for pasted memory exports from other AIs. Pure function — no DB/embeds.
@@ -42,9 +43,12 @@ describe('parseImportedMemories', () => {
   });
 
   it('drops "(none)" placeholders and exact duplicates', () => {
-    const raw = ['# Career', '(none)', 'Ex-banker turned engineer', 'Ex-banker turned engineer'].join(
-      '\n'
-    );
+    const raw = [
+      '# Career',
+      '(none)',
+      'Ex-banker turned engineer',
+      'Ex-banker turned engineer',
+    ].join('\n');
     expect(parseImportedMemories(raw)).toEqual(['Ex-banker turned engineer']);
   });
 
@@ -63,5 +67,27 @@ describe('parseImportedMemories', () => {
   it('caps the number of imported facts at 200', () => {
     const raw = Array.from({ length: 500 }, (_, i) => `Fact number ${i}`).join('\n');
     expect(parseImportedMemories(raw)).toHaveLength(200);
+  });
+});
+
+/**
+ * Export is the "right of exit" half — its output must round-trip back through
+ * the importer unchanged, so memory is portable to any AI (or back to OrangeCat).
+ */
+describe('formatMemoriesForExport round-trips through parseImportedMemories', () => {
+  it('re-parses to exactly the same facts', () => {
+    const facts = [
+      'Name is George, based in Zürich, Switzerland',
+      'Building OrangeCat, a Bitcoin-native platform',
+      'Prefers Lightning over on-chain payments',
+    ];
+    const exported = formatMemoriesForExport(facts);
+    expect(parseImportedMemories(exported)).toEqual(facts);
+  });
+
+  it('drops blank entries and trims on export', () => {
+    expect(formatMemoriesForExport(['  Likes concise answers  ', '', '   '])).toBe(
+      'Likes concise answers'
+    );
   });
 });

--- a/tests/unit/cat-memory-import.test.ts
+++ b/tests/unit/cat-memory-import.test.ts
@@ -1,0 +1,67 @@
+import { parseImportedMemories } from '@/services/cat/memory';
+
+/**
+ * Parser for pasted memory exports from other AIs. Pure function — no DB/embeds.
+ * Covers the shapes we actually receive: category-grouped markdown with date
+ * tags and bullets, a plain JSON array, and the junk we must drop.
+ */
+describe('parseImportedMemories', () => {
+  it('returns [] for empty or whitespace input', () => {
+    expect(parseImportedMemories('')).toEqual([]);
+    expect(parseImportedMemories('   \n  ')).toEqual([]);
+  });
+
+  it('strips category headers, bullets, numbering and date prefixes', () => {
+    const raw = [
+      '# Identity',
+      '- [2026-01-01] - Based in Zürich',
+      '* Speaks English and Russian',
+      '## Projects',
+      '1. [unknown] - Building FleetCrown, a life-OS for builders',
+      '**Preferences**',
+      'Prefers Lightning over on-chain payments',
+    ].join('\n');
+
+    const facts = parseImportedMemories(raw);
+
+    expect(facts).toEqual([
+      'Based in Zürich',
+      'Speaks English and Russian',
+      'Building FleetCrown, a life-OS for builders',
+      'Prefers Lightning over on-chain payments',
+    ]);
+    // Category headings never become memories.
+    expect(facts).not.toContain('Identity');
+    expect(facts).not.toContain('Projects');
+    expect(facts).not.toContain('Preferences');
+  });
+
+  it('accepts a JSON array of strings verbatim', () => {
+    const raw = '```json\n["Prefers dark mode", "Works in Zürich"]\n```';
+    expect(parseImportedMemories(raw)).toEqual(['Prefers dark mode', 'Works in Zürich']);
+  });
+
+  it('drops "(none)" placeholders and exact duplicates', () => {
+    const raw = ['# Career', '(none)', 'Ex-banker turned engineer', 'Ex-banker turned engineer'].join(
+      '\n'
+    );
+    expect(parseImportedMemories(raw)).toEqual(['Ex-banker turned engineer']);
+  });
+
+  it('handles a code-fenced markdown export like the copy-back flow produces', () => {
+    const raw = [
+      '```',
+      'Identity',
+      '[2026-03-04] - Name is George',
+      'Preferences',
+      '- Likes concise answers',
+      '```',
+    ].join('\n');
+    expect(parseImportedMemories(raw)).toEqual(['Name is George', 'Likes concise answers']);
+  });
+
+  it('caps the number of imported facts at 200', () => {
+    const raw = Array.from({ length: 500 }, (_, i) => `Fact number ${i}`).join('\n');
+    expect(parseImportedMemories(raw)).toHaveLength(200);
+  });
+});


### PR DESCRIPTION
## What

Makes Cat's memory **portable** — the OrangeCat-differentiating framing, not a walled garden:

- **Import from another AI** — Grok-style *copy-a-prompt → paste-the-result* flow at `/settings/ai`. Bring context from ChatGPT/Grok/Gemini/Claude so Cat starts warm.
- **Export ("right of exit")** — download your stored memory in the *same* plain-line format, so it round-trips to any AI or back into OrangeCat.

Built entirely on Cat's existing substrate (`cat_memories` + pgvector) — **no schema migration** (`source` is free-text; imported rows use `source:'import'`).

## Pieces

| Piece | File |
|---|---|
| Prompt + portable-format SSOT | `src/config/cat-memory-import.ts` (`MEMORY_IMPORT_PROMPT`, `formatMemoriesForExport`) |
| Parser + importer | `src/services/cat/memory.ts` (`parseImportedMemories`, `importMemories`) |
| API (thin, RLS, rate-limited) | `src/app/api/cat/memories/import/route.ts` |
| Import UI | `src/components/ai/CatMemoryImport.tsx` |
| Export UI (+ manager refresh) | `src/components/ai/CatMemoryManager.tsx` |
| Unit tests (parser + round-trip) | `tests/unit/cat-memory-import.test.ts` |

## How it works

- `importMemories()` reuses the chat extractor's path: embed → **dedup** (exact-content + semantic `match_cat_memories`) → insert → prune. Degrades gracefully with no embeddings provider.
- `parseImportedMemories()` accepts category-grouped markdown (headers/bullets/`[date] -` stripped) or a raw JSON array; dedups, caps at 200.
- Export emits the exact shape the importer accepts — proven by a **round-trip unit test**.

## Verified

- ✅ **Import: browser-tested end-to-end** against the real app + prod Supabase — login → paste export → `200` → 7 clean facts stored (DB-confirmed `source:'import'`); memory list auto-refreshed. Re-import of known facts → **0 duplicates** (dedup fix). Test data cleaned up afterward.
- ✅ `type-check` 0 errors · `lint` clean · `audit:routes` clean · **8/8 unit tests**
- ⚠️ Export button not re-exercised in a live browser (client-side `Blob` download; format is round-trip-unit-proven). Semantic dedup/recall only active when `EMBEDDINGS_API_KEY` is set (prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
