### PR TITLE
fix(ai-prefill): make AI edits actually change already-filled fields

### DIFF
--- a/__tests__/manual/live-prefill-refine.test.ts
+++ b/__tests__/manual/live-prefill-refine.test.ts
@@ -1,0 +1,66 @@
+/**
+ * MANUAL / LIVE — hits the real AI provider, so it is skipped unless a key is
+ * present and it sits outside the `test:unit` path pattern. The mocked
+ * regression lock lives in `__tests__/unit/lib/ai/form-prefill-refine.test.ts`;
+ * this file exists to prove the model actually obeys the refine prompt.
+ *
+ * Run: npx jest --env=node __tests__/manual/live-prefill-refine.test.ts
+ * (needs GROQ_API_KEY or OPENROUTER_API_KEY in the environment)
+ */
+
+import { generateFormPrefill } from '@/lib/ai/form-prefill-service';
+import { getEntityConfig } from '@/config/entity-configs/get-config';
+
+const hasProviderKey = Boolean(process.env.GROQ_API_KEY || process.env.OPENROUTER_API_KEY);
+const describeLive = hasProviderKey ? describe : describe.skip;
+
+const CURRENT_FORM = {
+  title: 'Photography',
+  description: 'I offer photography.',
+  category: 'Photography',
+  pricing_model: 'hourly',
+  hourly_rate: 50,
+  currency: 'CHF',
+};
+
+const INSTRUCTION = 'make description longer and in english and german';
+
+describeLive('LIVE: the exact reported refinement', () => {
+  it('rewrites the description longer and bilingually', async () => {
+    const config = getEntityConfig('service');
+    const result = await generateFormPrefill(
+      'service',
+      INSTRUCTION,
+      config!,
+      CURRENT_FORM,
+      undefined,
+      'refine'
+    );
+
+    // eslint-disable-next-line no-console
+    console.log('\n=== REFINE RESULT ===\n', JSON.stringify(result, null, 2), '\n');
+
+    expect(result.success).toBe(true);
+    const description = String(result.data.description ?? '');
+    expect(description).not.toBe(CURRENT_FORM.description);
+    expect(description.length).toBeGreaterThan(CURRENT_FORM.description.length * 3);
+    // German half present (umlaut or a common German word)
+    expect(description).toMatch(/\b(ich|biete|und|für|Fotografie|Dienstleistung)\b/i);
+  }, 60000);
+
+  it('shows generate mode would still have preserved the old value', async () => {
+    const config = getEntityConfig('service');
+    const result = await generateFormPrefill(
+      'service',
+      INSTRUCTION,
+      config!,
+      CURRENT_FORM,
+      undefined,
+      'generate'
+    );
+
+    // eslint-disable-next-line no-console
+    console.log('\n=== GENERATE RESULT (old behaviour) ===\n', JSON.stringify(result.data), '\n');
+    expect(result.data.description).toBe(CURRENT_FORM.description);
+  }, 60000);
+});

