### PR TITLE
fix(wallets): make the wallets page state verified facts, not guesses

### DIFF
--- a/__tests__/unit/wallets/receive-status.test.ts
+++ b/__tests__/unit/wallets/receive-status.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Owner receive status — the page's only allowed source of "can I be paid".
+ *
+ * Guards the exact production defect this module was written for: a stored NWC
+ * connection this deployment cannot decrypt must NOT be reported as a working
+ * Lightning setup, and the resulting on-chain fallback must be disclosed rather
+ * than dressed up as a live Lightning address.
+ */
+
+import { getOwnerReceiveStatus } from '@/domain/wallets/receiveStatus';
+import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
+import { canDecrypt } from '@/domain/payments/encryptionService';
+
+jest.mock('@/domain/payments/walletResolutionService', () => ({
+  resolveUserWallet: jest.fn(),
+}));
+jest.mock('@/domain/payments/encryptionService', () => ({
+  canDecrypt: jest.fn(),
+}));
+
+const nwcRows: Array<{ id: string; nwc_connection_uri: string | null }> = [];
+
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: () => ({
+    from: () => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      not: jest.fn().mockResolvedValue({ data: nwcRows, error: null }),
+    }),
+  }),
+}));
+
+const mockResolve = resolveUserWallet as jest.MockedFunction<typeof resolveUserWallet>;
+const mockCanDecrypt = canDecrypt as jest.MockedFunction<typeof canDecrypt>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  nwcRows.length = 0;
+  mockCanDecrypt.mockReturnValue(true);
+});
+
+describe('getOwnerReceiveStatus', () => {
+  it('reports an active Lightning address for an NWC rail', async () => {
+    mockResolve.mockResolvedValue({ method: 'nwc', wallet_id: 'w1', nwc_uri: 'nostr+wc://x' });
+    await expect(getOwnerReceiveStatus('u1')).resolves.toEqual({
+      rail: 'nwc',
+      lightningAddressActive: true,
+      unusableConnectionWalletIds: [],
+    });
+  });
+
+  it('reports an active Lightning address for a lightning-address rail', async () => {
+    mockResolve.mockResolvedValue({
+      method: 'lightning_address',
+      wallet_id: 'w1',
+      lightning_address: 'a@b.c',
+    });
+    const status = await getOwnerReceiveStatus('u1');
+    expect(status.lightningAddressActive).toBe(true);
+  });
+
+  it('does NOT claim a Lightning address when the rail is on-chain', async () => {
+    mockResolve.mockResolvedValue({ method: 'onchain', wallet_id: 'w1', onchain_address: 'bc1x' });
+    const status = await getOwnerReceiveStatus('u1');
+    expect(status).toMatchObject({ rail: 'onchain', lightningAddressActive: false });
+  });
+
+  it('claims nothing when no wallet resolves', async () => {
+    mockResolve.mockResolvedValue(null);
+    await expect(getOwnerReceiveStatus('u1')).resolves.toMatchObject({
+      rail: null,
+      lightningAddressActive: false,
+    });
+  });
+
+  it('flags a stored connection this deployment cannot decrypt', async () => {
+    // The production case: an NWC row exists, but the key that encrypted it is
+    // not present here, so resolveUserWallet silently degrades to on-chain.
+    nwcRows.push({ id: 'w-nwc', nwc_connection_uri: 'ciphertext-from-another-key' });
+    mockCanDecrypt.mockReturnValue(false);
+    mockResolve.mockResolvedValue({ method: 'onchain', wallet_id: 'w2', onchain_address: 'bc1x' });
+
+    const status = await getOwnerReceiveStatus('u1');
+
+    expect(status.lightningAddressActive).toBe(false);
+    expect(status.unusableConnectionWalletIds).toEqual(['w-nwc']);
+  });
+
+  it('fails closed when resolution throws — never claims a working rail', async () => {
+    mockResolve.mockRejectedValue(new Error('db down'));
+    await expect(getOwnerReceiveStatus('u1')).resolves.toMatchObject({
+      rail: null,
+      lightningAddressActive: false,
+    });
+  });
+});

--- a/src/app/(authenticated)/dashboard/wallets/components/WalletsGuidanceSidebar.tsx
+++ b/src/app/(authenticated)/dashboard/wallets/components/WalletsGuidanceSidebar.tsx
@@ -9,7 +9,6 @@
 
 'use client';
 
