### PR TITLE
feat(articles): multi-draft autosave, auto-growing editor, jest storage-mock fix

### DIFF
--- a/__tests__/unit/services/articles/local-drafts.test.ts
+++ b/__tests__/unit/services/articles/local-drafts.test.ts
@@ -1,0 +1,111 @@
+import {
+  deleteLocalDraft,
+  listLocalDrafts,
+  MAX_LOCAL_DRAFTS,
+  newDraftId,
+  saveLocalDraft,
+  type LocalArticleDraft,
+} from '@/services/articles/local-drafts';
+
+const STORE_KEY = 'oc:drafts:articles';
+const LEGACY_KEY = 'oc:draft:article';
+
+function makeDraft(overrides: Partial<LocalArticleDraft> = {}): LocalArticleDraft {
+  return {
+    id: newDraftId(),
+    title: 'Title',
+    excerpt: '',
+    coverImage: '',
+    body: 'Body',
+    visibility: 'public',
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('local article drafts', () => {
+  it('round-trips a draft through save and list', () => {
+    const draft = makeDraft({ title: 'My draft' });
+    saveLocalDraft(draft);
+    expect(listLocalDrafts()).toEqual([draft]);
+  });
+
+  it('lists drafts most recently touched first', () => {
+    const old = makeDraft({ title: 'old', updatedAt: 1000 });
+    const fresh = makeDraft({ title: 'fresh', updatedAt: 2000 });
+    saveLocalDraft(old);
+    saveLocalDraft(fresh);
+    expect(listLocalDrafts().map(d => d.title)).toEqual(['fresh', 'old']);
+  });
+
+  it('upserts by id instead of duplicating', () => {
+    const draft = makeDraft({ title: 'v1' });
+    saveLocalDraft(draft);
+    saveLocalDraft({ ...draft, title: 'v2', updatedAt: draft.updatedAt + 1 });
+    const drafts = listLocalDrafts();
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].title).toBe('v2');
+  });
+
+  it('deletes only the targeted draft', () => {
+    const keep = makeDraft({ title: 'keep' });
+    const drop = makeDraft({ title: 'drop' });
+    saveLocalDraft(keep);
+    saveLocalDraft(drop);
+    deleteLocalDraft(drop.id);
+    expect(listLocalDrafts().map(d => d.title)).toEqual(['keep']);
+  });
+
+  it('trims the store to MAX_LOCAL_DRAFTS, dropping the oldest', () => {
+    for (let i = 0; i < MAX_LOCAL_DRAFTS + 3; i++) {
+      saveLocalDraft(makeDraft({ title: `d${i}`, updatedAt: i }));
+    }
+    const drafts = listLocalDrafts();
+    expect(drafts).toHaveLength(MAX_LOCAL_DRAFTS);
+    // The oldest three (d0..d2) were dropped; the newest survives.
+    expect(drafts[0].title).toBe(`d${MAX_LOCAL_DRAFTS + 2}`);
+    expect(drafts.some(d => d.title === 'd0')).toBe(false);
+  });
+
+  it('migrates the legacy single-slot draft and removes the old key', () => {
+    localStorage.setItem(
+      LEGACY_KEY,
+      JSON.stringify({ title: 'Legacy', excerpt: '', coverImage: '', body: 'old body', visibility: 'followers' })
+    );
+    const drafts = listLocalDrafts();
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]).toMatchObject({ title: 'Legacy', body: 'old body', visibility: 'followers' });
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it('ignores an empty legacy slot without creating a draft', () => {
+    localStorage.setItem(
+      LEGACY_KEY,
+      JSON.stringify({ title: '', excerpt: '', coverImage: '', body: '', visibility: 'public' })
+    );
+    expect(listLocalDrafts()).toEqual([]);
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it('survives a corrupt store by treating it as empty', () => {
+    localStorage.setItem(STORE_KEY, 'not-json{');
+    expect(listLocalDrafts()).toEqual([]);
+    const draft = makeDraft();
+    saveLocalDraft(draft);
+    expect(listLocalDrafts()).toEqual([draft]);
+  });
+
+  it('filters malformed entries out of the store', () => {
+    const good = makeDraft({ title: 'good' });
+    localStorage.setItem(STORE_KEY, JSON.stringify([good, { nonsense: true }, null]));
+    expect(listLocalDrafts()).toEqual([good]);
+  });
+
+  it('generates unique draft ids', () => {
+    expect(newDraftId()).not.toBe(newDraftId());
+  });
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -105,31 +105,11 @@ Object.defineProperty(process.env, 'SUPABASE_SERVICE_ROLE_KEY', {
 // Mock fetch globally
 global.fetch = jest.fn();
 
-// Mock localStorage
-const localStorageMock = {
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-  clear: jest.fn(),
-  length: 0,
-  key: jest.fn(),
-};
-Object.defineProperty(window, 'localStorage', {
-  value: localStorageMock,
-});
-
-// Mock sessionStorage
-const sessionStorageMock = {
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-  clear: jest.fn(),
-  length: 0,
-  key: jest.fn(),
-};
-Object.defineProperty(window, 'sessionStorage', {
-  value: sessionStorageMock,
-});
+// localStorage / sessionStorage are already replaced above with spy-able,
+// store-backed mocks (createStorageMock) — these are just handles to them.
+// One mock, one source of truth: don't define a second stub here.
+const localStorageMock = window.localStorage as unknown as ReturnType<typeof createStorageMock>;
+const sessionStorageMock = window.sessionStorage as unknown as ReturnType<typeof createStorageMock>;
 
 // Mock window.location
 delete (window as any).location;
@@ -351,7 +331,10 @@ beforeEach(() => {
   // Reset all mocks
   jest.clearAllMocks();
 
-  // Reset localStorage and sessionStorage
+  // Empty the storage backing stores, then reset call history, so every test
+  // starts with clean storage and clean spies.
+  localStorageMock.clear();
+  sessionStorageMock.clear();
   if (localStorageMock.getItem?.mockClear) {
     localStorageMock.getItem.mockClear();
     localStorageMock.setItem.mockClear();

--- a/src/app/(public)/articles/new/ArticleComposer.tsx
+++ b/src/app/(public)/articles/new/ArticleComposer.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, Eye, PenLine } from 'lucide-react';
+import { ArrowLeft, Eye, PenLine, Trash2 } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
 import Textarea from '@/components/ui/Textarea';
@@ -15,21 +15,19 @@ import { publishArticle } from '@/services/articles/create';
 import { updateArticle } from '@/services/articles/update';
 import type { TimelineVisibility } from '@/types/timeline';
 import type { ArticleDraft } from '@/services/cat/writing-types';
+import {
+  deleteLocalDraft,
+  listLocalDrafts,
+  newDraftId,
+  saveLocalDraft,
+  type LocalArticleDraft,
+} from '@/services/articles/local-drafts';
+import { formatRelativeTime } from '@/utils/dates';
 import ArticleMarkdown from '../[slug]/ArticleMarkdown';
 import MarkdownToolbar from '@/components/articles/MarkdownToolbar';
 import { useMarkdownTextarea } from '@/components/articles/useMarkdownTextarea';
 import AiWriterPanel from '@/components/articles/AiWriterPanel';
 import CoverImageUpload from '@/components/articles/CoverImageUpload';
-
-const DRAFT_KEY = 'oc:draft:article';
-
-interface DraftShape {
-  title: string;
-  excerpt: string;
-  coverImage: string;
-  body: string;
-  visibility: TimelineVisibility;
-}
 
 /** Existing article passed when the composer is opened in edit mode. */
 export interface ArticleInitial {
@@ -60,35 +58,31 @@ export default function ArticleComposer({
   const [publishing, setPublishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [restored, setRestored] = useState(false);
+  const [draftId, setDraftId] = useState(() => newDraftId());
+  const [otherDrafts, setOtherDrafts] = useState<LocalArticleDraft[]>([]);
 
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const md = useMarkdownTextarea(bodyRef, body, setBody);
 
-  // Restore an in-progress draft once on mount (new articles only — never clobber
-  // an article being edited with a stale local draft).
+  // Restore the most recent draft once on mount (new articles only — never
+  // clobber an article being edited with a stale local draft). Older drafts
+  // stay listed so starting a new article never destroys an in-progress one.
   useEffect(() => {
     if (isEditing) {
       return;
     }
-    try {
-      const raw = localStorage.getItem(DRAFT_KEY);
-      if (!raw) {
-        return;
-      }
-      const d = JSON.parse(raw) as Partial<DraftShape>;
-      if (d.title || d.body) {
-        setTitle(d.title ?? '');
-        setExcerpt(d.excerpt ?? '');
-        setCoverImage(d.coverImage ?? '');
-        setBody(d.body ?? '');
-        if (d.visibility) {
-          setVisibility(d.visibility);
-        }
-        setRestored(true);
-      }
-    } catch {
-      /* ignore corrupt draft */
+    const drafts = listLocalDrafts();
+    const [latest, ...rest] = drafts;
+    if (latest) {
+      setTitle(latest.title);
+      setExcerpt(latest.excerpt);
+      setCoverImage(latest.coverImage);
+      setBody(latest.body);
+      setVisibility(latest.visibility);
+      setDraftId(latest.id);
+      setRestored(true);
     }
+    setOtherDrafts(rest);
   }, [isEditing]);
 
   // Autosave (debounced) whenever content changes (new articles only).
@@ -100,17 +94,29 @@ export default function ArticleComposer({
       return;
     }
     const id = setTimeout(() => {
-      try {
-        localStorage.setItem(
-          DRAFT_KEY,
-          JSON.stringify({ title, excerpt, coverImage, body, visibility } satisfies DraftShape)
-        );
-      } catch {
-        /* storage full / disabled — non-fatal */
-      }
+      saveLocalDraft({
+        id: draftId,
+        title,
+        excerpt,
+        coverImage,
+        body,
+        visibility,
+        updatedAt: Date.now(),
+      });
     }, 600);
     return () => clearTimeout(id);
-  }, [isEditing, title, excerpt, coverImage, body, visibility]);
+  }, [isEditing, draftId, title, excerpt, coverImage, body, visibility]);
+
+  // Grow the body textarea with its content so the page scrolls, never an inner
+  // box — long-form writing shouldn't happen inside a fixed scroll trap.
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (!el) {
+      return;
+    }
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, [body, tab]);
 
   const wordCount = body.trim() ? body.trim().split(/\s+/).length : 0;
   const readingTime = wordCount ? estimateReadingTime(body) : 0;
@@ -124,6 +130,37 @@ export default function ArticleComposer({
     setBody(draft.body);
     setTab('write');
     setRestored(false);
+  }
+
+  /** Delete the current draft and reset to a blank one; other drafts survive. */
+  function discardCurrentDraft() {
+    deleteLocalDraft(draftId);
+    setTitle('');
+    setExcerpt('');
+    setCoverImage('');
+    setBody('');
+    setVisibility('public');
+    setDraftId(newDraftId());
+    setRestored(false);
+    setOtherDrafts(listLocalDrafts());
+  }
+
+  /** Switch to another saved draft; the current one is already autosaved. */
+  function loadDraft(draft: LocalArticleDraft) {
+    setTitle(draft.title);
+    setExcerpt(draft.excerpt);
+    setCoverImage(draft.coverImage);
+    setBody(draft.body);
+    setVisibility(draft.visibility);
+    setDraftId(draft.id);
+    setRestored(true);
+    setTab('write');
+    setOtherDrafts(listLocalDrafts().filter(d => d.id !== draft.id));
+  }
+
+  function deleteOtherDraft(id: string) {
+    deleteLocalDraft(id);
+    setOtherDrafts(prev => prev.filter(d => d.id !== id));
   }
 
   function handleBodyKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -140,6 +177,20 @@ export default function ArticleComposer({
     } else if (k === 'k') {
       e.preventDefault();
       md.insertLink();
+    } else if (k === 's') {
+      // Flush the draft now instead of letting the browser offer to save the page.
+      e.preventDefault();
+      if (!isEditing && (title || body || excerpt || coverImage)) {
+        saveLocalDraft({
+          id: draftId,
+          title,
+          excerpt,
+          coverImage,
+          body,
+          visibility,
+          updatedAt: Date.now(),
+        });
+      }
     }
   }
 
@@ -175,11 +226,7 @@ export default function ArticleComposer({
       setPublishing(false);
       return;
     }
-    try {
-      localStorage.removeItem(DRAFT_KEY);
-    } catch {
-      /* ignore */
-    }
+    deleteLocalDraft(draftId);
     router.push(ROUTES.ARTICLE(result.slug));
   }
 
@@ -210,9 +257,49 @@ export default function ArticleComposer({
         )}
 
         {restored && (
-          <p className="mb-4 rounded-md border border-subtle bg-surface-raised/30 px-3 py-2 text-xs text-fg-secondary">
-            Restored your saved draft.
-          </p>
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-subtle bg-surface-raised/30 px-3 py-2 text-xs text-fg-secondary">
+            <span>Restored your saved draft.</span>
+            <button
+              type="button"
+              onClick={discardCurrentDraft}
+              className="shrink-0 font-medium text-fg-secondary underline-offset-2 transition-colors hover:text-status-negative hover:underline"
+            >
+              Discard draft
+            </button>
+          </div>
+        )}
+
+        {otherDrafts.length > 0 && (
+          <div className="mb-4 rounded-md border border-subtle bg-surface-raised/30 px-3 py-2">
+            <p className="mb-1.5 text-xs font-medium text-fg-secondary">
+              {otherDrafts.length === 1 ? 'Another draft' : `${otherDrafts.length} more drafts`}
+            </p>
+            <ul className="space-y-1">
+              {otherDrafts.map(draft => (
+                <li key={draft.id} className="flex items-center gap-2 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => loadDraft(draft)}
+                    className="min-w-0 flex-1 truncate text-left text-fg-primary underline-offset-2 hover:underline"
+                    title="Open this draft"
+                  >
+                    {draft.title.trim() || 'Untitled draft'}
+                  </button>
+                  <span className="shrink-0 text-fg-tertiary">
+                    {formatRelativeTime(new Date(draft.updatedAt))}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => deleteOtherDraft(draft.id)}
+                    className="shrink-0 text-fg-tertiary transition-colors hover:text-status-negative"
+                    aria-label="Delete draft"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
 
         {/* Write / Preview tabs */}
@@ -274,7 +361,7 @@ export default function ArticleComposer({
                 rows={18}
                 maxLength={ARTICLE_LIMITS.body}
                 aria-label="Article body"
-                className="rounded-t-none font-mono text-sm leading-6"
+                className="resize-none overflow-hidden rounded-t-none font-mono text-sm leading-6"
               />
             </div>
           </div>

--- a/src/services/articles/local-drafts.ts
+++ b/src/services/articles/local-drafts.ts
@@ -1,0 +1,116 @@
+/**
+ * Client-side article draft store (localStorage). Multiple drafts live under one
+ * key so starting a new article never clobbers an in-progress one. The legacy
+ * single-slot key (`oc:draft:article`) is migrated into the store on first read.
+ */
+
+import type { TimelineVisibility } from '@/types/timeline';
+
+export interface LocalArticleDraft {
+  id: string;
+  title: string;
+  excerpt: string;
+  coverImage: string;
+  body: string;
+  visibility: TimelineVisibility;
+  /** Epoch ms of the last autosave — drives "most recent first" ordering. */
+  updatedAt: number;
+}
+
+const STORE_KEY = 'oc:drafts:articles';
+const LEGACY_KEY = 'oc:draft:article';
+
+/** Oldest drafts are dropped beyond this — localStorage is a ~5MB budget. */
+export const MAX_LOCAL_DRAFTS = 20;
+
+function hasStorage(): boolean {
+  return typeof window !== 'undefined' && !!window.localStorage;
+}
+
+function readStore(): LocalArticleDraft[] {
+  if (!hasStorage()) {
+    return [];
+  }
+  try {
+    const raw = localStorage.getItem(STORE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(
+      (d): d is LocalArticleDraft =>
+        !!d &&
+        typeof d === 'object' &&
+        typeof (d as LocalArticleDraft).id === 'string' &&
+        typeof (d as LocalArticleDraft).body === 'string'
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeStore(drafts: LocalArticleDraft[]): void {
+  if (!hasStorage()) {
+    return;
+  }
+  try {
+    localStorage.setItem(STORE_KEY, JSON.stringify(drafts));
+  } catch {
+    /* storage full / disabled — autosave is best-effort */
+  }
+}
+
+/** Import the pre-multi-draft single slot, then remove it. */
+function migrateLegacyDraft(): void {
+  if (!hasStorage()) {
+    return;
+  }
+  try {
+    const raw = localStorage.getItem(LEGACY_KEY);
+    if (!raw) {
+      return;
+    }
+    const d = JSON.parse(raw) as Partial<LocalArticleDraft>;
+    if (d.title || d.body) {
+      saveLocalDraft({
+        id: newDraftId(),
+        title: d.title ?? '',
+        excerpt: d.excerpt ?? '',
+        coverImage: d.coverImage ?? '',
+        body: d.body ?? '',
+        visibility: d.visibility ?? 'public',
+        updatedAt: Date.now(),
+      });
+    }
+    localStorage.removeItem(LEGACY_KEY);
+  } catch {
+    /* corrupt legacy draft — leave it untouched rather than destroy it */
+  }
+}
+
+export function newDraftId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `draft-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** All drafts, most recently touched first. Runs the legacy migration. */
+export function listLocalDrafts(): LocalArticleDraft[] {
+  migrateLegacyDraft();
+  return readStore().sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/** Upsert by id; trims the store to MAX_LOCAL_DRAFTS (oldest dropped). */
+export function saveLocalDraft(draft: LocalArticleDraft): void {
+  const rest = readStore().filter(d => d.id !== draft.id);
+  const next = [draft, ...rest].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, MAX_LOCAL_DRAFTS);
+  writeStore(next);
+}
+
+export function deleteLocalDraft(id: string): void {
+  writeStore(readStore().filter(d => d.id !== id));
+}


### PR DESCRIPTION
Writing-experience improvements for the article composer, from dogfooding the publish flow as a real author:

## Composer (`/articles/new`)
- **Multi-draft local store** (`src/services/articles/local-drafts.ts`): drafts live under `oc:drafts:articles` keyed by id. Starting a new article no longer clobbers an in-progress draft — during the field-report publish, the only thing that saved the existing draft ("Embracing Sovereign Economic Agency in Zurich") was a manual localStorage backup. Older drafts are listed in the composer with load/delete; the legacy single-slot `oc:draft:article` key is migrated on first read; store trimmed to 20 drafts.
- **Auto-growing editor**: the body textarea grows with content so the page scrolls, never an inner 18-row scroll trap. Also removes the End-key dead-space behavior logged while writing the article.
- **Discard draft** action on the restore banner (previously there was no way out of a restored draft).
- **Ctrl/Cmd+S** flushes the draft immediately instead of opening the browser save dialog.

## Test infrastructure
- `jest.setup.ts` defined localStorage/sessionStorage mocks **twice**; the second store-less stub overrode the functional one, so no test could ever read back what it wrote to storage. Consolidated to the single store-backed mock, emptied per-test in the global `beforeEach`. The new local-drafts tests are what exposed this.

## Verification
- 10 new unit tests for the draft store (round-trip, ordering, upsert, trim, legacy migration, corrupt-store recovery).
- `npm run verify`: type-check, lint, and full unit suite green (1231 tests, 110 suites). One run showed a single order-dependent test failure that passed in isolation and did not reproduce across three subsequent full runs — flagging as a pre-existing/latent flake to watch in CI.

## Deferred (logged during the same session, separate concerns)
- `/` → `/dashboard/cat` multi-second "Loading your account..." hold
- Home nav icon bouncing `/dashboard` → `/dashboard/cat`
- Stale tab title after profile save

🤖 Generated with [Claude Code](https://claude.com/claude-code)