--- a/__tests__/unit/lib/ai/form-prefill-refine.test.ts
+++ b/__tests__/unit/lib/ai/form-prefill-refine.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression lock: AI form prefill must be able to CHANGE fields that are
+ * already filled.
+ *
+ * The reported failure: on the Create Service form a user typed "make
+ * description longer and in english and german". The UI reported "AI filled the
+ * form" / "Form updated" and the description stayed "I offer photography."
+ *
+ * Two independent causes, both locked here:
+ *  1. the service re-applied every non-empty existing value ON TOP of the AI's
+ *     output, so a refinement could never change a filled field;
+ *  2. the prompt told the model to "Preserve these existing values (do not
+ *     overwrite)" — including the very field the user asked to rewrite.
+ */
+
+import { generateFormPrefill } from '@/lib/ai/form-prefill-service';
+import { getSystemPrompt, getUserPrompt } from '@/lib/ai/prompts/form-prefill';
+import { PREFILL_MIN_INPUT_LENGTH } from '@/config/ai-prefill';
+import type { EntityConfig } from '@/components/create/types';
+
+const ENTITY_CONFIG = {
+  fieldGroups: [
+    {
+      id: 'basic',
+      title: 'Basic Information',
+      fields: [
+        { name: 'title', label: 'Service Title', type: 'text', required: true },
+        { name: 'description', label: 'Description', type: 'textarea' },
+      ],
+    },
+  ],
+} as unknown as EntityConfig;
+
+const CURRENT_FORM = {
+  title: 'Photography',
+  description: 'I offer photography.',
+  category: 'Photography',
+  hourly_rate: 50,
+  currency: 'CHF',
+};
+
+const LONGER_BILINGUAL = [
+  'I offer professional photography for portraits, events and products.',
+  'Ich biete professionelle Fotografie für Porträts, Events und Produkte an.',
+].join('\n\n');
+
+function mockAIResponse(data: Record<string, unknown>) {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      choices: [{ message: { content: JSON.stringify({ data, confidence: {} }) } }],
+    }),
+  });
+}
+
+/** The user prompt sent to the model on the most recent call. */
+function sentUserPrompt(fetchMock: jest.Mock): string {
+  const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+  return body.messages.find((m: { role: string }) => m.role === 'user').content;
+}
+
+describe('AI form prefill — refine mode', () => {
+  const originalFetch = global.fetch;
+  const originalGroqKey = process.env.GROQ_API_KEY;
+
+  beforeEach(() => {
+    process.env.GROQ_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.GROQ_API_KEY = originalGroqKey;
+    jest.restoreAllMocks();
+  });
+
+  it('returns the AI rewrite of a field that is already filled', async () => {
+    const fetchMock = mockAIResponse({ description: LONGER_BILINGUAL });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await generateFormPrefill(
+      'service',
+      'make description longer and in english and german',
+      ENTITY_CONFIG,
+      CURRENT_FORM,
+      undefined,
+      'refine'
+    );
+
+    expect(result.success).toBe(true);
+    // The whole point: the old value must NOT come back.
+    expect(result.data.description).toBe(LONGER_BILINGUAL);
+    expect(result.data.description).not.toBe(CURRENT_FORM.description);
+  });
+
+  it('does not resurrect existing values for fields the AI rewrote', async () => {
+    const fetchMock = mockAIResponse({ title: 'Professional Photography', hourly_rate: 90 });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await generateFormPrefill(
+      'service',
+      'better title, raise the rate to 90',
+      ENTITY_CONFIG,
+      CURRENT_FORM,
+      undefined,
+      'refine'
+    );
+
+    expect(result.data).toEqual({ title: 'Professional Photography', hourly_rate: 90 });
+    // Untouched fields are simply absent — the client merges them over form state.
+    expect(result.data).not.toHaveProperty('category');
+  });
+
+  it('accepts a short instruction that generate mode would reject', async () => {
+    const fetchMock = mockAIResponse({ title: 'Photos' });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const shortInstruction = 'shorter';
+    expect(shortInstruction.length).toBeLessThan(PREFILL_MIN_INPUT_LENGTH.generate);
+
+    const refined = await generateFormPrefill(
+      'service',
+      shortInstruction,
+      ENTITY_CONFIG,
+      CURRENT_FORM,
+      undefined,
+      'refine'
+    );
+    expect(refined.success).toBe(true);
+
+    const generated = await generateFormPrefill(
+      'service',
+      shortInstruction,
+      ENTITY_CONFIG,
+      CURRENT_FORM,
+      undefined,
+      'generate'
+    );
+    expect(generated.success).toBe(false);
+  });
+
+  it('sends the current values as context, never as a preservation lock', async () => {
+    const fetchMock = mockAIResponse({ description: LONGER_BILINGUAL });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await generateFormPrefill(
+      'service',
+      'make description longer and in english and german',
+      ENTITY_CONFIG,
+      CURRENT_FORM,
+      undefined,
+      'refine'
+    );
+
+    const prompt = sentUserPrompt(fetchMock);
+    expect(prompt).toContain('I offer photography.');
+    expect(prompt).not.toMatch(/do not overwrite/i);
+    expect(prompt).not.toMatch(/preserve these existing values/i);
+  });
+});
+
+describe('AI form prefill — generate mode still protects typed input', () => {
+  const originalFetch = global.fetch;
+  const originalGroqKey = process.env.GROQ_API_KEY;
+
+  beforeEach(() => {
+    process.env.GROQ_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.GROQ_API_KEY = originalGroqKey;
+  });
+
+  it('keeps a value the user typed rather than the AI-generated one', async () => {
+    const fetchMock = mockAIResponse({ title: 'AI Title', description: 'AI description' });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await generateFormPrefill(
+      'service',
+      'I photograph weddings around Zurich, 50 CHF per hour',
+      ENTITY_CONFIG,
+      { title: 'My own title' },
+      undefined,
+      'generate'
+    );
+
+    expect(result.data.title).toBe('My own title');
+    expect(result.data.description).toBe('AI description');
+  });
+
+  it('defaults to generate when no mode is given (back-compat)', async () => {
+    const fetchMock = mockAIResponse({ title: 'AI Title' });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await generateFormPrefill(
+      'service',
+      'I photograph weddings around Zurich, 50 CHF per hour',
+      ENTITY_CONFIG,
+      { title: 'My own title' }
+    );
+
+    expect(result.data.title).toBe('My own title');
+  });
+});
+
+describe('AI form prefill prompts', () => {
+  it('tells the model to overwrite in refine mode', () => {
+    const system = getSystemPrompt('service', 'refine');
+    expect(system).toMatch(/overwrite existing values/i);
+    expect(system).not.toMatch(/Do not make up information/i);
+  });
+
+  it('keeps extraction semantics in generate mode', () => {
+    const system = getSystemPrompt('service', 'generate');
+    expect(system).toMatch(/extract structured data/i);
+    expect(system).toMatch(/Do not make up information/i);
+  });
+
+  it('honours explicit language and length instructions in refine mode', () => {
+    const system = getSystemPrompt('service', 'refine');
+    expect(system).toMatch(/languages are named/i);
+    expect(system).toMatch(/substantially expand/i);
+  });
+
+  it('shows current values without a preserve instruction in refine mode', () => {
+    const prompt = getUserPrompt(
+      'service',
+      'make the description longer',
+      '- description (textarea): Description',
+      '',
+      CURRENT_FORM,
+      'refine'
+    );
+
+    expect(prompt).toContain('I offer photography.');
+    // Prices are context in refine mode too — the instruction may target them.
+    expect(prompt).toContain('50');
+    expect(prompt).not.toMatch(/do not overwrite/i);
+  });
+
+  it('still asks generate mode to preserve filled fields', () => {
+    const prompt = getUserPrompt(
+      'service',
+      'I photograph weddings around Zurich',
+      '- description (textarea): Description',
+      '',
+      { title: 'My own title' },
+      'generate'
+    );
+
+    expect(prompt).toMatch(/do not overwrite/i);
+    expect(prompt).toContain('My own title');
+  });
+});