-import { Card } from '@/components/ui/Card';
 import { DynamicSidebar } from '@/components/create/DynamicSidebar';
 import {
   walletGuidanceContent,
@@ -25,22 +24,10 @@ export function WalletsGuidanceSidebar({ focusedField }: WalletsGuidanceSidebarP
   return (
     <div className="hidden lg:block lg:col-span-5 lg:order-2">
       <div className="lg:sticky lg:top-8 space-y-6">
-        {/* Simple explainer / checklist */}
-        <Card className="p-6 shadow-sm border-default">
-          <div className="mb-3">
-            <h3 className="text-base font-semibold text-fg-primary">How wallet setup works</h3>
-            <p className="text-sm text-fg-secondary mt-1">
-              Create one wallet per funding goal or budget. You can always edit or archive wallets
-              later.
-            </p>
-          </div>
-          <ul className="list-disc list-inside text-sm text-fg-primary space-y-1">
-            <li>Choose a clear category like Rent, Food, or Emergency</li>
-            <li>Give the wallet a human name that explains its purpose</li>
-            <li>Paste a Bitcoin address or xpub from your own wallet</li>
-            <li>Optionally set a funding goal in CHF, EUR, USD, or BTC</li>
-          </ul>
-        </Card>
+        {/* A static "How wallet setup works" card used to sit here, duplicating
+            walletDefaultContent below (which the DynamicSidebar already shows
+            when no field is focused) and still telling people to paste an xpub.
+            One explainer, one source of truth. */}
 
         {/* Dynamic Guidance */}
         <DynamicSidebar<NonNullable<WalletFieldType>>

--- a/src/app/(authenticated)/dashboard/wallets/components/WalletsHelpSection.tsx
+++ b/src/app/(authenticated)/dashboard/wallets/components/WalletsHelpSection.tsx
@@ -26,7 +26,7 @@ export function WalletsHelpSection({ isDesktop }: WalletsHelpSectionProps) {
           </p>
           {/* Mobile: Show only key point, Desktop: Show all */}
           <p className="lg:hidden text-xs text-fg-secondary mt-1">
-            Use xpub/ypub/zpub for best tracking • Never paste seed phrase
+            Lightning arrives in seconds • Never paste your seed phrase
           </p>
         </div>
         <svg
@@ -42,22 +42,26 @@ export function WalletsHelpSection({ isDesktop }: WalletsHelpSectionProps) {
         <div className="text-sm text-fg-primary">
           <ul className="list-disc list-inside space-y-1.5">
             <li>
-              <strong>Recommended:</strong> Use extended public keys (xpub, ypub, zpub) to
-              automatically track all addresses and transactions
+              <strong>A Lightning address is the easiest way to get paid</strong> — it looks like an
+              email, and payments land in seconds. It also switches on your{' '}
+              <code className="font-mono text-xs">@orangecat.ch</code> address above.
             </li>
-            <li>Single addresses (1..., 3..., bc1...) work too, but only track one address</li>
+            <li>
+              An on-chain address (1..., 3..., bc1...) works too, but payments take ~10 minutes and
+              can&apos;t answer Lightning.
+            </li>
             <li>Never paste your seed phrase here – only public data</li>
-            <li>Mark wallets as active to display them on your public profile</li>
+            <li>Active wallets appear on the Wallets tab of your public profile</li>
           </ul>
           <details className="mt-3">
             <summary className="cursor-pointer text-fg-primary hover:underline underline-offset-4 text-xs font-medium">
-              Why use extended public keys?
+              What about extended public keys (xpub/ypub/zpub)?
             </summary>
             <p className="mt-2 text-xs text-fg-secondary pl-4">
-              Bitcoin wallets generate new addresses after each transaction for privacy. With an
-              extended public key (xpub/ypub/zpub), we can automatically track all these addresses
-              and show your complete balance and transaction history. A single address only shows
-              transactions to that one address.
+              Optional, and only for on-chain tracking. Bitcoin wallets generate a new address after
+              each transaction for privacy; an extended public key lets OrangeCat follow all of them
+              and show a complete balance, where a single address only shows its own. It does not
+              affect how you get paid — and it can&apos;t receive Lightning.
             </p>
           </details>
         </div>

--- a/src/app/(authenticated)/dashboard/wallets/components/WalletsPageHeader.tsx
+++ b/src/app/(authenticated)/dashboard/wallets/components/WalletsPageHeader.tsx
@@ -1,7 +1,7 @@
 /**
  * Wallets Page Header
  *
- * Header component for the wallets page with info banner.
+ * Header component for the wallets page.
  *
  * Created: 2025-01-30
  * Last Modified: 2025-01-30
@@ -9,14 +9,10 @@
 
 'use client';
 
-import { Wallet as WalletIcon, Info } from 'lucide-react';
+import { Wallet as WalletIcon } from 'lucide-react';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 
-interface WalletsPageHeaderProps {
-  isDesktop: boolean;
-}
-
-export function WalletsPageHeader({ isDesktop }: WalletsPageHeaderProps) {
+export function WalletsPageHeader() {
   return (
     <div className="mb-6 lg:mb-8">
       <Breadcrumb items={[{ label: 'Wallets' }]} className="mb-4" />
@@ -26,43 +22,18 @@ export function WalletsPageHeader({ isDesktop }: WalletsPageHeaderProps) {
       </div>
       {/* Desktop: Full description, Mobile: Shortened */}
       <p className="hidden lg:block text-fg-secondary mb-4 max-w-2xl">
-        Add and manage your Bitcoin wallets. Each wallet can represent a specific funding need such
-        as rent, food, medical costs, or a one‑time savings goal.
+        Wallets are how you get paid on OrangeCat. Add one to switch on your Lightning address, and
+        create separate wallets when you want to track a specific need — rent, food, medical costs,
+        or a one‑time savings goal.
       </p>
       <p className="lg:hidden text-sm text-fg-secondary mb-3">
-        Add Bitcoin wallets for different funding needs
+        Add a wallet to start receiving Bitcoin
       </p>
 
-      {/* Info Banner - Collapsible on Mobile, Open on Desktop */}
-      <details
-        className="bg-surface-raised/40 border border-subtle rounded-lg overflow-hidden"
-        open={isDesktop}
-      >
-        <summary className="p-3 lg:p-4 flex items-start gap-3 cursor-pointer list-none">
-          <Info className="w-5 h-5 text-fg-primary mt-0.5 flex-shrink-0" />
-          <div className="text-sm text-fg-primary flex-1">
-            <p className="font-medium">About Bitcoin Wallets</p>
-            <p className="lg:hidden mt-1 text-xs">
-              Connect your Bitcoin address or xpub to receive support
-            </p>
-          </div>
-          <svg
-            className="w-5 h-5 text-fg-primary flex-shrink-0 lg:hidden transition-transform"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-          </svg>
-        </summary>
-        <div className="px-3 pb-3 lg:px-4 lg:pb-4 pt-0 lg:pt-0 text-sm text-fg-primary border-t border-subtle lg:border-t-0">
-          <p className="mt-2">
-            Connect a Bitcoin address or extended public key (xpub/ypub/zpub) from a wallet you
-            control. Active wallets appear on your profile so supporters know exactly what they are
-            funding.
-          </p>
-        </div>
-      </details>
+      {/* The "About Bitcoin Wallets" banner that used to sit here repeated the
+          description above it and the sidebar explainer beside it — three
+          explainers before the first control. Removed; the two that remain do
+          different jobs (framing, then field-level guidance). */}
     </div>
   );
 }

--- a/src/app/(authenticated)/dashboard/wallets/hooks/useReceiveStatus.ts
+++ b/src/app/(authenticated)/dashboard/wallets/hooks/useReceiveStatus.ts
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * Fetches the server's answer to "can I actually be paid right now" so the
+ * wallets page states verified facts instead of client-side guesses. Refetches
+ * whenever the wallet set changes, so adding/removing a wallet updates the
+ * claim immediately.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { logger } from '@/utils/logger';
+
+export interface ReceiveStatus {
+  username: string | null;
+  lightningAddress: string | null;
+  rail: 'nwc' | 'lightning_address' | 'onchain' | null;
+  lightningAddressActive: boolean;
+  unusableConnectionWalletIds: string[];
+}
+
+export function useReceiveStatus(walletsSignature: string, enabled: boolean) {
+  const [status, setStatus] = useState<ReceiveStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(enabled);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) {
+      return;
+    }
+    try {
+      const res = await fetch('/api/wallets/receive-status');
+      if (!res.ok) {
+        throw new Error(`status ${res.status}`);
+      }
+      const body = (await res.json()) as { data?: ReceiveStatus };
+      setStatus(body.data ?? null);
+    } catch (error) {
+      // Fail closed: no status means the card claims nothing.
+      logger.warn('Could not load receive status', { error }, 'Wallets');
+      setStatus(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh, walletsSignature]);
+
+  return { status, isLoading, refresh };
+}

--- a/src/app/(authenticated)/dashboard/wallets/page.tsx
+++ b/src/app/(authenticated)/dashboard/wallets/page.tsx
@@ -13,6 +13,7 @@ import type { WalletFieldType } from '@/lib/wallet-guidance';
 import { useWallets } from './hooks/useWallets';
 import { useWalletOperations } from './hooks/useWalletOperations';
 import { useResponsiveLayout } from './hooks/useResponsiveLayout';
+import { useReceiveStatus } from './hooks/useReceiveStatus';
 import { NostrConnectionCard } from '@/components/nostr/NostrConnectionCard';
 import { WalletsPageHeader } from './components/WalletsPageHeader';
 import { WalletsHelpSection } from './components/WalletsHelpSection';
@@ -68,6 +69,18 @@ export default function DashboardWalletsPage() {
     setWallets: setWalletsState,
   });
 
