### PR TITLE
feat: AI writing help for articles + posts (topic input, in-editor edits, AI replies, AI images)

### DIFF
--- a/src/app/(authenticated)/post/[id]/page.tsx
+++ b/src/app/(authenticated)/post/[id]/page.tsx
@@ -165,6 +165,8 @@ export default function PostPage() {
               showBanner={false}
               onPostCreated={handleReplyCreated}
               parentEventId={mainPost.id}
+              parentPostText={mainPost.description || mainPost.title}
+              parentAuthorName={mainPost.actor.username || mainPost.actor.name}
             />
           </div>
         )}

--- a/src/app/(public)/articles/new/ArticleComposer.tsx
+++ b/src/app/(public)/articles/new/ArticleComposer.tsx
@@ -19,6 +19,7 @@ import ArticleMarkdown from '../[slug]/ArticleMarkdown';
 import MarkdownToolbar from '@/components/articles/MarkdownToolbar';
 import { useMarkdownTextarea } from '@/components/articles/useMarkdownTextarea';
 import AiWriterPanel from '@/components/articles/AiWriterPanel';
+import ArticleAiControls from '@/components/articles/ArticleAiControls';
 import CoverImageUpload from '@/components/articles/CoverImageUpload';
 
 const DRAFT_KEY = 'oc:draft:article';