--- a/src/app/api/ai/form-prefill/route.ts
+++ b/src/app/api/ai/form-prefill/route.ts
@@ -21,17 +21,43 @@ import { NextResponse } from 'next/server';
 import { generateFormPrefill } from '@/lib/ai/form-prefill-service';
 import { getEntityConfig } from '@/config/entity-configs/get-config';
 import { isValidEntityType, type EntityType } from '@/config/entity-registry';
+import {
+  DEFAULT_PREFILL_MODE,
+  PREFILL_MIN_INPUT_LENGTH,
+  PREFILL_MODES,
+  type PrefillMode,
+} from '@/config/ai-prefill';
 import { logger } from '@/utils/logger';
 import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 
 /**
  * Request validation schema
+ *
+ * `mode` distinguishes filling an empty form from editing a filled one. It
+ * defaults to `generate` so older clients keep their existing behaviour.
+ * The length floor is per-mode: refinement instructions ("shorter", "in German
+ * too") are legitimately short and were being rejected by a flat 10-char rule.
  */
-const requestSchema = z.object({
-  entityType: z.string().min(1, 'Entity type is required'),
-  description: z.string().min(10, 'Description must be at least 10 characters'),
-  existingData: z.record(z.unknown()).optional(),
-});
+const requestSchema = z
+  .object({
+    entityType: z.string().min(1, 'Entity type is required'),
+    description: z.string().min(1, 'Description is required'),
+    existingData: z.record(z.unknown()).optional(),
+    mode: z.enum(PREFILL_MODES as unknown as [PrefillMode, ...PrefillMode[]]).optional(),
+  })
+  .superRefine((value, ctx) => {
+    const min = PREFILL_MIN_INPUT_LENGTH[value.mode ?? DEFAULT_PREFILL_MODE];
+    if (value.description.trim().length < min) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.too_small,
+        minimum: min,
+        type: 'string',
+        inclusive: true,
+        path: ['description'],
+        message: `Must be at least ${min} characters`,
+      });
+    }
+  });
 
 /**
  * POST /api/ai/form-prefill
@@ -58,6 +84,7 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
     }
 
     const { entityType, description, existingData } = parseResult.data;
+    const mode: PrefillMode = parseResult.data.mode ?? DEFAULT_PREFILL_MODE;
 
     // Validate entity type
     if (!isValidEntityType(entityType)) {
@@ -75,13 +102,21 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
       {
         userId: user.id,
         entityType,
+        mode,
         descriptionLength: description.length,
       },
       'AI'
     );
 
     // Generate form prefill using AI
-    const result = await generateFormPrefill(entityType, description, entityConfig, existingData);
+    const result = await generateFormPrefill(
+      entityType,
+      description,
+      entityConfig,
+      existingData,
+      undefined,
+      mode
+    );
 
     if (!result.success) {
       logger.warn(
@@ -89,6 +124,7 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
         {
           userId: user.id,
           entityType,
+          mode,
           error: result.error,
         },
         'AI'
@@ -102,6 +138,7 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
       {
         userId: user.id,
         entityType,
+        mode,
         fieldsGenerated: Object.keys(result.data).length,
       },
       'AI'

--- a/src/components/create/AIPrefillBar.tsx
+++ b/src/components/create/AIPrefillBar.tsx
@@ -11,6 +11,23 @@ import Button from '@/components/ui/Button';
 import type { AIPrefillBarProps, AIPrefillResponse } from './types';
 import { getExampleDescriptions } from '@/lib/ai/prompts/form-prefill';
 import type { EntityType } from '@/config/entity-registry';
+import { PREFILL_MIN_INPUT_LENGTH, type PrefillMode } from '@/config/ai-prefill';
+
+/**
+ * Fields whose returned value actually differs from what is in the form.
+ *
+ * A refinement that changes nothing is a failure, not a success — reporting
+ * "Form updated" over an unchanged form is how the original bug stayed
+ * invisible. Values include arrays (tags), so compare structurally.
+ */
+function changedFieldCount(
+  returned: Record<string, unknown>,
+  current: Record<string, unknown> | undefined
+): number {
+  return Object.entries(returned).filter(
+    ([key, value]) => JSON.stringify(current?.[key] ?? null) !== JSON.stringify(value ?? null)
+  ).length;
+}
 
 export function AIPrefillBar({
   entityType,
@@ -38,6 +55,9 @@ export function AIPrefillBar({
   const callAI = useCallback(
     async (prompt: string, isRefinement: boolean) => {
       const setter = isRefinement ? setIsRefining : setIsGenerating;
+      // Editing an existing entity is a refinement even on the first call — the
+      // box asks for "the change you want", not a fresh description.
+      const prefillMode: PrefillMode = isRefinement || isEdit ? 'refine' : 'generate';
       setter(true);
       setError(null);
 
@@ -49,6 +69,7 @@ export function AIPrefillBar({
             entityType,
             description: prompt.trim(),
             existingData,
+            mode: prefillMode,
           }),
         });
 
@@ -63,12 +84,23 @@ export function AIPrefillBar({
           throw new Error(result.error || 'Failed to generate form data');
         }
 
+        const changed = changedFieldCount(result.data, existingData);
+
+        // Never report success over an unchanged form. Keep the instruction in
+        // the box so the user can rephrase instead of retyping it.
+        if (prefillMode === 'refine' && changed === 0) {
+          setError(
+            "AI couldn't apply that change — try naming the field, e.g. \"rewrite the description in English and German\"."
+          );
+          return;
+        }
+
         onPrefill(result.data, result.confidence);
         setHasFilled(true);
 
         if (isRefinement) {
           setRefineInput('');
-          toast.success('Form updated');
+          toast.success(changed === 1 ? '1 field updated' : `${changed} fields updated`);
         } else {
           toast.success(
             isEdit ? 'Changes applied — review below' : 'Form filled — review and adjust below',
@@ -86,11 +118,12 @@ export function AIPrefillBar({
   );
 
   const handleGenerate = useCallback(() => {
-    if (!description.trim() || description.trim().length < 10) {
+    const min = PREFILL_MIN_INPUT_LENGTH[isEdit ? 'refine' : 'generate'];
+    if (description.trim().length < min) {
       setError(
         isEdit
-          ? 'Please describe the change you want (at least 10 characters)'
-          : 'Please describe what you want to create (at least 10 characters)'
+          ? `Please describe the change you want (at least ${min} characters)`
+          : `Please describe what you want to create (at least ${min} characters)`
       );
       return;
     }
@@ -98,7 +131,7 @@ export function AIPrefillBar({
   }, [description, callAI, isEdit]);
 
   const handleRefine = useCallback(() => {
-    if (!refineInput.trim()) {
+    if (refineInput.trim().length < PREFILL_MIN_INPUT_LENGTH.refine) {
       return;
     }
     callAI(refineInput, true);

--- a/src/components/create/types.ts
+++ b/src/components/create/types.ts
@@ -20,6 +20,7 @@ import { ReactNode, ComponentType } from 'react';
 import { LucideIcon } from 'lucide-react';
 import { ZodType, ZodTypeDef } from 'zod';
 import type { EntityType } from '@/config/entity-registry';
+import type { PrefillMode } from '@/config/ai-prefill';
 
 // ==================== FIELD TYPES ====================
 
@@ -359,10 +360,15 @@ export interface UseTemplateSelectionReturn<T extends Record<string, unknown>> {
 export interface AIPrefillRequest {
   /** Entity type to generate fields for */
   entityType: string;
-  /** User's natural language description */
+  /** User's natural language description (generate) or edit instruction (refine) */
   description: string;
-  /** Any fields already filled (to preserve user input) */
+  /**
+   * Fields already filled. In `generate` these are preserved; in `refine` they
+   * are the values the instruction operates on and may be rewritten.
+   */
   existingData?: Record<string, unknown>;
+  /** Which intent this request is. Defaults to `generate`. */
+  mode?: PrefillMode;
 }
 
 /**

--- a/src/config/ai-prefill.ts
+++ b/src/config/ai-prefill.ts
@@ -1,0 +1,42 @@
+/**
+ * AI Form Prefill — configuration SSOT
+ *
+ * The prefill bar serves two genuinely different intents, and conflating them
+ * is what made "make the description longer" a silent no-op: the refinement was
+ * treated as a fresh description, and every already-filled field was force-kept.
+ *
+ *  - `generate`: the user describes what they want to create. Fields they typed
+ *    themselves are sacred — AI output must never clobber them.
+ *  - `refine`:   the user issues an instruction against the form as it stands.
+ *    Already-filled fields are exactly what the instruction is about, so AI
+ *    output MUST win. Preserving them here defeats the whole feature.
+ */
+
+export type PrefillMode = 'generate' | 'refine';
+
+export const PREFILL_MODES: readonly PrefillMode[] = ['generate', 'refine'] as const;
+
+export const DEFAULT_PREFILL_MODE: PrefillMode = 'generate';
+
+/**
+ * Minimum length of the user's input, per mode.
+ *
+ * A first description needs enough substance for the AI to extract fields from.
+ * A refinement is an instruction, and useful ones are short ("shorter", "in
+ * German too") — holding them to the same floor rejected valid instructions.
+ */
+export const PREFILL_MIN_INPUT_LENGTH: Record<PrefillMode, number> = {
+  generate: 10,
+  refine: 2,
+};
+
+/**
+ * Token ceiling for the AI response. Refinements like "longer, in English and
+ * German" legitimately produce long field values; too low a ceiling truncates
+ * the JSON mid-string and surfaces as "Could not parse AI response".
+ */
+export const PREFILL_MAX_TOKENS = 2000;
+
+export function isPrefillMode(value: unknown): value is PrefillMode {
+  return typeof value === 'string' && (PREFILL_MODES as readonly string[]).includes(value);
+}

--- a/src/lib/ai/form-prefill-service.ts
+++ b/src/lib/ai/form-prefill-service.ts
@@ -7,6 +7,12 @@
 
 import type { EntityType } from '@/config/entity-registry';
 import { isValidEntityType } from '@/config/entity-registry';
+import {
+  DEFAULT_PREFILL_MODE,
+  PREFILL_MAX_TOKENS,
+  PREFILL_MIN_INPUT_LENGTH,
+  type PrefillMode,
+} from '@/config/ai-prefill';
 import type { AIPrefillResponse, EntityConfig } from '@/components/create/types';
 import { logger } from '@/utils/logger';
 import {
@@ -44,7 +50,8 @@ export async function generateFormPrefill(
   description: string,
   entityConfig: EntityConfig,
   existingData?: Record<string, unknown>,
-  config?: FormPrefillConfig
+  config?: FormPrefillConfig,
+  mode: PrefillMode = DEFAULT_PREFILL_MODE
 ): Promise<AIPrefillResponse> {
   // Validate entity type
   if (!isValidEntityType(entityType)) {
@@ -56,13 +63,17 @@ export async function generateFormPrefill(
     };
   }
 
-  // Validate description
-  if (!description || description.trim().length < 10) {
+  // Validate input length (a refinement instruction is legitimately short)
+  const minLength = PREFILL_MIN_INPUT_LENGTH[mode];
+  if (!description || description.trim().length < minLength) {
     return {
       success: false,
       data: {},
       confidence: {},
-      error: 'Please provide a longer description (at least 10 characters)',
+      error:
+        mode === 'refine'
+          ? `Please describe the change you want (at least ${minLength} characters)`
+          : `Please provide a longer description (at least ${minLength} characters)`,
     };
   }
 
@@ -73,13 +84,14 @@ export async function generateFormPrefill(
     const specialInstructions = getSpecialFieldInstructions(entityType as EntityType);
 
     // Build prompts
-    const systemPrompt = getSystemPrompt(entityType as EntityType);
+    const systemPrompt = getSystemPrompt(entityType as EntityType, mode);
     const userPrompt = getUserPrompt(
       entityType as EntityType,
       description,
       fieldsPrompt,
       specialInstructions,
-      existingData
+      existingData,
+      mode
     );
 
     // Determine provider: Groq first, OpenRouter fallback
@@ -123,7 +135,7 @@ export async function generateFormPrefill(
           { role: 'user', content: userPrompt },
         ],
         temperature: config?.temperature ?? 0.3,
-        max_tokens: config?.maxTokens ?? 1000,
+        max_tokens: config?.maxTokens ?? PREFILL_MAX_TOKENS,
         ...(useGroq ? {} : { response_format: { type: 'json_object' } }),
       }),
     });
@@ -163,7 +175,19 @@ export async function generateFormPrefill(
       };
     }
 
-    // Merge with existing data (preserve user's input)
+    // In `refine` the user's instruction IS a request to change filled fields,
+    // so the AI's values are returned untouched. Re-applying existingData here
+    // (as generate does) silently reverted every edit — "make the description
+    // longer" came back as the original description, with a success toast.
+    if (mode === 'refine') {
+      return {
+        success: true,
+        data: parsed.data,
+        confidence: parsed.confidence,
+      };
+    }
+
+    // In `generate` the user typed those values themselves; never clobber them.
     const mergedData = { ...parsed.data };
     if (existingData) {
       for (const [key, value] of Object.entries(existingData)) {

--- a/src/lib/ai/prompts/form-prefill.ts
+++ b/src/lib/ai/prompts/form-prefill.ts
@@ -6,34 +6,16 @@
 
 import type { EntityType } from '@/config/entity-registry';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
+import { DEFAULT_PREFILL_MODE, type PrefillMode } from '@/config/ai-prefill';
 import { logger } from '@/utils/logger';
 
-/**
- * System prompt for form prefill AI
- */
-export function getSystemPrompt(entityType: EntityType): string {
-  const meta = ENTITY_REGISTRY[entityType];
-  const entityName = meta?.name || entityType;
-
-  return `You are a helpful assistant for OrangeCat, an AI-powered platform for economic activity.
-
-Your task is to extract structured data from a user's natural language description to help them create a ${entityName} listing.
-
-IMPORTANT CONTEXT:
+const BITCOIN_CONTEXT = `IMPORTANT CONTEXT:
 - OrangeCat settles payments in Bitcoin/Lightning; fiat currencies are for pricing and display only
 - Express Bitcoin amounts in BTC (e.g., 0.001 BTC) EVERYWHERE — in prices and in any title/description text. NEVER write "sats" or "satoshis"; rephrase to BTC even if the user's description used sats.
 - Keep fiat prices in their original currency (CHF, USD, EUR, etc.)
-- Price examples: "0.001 BTC", "CHF 50", "$25", "€100"
+- Price examples: "0.001 BTC", "CHF 50", "$25", "€100"`;
 
-RULES:
-1. Only output valid JSON - no markdown, no explanations
-2. Only include fields you can confidently extract from the description
-3. Include a "confidence" object with scores (0-1) for each field
-4. Do not make up information not in the description
-5. For unclear values, omit them rather than guess
-6. Keep prices in the currency the user mentioned — do not convert
-
-OUTPUT FORMAT:
+const OUTPUT_FORMAT = `OUTPUT FORMAT:
 {
   "data": {
     "field_name": "value",
@@ -44,6 +26,62 @@ OUTPUT FORMAT:
     ...
   }
 }`;
+
+/**
+ * System prompt for form prefill AI.
+ *
+ * The two modes are deliberately different instructions, not cosmetic wording.
+ * In `refine` the user is editing values that already exist, so the model is
+ * told to rewrite them — the `generate` rules ("only what you can extract",
+ * "do not make up information") would make an instruction like "make the
+ * description longer" impossible to satisfy.
+ */
+export function getSystemPrompt(
+  entityType: EntityType,
+  mode: PrefillMode = DEFAULT_PREFILL_MODE
+): string {
+  const meta = ENTITY_REGISTRY[entityType];
+  const entityName = meta?.name || entityType;
+
+  if (mode === 'refine') {
+    return `You are a helpful assistant for OrangeCat, an AI-powered platform for economic activity.
+
+The user has a ${entityName} listing form in front of them, already filled in. They will give you an instruction describing how they want it changed. Your task is to APPLY that instruction and return the new values.
+
+${BITCOIN_CONTEXT}
+
+RULES:
+1. Only output valid JSON - no markdown, no explanations
+2. Return ONLY the fields the instruction changes, each with its complete new value (not a diff, not a fragment)
+3. You MUST overwrite existing values when the instruction asks for it — that is the entire point of the request. Never echo a field back unchanged.
+4. Follow the instruction literally, including any request about language, length, tone or detail:
+   - "longer"/"more detail" means substantially expand the text, not reword it
+   - "shorter" means genuinely cut it down
+   - If specific languages are named (e.g. English and German), include ALL of them in the same field value, each version clearly separated
+5. Expanding text is expected to add plausible, concrete detail consistent with the values already in the form. Do not invent facts that contradict them (prices, dates, categories), and never change a field the instruction did not ask about.
+6. Keep prices in the currency already set unless the instruction says otherwise — do not convert
+7. Respect each field's stated constraints and length limits; where no limit is given, keep a description to a few short paragraphs at most
+8. Include a "confidence" object with scores (0-1) for each field you return
+9. If the instruction cannot be applied to any of the available fields, return an empty "data" object rather than guessing
+
+${OUTPUT_FORMAT}`;
+  }
+
+  return `You are a helpful assistant for OrangeCat, an AI-powered platform for economic activity.
+
+Your task is to extract structured data from a user's natural language description to help them create a ${entityName} listing.
+
+${BITCOIN_CONTEXT}
+
+RULES:
+1. Only output valid JSON - no markdown, no explanations
+2. Only include fields you can confidently extract from the description
+3. Include a "confidence" object with scores (0-1) for each field
+4. Do not make up information not in the description
+5. For unclear values, omit them rather than guess
+6. Keep prices in the currency the user mentioned — do not convert
+
+${OUTPUT_FORMAT}`;
 }
 
 /**
@@ -51,14 +89,33 @@ OUTPUT FORMAT:
  */
 export function getUserPrompt(
   entityType: EntityType,
+  userInput: string,
+  fieldsDescription: string,
+  specialInstructions: string,
+  existingData?: Record<string, unknown>,
+  mode: PrefillMode = DEFAULT_PREFILL_MODE
+): string {
+  const meta = ENTITY_REGISTRY[entityType];
+  const entityName = meta?.name || entityType;
+
+  return mode === 'refine'
+    ? buildRefinePrompt(entityName, userInput, fieldsDescription, specialInstructions, existingData)
+    : buildGeneratePrompt(
+        entityName,
+        userInput,
+        fieldsDescription,
+        specialInstructions,
+        existingData
+      );
+}
+
+function buildGeneratePrompt(
+  entityName: string,
   userDescription: string,
   fieldsDescription: string,
   specialInstructions: string,
   existingData?: Record<string, unknown>
 ): string {
-  const meta = ENTITY_REGISTRY[entityType];
-  const entityName = meta?.name || entityType;
-
   let prompt = `I want to create a ${entityName} listing.
 
 Here's my description:
@@ -69,23 +126,65 @@ ${fieldsDescription}
 
 ${specialInstructions ? `Special instructions:\n${specialInstructions}\n` : ''}`;
 
-  if (existingData && Object.keys(existingData).length > 0) {
-    // Price and currency are always overridable — if the user mentions them in their description,
-    // the AI should pick them up rather than keeping template defaults.
-    const userOverridableFields = new Set(['price', 'currency', 'hourly_rate', 'fixed_price']);
-    const nonEmptyData = Object.entries(existingData).filter(
-      ([k, v]) => v !== '' && v !== null && v !== undefined && !userOverridableFields.has(k)
-    );
-    if (nonEmptyData.length > 0) {
-      prompt += `\nPreserve these existing values (do not overwrite):
-${JSON.stringify(Object.fromEntries(nonEmptyData), null, 2)}\n`;
-    }
+  const filled = nonEmptyEntries(existingData, PRICE_FIELDS);
+  if (filled.length > 0) {
+    prompt += `\nPreserve these existing values (do not overwrite):
+${JSON.stringify(Object.fromEntries(filled), null, 2)}\n`;
   }
 
   prompt += `
 Extract the relevant field values from my description. Output ONLY valid JSON with "data" and "confidence" objects.`;
 
   return prompt;
+}
+
+function buildRefinePrompt(
+  entityName: string,
+  instruction: string,
+  fieldsDescription: string,
+  specialInstructions: string,
+  existingData?: Record<string, unknown>
+): string {
+  // Every filled field is shown, prices included: in refine mode the current
+  // values are context for the edit, never a set of values to protect.
+  const current = nonEmptyEntries(existingData);
+
+  return `I am editing my ${entityName} listing.
+
+${
+  current.length > 0
+    ? `These are the values currently in the form:
+${JSON.stringify(Object.fromEntries(current), null, 2)}`
+    : 'The form is currently empty.'
+}
+
+This is what I want you to change:
+"${instruction}"
+
+Available fields for this ${entityName}:
+${fieldsDescription}
+
+${specialInstructions ? `Special instructions:\n${specialInstructions}\n` : ''}
+Apply my instruction to the current values. Output ONLY valid JSON with "data" (every field you changed, each holding its complete new value) and "confidence" objects. Do not include fields my instruction did not ask you to change.`;
+}
+
+/**
+ * Price and currency are always overridable in `generate` — if the user mentions
+ * them in their description, the AI should pick them up rather than keeping
+ * template defaults.
+ */
+const PRICE_FIELDS = new Set(['price', 'currency', 'hourly_rate', 'fixed_price']);
+
+function nonEmptyEntries(
+  data: Record<string, unknown> | undefined,
+  exclude?: Set<string>
+): [string, unknown][] {
+  if (!data) {
+    return [];
+  }
+  return Object.entries(data).filter(
+    ([k, v]) => v !== '' && v !== null && v !== undefined && !exclude?.has(k)
+  );
 }
 
 /**


### PR DESCRIPTION
## The bug

On **Create Service**, the user filled the form with AI, then typed:

> make description longer and in english and german

The UI said **"AI filled the form"**, the toast said **"Form updated"**, and the description stayed `I offer photography.`

## Why it could never have worked

Two independent structural defects, either one sufficient to guarantee a silent no-op:

1. **`form-prefill-service.ts` reverted the AI's work.** After parsing the model's response it looped over `existingData` and re-applied every non-empty value *on top* of the AI output. Any field the user asked to change was deterministically restored to its old value before the response was even returned.

2. **The prompt asked for the opposite of the request.** `getUserPrompt` appended `Preserve these existing values (do not overwrite):` with the very field the instruction targeted. The `generate` system rules ("only include fields you can confidently extract", "do not make up information not in the description") also make *"make it longer"* impossible to satisfy — there is nothing to extract from an edit instruction.

The root cause is one code path serving two different intents.

## The fix — split the intents

New SSOT `src/config/ai-prefill.ts` defines `PrefillMode = 'generate' | 'refine'`, the per-mode input floor, and the token ceiling.

| | `generate` | `refine` |
|---|---|---|
| Input | "what I want to create" | "what I want changed" |
| Existing values | user typed them → **never clobbered** | the subject of the edit → **AI wins** |
| Returns | full merged form | only the fields it changed |
| Min input length | 10 | 2 |

Other changes that fall out of this:

- The refine prompt instructs overwriting and honours explicit **language, length and tone** requests — named languages land together in one field value.
- Short refinements (`"shorter"`, `"in German too"`) were rejected by a flat 10-char floor. Now allowed.
- `max_tokens` 1000 → 2000. A long bilingual value truncated the JSON mid-string, surfacing as *"Could not parse AI response"*.
- **Honest UI.** A refinement that changes zero fields now says it couldn't be applied and keeps the instruction in the box for rephrasing, instead of a green "Form updated" over an unchanged form. On success the toast names how many fields actually changed.

## Never twice

`__tests__/unit/lib/ai/form-prefill-refine.test.ts` — 11 tests locking the class, including the exact reported case (refine must return the rewritten description, not the original), that `generate` still protects user-typed values, that the refine prompt contains no "do not overwrite", and that the no-mode call still behaves as `generate` for back-compat.

## Verification

- `npm run type-check` — clean
- `eslint` on changed files — clean (3 pre-existing warnings on untouched lines)
- Full pre-push gate: **1240 unit tests / 111 suites passed**
- The Cat `tool-executor` call sites create from scratch with no existing data, so they correctly stay on `generate` — unchanged.

**Verified against the live model too.** `__tests__/manual/live-prefill-refine.test.ts` runs the exact reported instruction through the real provider (skipped unless a provider key is set, and outside the `test:unit` path pattern so no suite depends on a live API). Result:

- **refine (fixed)** — `"I offer professional photography services, including portrait, landscape, and event photography… Ich biete professionelle Fotografiedienstleistungen an, einschließlich Porträt-, Landschafts- und Ereignisfotografie…"` — longer, English *and* German, in one description value.
- **generate (the old path)** — still returns `"I offer photography."`, the reverted value. That contrast is the whole bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