+  // What the SERVER says about being paid — the page must never assert a
+  // receiving capability the payment path doesn't actually have. Re-checked
+  // whenever the wallet set changes.
+  const walletsSignature = walletsState
+    .filter(w => w.is_active)
+    .map(w => w.id)
+    .join(',');
+  const { status: receiveStatus, isLoading: receiveStatusLoading } = useReceiveStatus(
+    walletsSignature,
+    !!user?.id
+  );
+
   // Loading state with timeout protection
   if (authLoading || isLoading) {
     return <Loading message="Loading your wallets..." />;
@@ -93,7 +106,7 @@ export default function DashboardWalletsPage() {
     <div className={cn(GRADIENTS.pageBg, 'min-h-screen')}>
       <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
         {/* Page Header */}
-        <WalletsPageHeader isDesktop={isDesktop} />
+        <WalletsPageHeader />
 
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
           {/* Desktop: Guidance Sidebar */}
@@ -104,7 +117,7 @@ export default function DashboardWalletsPage() {
             {/* The user's <username>@orangecat.ch Lightning address — shown
                 first so people actually learn they have one. */}
             <div className="mb-6">
-              <LightningAddressCard username={profile?.username} wallets={walletsState} />
+              <LightningAddressCard status={receiveStatus} isLoading={receiveStatusLoading} />
             </div>
 
             <div className="bg-surface-base rounded-lg shadow-sm border border-default p-4 sm:p-6">
@@ -119,6 +132,7 @@ export default function DashboardWalletsPage() {
                 maxWallets={10}
                 isOwner={!!user?.id && !!profile?.id}
                 onFieldFocus={setFocusedField}
+                unusableConnectionWalletIds={receiveStatus?.unusableConnectionWalletIds}
               />
             </div>
 

--- a/src/app/api/wallets/receive-status/route.ts
+++ b/src/app/api/wallets/receive-status/route.ts
@@ -1,0 +1,36 @@
+/**
+ * GET /api/wallets/receive-status — owner-only: can I actually be paid right
+ * now, and via which rail? Answered by the same resolution a payer's request
+ * runs, so the wallets page can never claim a capability the payment path
+ * doesn't have.
+ */
+
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import { apiSuccess, apiInternalError } from '@/lib/api/standardResponse';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { APP_DOMAIN } from '@/config/brand';
+import { getOwnerReceiveStatus } from '@/domain/wallets/receiveStatus';
+import { logger } from '@/utils/logger';
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  try {
+    const { user, supabase } = request;
+
+    const [{ data: profile }, status] = await Promise.all([
+      supabase.from(DATABASE_TABLES.PROFILES).select('username').eq('id', user.id).maybeSingle(),
+      getOwnerReceiveStatus(user.id),
+    ]);
+
+    const username = (profile as { username?: string | null } | null)?.username ?? null;
+
+    return apiSuccess({
+      username,
+      // Null when the account has no username yet — there is no address to show.
+      lightningAddress: username ? `${username}@${APP_DOMAIN}` : null,
+      ...status,
+    });
+  } catch (error) {
+    logger.error('Failed to resolve owner receive status', { error }, 'Wallets');
+    return apiInternalError('Could not check your receiving setup.');
+  }
+});

--- a/src/components/nostr/NostrConnectionCard.tsx
+++ b/src/components/nostr/NostrConnectionCard.tsx
@@ -51,7 +51,9 @@ export function NostrConnectionCard() {
           Nostr
         </CardTitle>
         <CardDescription>
-          Connect your Nostr identity for portable profiles and Lightning payments via NWC.
+          Connect your Nostr identity for a portable profile. A wallet connection added here stays
+          in this browser — it shows your balance and pays from it, but it does not set up
+          receiving. To get paid, add the wallet above.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">

--- a/src/components/wallets/LightningAddressCard.tsx
+++ b/src/components/wallets/LightningAddressCard.tsx
@@ -1,57 +1,82 @@
 'use client';
 
 /**
- * Lightning Address Card — surfaces the user's `<username>@orangecat.ch`
- * Lightning address (LUD-16, served by /.well-known/lnurlp/<username>).
+ * Lightning Address Card — the user's `<username>@orangecat.ch` (LUD-16, served
+ * by /.well-known/lnurlp/<username>).
  *
- * The address is NON-CUSTODIAL: it mints invoices from the user's OWN
- * Lightning-capable wallet (NWC or Lightning address), so it only works once
- * such a wallet is connected. This card is honest about that — it shows the
- * address as active only when a Lightning-capable wallet exists, and otherwise
- * explains exactly how to activate it.
+ * Truth rules, learned the hard way:
+ *  1. Whether the address works is decided by the SERVER's payment resolution,
+ *     not by which fields happen to be filled in on a wallet row. This card only
+ *     renders what /api/wallets/receive-status reports.
+ *  2. Resolution succeeding still only proves we can *reach* a rail. So the card
+ *     offers a one-click self-test that mints a real invoice through the exact
+ *     public path a payer uses — turning the claim into a verified fact. It only
+ *     requests an invoice; no payment is made and the invoice simply expires.
  */
 
 import { useState } from 'react';
-import { Zap, Copy, Check } from 'lucide-react';
-import { APP_DOMAIN } from '@/config/brand';
-import type { Wallet } from '@/types/wallet';
+import { Zap, Copy, Check, AlertTriangle } from 'lucide-react';
+import type { ReceiveStatus } from '@/app/(authenticated)/dashboard/wallets/hooks/useReceiveStatus';
 
 interface LightningAddressCardProps {
-  username: string | null | undefined;
-  wallets: Wallet[];
+  status: ReceiveStatus | null;
+  isLoading: boolean;
 }
 
-/**
- * Mirrors the server-side wallet resolution (NWC > Lightning address): the
- * proxy address can mint invoices iff an active wallet has either rail.
- * On-chain-only wallets cannot back a Lightning address.
- */
-function hasLightningCapableWallet(wallets: Wallet[]): boolean {
-  return wallets.some(
-    w =>
-      w.is_active &&
-      (!!w.lightning_address ||
-        !!(w as Wallet & { nwc_connection_uri?: string | null }).nwc_connection_uri)
-  );
-}
+type TestResult = { ok: true } | { ok: false; reason: string } | null;
 
-export function LightningAddressCard({ username, wallets }: LightningAddressCardProps) {
+const TEST_AMOUNT_MSAT = 1000; // 1 sat — the minimum a payer could send.
+
+export function LightningAddressCard({ status, isLoading }: LightningAddressCardProps) {
   const [copied, setCopied] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<TestResult>(null);
 
-  if (!username) {
+  if (isLoading) {
+    return (
+      <div className="bg-surface-base rounded-lg border border-default p-4 sm:p-6">
+        <div className="h-5 w-48 animate-pulse rounded bg-surface-raised" />
+        <div className="mt-3 h-9 w-72 max-w-full animate-pulse rounded bg-surface-raised" />
+      </div>
+    );
+  }
+
+  // No status (request failed) or no username yet: claim nothing at all.
+  if (!status?.lightningAddress) {
     return null;
   }
 
-  const address = `${username}@${APP_DOMAIN}`;
-  const active = hasLightningCapableWallet(wallets);
+  const { lightningAddress, lightningAddressActive, rail, unusableConnectionWalletIds } = status;
+  const hasUnusableConnection = unusableConnectionWalletIds.length > 0;
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(address);
+      await navigator.clipboard.writeText(lightningAddress);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Clipboard unavailable (permissions/insecure context) — nothing to do.
+      // Clipboard unavailable (permissions / insecure context) — nothing to do.
+    }
+  };
+
+  /** Mint a real invoice through the public LNURL callback — no payment occurs. */
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const res = await fetch(
+        `/api/lnurlp/${encodeURIComponent(status.username ?? '')}/callback?amount=${TEST_AMOUNT_MSAT}`
+      );
+      const body = (await res.json()) as { pr?: string; status?: string; reason?: string };
+      setTestResult(
+        body.pr
+          ? { ok: true }
+          : { ok: false, reason: body.reason || 'Your wallet did not return an invoice.' }
+      );
+    } catch {
+      setTestResult({ ok: false, reason: 'Could not reach your wallet just now.' });
+    } finally {
+      setTesting(false);
     }
   };
 
@@ -59,16 +84,25 @@ export function LightningAddressCard({ username, wallets }: LightningAddressCard
     <div className="bg-surface-base rounded-lg border border-default p-4 sm:p-6">
       <div className="flex items-start gap-3">
         <div className="mt-0.5 rounded-full bg-surface-raised p-2">
-          <Zap className="h-5 w-5 text-bitcoinOrange" aria-hidden="true" />
+          <Zap
+            className={lightningAddressActive ? 'h-5 w-5 text-bitcoinOrange' : 'h-5 w-5 text-fg-secondary'}
+            aria-hidden="true"
+          />
         </div>
+
         <div className="min-w-0 flex-1">
           <h3 className="text-sm font-semibold text-fg-primary">Your Lightning address</h3>
-          {active ? (
-            <>
-              <div className="mt-2 flex items-center gap-2">
-                <code className="truncate rounded bg-surface-raised px-2 py-1 font-mono text-sm text-fg-primary">
-                  {address}
-                </code>
+
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <code
+              className={`truncate rounded bg-surface-raised px-2 py-1 font-mono text-sm ${
+                lightningAddressActive ? 'text-fg-primary' : 'text-fg-secondary line-through'
+              }`}
+            >
+              {lightningAddress}
+            </code>
+            {lightningAddressActive && (
+              <>
                 <button
                   type="button"
                   onClick={handleCopy}
@@ -81,17 +115,51 @@ export function LightningAddressCard({ username, wallets }: LightningAddressCard
                     <Copy className="h-4 w-4" aria-hidden="true" />
                   )}
                 </button>
-              </div>
-              <p className="mt-2 text-xs text-fg-secondary">
-                Share it anywhere — payments arrive directly in your own wallet. OrangeCat never
-                holds your funds.
-              </p>
-            </>
+                <button
+                  type="button"
+                  onClick={handleTest}
+                  disabled={testing}
+                  className="flex min-h-11 items-center rounded-md border border-default px-3 text-sm text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary disabled:opacity-60"
+                >
+                  {testing ? 'Testing…' : 'Test it'}
+                </button>
+              </>
+            )}
+          </div>
+
+          {lightningAddressActive ? (
+            <p className="mt-2 text-xs text-fg-secondary">
+              Payments arrive directly in your own wallet — OrangeCat never holds your funds.
+            </p>
           ) : (
-            <p className="mt-1 text-sm text-fg-secondary">
-              <span className="font-mono">{address}</span> activates once you add a Lightning
-              wallet below (a Lightning address or wallet connection). On-chain-only wallets
-              can&apos;t receive Lightning payments.
+            <p className="mt-2 text-sm text-fg-secondary">
+              {rail === 'onchain'
+                ? 'Not active yet. Your active wallet only has an on-chain Bitcoin address, which can’t answer Lightning payments. Add a Lightning address or connect a Lightning wallet below to switch it on.'
+                : 'Not active yet. Add a wallet below that can receive Lightning — a Lightning address or a wallet connection — and this address starts working.'}
+            </p>
+          )}
+
+          {/* Verified fact, not a claim: the result of a real invoice request. */}
+          {testResult?.ok === true && (
+            <p className="mt-2 flex items-center gap-1.5 text-xs text-status-positive">
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+              Verified just now — your wallet issued a real invoice. Nothing was paid.
+            </p>
+          )}
+          {testResult?.ok === false && (
+            <p className="mt-2 flex items-start gap-1.5 text-xs text-status-negative">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+              <span>Test failed: {testResult.reason}</span>
+            </p>
+          )}
+
+          {hasUnusableConnection && (
+            <p className="mt-3 flex items-start gap-1.5 rounded-md bg-surface-raised p-2 text-xs text-status-warning">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+              <span>
+                A connected wallet below can’t be used by this deployment, so payments skip it.
+                Reconnect it to use Lightning.
+              </span>
             </p>
           )}
         </div>

--- a/src/components/wallets/WalletManager/components/WalletCard.tsx
+++ b/src/components/wallets/WalletManager/components/WalletCard.tsx
@@ -3,7 +3,7 @@
  * Displays a single wallet with balance, actions, and address
  */
 
-import { Pencil, Trash2, Star, RefreshCw, Copy } from 'lucide-react';
+import { Pencil, Trash2, Star, RefreshCw, Copy, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 import { WALLET_CATEGORIES } from '@/types/wallet';
 import { WalletForm } from './WalletForm';
@@ -21,6 +21,7 @@ export function WalletCard({
   onDelete,
   onRefresh,
   onFieldFocus,
+  isConnectionUnusable = false,
 }: WalletCardProps) {
   if (isEditing && isOwner) {
     return (
@@ -47,6 +48,12 @@ export function WalletCard({
   const categoryInfo = WALLET_CATEGORIES[wallet.category];
   const progressPercent = wallet.goal_amount ? (wallet.balance_btc / wallet.goal_amount) * 100 : 0;
 
+  // Balance is read from the blockchain against `address_or_xpub`. A Lightning
+  // or connection-only wallet has no such address, so its stored balance is
+  // structurally always 0 — rendering "Current Balance 0 BTC" there states a
+  // fact we never measured. Show the balance only where it is actually tracked.
+  const tracksOnChainBalance = !!wallet.address_or_xpub;
+
   // The public receive handle to show + copy. A wallet may have an on-chain
   // address, a Lightning address, or only a wallet connection (NWC — no public
   // handle). Handle all three so a Lightning/NWC-only wallet renders instead of
@@ -65,7 +72,9 @@ export function WalletCard({
         }
       : {
           label: 'Connected wallet',
-          display: 'Auto-receive via a connected wallet',
+          display: isConnectionUnusable
+            ? 'Connection unavailable — payments skip this wallet'
+            : 'Receives Lightning payments via the connected wallet',
           copyValue: null as string | null,
         };
 
@@ -148,33 +157,37 @@ export function WalletCard({
         )}
       </div>
 
-      {/* Balance */}
-      <div className="bg-surface-raised rounded-lg p-3 sm:p-4 mb-4">
-        <div className="flex items-center justify-between mb-2">
-          <span className="text-sm font-medium text-fg-primary">Current Balance</span>
-          {isOwner && wallet.balance_updated_at && (
-            <button
-              onClick={onRefresh}
-              className="p-1.5 rounded-md hover:bg-surface-overlay dark:hover:bg-surface-raised/50 text-fg-secondary hover:text-fg-primary transition-colors min-h-11 min-w-11 flex items-center justify-center"
-              title="Refresh balance"
-              aria-label="Refresh balance"
-            >
-              <RefreshCw className="w-4 h-4" />
-            </button>
-          )}
-        </div>
-        <div className="text-2xl sm:text-3xl font-bold text-bitcoinOrange">
-          {displayBTC(wallet.balance_btc)}
-        </div>
-        {wallet.balance_updated_at && (
-          <div className="text-xs text-fg-secondary mt-2">
-            Updated {new Date(wallet.balance_updated_at).toLocaleString()}
+      {/* Balance — on-chain wallets only (see tracksOnChainBalance) */}
+      {tracksOnChainBalance && (
+        <div className="bg-surface-raised rounded-lg p-3 sm:p-4 mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium text-fg-primary">Current Balance</span>
+            {/* Refresh was previously gated on balance_updated_at, so a wallet
+                that had never been checked offered no way to check it. */}
+            {isOwner && (
+              <button
+                onClick={onRefresh}
+                className="p-1.5 rounded-md hover:bg-surface-overlay dark:hover:bg-surface-raised/50 text-fg-secondary hover:text-fg-primary transition-colors min-h-11 min-w-11 flex items-center justify-center"
+                title="Refresh balance"
+                aria-label="Refresh balance"
+              >
+                <RefreshCw className="w-4 h-4" />
+              </button>
+            )}
           </div>
-        )}
-      </div>
+          <div className="text-2xl sm:text-3xl font-bold text-bitcoinOrange">
+            {displayBTC(wallet.balance_btc)}
+          </div>
+          <div className="text-xs text-fg-secondary mt-2">
+            {wallet.balance_updated_at
+              ? `Updated ${new Date(wallet.balance_updated_at).toLocaleString()}`
+              : 'Not checked yet — refresh to read it from the blockchain'}
+          </div>
+        </div>
+      )}
 
-      {/* Goal progress */}
-      {wallet.goal_amount && (
+      {/* Goal progress — tracked from the on-chain balance, so same condition */}
+      {tracksOnChainBalance && wallet.goal_amount && (
         <div className="mb-4">
           <div className="flex justify-between text-sm mb-2">
             <span className="text-fg-secondary font-medium">Goal</span>
@@ -194,6 +207,15 @@ export function WalletCard({
 
       {/* Receive handle (address / lightning / connection) */}
       <div className="pt-4 border-t border-default">
+        {isConnectionUnusable && (
+          <p className="mb-3 flex items-start gap-1.5 rounded-md bg-surface-raised p-2 text-xs text-status-warning">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+            <span>
+              This connection can’t be used by OrangeCat, so incoming payments skip this wallet.
+              Edit it and paste the connection string again.
+            </span>
+          </p>
+        )}
         <div className="flex items-center justify-between mb-2">
           <span className="text-xs font-medium text-fg-secondary">{receiveHandle.label}</span>
           {receiveHandle.copyValue && (

--- a/src/components/wallets/WalletManager/index.tsx
+++ b/src/components/wallets/WalletManager/index.tsx
@@ -29,6 +29,7 @@ export function WalletManager({
   maxWallets = 10,
   isOwner = false,
   onFieldFocus,
+  unusableConnectionWalletIds,
 }: WalletManagerProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -109,6 +110,7 @@ export function WalletManager({
               }
             }}
             onFieldFocus={onFieldFocus}
+            isConnectionUnusable={unusableConnectionWalletIds?.includes(wallet.id)}
           />
         ))}
       </div>

--- a/src/components/wallets/WalletManager/types.ts
+++ b/src/components/wallets/WalletManager/types.ts
@@ -16,6 +16,12 @@ export interface WalletManagerProps {
   maxWallets?: number;
   isOwner?: boolean;
   onFieldFocus?: (field: WalletFieldType) => void;
+  /**
+   * Wallets whose stored connection this deployment cannot use — the payment
+   * path silently skips them, so the card must say so instead of implying the
+   * wallet is ready to receive.
+   */
+  unusableConnectionWalletIds?: string[];
 }
 
 export interface WalletCardProps {
@@ -28,6 +34,8 @@ export interface WalletCardProps {
   onDelete: () => void;
   onRefresh: () => Promise<void>;
   onFieldFocus?: (field: WalletFieldType) => void;
+  /** This wallet's stored connection can't be used — payments skip it. */
+  isConnectionUnusable?: boolean;
 }
 
 export interface WalletFormProps {

--- a/src/domain/lightning-address/lnurl-service.ts
+++ b/src/domain/lightning-address/lnurl-service.ts
@@ -63,10 +63,17 @@ export async function resolveLnurlRecipient(username: string): Promise<LnurlReci
  */
 export async function resolveLnurlWallet(userId: string): Promise<ResolvedWallet | null> {
   const wallet = await resolveUserWallet(admin(), userId);
-  if (!wallet || wallet.method === 'onchain') {
-    return null;
-  }
-  return wallet;
+  return isLightningCapable(wallet) ? wallet : null;
+}
+
+/**
+ * THE rule for "can this resolved wallet serve a Lightning address" — exported
+ * so owner-facing UI can answer the question with the exact predicate the
+ * public LNURL endpoint uses, instead of guessing from field presence. If these
+ * ever diverge, the wallet page starts lying about whether payments work.
+ */
+export function isLightningCapable(wallet: ResolvedWallet | null): boolean {
+  return !!wallet && wallet.method !== 'onchain';
 }
 
 /** LUD-06/16 metadata array (stringified) shown by the payer's wallet. */

--- a/src/domain/payments/encryptionService.ts
+++ b/src/domain/payments/encryptionService.ts
@@ -47,6 +47,24 @@ export function encrypt(plaintext: string): string {
 /**
  * Decrypt a base64-encoded ciphertext produced by encrypt().
  */
+/**
+ * Can this deployment actually use the stored ciphertext? A stored NWC URI is
+ * useless if the key is missing or was rotated (e.g. written by a dev machine
+ * whose key production doesn't have) — the payment path silently falls back to
+ * another rail, so the UI must be able to detect and disclose it.
+ */
+export function canDecrypt(encoded: string | null | undefined): boolean {
+  if (!encoded) {
+    return false;
+  }
+  try {
+    decrypt(encoded);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function decrypt(encoded: string): string {
   const key = getKey();
   const packed = Buffer.from(encoded, 'base64');

--- a/src/domain/wallets/receiveStatus.ts
+++ b/src/domain/wallets/receiveStatus.ts
@@ -1,0 +1,78 @@
+/**
+ * Owner-facing receive status — "what would actually happen if someone paid me
+ * right now", answered by the SAME resolution the payer's request runs.
+ *
+ * Why this exists: the wallets page used to infer capability from field
+ * presence in the client (`has an nwc_connection_uri` ⇒ "your Lightning address
+ * works"). That is a different question from the one the payment path asks, and
+ * the two silently disagreed in production: a stored NWC URI that this
+ * deployment cannot decrypt resolves to the on-chain rail, which cannot serve a
+ * Lightning address at all. The page claimed "share it anywhere" while
+ * /.well-known/lnurlp/<username> returned an error.
+ *
+ * So: one authority (`resolveUserWallet` + `isLightningCapable`), consumed by
+ * both the public LNURL endpoint and the owner's page. They cannot diverge.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
+import { isLightningCapable } from '@/domain/lightning-address/lnurl-service';
+import { canDecrypt } from '@/domain/payments/encryptionService';
+import type { ResolvedWallet } from '@/domain/payments/types';
+
+export interface OwnerReceiveStatus {
+  /** The rail a payer is actually given today. null = cannot receive at all. */
+  rail: ResolvedWallet['method'] | null;
+  /** Whether <username>@domain can mint invoices — same predicate as LNURL. */
+  lightningAddressActive: boolean;
+  /**
+   * Wallets holding an NWC connection this deployment cannot use. Their owner
+   * believes they are set up for Lightning; the payment path silently skips
+   * them. Surfaced so the UI can say "reconnect" instead of "auto-receive".
+   */
+  unusableConnectionWalletIds: string[];
+}
+
+/**
+ * Resolve the honest receive status for a user. Never throws — on failure it
+ * reports the most conservative answer (cannot receive), because claiming a
+ * working payment rail we could not verify is the failure mode this module
+ * exists to prevent.
+ */
+export async function getOwnerReceiveStatus(userId: string): Promise<OwnerReceiveStatus> {
+  const admin = getAdminClient() as unknown as SupabaseClient;
+
+  const [wallet, unusableConnectionWalletIds] = await Promise.all([
+    resolveUserWallet(admin, userId).catch(() => null),
+    findUnusableConnections(admin, userId),
+  ]);
+
+  return {
+    rail: wallet?.method ?? null,
+    lightningAddressActive: isLightningCapable(wallet),
+    unusableConnectionWalletIds,
+  };
+}
+
+/**
+ * Probe each active wallet's stored NWC URI. Mirrors the filter
+ * `resolveUserWallet` uses, so "unusable" here means exactly "the payment path
+ * will skip this". Decryption happens server-side and the plaintext is dropped
+ * immediately — it is never returned or logged.
+ */
+async function findUnusableConnections(
+  admin: SupabaseClient,
+  userId: string
+): Promise<string[]> {
+  const { data } = await admin
+    .from(DATABASE_TABLES.WALLETS)
+    .select('id, nwc_connection_uri')
+    .eq('profile_id', userId)
+    .eq('is_active', true)
+    .not('nwc_connection_uri', 'is', null);
+
+  const rows = (data ?? []) as Array<{ id: string; nwc_connection_uri: string | null }>;
+  return rows.filter(row => !canDecrypt(row.nwc_connection_uri)).map(row => row.id);
+}

--- a/src/lib/wallet-guidance.ts
+++ b/src/lib/wallet-guidance.ts
@@ -138,11 +138,11 @@ export const walletGuidanceContent: Record<NonNullable<WalletFieldType>, FieldGu
 export const walletDefaultContent: DefaultContent = {
   title: 'What is a Wallet on OrangeCat?',
   description:
-    'A wallet on OrangeCat is a funding bucket connected to your own Bitcoin wallet. Each wallet can represent a concrete need such as rent, food, or a savings goal.',
+    'A wallet on OrangeCat is how you get paid: a pointer to a Bitcoin wallet you already control. Add several when you want to track separate needs — rent, food, or a savings goal.',
   features: [
     {
       icon: React.createElement(Wallet, { className: 'w-4 h-4 text-fg-primary' }),
-      text: 'Connect addresses or xpubs from wallets you control',
+      text: 'A Lightning address gets you paid in seconds and switches on your @orangecat.ch address',
     },
     {
       icon: React.createElement(PiggyBank, { className: 'w-4 h-4 text-fg-primary' }),


### PR DESCRIPTION
Follow-up audit of the page shipped in #494 — it was lying.

**The bug:** the card said *"Share it anywhere — payments arrive directly in your own wallet"* while production returned:
```
GET /.well-known/lnurlp/mao → {"status":"ERROR","reason":"Mao Nakamoto can't receive Lightning payments yet"}
```
The card inferred capability from client-side field presence; the payer path runs `resolveUserWallet` → decrypt → NWC. Two different questions, and they disagreed in production.

## Changes

- **One authority.** `getOwnerReceiveStatus()` + `GET /api/wallets/receive-status` answer "can I be paid, via which rail" using the same resolution a payer runs, via a new exported `isLightningCapable()` predicate shared with the public LNURL route. The page and the endpoint cannot diverge.
- **Verified, not claimed.** The card offers a one-click self-test that mints a real invoice through the public callback and reports the real result. Nothing is paid; the invoice expires.
- **Silent degradation disclosed.** An NWC connection this deployment can't decrypt previously made the payment path fall back to on-chain with zero signal. Now flagged on both the address card and the wallet card.
- **No unmeasured numbers.** "Current Balance 0 BTC" no longer renders on Lightning/connection wallets (balance is a chain lookup keyed on `address_or_xpub`, so it was structurally always 0). Refresh no longer gated on `balance_updated_at`, which left a never-checked wallet with no way to check it.
- **Copy.** Dropped "Recommended: use extended public keys" — it contradicted the #481 Lightning-first reframe and the Lightning address advertised three inches above it. Removed two of three overlapping explainers. The Nostr card no longer implies its browser-local NWC enables receiving (it stores to localStorage and never reaches the server).

## Tests
6 new, including the exact production failure: an undecryptable connection must never be reported as a working Lightning setup, and resolution failure fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)