@@ -264,6 +265,15 @@ export default function ArticleComposer({
               disabled={publishing}
             />
             <div>
+              <ArticleAiControls
+                md={md}
+                title={title}
+                body={body}
+                setTitle={setTitle}
+                setExcerpt={setExcerpt}
+                setBody={setBody}
+                disabled={publishing}
+              />
               <MarkdownToolbar actions={md} disabled={publishing} />
               <Textarea
                 ref={bodyRef}

--- a/src/app/(public)/articles/new/ArticleComposer.tsx
+++ b/src/app/(public)/articles/new/ArticleComposer.tsx
@@ -21,6 +21,8 @@ import { useMarkdownTextarea } from '@/components/articles/useMarkdownTextarea';
 import AiWriterPanel from '@/components/articles/AiWriterPanel';
 import ArticleAiControls from '@/components/articles/ArticleAiControls';
 import CoverImageUpload from '@/components/articles/CoverImageUpload';
+import ImageSuggestPicker from '@/components/articles/ImageSuggestPicker';
+import type { StockImage } from '@/services/images/types';
 
 const DRAFT_KEY = 'oc:draft:article';
 
@@ -61,6 +63,8 @@ export default function ArticleComposer({
   const [publishing, setPublishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [restored, setRestored] = useState(false);
+  // Which target the AI image picker is open for (null = closed).
+  const [imagePicker, setImagePicker] = useState<null | 'cover' | 'inline'>(null);
 
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const md = useMarkdownTextarea(bodyRef, body, setBody);
@@ -125,6 +129,16 @@ export default function ArticleComposer({
     setBody(draft.body);
     setTab('write');
     setRestored(false);
+  }
+
+  function handlePickImage(img: StockImage) {
+    if (imagePicker === 'cover') {
+      setCoverImage(img.fullUrl);
+    } else if (imagePicker === 'inline') {
+      md.insertAtCursor(`\n\n![${img.title}](${img.fullUrl})\n\n`);
+      setTab('write');
+    }
+    setImagePicker(null);
   }
 
   function handleBodyKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -263,7 +277,17 @@ export default function ArticleComposer({
               onChange={setCoverImage}
               userId={user.id}
               disabled={publishing}
+              onSuggest={() => setImagePicker(imagePicker === 'cover' ? null : 'cover')}
             />
+            {imagePicker === 'cover' && (
+              <ImageSuggestPicker
+                title={title}
+                body={body}
+                heading="Choose a cover image"
+                onPick={handlePickImage}
+                onClose={() => setImagePicker(null)}
+              />
+            )}
             <div>
               <ArticleAiControls
                 md={md}
@@ -273,7 +297,19 @@ export default function ArticleComposer({
                 setExcerpt={setExcerpt}
                 setBody={setBody}
                 disabled={publishing}
+                onInsertImage={() => setImagePicker(imagePicker === 'inline' ? null : 'inline')}
               />
+              {imagePicker === 'inline' && (
+                <div className="mb-2">
+                  <ImageSuggestPicker
+                    title={title}
+                    body={body}
+                    heading="Insert an image"
+                    onPick={handlePickImage}
+                    onClose={() => setImagePicker(null)}
+                  />
+                </div>
+              )}
               <MarkdownToolbar actions={md} disabled={publishing} />
               <Textarea
                 ref={bodyRef}

--- a/src/app/api/ai/images/suggest/route.ts
+++ b/src/app/api/ai/images/suggest/route.ts
@@ -1,0 +1,72 @@
+/**
+ * POST /api/ai/images/suggest — royalty-free image suggestions for an article.
+ * With an explicit `query`, it just searches; otherwise it asks the AI for
+ * concrete search terms from the article, searches the top few, and merges the
+ * results. Auth + write-tier rate limit (it makes an LLM + external call).
+ */
+
+import type { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import { createRateLimitResponse, rateLimitWriteAsync } from '@/lib/rate-limit';
+import { apiBadRequest, apiInternalError, apiSuccess } from '@/lib/api/standardResponse';
+import { suggestImageQueries } from '@/services/images/image-suggest';
+import { searchOpenverse } from '@/services/images/openverse';
+import type { StockImage } from '@/services/images/types';
+import { logger } from '@/utils/logger';
+
+const bodySchema = z.object({
+  title: z.string().trim().max(300).optional(),
+  body: z.string().trim().max(100_000).optional(),
+  /** Explicit search term — skips AI query suggestion. */
+  query: z.string().trim().max(80).optional(),
+});
+
+/** How many AI-suggested queries to actually search, and the total image cap. */
+const QUERIES_TO_SEARCH = 3;
+const MAX_IMAGES = 12;
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  const { user } = request;
+  try {
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return createRateLimitResponse(rl) as NextResponse;
+    }
+
+    const parsed = bodySchema.safeParse(await (request as NextRequest).json().catch(() => ({})));
+    if (!parsed.success) {
+      return apiBadRequest('Invalid request', parsed.error.flatten());
+    }
+    const { title, body, query } = parsed.data;
+
+    if (!query && !title && !body) {
+      return apiBadRequest('Add a title or some body text (or a search term) first.');
+    }
+
+    const queries = query ? [query] : await suggestImageQueries(title ?? '', body ?? '');
+    if (!queries.length) {
+      return apiSuccess({ queries: [], images: [] }) as NextResponse;
+    }
+
+    // Search the top few queries and merge, de-duping by image id.
+    const perQuery = await Promise.all(
+      queries.slice(0, QUERIES_TO_SEARCH).map(q => searchOpenverse(q, 8))
+    );
+    const seen = new Set<string>();
+    const images: StockImage[] = [];
+    for (const batch of perQuery) {
+      for (const img of batch) {
+        if (!seen.has(img.id)) {
+          seen.add(img.id);
+          images.push(img);
+        }
+      }
+    }
+
+    return apiSuccess({ queries, images: images.slice(0, MAX_IMAGES) }) as NextResponse;
+  } catch (error) {
+    logger.error('images/suggest failed', error, 'ImagesAPI');
+    return apiInternalError('Could not suggest images right now. Please try again.');
+  }
+});

--- a/src/app/api/ai/writing/draft/route.ts
+++ b/src/app/api/ai/writing/draft/route.ts
@@ -9,13 +9,17 @@ import { z } from 'zod';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { createRateLimitResponse, rateLimitWriteAsync } from '@/lib/rate-limit';
 import { apiBadRequest, apiError, apiInternalError, apiSuccess } from '@/lib/api/standardResponse';
-import { draftArticle, draftPost } from '@/services/cat/writing-engine';
+import { draftArticle, draftPost, draftReply } from '@/services/cat/writing-engine';
 import { logger } from '@/utils/logger';
 
 const bodySchema = z.object({
-  mode: z.enum(['post', 'article']),
+  mode: z.enum(['post', 'article', 'reply']),
   topic: z.string().trim().max(300).optional(),
   focus: z.string().trim().max(200).optional(),
+  // Reply mode: the post being answered + how to engage it.
+  parentText: z.string().trim().max(4000).optional(),
+  parentAuthor: z.string().trim().max(120).optional(),
+  intent: z.enum(['thoughtful', 'add', 'question', 'agree', 'pushback']).optional(),
 });
 
 export const POST = withAuth(async (request: AuthenticatedRequest) => {
@@ -31,11 +35,24 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       return apiBadRequest('Invalid request', parsed.error.flatten());
     }
 
-    const { mode, topic, focus } = parsed.data;
-    const draft =
-      mode === 'article'
-        ? await draftArticle(supabase, user.id, { topic, focus })
-        : await draftPost(supabase, user.id, { topic, focus });
+    const { mode, topic, focus, parentText, parentAuthor, intent } = parsed.data;
+
+    if (mode === 'reply' && !parentText) {
+      return apiBadRequest('Nothing to reply to — the post text is missing.');
+    }
+
+    let draft;
+    if (mode === 'article') {
+      draft = await draftArticle(supabase, user.id, { topic, focus });
+    } else if (mode === 'reply') {
+      draft = await draftReply(supabase, user.id, {
+        parentText: parentText ?? '',
+        parentAuthor,
+        intent,
+      });
+    } else {
+      draft = await draftPost(supabase, user.id, { topic, focus });
+    }
 
     if (!draft) {
       return apiError(

--- a/src/app/api/ai/writing/revise/route.ts
+++ b/src/app/api/ai/writing/revise/route.ts
@@ -1,0 +1,90 @@
+/**
+ * POST /api/ai/writing/revise — in-editor AI writing help: transform the
+ * author's own article text (improve/continue/tighten/expand/grammar/tone),
+ * seed an outline, suggest titles, or generate an excerpt. Thin wrapper over the
+ * revise-engine; auth + write-tier rate limit. Never leaks engine internals.
+ */
+
+import type { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import { createRateLimitResponse, rateLimitWriteAsync } from '@/lib/rate-limit';
+import { apiBadRequest, apiError, apiInternalError, apiSuccess } from '@/lib/api/standardResponse';
+import { generateExcerpt, reviseText, suggestTitles } from '@/services/cat/writing-revise';
+import { logger } from '@/utils/logger';
+
+const bodySchema = z.object({
+  action: z.enum([
+    'improve',
+    'continue',
+    'tighten',
+    'expand',
+    'grammar',
+    'tone',
+    'outline',
+    'title',
+    'excerpt',
+  ]),
+  text: z.string().trim().max(100_000).optional(),
+  tone: z.enum(['casual', 'formal', 'punchy', 'warm']).optional(),
+  title: z.string().trim().max(300).optional(),
+  topic: z.string().trim().max(300).optional(),
+  instruction: z.string().trim().max(300).optional(),
+});
+
+const AI_UNAVAILABLE =
+  'The AI writer is busy right now. Try again in a moment, or add your own free Groq key in Settings → AI.';
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+  try {
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return createRateLimitResponse(rl) as NextResponse;
+    }
+
+    const parsed = bodySchema.safeParse(await (request as NextRequest).json().catch(() => ({})));
+    if (!parsed.success) {
+      return apiBadRequest('Invalid request', parsed.error.flatten());
+    }
+    const { action, text, tone, title, topic, instruction } = parsed.data;
+
+    // Title suggestions return a list; everything else returns transformed text.
+    if (action === 'title') {
+      const suggestions = await suggestTitles(supabase, user.id, text ?? '');
+      if (!suggestions.length) {
+        return apiError(AI_UNAVAILABLE, 'AI_UNAVAILABLE', 503) as NextResponse;
+      }
+      return apiSuccess({ suggestions }) as NextResponse;
+    }
+
+    if (action === 'excerpt') {
+      const result = await generateExcerpt(supabase, user.id, text ?? '', title);
+      if (!result) {
+        return apiError(AI_UNAVAILABLE, 'AI_UNAVAILABLE', 503) as NextResponse;
+      }
+      return apiSuccess({ result }) as NextResponse;
+    }
+
+    // outline may use `topic`; the rest need `text`.
+    if (action !== 'outline' && !text) {
+      return apiBadRequest('Nothing to revise — select some text first.');
+    }
+
+    const result = await reviseText(supabase, user.id, {
+      action,
+      text: text ?? '',
+      tone,
+      title,
+      topic,
+      instruction,
+    });
+    if (!result) {
+      return apiError(AI_UNAVAILABLE, 'AI_UNAVAILABLE', 503) as NextResponse;
+    }
+    return apiSuccess({ result }) as NextResponse;
+  } catch (error) {
+    logger.error('writing/revise failed', error, 'WritingAPI');
+    return apiInternalError('Could not revise that right now. Please try again.');
+  }
+});

--- a/src/components/articles/AiWriterPanel.tsx
+++ b/src/components/articles/AiWriterPanel.tsx
@@ -7,9 +7,11 @@ import { fetchArticleDraft, fetchWritingTopics } from '@/services/articles/ai-cl
 import type { ArticleDraft, ProposedTopic } from '@/services/cat/writing-types';
 
 /**
- * One-click AI writing for the article composer. "Write a full draft" fills the
- * whole editor; "Suggest topics" grounds ideas in the user's own interests and
- * drafts the one they pick. Fails soft — errors surface inline, never block.
+ * One-click AI writing for the article composer. Give it a topic (or leave it
+ * blank and it grounds in what you care about): "Write a full draft" fills the
+ * whole editor; "Suggest topics" proposes ideas from your own interests and
+ * drafts the one you pick. Fails soft — errors and empty results surface inline,
+ * never block.
  */
 export default function AiWriterPanel({
   title,
@@ -20,17 +22,22 @@ export default function AiWriterPanel({
   onApplyDraft: (draft: ArticleDraft) => void;
   disabled?: boolean;
 }) {
+  const [prompt, setPrompt] = useState('');
   const [busy, setBusy] = useState<null | 'draft' | 'topics' | string>(null);
   const [topics, setTopics] = useState<ProposedTopic[]>([]);
+  const [noTopics, setNoTopics] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const anyBusy = busy !== null || disabled;
+  // The prompt box is the primary steer; fall back to the title field.
+  const steer = prompt.trim() || title.trim();
 
   async function writeDraft(topic?: string) {
     setBusy(topic ?? 'draft');
     setError(null);
+    setNoTopics(false);
     try {
-      const draft = await fetchArticleDraft({ topic: topic || title.trim() || undefined });
+      const draft = await fetchArticleDraft({ topic: topic || steer || undefined });
       onApplyDraft(draft);
       setTopics([]);
     } catch (e) {
@@ -43,8 +50,15 @@ export default function AiWriterPanel({
   async function loadTopics() {
     setBusy('topics');
     setError(null);
+    setNoTopics(false);
     try {
-      setTopics(await fetchWritingTopics({ kind: 'article', count: 5 }));
+      const found = await fetchWritingTopics({
+        kind: 'article',
+        count: 5,
+        focus: prompt.trim() || undefined,
+      });
+      setTopics(found);
+      setNoTopics(found.length === 0);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not suggest topics. Please try again.');
     } finally {
@@ -61,10 +75,26 @@ export default function AiWriterPanel({
         <div className="min-w-0 flex-1">
           <p className="text-sm font-semibold text-fg-primary">Write with AI</p>
           <p className="text-xs text-fg-secondary">
-            Grounded in what you care about and what you've written before.
+            Grounded in what you care about and what you&apos;ve written before.
           </p>
 
-          <div className="mt-3 flex flex-wrap gap-2">
+          <input
+            type="text"
+            value={prompt}
+            onChange={e => setPrompt(e.target.value)}
+            disabled={anyBusy}
+            placeholder="What do you want to write about? (optional)"
+            aria-label="What do you want to write about?"
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                void writeDraft();
+              }
+            }}
+            className="mt-3 w-full rounded-md border border-default bg-surface-page px-3 py-2 text-sm text-fg-primary placeholder:text-fg-tertiary focus:border-accent-warm focus:outline-none disabled:opacity-50"
+          />
+
+          <div className="mt-2.5 flex flex-wrap gap-2">
             <button
               type="button"
               disabled={anyBusy}
@@ -76,7 +106,7 @@ export default function AiWriterPanel({
               ) : (
                 <PenLine className="h-4 w-4" />
               )}
-              {title.trim() ? 'Write a full draft' : 'Write me a draft'}
+              {steer ? 'Write a full draft' : 'Write me a draft'}
             </button>
             <button
               type="button"
@@ -122,6 +152,13 @@ export default function AiWriterPanel({
                 </li>
               ))}
             </ul>
+          )}
+
+          {noTopics && (
+            <p className="mt-2 text-xs text-fg-secondary">
+              Couldn&apos;t suggest topics from your context yet. Add a hint above (a theme or
+              keyword) and try again — or just write a draft.
+            </p>
           )}
 
           {error && <p className="mt-2 text-xs text-status-negative">{error}</p>}

--- a/src/components/articles/ArticleAiControls.tsx
+++ b/src/components/articles/ArticleAiControls.tsx
@@ -47,6 +47,7 @@ export default function ArticleAiControls({
   setExcerpt,
   setBody,
   disabled,
+  onInsertImage,
 }: {
   md: MarkdownActions;
   title: string;
@@ -55,6 +56,8 @@ export default function ArticleAiControls({
   setExcerpt: (v: string) => void;
   setBody: (v: string) => void;
   disabled?: boolean;
+  /** When provided, adds an "Insert an image" action that opens the image picker. */
+  onInsertImage?: () => void;
 }) {
   const ai = useArticleAi({ md, title, body, setTitle, setExcerpt, setBody });
   const anyBusy = ai.busy !== null || !!disabled;
@@ -124,6 +127,11 @@ export default function ArticleAiControls({
             <DropdownMenuItem className={item} onSelect={() => ai.makeExcerpt()}>
               Write the excerpt
             </DropdownMenuItem>
+            {onInsertImage && (
+              <DropdownMenuItem className={item} onSelect={() => onInsertImage()}>
+                Insert an image
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
 

--- a/src/components/articles/ArticleAiControls.tsx
+++ b/src/components/articles/ArticleAiControls.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { Sparkles, Loader2, ChevronDown, X } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+import { useArticleAi, type AiBusy } from './useArticleAi';
+import type { MarkdownActions } from './useMarkdownTextarea';
+import type { TonePreset } from '@/services/cat/writing-types';
+
+const TONES: { key: TonePreset; label: string }[] = [
+  { key: 'casual', label: 'More casual' },
+  { key: 'formal', label: 'More formal' },
+  { key: 'punchy', label: 'More punchy' },
+  { key: 'warm', label: 'Warmer' },
+];
+
+const BUSY_LABEL: Record<AiBusy, string> = {
+  improve: 'Improving',
+  continue: 'Continuing',
+  tighten: 'Tightening',
+  expand: 'Expanding',
+  grammar: 'Fixing grammar',
+  tone: 'Rewriting',
+  outline: 'Outlining',
+  title: 'Finding titles',
+  excerpt: 'Writing excerpt',
+};
+
+/**
+ * The in-editor "Ask AI" strip: a single dropdown of writing actions that
+ * operate on the current selection (or the whole body), plus whole-article
+ * helpers (outline, title, excerpt). Owns its own {@link useArticleAi} state so
+ * the composer stays a thin host.
+ */
+export default function ArticleAiControls({
+  md,
+  title,
+  body,
+  setTitle,
+  setExcerpt,
+  setBody,
+  disabled,
+}: {
+  md: MarkdownActions;
+  title: string;
+  body: string;
+  setTitle: (v: string) => void;
+  setExcerpt: (v: string) => void;
+  setBody: (v: string) => void;
+  disabled?: boolean;
+}) {
+  const ai = useArticleAi({ md, title, body, setTitle, setExcerpt, setBody });
+  const anyBusy = ai.busy !== null || !!disabled;
+
+  const item =
+    'cursor-pointer text-sm text-fg-primary focus:bg-surface-raised focus:text-fg-primary';
+
+  return (
+    <div className="mb-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <DropdownMenu onOpenChange={open => open && ai.captureSelection()}>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              disabled={anyBusy}
+              className="inline-flex items-center gap-1.5 rounded-md border border-default bg-surface-raised/40 px-3 py-1.5 text-sm font-medium text-fg-primary transition-colors hover:bg-surface-raised disabled:opacity-50"
+            >
+              {ai.busy ? (
+                <Loader2 className="h-4 w-4 animate-spin text-accent-warm" />
+              ) : (
+                <Sparkles className="h-4 w-4 text-accent-warm" />
+              )}
+              Ask AI
+              <ChevronDown className="h-3.5 w-3.5 text-fg-tertiary" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-60">
+            <DropdownMenuLabel className="text-fg-tertiary">
+              Selection, or the whole article
+            </DropdownMenuLabel>
+            <DropdownMenuItem className={item} onSelect={() => ai.transform('improve')}>
+              Improve the writing
+            </DropdownMenuItem>
+            <DropdownMenuItem className={item} onSelect={() => ai.continueWriting()}>
+              Continue writing
+            </DropdownMenuItem>
+            <DropdownMenuItem className={item} onSelect={() => ai.transform('tighten')}>
+              Make it tighter
+            </DropdownMenuItem>
+            <DropdownMenuItem className={item} onSelect={() => ai.transform('expand')}>
+              Expand / add depth
+            </DropdownMenuItem>
+            <DropdownMenuItem className={item} onSelect={() => ai.transform('grammar')}>
+              Fix grammar &amp; spelling
+            </DropdownMenuItem>
+
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-fg-tertiary">Change tone</DropdownMenuLabel>
+            {TONES.map(t => (
+              <DropdownMenuItem
+                key={t.key}
+                className={item}
+                onSelect={() => ai.transform('tone', t.key)}
+              >
+                {t.label}
+              </DropdownMenuItem>
+            ))}
+
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-fg-tertiary">Whole article</DropdownMenuLabel>
+            <DropdownMenuItem className={item} onSelect={() => ai.outline()}>
+              Outline this topic
+            </DropdownMenuItem>
+            <DropdownMenuItem className={item} onSelect={() => ai.suggestTitles()}>
+              Suggest a title
+            </DropdownMenuItem>
+            <DropdownMenuItem className={item} onSelect={() => ai.makeExcerpt()}>
+              Write the excerpt
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {ai.busy && (
+          <span className="inline-flex items-center gap-1.5 text-xs text-fg-tertiary">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            {BUSY_LABEL[ai.busy]}…
+          </span>
+        )}
+        {!ai.busy && (
+          <span className="text-xs text-fg-tertiary">
+            Select text to edit part of it, or run it on the whole draft.
+          </span>
+        )}
+      </div>
+
+      {ai.error && <p className="mt-2 text-xs text-status-negative">{ai.error}</p>}
+
+      {ai.titleSuggestions && (
+        <div className="mt-2 rounded-md border border-subtle bg-surface-raised/25 p-2">
+          <div className="mb-1 flex items-center justify-between px-1">
+            <span className="text-xs font-medium text-fg-secondary">Pick a title</span>
+            <button
+              type="button"
+              onClick={ai.dismissTitles}
+              className="text-fg-tertiary transition-colors hover:text-fg-primary"
+              aria-label="Dismiss title suggestions"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <ul className="space-y-1">
+            {ai.titleSuggestions.map((t, i) => (
+              <li key={i}>
+                <button
+                  type="button"
+                  onClick={() => ai.applyTitle(t)}
+                  className={cn(
+                    'w-full truncate rounded px-2 py-1.5 text-left text-sm text-fg-primary transition-colors hover:bg-surface-raised'
+                  )}
+                >
+                  {t}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/articles/CoverImageUpload.tsx
+++ b/src/components/articles/CoverImageUpload.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { ImagePlus, Link2, Loader2, X } from 'lucide-react';
+import { ImagePlus, Link2, Loader2, Sparkles, X } from 'lucide-react';
 import Input from '@/components/ui/Input';
 import { cn } from '@/lib/utils';
 import { COVER_ACCEPT, COVER_MAX_MB, uploadArticleCover } from '@/services/articles/cover-storage';
@@ -16,11 +16,14 @@ export default function CoverImageUpload({
   onChange,
   userId,
   disabled,
+  onSuggest,
 }: {
   value: string;
   onChange: (url: string) => void;
   userId: string;
   disabled?: boolean;
+  /** When provided, shows a "Suggest with AI" button that opens the image picker. */
+  onSuggest?: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
@@ -145,7 +148,17 @@ export default function CoverImageUpload({
         className="hidden"
         onChange={e => handleFile(e.target.files?.[0])}
       />
-      <div className="mt-2">
+      <div className="mt-2 flex flex-wrap items-center gap-3">
+        {onSuggest && (
+          <button
+            type="button"
+            onClick={onSuggest}
+            disabled={disabled}
+            className="inline-flex items-center gap-1 text-xs font-medium text-accent-warm hover:text-accent-warm-hover disabled:opacity-50"
+          >
+            <Sparkles className="h-3.5 w-3.5" /> Suggest with AI
+          </button>
+        )}
         <button
           type="button"
           onClick={() => setUrlMode(true)}

--- a/src/components/articles/ImageSuggestPicker.tsx
+++ b/src/components/articles/ImageSuggestPicker.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Search, Loader2, X, ImageOff } from 'lucide-react';
+import { suggestArticleImages } from '@/services/articles/image-client';
+import type { StockImage } from '@/services/images/types';
+import { cn } from '@/lib/utils';
+
+/**
+ * AI image picker: on open it turns the article into concrete search terms and
+ * shows royalty-free (CC0 / public-domain) candidates; the user can also search
+ * manually or click a suggested term. Picking one hands back the full-res URL.
+ * Used for both the cover and inline body images.
+ */
+export default function ImageSuggestPicker({
+  title,
+  body,
+  heading = 'Add an image',
+  onPick,
+  onClose,
+}: {
+  title: string;
+  body: string;
+  heading?: string;
+  onPick: (image: StockImage) => void;
+  onClose: () => void;
+}) {
+  const [images, setImages] = useState<StockImage[]>([]);
+  const [queries, setQueries] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [manual, setManual] = useState('');
+
+  const load = useCallback(
+    async (query?: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await suggestArticleImages(query ? { query } : { title, body });
+        setImages(result.images);
+        setQueries(result.queries);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Could not load images. Try again.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [title, body]
+  );
+
+  // Initial suggestions from the article itself.
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="rounded-lg border border-default bg-surface-raised/30 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-semibold text-fg-primary">{heading}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-fg-tertiary transition-colors hover:text-fg-primary"
+          aria-label="Close image picker"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          if (manual.trim()) {
+            void load(manual.trim());
+          }
+        }}
+        className="mb-2 flex gap-2"
+      >
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-fg-tertiary" />
+          <input
+            type="text"
+            value={manual}
+            onChange={e => setManual(e.target.value)}
+            placeholder="Search free images…"
+            aria-label="Search images"
+            className="w-full rounded-md border border-default bg-surface-page py-1.5 pl-8 pr-3 text-sm text-fg-primary placeholder:text-fg-tertiary focus:border-accent-warm focus:outline-none"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={!manual.trim() || loading}
+          className="rounded-md border border-default px-3 py-1.5 text-sm font-medium text-fg-primary transition-colors hover:bg-surface-raised disabled:opacity-50"
+        >
+          Search
+        </button>
+      </form>
+
+      {queries.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {queries.map(q => (
+            <button
+              key={q}
+              type="button"
+              onClick={() => {
+                setManual(q);
+                void load(q);
+              }}
+              className="rounded-full border border-subtle px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:border-default hover:text-fg-primary"
+            >
+              {q}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center gap-2 py-10 text-sm text-fg-tertiary">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Finding images…
+        </div>
+      ) : error ? (
+        <p className="py-6 text-center text-xs text-status-negative">{error}</p>
+      ) : images.length === 0 ? (
+        <div className="flex flex-col items-center gap-1.5 py-8 text-center text-fg-tertiary">
+          <ImageOff className="h-6 w-6" />
+          <p className="text-xs">No images found. Try a different search term.</p>
+        </div>
+      ) : (
+        <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {images.map(img => (
+            <li key={img.id}>
+              <button
+                type="button"
+                onClick={() => onPick(img)}
+                className={cn(
+                  'group block w-full overflow-hidden rounded-md border border-subtle transition-colors hover:border-accent-warm'
+                )}
+                title={img.creator ? `${img.title} · ${img.creator}` : img.title}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={img.thumbUrl}
+                  alt={img.title}
+                  loading="lazy"
+                  className="aspect-[4/3] w-full bg-surface-page object-cover"
+                />
+                <span className="block truncate px-1.5 py-1 text-left text-2xs text-fg-tertiary">
+                  {img.creator
+                    ? `${img.creator} · ${img.license.toUpperCase()}`
+                    : img.license.toUpperCase()}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="mt-2 text-2xs text-fg-tertiary">
+        Free to use (CC0 / public domain) via Openverse.
+      </p>
+    </div>
+  );
+}

--- a/src/components/articles/useArticleAi.ts
+++ b/src/components/articles/useArticleAi.ts
@@ -1,0 +1,155 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import {
+  generateArticleExcerpt,
+  reviseArticleText,
+  suggestArticleTitles,
+} from '@/services/articles/ai-client';
+import type { ReviseAction, TonePreset } from '@/services/cat/writing-types';
+import type { MarkdownActions, EditorSelection } from './useMarkdownTextarea';
+
+/** Which control is mid-flight, so the UI can show a targeted spinner. */
+export type AiBusy = ReviseAction | 'title' | 'excerpt';
+
+interface Params {
+  md: MarkdownActions;
+  title: string;
+  body: string;
+  setTitle: (v: string) => void;
+  setExcerpt: (v: string) => void;
+  setBody: (v: string) => void;
+}
+
+/**
+ * Orchestrates the in-editor AI writing actions: snapshots the caret/selection
+ * at menu-open (focus moves to the menu, so we can't read it later), calls the
+ * revise endpoint, and applies the result back into the editor — replacing the
+ * selection, replacing the whole body, or inserting a continuation. Never
+ * throws; failures surface as an inline message and leave the text untouched.
+ */
+export function useArticleAi({ md, title, body, setTitle, setExcerpt, setBody }: Params) {
+  const [busy, setBusy] = useState<AiBusy | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [titleSuggestions, setTitleSuggestions] = useState<string[] | null>(null);
+  const selRef = useRef<EditorSelection | null>(null);
+
+  /** Call on menu-open — the textarea still holds the live selection here. */
+  const captureSelection = useCallback(() => {
+    selRef.current = md.getSelection();
+  }, [md]);
+
+  const guard = useCallback(async (key: AiBusy, fn: () => Promise<void>) => {
+    setError(null);
+    setBusy(key);
+    try {
+      await fn();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'The AI writer is unavailable. Please try again.');
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  /** improve / tighten / expand / grammar / tone — on the selection, else whole body. */
+  const transform = useCallback(
+    (action: Exclude<ReviseAction, 'continue' | 'outline'>, tone?: TonePreset) => {
+      const sel = selRef.current;
+      const hasSel = !!sel && sel.text.trim().length > 0;
+      const target = hasSel ? sel!.text : body;
+      if (!target.trim()) {
+        setError('Write or select some text first.');
+        return;
+      }
+      void guard(action, async () => {
+        const result = await reviseArticleText({ action, text: target, tone, title });
+        if (hasSel && sel) {
+          md.replaceRange(sel.start, sel.end, result);
+        } else {
+          setBody(result);
+        }
+      });
+    },
+    [body, title, md, setBody, guard]
+  );
+
+  const continueWriting = useCallback(() => {
+    if (!body.trim()) {
+      setError('Write a little first, then let AI continue.');
+      return;
+    }
+    void guard('continue', async () => {
+      const result = await reviseArticleText({
+        action: 'continue',
+        text: body.slice(-6000),
+        title,
+      });
+      md.insertAtCursor(`${body.endsWith('\n') ? '' : '\n\n'}${result}`);
+    });
+  }, [body, title, md, guard]);
+
+  const outline = useCallback(() => {
+    const sel = selRef.current;
+    const topic = title.trim() || (sel?.text.trim() ?? '') || body.trim().slice(0, 200);
+    if (!topic) {
+      setError('Add a title (or select a topic) to outline.');
+      return;
+    }
+    void guard('outline', async () => {
+      const result = await reviseArticleText({ action: 'outline', topic, title });
+      if (!body.trim()) {
+        setBody(result);
+      } else {
+        md.insertAtCursor(`\n\n${result}`);
+      }
+    });
+  }, [title, body, md, setBody, guard]);
+
+  const suggestTitles = useCallback(() => {
+    if (!body.trim()) {
+      setError('Write the article first — then AI can suggest titles.');
+      return;
+    }
+    void guard('title', async () => {
+      const list = await suggestArticleTitles(body);
+      setTitleSuggestions(list.length ? list : null);
+      if (!list.length) {
+        setError('Could not come up with titles. Try again.');
+      }
+    });
+  }, [body, guard]);
+
+  const applyTitle = useCallback(
+    (t: string) => {
+      setTitle(t);
+      setTitleSuggestions(null);
+    },
+    [setTitle]
+  );
+
+  const makeExcerpt = useCallback(() => {
+    if (!body.trim()) {
+      setError('Write the article first — then AI can write an excerpt.');
+      return;
+    }
+    void guard('excerpt', async () => {
+      const result = await generateArticleExcerpt(body, title);
+      setExcerpt(result);
+    });
+  }, [body, title, setExcerpt, guard]);
+
+  return {
+    busy,
+    error,
+    titleSuggestions,
+    captureSelection,
+    transform,
+    continueWriting,
+    outline,
+    suggestTitles,
+    applyTitle,
+    makeExcerpt,
+    dismissTitles: useCallback(() => setTitleSuggestions(null), []),
+    clearError: useCallback(() => setError(null), []),
+  };
+}

--- a/src/components/articles/useMarkdownTextarea.ts
+++ b/src/components/articles/useMarkdownTextarea.ts
@@ -8,6 +8,13 @@ import { useCallback, type RefObject } from 'react';
  * onChange, then restores the selection on the next frame (the textarea DOM node
  * is stable via the ref, so the caret survives React's re-render).
  */
+export interface EditorSelection {
+  start: number;
+  end: number;
+  /** The selected substring ('' when the caret is collapsed). */
+  text: string;
+}
+
 export interface MarkdownActions {
   /** Wrap the selection with `before`/`after` (e.g. ** ** ); inserts `placeholder` if empty. */
   wrap: (before: string, after?: string, placeholder?: string) => void;
@@ -15,6 +22,12 @@ export interface MarkdownActions {
   prefixLines: (prefix: string) => void;
   /** Insert a markdown link around the selection. */
   insertLink: () => void;
+  /** Current selection (or collapsed caret). Reads live from the DOM node. */
+  getSelection: () => EditorSelection;
+  /** Replace [start, end) with `replacement`; caret lands at the end of the insert. */
+  replaceRange: (start: number, end: number, replacement: string) => void;
+  /** Insert `text` at the caret / after the selection; caret lands after it. */
+  insertAtCursor: (text: string) => void;
 }
 
 export function useMarkdownTextarea(
@@ -89,5 +102,35 @@ export function useMarkdownTextarea(
     apply(next, urlStart, urlStart + 3);
   }, [apply, ref, value]);
 
-  return { wrap, prefixLines, insertLink };
+  const getSelection = useCallback((): EditorSelection => {
+    const el = ref.current;
+    if (!el) {
+      return { start: 0, end: 0, text: '' };
+    }
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    return { start, end, text: value.slice(start, end) };
+  }, [ref, value]);
+
+  const replaceRange = useCallback(
+    (start: number, end: number, replacement: string) => {
+      const next = value.slice(0, start) + replacement + value.slice(end);
+      const caret = start + replacement.length;
+      apply(next, caret, caret);
+    },
+    [apply, value]
+  );
+
+  const insertAtCursor = useCallback(
+    (text: string) => {
+      const el = ref.current;
+      const at = el ? el.selectionEnd : value.length;
+      const next = value.slice(0, at) + text + value.slice(at);
+      const caret = at + text.length;
+      apply(next, caret, caret);
+    },
+    [apply, ref, value]
+  );
+
+  return { wrap, prefixLines, insertLink, getSelection, replaceRange, insertAtCursor };
 }

--- a/src/components/timeline/PostCard.tsx
+++ b/src/components/timeline/PostCard.tsx
@@ -16,6 +16,7 @@ import AvatarLink from '@/components/ui/AvatarLink';
 import { cn } from '@/lib/utils';
 import { Check } from 'lucide-react';
 import { usePostCardActions } from './usePostCardActions';
+import ReplyAiButton from './ReplyAiButton';
 import { TIMELINE_SURFACE } from '@/config/timeline';
 
 interface PostCardProps {
@@ -205,7 +206,13 @@ export function PostCard({
                     disabled={isReplying}
                     autoFocus
                   />
-                  <div className="flex justify-end mt-2">
+                  <div className="flex items-center justify-between gap-2 mt-2">
+                    <ReplyAiButton
+                      parentText={event.description || event.title || ''}
+                      parentAuthor={event.actor?.username || event.actor?.name}
+                      onDraft={setReplyText}
+                      disabled={isReplying}
+                    />
                     <Button
                       onClick={handleReplySubmit}
                       disabled={!replyText.trim() || isReplying}

--- a/src/components/timeline/ReplyAiButton.tsx
+++ b/src/components/timeline/ReplyAiButton.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { Sparkles, Loader2, ChevronDown } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+import { fetchReplyDraft } from '@/services/articles/ai-client';
+import type { ReplyIntent } from '@/services/cat/writing-types';
+import { TIMELINE_SURFACE } from '@/config/timeline';
+import { cn } from '@/lib/utils';
+
+const INTENTS: { key: ReplyIntent; label: string }[] = [
+  { key: 'thoughtful', label: 'Thoughtful reply' },
+  { key: 'add', label: 'Add a point' },
+  { key: 'question', label: 'Ask a question' },
+  { key: 'agree', label: 'Agree & build on it' },
+  { key: 'pushback', label: 'Respectful pushback' },
+];
+
+/**
+ * "AI reply" for a post — drafts a comment grounded in the post being answered
+ * plus the user's own context/voice, then drops it into the reply box for the
+ * user to edit and send. Intent picker steers how it engages. Fails soft.
+ */
+export default function ReplyAiButton({
+  parentText,
+  parentAuthor,
+  onDraft,
+  disabled,
+}: {
+  parentText: string;
+  parentAuthor?: string;
+  onDraft: (text: string) => void;
+  disabled?: boolean;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasParent = parentText.trim().length > 0;
+  const blocked = busy || disabled || !hasParent;
+
+  async function draft(intent: ReplyIntent) {
+    if (blocked) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await fetchReplyDraft({ parentText, parentAuthor, intent });
+      onDraft(result.text);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not draft a reply. Try again.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="inline-flex items-center gap-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            disabled={blocked}
+            className={cn(TIMELINE_SURFACE.chip, 'gap-1.5')}
+            title="Draft a reply with AI, grounded in this post"
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+            {busy ? 'Writing…' : 'AI reply'}
+            <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-52">
+          {INTENTS.map(i => (
+            <DropdownMenuItem
+              key={i.key}
+              className="cursor-pointer text-sm text-fg-primary focus:bg-surface-raised"
+              onSelect={() => draft(i.key)}
+            >
+              {i.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {error && <span className="text-xs text-status-negative">{error}</span>}
+    </div>
+  );
+}

--- a/src/components/timeline/TimelineComposer.tsx
+++ b/src/components/timeline/TimelineComposer.tsx
@@ -24,6 +24,7 @@ import {
   ContextIndicator,
 } from './ComposerShared';
 import PostAiButton from './PostAiButton';
+import ReplyAiButton from './ReplyAiButton';
 
 export interface TimelineComposerProps {
   targetOwnerId?: string;
@@ -37,6 +38,9 @@ export interface TimelineComposerProps {
   buttonText?: string;
   showBanner?: boolean;
   parentEventId?: string;
+  /** In reply mode: the post being answered, so AI can draft a grounded reply. */
+  parentPostText?: string;
+  parentAuthorName?: string;
   simpleMode?: boolean;
 }
 
@@ -52,6 +56,8 @@ const TimelineComposer = React.memo(function TimelineComposer({
   buttonText = TIMELINE_COPY.postButton,
   showBanner = true,
   parentEventId,
+  parentPostText,
+  parentAuthorName,
   simpleMode = true,
 }: TimelineComposerProps) {
   const { user, profile } = useAuth();
@@ -193,6 +199,14 @@ const TimelineComposer = React.memo(function TimelineComposer({
             <div className="flex flex-wrap items-center gap-2">
               {!parentEventId && (
                 <PostAiButton onDraft={postComposer.setContent} disabled={postComposer.isPosting} />
+              )}
+              {parentEventId && parentPostText && (
+                <ReplyAiButton
+                  parentText={parentPostText}
+                  parentAuthor={parentAuthorName}
+                  onDraft={postComposer.setContent}
+                  disabled={postComposer.isPosting}
+                />
               )}
               {!simpleMode && <TextFormatToolbar onFormat={handleFormat} />}
 

--- a/src/services/articles/ai-client.ts
+++ b/src/services/articles/ai-client.ts
@@ -7,6 +7,7 @@ import type {
   ArticleDraft,
   PostDraft,
   ProposedTopic,
+  ReplyIntent,
   ReviseAction,
   TonePreset,
   WritingKind,
@@ -49,6 +50,21 @@ export function fetchPostDraft(opts: { topic?: string; focus?: string }): Promis
   return postJson<{ draft: PostDraft }>('/api/ai/writing/draft', { mode: 'post', ...opts }).then(
     d => d.draft
   );
+}
+
+/**
+ * Draft a reply to someone else's post, grounded in that post + the user's own
+ * context and voice. `intent` steers how it engages (add a point, ask, push back…).
+ */
+export function fetchReplyDraft(opts: {
+  parentText: string;
+  parentAuthor?: string;
+  intent?: ReplyIntent;
+}): Promise<PostDraft> {
+  return postJson<{ draft: PostDraft }>('/api/ai/writing/draft', {
+    mode: 'reply',
+    ...opts,
+  }).then(d => d.draft);
 }
 
 /**

--- a/src/services/articles/ai-client.ts
+++ b/src/services/articles/ai-client.ts
@@ -7,6 +7,8 @@ import type {
   ArticleDraft,
   PostDraft,
   ProposedTopic,
+  ReviseAction,
+  TonePreset,
   WritingKind,
 } from '@/services/cat/writing-types';
 
@@ -47,4 +49,36 @@ export function fetchPostDraft(opts: { topic?: string; focus?: string }): Promis
   return postJson<{ draft: PostDraft }>('/api/ai/writing/draft', { mode: 'post', ...opts }).then(
     d => d.draft
   );
+}
+
+/**
+ * Transform the author's own article text (improve / continue / tighten / expand
+ * / grammar / tone) or seed an outline. Returns the revised markdown.
+ */
+export function reviseArticleText(opts: {
+  action: ReviseAction;
+  text?: string;
+  tone?: TonePreset;
+  title?: string;
+  topic?: string;
+  instruction?: string;
+}): Promise<string> {
+  return postJson<{ result: string }>('/api/ai/writing/revise', opts).then(d => d.result);
+}
+
+/** Suggest sharper headline options grounded in the article body. */
+export function suggestArticleTitles(body: string): Promise<string[]> {
+  return postJson<{ suggestions: string[] }>('/api/ai/writing/revise', {
+    action: 'title',
+    text: body,
+  }).then(d => d.suggestions);
+}
+
+/** Generate a one-line excerpt/hook from the article body. */
+export function generateArticleExcerpt(body: string, title?: string): Promise<string> {
+  return postJson<{ result: string }>('/api/ai/writing/revise', {
+    action: 'excerpt',
+    text: body,
+    title,
+  }).then(d => d.result);
 }

--- a/src/services/articles/image-client.ts
+++ b/src/services/articles/image-client.ts
@@ -1,0 +1,29 @@
+/**
+ * Browser client for AI image suggestions. Thin fetch wrapper that returns the
+ * suggested search terms + royalty-free candidates, or throws a friendly Error
+ * the picker can surface.
+ */
+
+import type { ImageSuggestResult } from '@/services/images/types';
+
+export function suggestArticleImages(opts: {
+  title?: string;
+  body?: string;
+  query?: string;
+}): Promise<ImageSuggestResult> {
+  return fetch('/api/ai/images/suggest', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(opts),
+  }).then(async res => {
+    const json = await res.json().catch(() => null);
+    if (!res.ok || !json?.success) {
+      const err = json?.error;
+      const message =
+        (typeof err === 'string' ? err : err?.message) ||
+        'Could not suggest images right now. Please try again.';
+      throw new Error(message);
+    }
+    return json.data as ImageSuggestResult;
+  });
+}

--- a/src/services/cat/writing-context.ts
+++ b/src/services/cat/writing-context.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared grounding + context-building for every AI writing feature (topic
+ * suggestions, drafts, and in-editor revisions). Extracted so the draft engine
+ * and the revise engine ground on the SAME real user context and obey the SAME
+ * hard rules — one source of truth for "what the AI knows and may not fabricate".
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { fetchFullContextForCat } from '@/services/ai/document-context';
+import { buildFullContextString } from '@/services/ai/context-string-builder';
+import { getUserActorId } from '@/domain/actors';
+import { TIMELINE_TABLES } from '@/config/database-tables';
+import { listMemories } from './memory';
+
+export const GROUNDING_RULES = `GROUNDING RULES (hard constraints):
+- Ground everything in something SPECIFIC and REAL from the context provided (their work, skills, entities, stated interests, or the posts they've already written).
+- NEVER invent facts, statistics, quotes, events, or people. If the context is thin, write about the themes that ARE present rather than fabricating detail.
+- Write in the user's own voice — match the tone of the posts they've already written when samples are provided.
+- Money is Bitcoin (BTC) or a fiat currency; NEVER write "sats" or "satoshis".
+- No clichés, no clickbait, no hashtag spam, no corporate filler. Sound like a real, thoughtful person.`;
+
+/** The last posts/articles the user authored — their voice, for tone-matching. */
+export async function fetchRecentAuthored(
+  supabase: AnySupabaseClient,
+  actorId: string
+): Promise<string> {
+  try {
+    const { data } = await supabase
+      .from(TIMELINE_TABLES.EVENTS)
+      .select('title, description, metadata')
+      .eq('actor_id', actorId)
+      .eq('metadata->>is_user_post', 'true')
+      .eq('is_deleted', false)
+      .order('event_timestamp', { ascending: false })
+      .limit(20);
+
+    const rows = (data ?? []) as Array<{
+      title: string | null;
+      description: string | null;
+      metadata: { is_article?: boolean } | null;
+    }>;
+    const lines = rows
+      .map(r => {
+        const text = (r.description || r.title || '').replace(/\s+/g, ' ').trim().slice(0, 200);
+        if (!text) {
+          return '';
+        }
+        return `- ${r.metadata?.is_article ? '[article] ' : ''}${text}`;
+      })
+      .filter(Boolean);
+    return lines.length ? lines.join('\n') : '(none yet)';
+  } catch {
+    return '(none yet)';
+  }
+}
+
+export interface WriterContext {
+  contextBlob: string;
+  memoryBlob: string;
+  recentBlob: string;
+}
+
+/**
+ * Full context — profile, entities, durable memories, and voice samples. Used
+ * for open-ended generation (topics, full drafts) where the AI needs to know
+ * what the person is about.
+ */
+export async function buildWriterContext(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<WriterContext> {
+  const [context, memories, actorId] = await Promise.all([
+    fetchFullContextForCat(supabase, userId),
+    listMemories(supabase, userId),
+    getUserActorId(supabase, userId),
+  ]);
+  const contextBlob = buildFullContextString(context);
+  const memoryBlob = memories.length
+    ? memories
+        .slice(0, 40)
+        .map(m => `- ${m.content}`)
+        .join('\n')
+    : '(none)';
+  const recentBlob = actorId ? await fetchRecentAuthored(supabase, actorId) : '(none yet)';
+  return { contextBlob, memoryBlob, recentBlob };
+}
+
+/**
+ * Voice-only context — just the user's recent posts. Used for in-editor
+ * revisions (improve, tighten, continue…) where the AI is transforming text the
+ * user already wrote and only needs their tone, not their whole world model.
+ * One query instead of three — revisions stay fast.
+ */
+export async function buildVoiceContext(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<{ recentBlob: string }> {
+  const actorId = await getUserActorId(supabase, userId);
+  const recentBlob = actorId ? await fetchRecentAuthored(supabase, actorId) : '(none yet)';
+  return { recentBlob };
+}
+
+export function contextPrompt(ctx: WriterContext, focus?: string): string {
+  return `Everything OrangeCat knows about this user:
+
+${ctx.contextBlob}
+
+DURABLE MEMORIES:
+${ctx.memoryBlob}
+
+POSTS THEY'VE ALREADY WRITTEN (their voice — match this tone):
+${ctx.recentBlob}
+${focus ? `\nThe user asked to focus on: ${focus}\n` : ''}`;
+}

--- a/src/services/cat/writing-engine.ts
+++ b/src/services/cat/writing-engine.ts
@@ -13,94 +13,16 @@
  */
 
 import type { AnySupabaseClient } from '@/lib/supabase/types';
-import { fetchFullContextForCat } from '@/services/ai/document-context';
-import { buildFullContextString } from '@/services/ai/context-string-builder';
-import { getUserActorId } from '@/domain/actors';
-import { TIMELINE_TABLES } from '@/config/database-tables';
 import { ARTICLE_LIMITS } from '@/config/articles';
 import { TIMELINE_CONTENT_LIMITS } from '@/config/timeline';
-import { listMemories } from './memory';
 import { callPlatformJson, parseJsonLoose } from './platform-llm';
+import { GROUNDING_RULES, buildWriterContext, contextPrompt } from './writing-context';
 import type { ArticleDraft, PostDraft, ProposedTopic, WritingKind } from './writing-types';
 import { logger } from '@/utils/logger';
 
 export type { ArticleDraft, PostDraft, ProposedTopic, WritingKind } from './writing-types';
 
 const MAX_TOPICS = 8;
-
-const GROUNDING_RULES = `GROUNDING RULES (hard constraints):
-- Ground everything in something SPECIFIC and REAL from the context below (their work, skills, entities, stated interests, or the posts they've already written).
-- NEVER invent facts, statistics, quotes, events, or people. If the context is thin, write about the themes that ARE present rather than fabricating detail.
-- Write in the user's own voice — match the tone of the posts they've already written when samples are provided.
-- Money is Bitcoin (BTC) or a fiat currency; NEVER write "sats" or "satoshis".
-- No clichés, no clickbait, no hashtag spam, no corporate filler. Sound like a real, thoughtful person.`;
-
-async function fetchRecentAuthored(supabase: AnySupabaseClient, actorId: string): Promise<string> {
-  try {
-    const { data } = await supabase
-      .from(TIMELINE_TABLES.EVENTS)
-      .select('title, description, metadata')
-      .eq('actor_id', actorId)
-      .eq('metadata->>is_user_post', 'true')
-      .eq('is_deleted', false)
-      .order('event_timestamp', { ascending: false })
-      .limit(20);
-
-    const rows = (data ?? []) as Array<{
-      title: string | null;
-      description: string | null;
-      metadata: { is_article?: boolean } | null;
-    }>;
-    const lines = rows
-      .map(r => {
-        const text = (r.description || r.title || '').replace(/\s+/g, ' ').trim().slice(0, 200);
-        if (!text) {
-          return '';
-        }
-        return `- ${r.metadata?.is_article ? '[article] ' : ''}${text}`;
-      })
-      .filter(Boolean);
-    return lines.length ? lines.join('\n') : '(none yet)';
-  } catch {
-    return '(none yet)';
-  }
-}
-
-async function buildWriterContext(
-  supabase: AnySupabaseClient,
-  userId: string
-): Promise<{ contextBlob: string; memoryBlob: string; recentBlob: string }> {
-  const [context, memories, actorId] = await Promise.all([
-    fetchFullContextForCat(supabase, userId),
-    listMemories(supabase, userId),
-    getUserActorId(supabase, userId),
-  ]);
-  const contextBlob = buildFullContextString(context);
-  const memoryBlob = memories.length
-    ? memories
-        .slice(0, 40)
-        .map(m => `- ${m.content}`)
-        .join('\n')
-    : '(none)';
-  const recentBlob = actorId ? await fetchRecentAuthored(supabase, actorId) : '(none yet)';
-  return { contextBlob, memoryBlob, recentBlob };
-}
-
-function contextPrompt(
-  ctx: { contextBlob: string; memoryBlob: string; recentBlob: string },
-  focus?: string
-): string {
-  return `Everything OrangeCat knows about this user:
-
-${ctx.contextBlob}
-
-DURABLE MEMORIES:
-${ctx.memoryBlob}
-
-POSTS THEY'VE ALREADY WRITTEN (their voice — match this tone):
-${ctx.recentBlob}
-${focus ? `\nThe user asked to focus on: ${focus}\n` : ''}`;
-}
 
 // ---------------------------------------------------------------------------
 // Topic suggestions

--- a/src/services/cat/writing-engine.ts
+++ b/src/services/cat/writing-engine.ts
@@ -17,7 +17,13 @@ import { ARTICLE_LIMITS } from '@/config/articles';
 import { TIMELINE_CONTENT_LIMITS } from '@/config/timeline';
 import { callPlatformJson, parseJsonLoose } from './platform-llm';
 import { GROUNDING_RULES, buildWriterContext, contextPrompt } from './writing-context';
-import type { ArticleDraft, PostDraft, ProposedTopic, WritingKind } from './writing-types';
+import type {
+  ArticleDraft,
+  PostDraft,
+  ProposedTopic,
+  ReplyIntent,
+  WritingKind,
+} from './writing-types';
 import { logger } from '@/utils/logger';
 
 export type { ArticleDraft, PostDraft, ProposedTopic, WritingKind } from './writing-types';
@@ -123,6 +129,60 @@ Output ONLY JSON: {"text":"the post"}.`;
   const text = typeof parsed?.text === 'string' ? parsed.text.trim() : '';
   if (!text) {
     logger.warn('writing-engine: empty post draft', {}, 'WritingEngine');
+    return null;
+  }
+  return { text: text.slice(0, TIMELINE_CONTENT_LIMITS.editPost) };
+}
+
+// ---------------------------------------------------------------------------
+// Reply draft — help the user comment on someone else's post
+// ---------------------------------------------------------------------------
+
+const REPLY_INTENTS: Record<ReplyIntent, string> = {
+  thoughtful:
+    'Add a thoughtful, substantive response that genuinely moves the conversation forward.',
+  add: 'Add a specific point, example, or angle the post did NOT already mention.',
+  question: 'Ask ONE genuine, specific question that invites the author to say more.',
+  agree: 'Affirm the point and build on it with your own concrete experience or example.',
+  pushback:
+    'Offer respectful disagreement — name clearly where you see it differently, without hostility or snark.',
+};
+
+export async function draftReply(
+  supabase: AnySupabaseClient,
+  userId: string,
+  opts: { parentText: string; parentAuthor?: string; intent?: ReplyIntent }
+): Promise<PostDraft | null> {
+  const parentText = opts.parentText.trim().slice(0, 4000);
+  if (!parentText) {
+    return null;
+  }
+  const intent = opts.intent ?? 'thoughtful';
+  const ctx = await buildWriterContext(supabase, userId);
+  const system = `You are the user's writing companion inside OrangeCat. Write ONE reply the user can post to the conversation below, in THEIR authentic voice, as a real contribution. ${REPLY_INTENTS[intent]}
+
+- React to what the post ACTUALLY says — do not restate or summarise it back.
+- Keep it under ${TIMELINE_CONTENT_LIMITS.post} characters. No hashtags, no emoji spam, no "Great post!" filler.
+- Sound like a real person joining the discussion, not a brand.
+
+${GROUNDING_RULES}
+
+Output ONLY JSON: {"text":"the reply"}.`;
+
+  const userPrompt = `${contextPrompt(ctx)}
+
+The post you are replying to${opts.parentAuthor ? ` (by @${opts.parentAuthor})` : ''}:
+"""
+${parentText}
+"""
+
+Write the reply as JSON.`;
+
+  const raw = await callPlatformJson(system, userPrompt, { temperature: 0.8, maxTokens: 600 });
+  const parsed = parseJsonLoose<{ text?: unknown }>(raw);
+  const text = typeof parsed?.text === 'string' ? parsed.text.trim() : '';
+  if (!text) {
+    logger.warn('writing-engine: empty reply draft', { intent }, 'WritingEngine');
     return null;
   }
   return { text: text.slice(0, TIMELINE_CONTENT_LIMITS.editPost) };

--- a/src/services/cat/writing-revise.ts
+++ b/src/services/cat/writing-revise.ts
@@ -1,0 +1,224 @@
+/**
+ * Revise engine — the in-editor AI writing help. Where the draft engine writes a
+ * whole post/article from scratch, this transforms text the author ALREADY wrote:
+ * improve it, continue it, tighten it, change its tone, or fix its grammar — plus
+ * two whole-document helpers (suggest titles, generate an excerpt) and an outline
+ * seeder. Same grounding + never-throw contract as the draft engine: any failure
+ * returns null / [] so the editor degrades to "nothing happened", never a crash.
+ *
+ * Voice-grounded, not fact-grounded: these ops rework the user's own words, so we
+ * fetch only their voice (recent posts), not their full world model — keeps every
+ * keystroke-triggered revision fast.
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { ARTICLE_LIMITS } from '@/config/articles';
+import { callPlatformJson, parseJsonLoose } from './platform-llm';
+import { GROUNDING_RULES, buildVoiceContext } from './writing-context';
+import type { ReviseAction, TonePreset } from './writing-types';
+import { logger } from '@/utils/logger';
+
+const TONE_INSTRUCTIONS: Record<TonePreset, string> = {
+  casual: 'Rewrite in a relaxed, conversational tone — like talking to a friend, plain words.',
+  formal: 'Rewrite in a polished, professional tone — precise, measured, no slang.',
+  punchy: 'Rewrite to be punchy and direct — short sentences, strong verbs, no filler.',
+  warm: 'Rewrite to be warm and human — empathetic, encouraging, generous in spirit.',
+};
+
+const ACTION_INSTRUCTIONS: Record<Exclude<ReviseAction, 'tone' | 'outline'>, string> = {
+  improve:
+    'Rewrite this text to be clearer, sharper, and better-flowing WITHOUT changing its meaning, facts, or the author’s voice. Keep roughly the same length.',
+  continue:
+    'Continue the text naturally from where it stops — write the NEXT one or two paragraphs. Do NOT repeat or rephrase what is already there; only return the new continuation.',
+  tighten:
+    'Make this text more concise — cut filler and redundancy, keep every real idea and the author’s voice. Shorter is the goal.',
+  expand:
+    'Expand this text with more depth — add a concrete detail, example, or consequence that follows from what is already there. Do not pad with filler or fabricate facts.',
+  grammar:
+    'Fix ONLY grammar, spelling, and punctuation. Do not rephrase, restructure, or change word choice beyond what correctness requires.',
+};
+
+const REVISE_SYSTEM_PREAMBLE = `You are the writing companion inside OrangeCat, editing a long-form article the user is writing. You transform the user's OWN text — you never lecture, never add meta-commentary, never wrap the result in quotes or code fences. Return only the revised prose as Markdown.`;
+
+/** Clamp text sent to the model — a runaway body shouldn't blow the token budget. */
+const MAX_INPUT_CHARS = 8000;
+
+function clampInput(text: string): string {
+  return text.length > MAX_INPUT_CHARS ? text.slice(0, MAX_INPUT_CHARS) : text;
+}
+
+export interface ReviseInput {
+  action: ReviseAction;
+  /** The selected text, or the whole body, to operate on. */
+  text: string;
+  /** For action:'tone'. */
+  tone?: TonePreset;
+  /** Article title, for grounding the revision in what the piece is about. */
+  title?: string;
+  /** For action:'outline' — the topic to outline. */
+  topic?: string;
+  /** Optional free-form steer ("make it less salesy"). */
+  instruction?: string;
+}
+
+/**
+ * Transform the user's text per `action`. Returns the revised Markdown, or null
+ * on any failure (caller leaves the editor untouched).
+ */
+export async function reviseText(
+  supabase: AnySupabaseClient,
+  userId: string,
+  input: ReviseInput
+): Promise<string | null> {
+  if (input.action === 'outline') {
+    return outlineForTopic(supabase, userId, input.topic || input.text, input.instruction);
+  }
+
+  const text = clampInput(input.text.trim());
+  if (!text) {
+    return null;
+  }
+
+  const directive =
+    input.action === 'tone'
+      ? TONE_INSTRUCTIONS[input.tone ?? 'casual']
+      : ACTION_INSTRUCTIONS[input.action];
+
+  const { recentBlob } = await buildVoiceContext(supabase, userId);
+  const system = `${REVISE_SYSTEM_PREAMBLE}
+
+TASK: ${directive}
+${input.instruction ? `The user also asked: ${input.instruction}\n` : ''}
+${GROUNDING_RULES}
+
+Output ONLY JSON: {"result":"the revised markdown"}.`;
+
+  const user = `${input.title ? `Article title: ${input.title}\n` : ''}The author's recent posts (their voice — match it):
+${recentBlob}
+
+TEXT TO ${input.action === 'continue' ? 'CONTINUE FROM' : 'REVISE'}:
+"""
+${text}
+"""
+
+Return the ${input.action === 'continue' ? 'continuation' : 'revised text'} as JSON.`;
+
+  const raw = await callPlatformJson(system, user, { temperature: 0.6, maxTokens: 2000 });
+  const parsed = parseJsonLoose<{ result?: unknown }>(raw);
+  const result = typeof parsed?.result === 'string' ? parsed.result.trim() : '';
+  if (!result) {
+    logger.warn('writing-revise: empty result', { action: input.action }, 'WritingRevise');
+    return null;
+  }
+  return result.slice(0, ARTICLE_LIMITS.body);
+}
+
+async function outlineForTopic(
+  supabase: AnySupabaseClient,
+  userId: string,
+  topic: string,
+  instruction?: string
+): Promise<string | null> {
+  const cleanTopic = topic.trim().slice(0, 300);
+  if (!cleanTopic) {
+    return null;
+  }
+  const { recentBlob } = await buildVoiceContext(supabase, userId);
+  const system = `${REVISE_SYSTEM_PREAMBLE}
+
+TASK: Propose a section outline for a long-form article on the given topic, so the author can start writing. Return Markdown: 3–6 "## " section headings, each followed by a single italic line (one sentence) describing what that section covers. Do NOT write the article body itself.
+${instruction ? `The user also asked: ${instruction}\n` : ''}
+${GROUNDING_RULES}
+
+Output ONLY JSON: {"result":"the markdown outline"}.`;
+  const user = `The author's recent posts (their voice):
+${recentBlob}
+
+TOPIC: ${cleanTopic}
+
+Return the outline as JSON.`;
+  const raw = await callPlatformJson(system, user, { temperature: 0.6, maxTokens: 900 });
+  const parsed = parseJsonLoose<{ result?: unknown }>(raw);
+  const result = typeof parsed?.result === 'string' ? parsed.result.trim() : '';
+  return result ? result.slice(0, ARTICLE_LIMITS.body) : null;
+}
+
+/**
+ * Suggest sharper headline options for a body the user has written. Grounded in
+ * the actual body (never generic), returns up to `count` titles.
+ */
+export async function suggestTitles(
+  supabase: AnySupabaseClient,
+  userId: string,
+  body: string,
+  count = 5
+): Promise<string[]> {
+  const text = clampInput(body.trim());
+  if (!text) {
+    return [];
+  }
+  const n = Math.min(Math.max(count, 1), 8);
+  const { recentBlob } = await buildVoiceContext(supabase, userId);
+  const system = `${REVISE_SYSTEM_PREAMBLE}
+
+TASK: Suggest ${n} strong, specific headline options for the article below. Each a real headline (not a category), concrete, in the author's voice, no clickbait, no colon-subtitle cliché unless it genuinely helps. Each must fit within ${ARTICLE_LIMITS.title} characters.
+
+${GROUNDING_RULES}
+
+Output ONLY JSON: {"titles":["...","..."]}.`;
+  const user = `Author's voice (recent posts):
+${recentBlob}
+
+ARTICLE BODY:
+"""
+${text}
+"""
+
+Return ${n} titles as JSON.`;
+  const raw = await callPlatformJson(system, user, { temperature: 0.8, maxTokens: 500 });
+  const parsed = parseJsonLoose<{ titles?: unknown }>(raw);
+  const arr = Array.isArray(parsed?.titles) ? parsed.titles : [];
+  return arr
+    .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+    .map(t =>
+      t
+        .trim()
+        .replace(/^["']|["']$/g, '')
+        .slice(0, ARTICLE_LIMITS.title)
+    )
+    .slice(0, n);
+}
+
+/**
+ * Generate a one-line excerpt/subtitle for a body. Complements the non-AI
+ * `deriveExcerpt` fallback — this one reads the whole piece and writes a hook.
+ */
+export async function generateExcerpt(
+  supabase: AnySupabaseClient,
+  userId: string,
+  body: string,
+  title?: string
+): Promise<string | null> {
+  const text = clampInput(body.trim());
+  if (!text) {
+    return null;
+  }
+  // Voice matters less for a one-liner; keep it a single fast call.
+  const system = `${REVISE_SYSTEM_PREAMBLE}
+
+TASK: Write ONE compelling sentence (max ${ARTICLE_LIMITS.excerpt} characters) that makes someone want to read this article. It appears in the feed and previews. No "In this article…", no clickbait — a real hook drawn from the actual content.
+
+${GROUNDING_RULES}
+
+Output ONLY JSON: {"result":"the excerpt"}.`;
+  const user = `${title ? `Title: ${title}\n` : ''}ARTICLE BODY:
+"""
+${text}
+"""
+
+Return the excerpt as JSON.`;
+  const raw = await callPlatformJson(system, user, { temperature: 0.7, maxTokens: 200 });
+  const parsed = parseJsonLoose<{ result?: unknown }>(raw);
+  const result = typeof parsed?.result === 'string' ? parsed.result.trim() : '';
+  return result ? result.replace(/^["']|["']$/g, '').slice(0, ARTICLE_LIMITS.excerpt) : null;
+}

--- a/src/services/cat/writing-types.ts
+++ b/src/services/cat/writing-types.ts
@@ -44,3 +44,13 @@ export type ReviseAction =
   | 'outline';
 
 export type TonePreset = 'casual' | 'formal' | 'punchy' | 'warm';
+
+/**
+ * How an AI-drafted reply should engage the post it answers:
+ * - thoughtful → substantive response that moves the conversation forward
+ * - add        → a specific point/example the post didn't mention
+ * - question   → one genuine question inviting the author to say more
+ * - agree      → affirm and build on it with your own experience
+ * - pushback   → respectful disagreement, no hostility
+ */
+export type ReplyIntent = 'thoughtful' | 'add' | 'question' | 'agree' | 'pushback';

--- a/src/services/cat/writing-types.ts
+++ b/src/services/cat/writing-types.ts
@@ -22,3 +22,25 @@ export interface ArticleDraft {
 export interface PostDraft {
   text: string;
 }
+
+/**
+ * In-editor AI revision actions. Each transforms the author's own text (their
+ * selection, or the whole body) rather than generating from scratch:
+ * - improve   → sharpen clarity & flow, keep the meaning and voice
+ * - continue  → write the next paragraph(s) from where they stopped
+ * - tighten   → same idea, fewer words
+ * - expand    → add depth, detail, a concrete example
+ * - grammar   → fix grammar/spelling only, minimal changes
+ * - tone      → rewrite in a different register (see TonePreset)
+ * - outline   → propose a section outline for a topic (seeds an empty body)
+ */
+export type ReviseAction =
+  | 'improve'
+  | 'continue'
+  | 'tighten'
+  | 'expand'
+  | 'grammar'
+  | 'tone'
+  | 'outline';
+
+export type TonePreset = 'casual' | 'formal' | 'punchy' | 'warm';

--- a/src/services/images/image-suggest.ts
+++ b/src/services/images/image-suggest.ts
@@ -1,0 +1,63 @@
+/**
+ * Turn an article into concrete image SEARCH TERMS. The value the AI adds here
+ * is translation: an article about "sovereignty and self-hosting" doesn't search
+ * well, but "server room", "lighthouse", "open road" do. Pure LLM (no DB) so it
+ * works even when the rest of the platform can't reach the database. Never throws.
+ */
+
+import { callPlatformJson, parseJsonLoose } from '@/services/cat/platform-llm';
+
+const MAX_QUERIES = 6;
+
+/**
+ * Fallback when the model is unavailable: the longest words from the title make
+ * a serviceable-if-blunt search. Better than nothing; keeps the picker useful.
+ */
+function fallbackQueries(title: string): string[] {
+  const words = title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 3);
+  return words.slice(0, 3);
+}
+
+export async function suggestImageQueries(title: string, body: string): Promise<string[]> {
+  const cleanTitle = title.trim().slice(0, 200);
+  const cleanBody = body.trim().slice(0, 2000);
+  if (!cleanTitle && !cleanBody) {
+    return [];
+  }
+
+  const system = `You suggest IMAGE SEARCH TERMS to illustrate an article — a cover photo and inline images.
+
+Rules:
+- Return ${MAX_QUERIES} short queries, each 1–3 words.
+- CONCRETE and VISUAL: real objects, scenes, places, materials (e.g. "server room", "open road", "hands soldering", "mountain lake"). A stock-photo library must return real photos for it.
+- NOT abstract nouns ("freedom", "sovereignty", "innovation") — translate the idea into something photographable.
+- Order from most to least on-topic.
+
+Output ONLY JSON: {"queries":["...","..."]}.`;
+
+  const user = `Article title: ${cleanTitle || '(none)'}
+
+Article body (excerpt):
+${cleanBody || '(none)'}
+
+Return the search terms as JSON.`;
+
+  const raw = await callPlatformJson(system, user, { temperature: 0.7, maxTokens: 300 });
+  const parsed = parseJsonLoose<{ queries?: unknown }>(raw);
+  const arr = Array.isArray(parsed?.queries) ? parsed.queries : [];
+  const queries = arr
+    .filter((q): q is string => typeof q === 'string' && q.trim().length > 0)
+    .map(q =>
+      q
+        .trim()
+        .replace(/^["']|["']$/g, '')
+        .slice(0, 60)
+    )
+    .slice(0, MAX_QUERIES);
+
+  return queries.length ? queries : fallbackQueries(cleanTitle);
+}

--- a/src/services/images/openverse.ts
+++ b/src/services/images/openverse.ts
@@ -1,0 +1,71 @@
+/**
+ * Openverse image search — free, no API key, Creative-Commons licensed images.
+ * We default to CC0 + Public-Domain-Mark so a chosen image needs no attribution
+ * (there's no caption slot on an article cover), which keeps reuse legally clean.
+ * Never throws — returns [] on any failure so the picker degrades to "no results".
+ *
+ * Why Openverse (not a paid generator): the whole AI-writing surface runs on the
+ * free pool and touches no credits; image help should stay the same — zero cost,
+ * zero new secrets.
+ */
+
+import type { StockImage } from './types';
+import { logger } from '@/utils/logger';
+
+const OPENVERSE_URL = 'https://api.openverse.org/v1/images/';
+/** CC0 + Public Domain Mark — reusable commercially, no attribution required. */
+const LICENSE_FILTER = 'cc0,pdm';
+
+interface OpenverseResult {
+  id?: string;
+  title?: string;
+  url?: string;
+  thumbnail?: string;
+  creator?: string | null;
+  license?: string;
+  foreign_landing_url?: string | null;
+}
+
+export async function searchOpenverse(query: string, count = 8): Promise<StockImage[]> {
+  const q = query.trim();
+  if (!q) {
+    return [];
+  }
+  const params = new URLSearchParams({
+    q,
+    license: LICENSE_FILTER,
+    page_size: String(Math.min(Math.max(count, 1), 20)),
+    mature: 'false',
+  });
+  try {
+    const res = await fetch(`${OPENVERSE_URL}?${params.toString()}`, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'OrangeCat/1.0 (+https://orangecat.ch)',
+      },
+      // Openverse results are stable; cache briefly to spare their rate limit.
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) {
+      logger.warn('openverse: search failed', { status: res.status }, 'Openverse');
+      return [];
+    }
+    const json = (await res.json()) as { results?: OpenverseResult[] };
+    return (json.results ?? [])
+      .filter(r => r.id && r.url && r.thumbnail)
+      .map(
+        (r): StockImage => ({
+          id: r.id as string,
+          thumbUrl: r.thumbnail as string,
+          fullUrl: r.url as string,
+          title: (r.title || 'Untitled').slice(0, 120),
+          creator: r.creator ?? null,
+          license: r.license || 'cc0',
+          sourceUrl: r.foreign_landing_url ?? null,
+        })
+      );
+  } catch (err) {
+    logger.warn('openverse: search threw', { err: String(err) }, 'Openverse');
+    return [];
+  }
+}

--- a/src/services/images/types.ts
+++ b/src/services/images/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Client-safe image types (no server imports) — shared by the Openverse search
+ * service, the API route, and the browser picker.
+ */
+
+export interface StockImage {
+  id: string;
+  /** Openverse thumbnail proxy — small, fast, for the grid. */
+  thumbUrl: string;
+  /** Full-resolution source image — what we set as the cover / insert inline. */
+  fullUrl: string;
+  title: string;
+  creator: string | null;
+  /** e.g. "cc0", "pdm". */
+  license: string;
+  /** Landing page on the source (Flickr, Wikimedia…), for a credit link. */
+  sourceUrl: string | null;
+}
+
+export interface ImageSuggestResult {
+  /** The AI-derived (or echoed manual) search terms used. */
+  queries: string[];
+  images: StockImage[];
+}


### PR DESCRIPTION
Closes the gaps George flagged: *"you can request AI to write an abstract article, but you cannot give it a topic, suggest topics does not work, very little AI can help with articles, no way to ask AI to comment on posts — lots of gaps compared to X."*

The backend writing engine was already solid; the problem was almost entirely missing surface + two real bugs. Mostly UI + thin engine/route additions, same never-throw + free-pool contract as the existing engine.

## 1 · Article writing core (`299cf0d3`)
- **Topic prompt field** in the AI panel — it silently reused the title before, so steering felt impossible ("can't give it a topic").
- **Fixed silent suggest-topics** — empty results rendered nothing with no feedback (backend worked; the empty state was the bug). Now shows an actionable message.
- **In-editor "Ask AI" strip** — Improve · Continue · Tighten · Expand · Fix grammar · Change tone (casual/formal/punchy/warm) · Outline · Suggest title · Write excerpt. Operates on selection or whole body. **Now available in edit mode too** (was `!isEditing`-gated).
- Extracted `writing-context.ts` (SSOT grounding) + new `writing-revise.ts` engine + `/api/ai/writing/revise` route.

## 2 · AI replies on posts (`0b094cb3`)
- Root cause: the composer explicitly hid the AI button in reply mode (`!parentEventId`).
- New `ReplyAiButton` with intent picker (Thoughtful / Add a point / Ask a question / Agree & build / Respectful pushback), grounded in the parent post + the user's voice. Wired into both reply surfaces (inline `PostCard` + detail-page composer). `reply` mode added to the draft engine/route.

## 3 · AI images (`f5acf37b`)
- No image-gen key exists and the writing surface runs on the free pool touching no credits — so images stay the same shape: **zero cost, zero new secrets**. AI turns the article into concrete search terms → **Openverse** (free, no key) filtered to **CC0 / public-domain** (no attribution needed, safe for a caption-less cover).
- `ImageSuggestPicker` wired to the cover ("Suggest with AI") and inline ("Insert an image" in the AI menu). New `/api/ai/images/suggest` route + `src/services/images/*`.

## Verification
- `tsc` **0 errors**, eslint **clean**, `audit:routes` **clean**, **1222/1222** unit tests pass. Every LLM prompt shape + Openverse validated against the real services.
- ⚠️ **Not** exercised E2E against the production DB (sandbox can't reach `supabase.orangecat.ch`), so the context-grounding paths are code-reviewed but not run with real data — worth a manual smoke on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)