### PR TITLE
fix(ai-form): make "Adjust" actually adjust + form-aware AI suggestions

### DIFF
--- a/__tests__/unit/components/create/AIAssistChip.a11y.test.tsx
+++ b/__tests__/unit/components/create/AIAssistChip.a11y.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * AIAssistChip — the tap target for every AI suggestion.
+ *
+ * These chips are the primary one-tap action on mobile, so the 44px minimum
+ * touch target from the frontend rules is a hard requirement, not styling
+ * taste. The chips this replaced were roughly half that.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AIAssistChip } from '@/components/create/AIAssistChip';
+
+describe('AIAssistChip', () => {
+  it('meets the 44px minimum touch target', () => {
+    render(<AIAssistChip label="Longer description" onClick={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Longer description' })).toHaveClass('min-h-11');
+  });
+
+  it('is a real button, so it is keyboard reachable and not a submit', () => {
+    render(<AIAssistChip label="Better tags" onClick={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Better tags' })).toHaveAttribute('type', 'button');
+  });
+
+  it('is not clickable while disabled', () => {
+    const onClick = jest.fn();
+    render(<AIAssistChip label="Shorter description" onClick={onClick} disabled />);
+
+    const chip = screen.getByRole('button', { name: 'Shorter description' });
+    expect(chip).toBeDisabled();
+    chip.click();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('goes full width on mobile when asked, for long example text', () => {
+    render(<AIAssistChip label="A long starter example…" onClick={jest.fn()} block />);
+
+    expect(screen.getByRole('button', { name: /long starter example/ })).toHaveClass(
+      'w-full',
+      'sm:w-auto'
+    );
+  });
+});

--- a/__tests__/unit/lib/ai-form-assist.test.ts
+++ b/__tests__/unit/lib/ai-form-assist.test.ts
@@ -1,0 +1,162 @@
+/**
+ * AI form assist — merge policy and form-aware adjustments.
+ *
+ * Regression guard for the bug that made "Adjust" useless: existing form
+ * values unconditionally overwrote the AI's output, so asking to rewrite a
+ * non-empty description could never change anything.
+ */
+
+import { mergePrefillResult } from '@/lib/ai/form-prefill-service';
+import {
+  AI_ADJUSTMENTS,
+  AI_ADJUSTMENT_CHIP_LIMIT,
+  USER_OVERRIDABLE_FIELDS,
+  getAdjustmentById,
+  getAdjustmentsForFields,
+  getExampleDescriptions,
+} from '@/config/ai-form-assist';
+import { ENTITY_TYPES, type EntityType } from '@/config/entity-registry';
+
+describe('mergePrefillResult — intent decides who wins', () => {
+  const existing = { title: 'Photography', description: 'I offer photography.', price: 50 };
+
+  describe('intent: refine', () => {
+    it('lets the AI overwrite a field the user already filled', () => {
+      const ai = { description: 'Portrait and event photography for people who hate posing…' };
+
+      const { data, changedFields } = mergePrefillResult(ai, existing, 'refine');
+
+      expect(data.description).toBe(ai.description);
+      expect(changedFields).toEqual(['description']);
+    });
+
+    it('keeps fields the AI did not return', () => {
+      const { data } = mergePrefillResult({ description: 'new' }, existing, 'refine');
+
+      expect(data.title).toBe('Photography');
+      expect(data.price).toBe(50);
+    });
+
+    it('reports nothing changed when the AI echoes the current value', () => {
+      const { changedFields } = mergePrefillResult(
+        { description: existing.description },
+        existing,
+        'refine'
+      );
+
+      expect(changedFields).toEqual([]);
+    });
+
+    it('compares structurally, so an identical array is not a change', () => {
+      const { changedFields } = mergePrefillResult(
+        { tags: ['a', 'b'] },
+        { tags: ['a', 'b'] },
+        'refine'
+      );
+
+      expect(changedFields).toEqual([]);
+    });
+  });
+
+  describe('intent: fill', () => {
+    it('protects what the user typed', () => {
+      const ai = { title: 'AI title', description: 'AI description' };
+
+      const { data, changedFields } = mergePrefillResult(ai, existing, 'fill');
+
+      expect(data.title).toBe('Photography');
+      expect(data.description).toBe('I offer photography.');
+      expect(changedFields).toEqual([]);
+    });
+
+    it('fills fields the user left empty', () => {
+      const { data, changedFields } = mergePrefillResult(
+        { description: 'written copy' },
+        { title: 'Photography', description: '' },
+        'fill'
+      );
+
+      expect(data.description).toBe('written copy');
+      expect(changedFields).toEqual(['description']);
+    });
+
+    it('lets the AI set price and currency over template defaults', () => {
+      const { data, changedFields } = mergePrefillResult(
+        { price: 150, currency: 'CHF' },
+        { price: 0, currency: 'USD' },
+        'fill'
+      );
+
+      expect(data.price).toBe(150);
+      expect(data.currency).toBe('CHF');
+      expect(changedFields).toEqual(expect.arrayContaining(['price', 'currency']));
+      // …and that permission is the one list both the prompt and the merge read
+      expect(USER_OVERRIDABLE_FIELDS).toEqual(
+        expect.arrayContaining(['price', 'currency', 'hourly_rate', 'fixed_price'])
+      );
+    });
+
+    it('works with no existing data at all', () => {
+      const { data, changedFields } = mergePrefillResult({ title: 'x' }, undefined, 'fill');
+
+      expect(data).toEqual({ title: 'x' });
+      expect(changedFields).toEqual(['title']);
+    });
+  });
+});
+
+describe('getAdjustmentsForFields — suggestions follow the actual form', () => {
+  const descriptionField = { name: 'description', label: 'Description', type: 'textarea' } as const;
+  const tagsField = { name: 'tags', label: 'Tags', type: 'tags' } as const;
+
+  it('offers description adjustments only when the form has a description', () => {
+    const withDescription = getAdjustmentsForFields([descriptionField]).map(a => a.id);
+    const withoutDescription = getAdjustmentsForFields([tagsField]).map(a => a.id);
+
+    expect(withDescription).toContain('description-longer');
+    expect(withoutDescription).not.toContain('description-longer');
+  });
+
+  it('matches by field type, not just name', () => {
+    expect(getAdjustmentsForFields([tagsField]).map(a => a.id)).toContain('tags-suggest');
+  });
+
+  it('always offers unscoped adjustments', () => {
+    expect(getAdjustmentsForFields([]).map(a => a.id)).toContain('fill-blanks');
+  });
+
+  it('caps how many chips a form shows', () => {
+    const everyField = AI_ADJUSTMENTS.flatMap(a => [
+      ...(a.appliesTo?.fieldNames ?? []).map(name => ({
+        name,
+        label: name,
+        type: 'text' as const,
+      })),
+      ...(a.appliesTo?.fieldTypes ?? []).map(type => ({ name: type, label: type, type })),
+    ]);
+
+    expect(getAdjustmentsForFields(everyField).length).toBeLessThanOrEqual(
+      AI_ADJUSTMENT_CHIP_LIMIT
+    );
+  });
+
+  it('gives every adjustment a unique id and a non-trivial instruction', () => {
+    const ids = AI_ADJUSTMENTS.map(a => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    for (const adjustment of AI_ADJUSTMENTS) {
+      expect(adjustment.label.length).toBeGreaterThan(0);
+      expect(adjustment.instruction.length).toBeGreaterThan(40);
+      expect(getAdjustmentById(adjustment.id)).toBe(adjustment);
+    }
+  });
+});
+
+describe('getExampleDescriptions — no entity type falls through to nothing', () => {
+  it.each(ENTITY_TYPES.filter(t => t !== 'wallet'))('returns a usable example for %s', type => {
+    const examples = getExampleDescriptions(type as EntityType);
+
+    expect(examples.length).toBeGreaterThan(0);
+    expect(examples[0].length).toBeGreaterThan(10);
+  });
+});

--- a/__tests__/unit/lib/ai-form-assist.test.ts
+++ b/__tests__/unit/lib/ai-form-assist.test.ts
@@ -10,6 +10,7 @@ import { mergePrefillResult } from '@/lib/ai/form-prefill-service';
 import {
   AI_ADJUSTMENTS,
   AI_ADJUSTMENT_CHIP_LIMIT,
+  AI_TRANSLATION_LANGUAGES,
   USER_OVERRIDABLE_FIELDS,
   getAdjustmentById,
   getAdjustmentsForFields,
@@ -123,6 +124,18 @@ describe('getAdjustmentsForFields — suggestions follow the actual form', () =>
 
   it('always offers unscoped adjustments', () => {
     expect(getAdjustmentsForFields([]).map(a => a.id)).toContain('fill-blanks');
+  });
+
+  it('derives a translation adjustment per configured language, not a hardcoded one', () => {
+    const ids = AI_ADJUSTMENTS.map(a => a.id);
+
+    for (const language of AI_TRANSLATION_LANGUAGES) {
+      expect(ids).toContain(`description-translate-${language.label.toLowerCase()}`);
+    }
+    // The primary language is offered up front, within the visible chip budget
+    expect(getAdjustmentsForFields([descriptionField]).map(a => a.id)).toContain(
+      `description-translate-${AI_TRANSLATION_LANGUAGES[0].label.toLowerCase()}`
+    );
   });
 
   it('caps how many chips a form shows', () => {

--- a/src/app/api/ai/form-prefill/route.ts
+++ b/src/app/api/ai/form-prefill/route.ts
@@ -31,6 +31,11 @@ const requestSchema = z.object({
   entityType: z.string().min(1, 'Entity type is required'),
   description: z.string().min(10, 'Description must be at least 10 characters'),
   existingData: z.record(z.unknown()).optional(),
+  /**
+   * `fill` protects what the user already typed; `refine` lets the AI rewrite
+   * it. A refine request that arrives as `fill` can never change anything.
+   */
+  intent: z.enum(['fill', 'refine']).default('fill'),
 });
 
 /**
@@ -57,7 +62,7 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
       return apiValidationError('Invalid request', parseResult.error.flatten().fieldErrors);
     }
 
-    const { entityType, description, existingData } = parseResult.data;
+    const { entityType, description, existingData, intent } = parseResult.data;
 
     // Validate entity type
     if (!isValidEntityType(entityType)) {
@@ -75,13 +80,20 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
       {
         userId: user.id,
         entityType,
+        intent,
         descriptionLength: description.length,
       },
       'AI'
     );
 
     // Generate form prefill using AI
-    const result = await generateFormPrefill(entityType, description, entityConfig, existingData);
+    const result = await generateFormPrefill({
+      entityType,
+      description,
+      entityConfig,
+      existingData,
+      intent,
+    });
 
     if (!result.success) {
       logger.warn(
@@ -102,15 +114,17 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
       {
         userId: user.id,
         entityType,
-        fieldsGenerated: Object.keys(result.data).length,
+        intent,
+        fieldsChanged: result.changedFields?.length ?? 0,
       },
       'AI'
     );
 
-    // Return flat structure — AIPrefillBar reads result.data and result.confidence directly
+    // Return flat structure — AIPrefillBar reads result.data/changedFields/confidence directly
     return NextResponse.json({
       success: true,
       data: result.data,
+      changedFields: result.changedFields ?? [],
       confidence: result.confidence,
     });
   } catch (error) {

--- a/src/components/create/AIAssistChip.tsx
+++ b/src/components/create/AIAssistChip.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface AIAssistChipProps {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  /** Show a spinner on THIS chip — feedback belongs where the finger landed */
+  isLoading?: boolean;
+  /**
+   * Full width on phones, intrinsic from `sm` up. For long text (starter
+   * examples) that would otherwise truncate to an unreadable stub on mobile.
+   */
+  block?: boolean;
+}
+
+/**
+ * One tappable AI suggestion.
+ *
+ * The single definition of a suggestion chip — starter examples and one-click
+ * adjustments render through this, so the touch target and focus ring can
+ * never drift apart between the two. `min-h-11` is the 44px minimum from the
+ * frontend rules; the previous inline chips were roughly half that.
+ */
+export function AIAssistChip({ label, onClick, disabled, isLoading, block }: AIAssistChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'inline-flex min-h-11 items-center gap-1.5 rounded-md border border-subtle bg-surface-page px-3 py-2',
+        'text-left text-sm text-fg-secondary transition-colors touch-manipulation',
+        'hover:bg-surface-raised hover:text-fg-primary',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'disabled:pointer-events-none disabled:opacity-50',
+        block ? 'w-full sm:w-auto sm:max-w-xs' : 'max-w-full'
+      )}
+    >
+      {isLoading && <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />}
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}
+
+export default AIAssistChip;

--- a/src/components/create/AIFillPanel.tsx
+++ b/src/components/create/AIFillPanel.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { Sparkles, Loader2 } from 'lucide-react';
+import Button from '@/components/ui/Button';
+import { AIAssistChip } from './AIAssistChip';
+
+interface AIFillPanelProps {
+  description: string;
+  onDescriptionChange: (value: string) => void;
+  /** Starter descriptions for this entity type — tap instead of composing */
+  examples: string[];
+  onSubmit: () => void;
+  busy: boolean;
+  disabled: boolean;
+}
+
+/**
+ * The empty-form surface: describe what you want, AI fills the fields.
+ *
+ * Mobile-first ordering — the textarea is the ask, examples are the shortcut
+ * for anyone who does not want to compose from scratch, and the CTA is full
+ * width on phones so it is never a thumb-stretch to the corner.
+ */
+export function AIFillPanel({
+  description,
+  onDescriptionChange,
+  examples,
+  onSubmit,
+  busy,
+  disabled,
+}: AIFillPanelProps) {
+  const isBlocked = busy || disabled;
+
+  return (
+    <div className="space-y-3">
+      <textarea
+        value={description}
+        onChange={e => onDescriptionChange(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            onSubmit();
+          }
+        }}
+        placeholder="Describe what you want to create — AI fills the form for you."
+        disabled={isBlocked}
+        rows={3}
+        // text-base on mobile: anything smaller makes iOS zoom in on focus
+        className="block w-full resize-none rounded-md border border-subtle bg-surface-page px-3 py-2 text-base placeholder:text-fg-tertiary focus:border-interactive focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 sm:text-sm"
+      />
+
+      {examples.length > 0 && !description && (
+        <div className="space-y-2">
+          <p className="text-xs text-fg-tertiary">Or start from an example:</p>
+          <div className="flex flex-wrap gap-2">
+            {examples.slice(0, 2).map(example => (
+              <AIAssistChip
+                key={example}
+                label={example}
+                block
+                disabled={isBlocked}
+                onClick={() => onDescriptionChange(example)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <Button
+        type="button"
+        size="lg"
+        onClick={onSubmit}
+        disabled={isBlocked || !description.trim()}
+        className="w-full gap-2 sm:ml-auto sm:w-auto"
+      >
+        {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+        <span>{busy ? 'Filling form…' : 'Fill form'}</span>
+      </Button>
+    </div>
+  );
+}
+
+export default AIFillPanel;

--- a/src/components/create/AIPrefillBar.tsx
+++ b/src/components/create/AIPrefillBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Sparkles, Loader2, AlertCircle, Lightbulb, CheckCircle2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
@@ -9,8 +9,14 @@ import { API_ROUTES } from '@/config/api-routes';
 
 import Button from '@/components/ui/Button';
 import type { AIPrefillBarProps, AIPrefillResponse } from './types';
-import { getExampleDescriptions } from '@/lib/ai/prompts/form-prefill';
+import {
+  getAdjustmentsForFields,
+  getExampleDescriptions,
+  type AiAssistIntent,
+} from '@/config/ai-form-assist';
 import type { EntityType } from '@/config/entity-registry';
+
+const EMPTY_FIELDS: NonNullable<AIPrefillBarProps['fields']> = [];
 
 export function AIPrefillBar({
   entityType,
@@ -18,6 +24,7 @@ export function AIPrefillBar({
   disabled,
   existingData,
   mode = 'create',
+  fields = EMPTY_FIELDS,
 }: AIPrefillBarProps) {
   const isEdit = mode === 'edit';
   // Seed the AI-fill box from a ?description= param on create — this is how the
@@ -32,14 +39,33 @@ export function AIPrefillBar({
   const [isRefining, setIsRefining] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasFilled, setHasFilled] = useState(false);
+  const [lastChanged, setLastChanged] = useState<string[] | null>(null);
 
   const examples = getExampleDescriptions(entityType as EntityType);
 
+  // Adjustments are filtered against THIS form's fields, so a form without a
+  // description never offers to lengthen one.
+  const adjustments = useMemo(() => getAdjustmentsForFields(fields), [fields]);
+
+  /**
+   * On edit the fields are already populated, so the bar starts in refine mode:
+   * "change what's here" is the only sensible ask. On create it flips to refine
+   * once the AI has filled the form.
+   */
+  const isRefineMode = isEdit || hasFilled;
+  const busy = isGenerating || isRefining;
+
+  const labelFor = useCallback(
+    (name: string) => fields.find(f => f.name === name)?.label ?? name,
+    [fields]
+  );
+
   const callAI = useCallback(
-    async (prompt: string, isRefinement: boolean) => {
-      const setter = isRefinement ? setIsRefining : setIsGenerating;
+    async (prompt: string, intent: AiAssistIntent) => {
+      const setter = intent === 'refine' ? setIsRefining : setIsGenerating;
       setter(true);
       setError(null);
+      setLastChanged(null);
 
       try {
         const response = await fetch(API_ROUTES.AI.FORM_PREFILL, {
@@ -49,6 +75,7 @@ export function AIPrefillBar({
             entityType,
             description: prompt.trim(),
             existingData,
+            intent,
           }),
         });
 
@@ -63,17 +90,23 @@ export function AIPrefillBar({
           throw new Error(result.error || 'Failed to generate form data');
         }
 
-        onPrefill(result.data, result.confidence);
+        const changedFields = result.changedFields ?? Object.keys(result.data);
+        onPrefill(result.data, result.confidence, changedFields);
         setHasFilled(true);
+        setLastChanged(changedFields);
 
-        if (isRefinement) {
+        if (intent === 'refine') {
           setRefineInput('');
-          toast.success('Form updated');
+          if (changedFields.length === 0) {
+            toast('Nothing changed', { description: 'Try naming the field you want changed.' });
+          } else {
+            const count = changedFields.length;
+            toast.success(`Updated ${count} field${count > 1 ? 's' : ''}`);
+          }
         } else {
-          toast.success(
-            isEdit ? 'Changes applied — review below' : 'Form filled — review and adjust below',
-            { description: 'You can also tell AI what to change' }
-          );
+          toast.success('Form filled — review and adjust below', {
+            description: 'You can also tell AI what to change',
+          });
         }
       } catch (err) {
         logger.error('AI prefill error', err, 'AI');
@@ -82,26 +115,23 @@ export function AIPrefillBar({
         setter(false);
       }
     },
-    [entityType, existingData, onPrefill, isEdit]
+    [entityType, existingData, onPrefill]
   );
 
   const handleGenerate = useCallback(() => {
     if (!description.trim() || description.trim().length < 10) {
-      setError(
-        isEdit
-          ? 'Please describe the change you want (at least 10 characters)'
-          : 'Please describe what you want to create (at least 10 characters)'
-      );
+      setError('Please describe what you want to create (at least 10 characters)');
       return;
     }
-    callAI(description, false);
-  }, [description, callAI, isEdit]);
+    callAI(description, 'fill');
+  }, [description, callAI]);
 
   const handleRefine = useCallback(() => {
-    if (!refineInput.trim()) {
+    const instruction = refineInput.trim();
+    if (instruction.length < 3) {
       return;
     }
-    callAI(refineInput, true);
+    callAI(instruction, 'refine');
   }, [refineInput, callAI]);
 
   const handleReset = () => {
@@ -109,6 +139,7 @@ export function AIPrefillBar({
     setDescription('');
     setRefineInput('');
     setError(null);
+    setLastChanged(null);
   };
 
   return (
@@ -118,17 +149,11 @@ export function AIPrefillBar({
         <div className="flex items-center gap-2">
           <Sparkles className="h-4 w-4 text-fg-primary" />
           <span className="text-sm font-semibold text-fg-primary">
-            {hasFilled
-              ? isEdit
-                ? 'AI updated the form'
-                : 'AI filled the form'
-              : isEdit
-                ? 'Edit with AI'
-                : 'Fill with AI'}
+            {isEdit ? 'Edit with AI' : hasFilled ? 'AI filled the form' : 'Fill with AI'}
           </span>
-          {hasFilled && <CheckCircle2 className="h-4 w-4 text-status-positive" />}
+          {hasFilled && !isEdit && <CheckCircle2 className="h-4 w-4 text-status-positive" />}
         </div>
-        {hasFilled && (
+        {hasFilled && !isEdit && (
           <button
             type="button"
             onClick={handleReset}
@@ -140,8 +165,8 @@ export function AIPrefillBar({
         )}
       </div>
 
-      {/* Initial description — shown until AI fills */}
-      {!hasFilled && (
+      {/* Describe-and-fill — create only, until the AI has filled the form */}
+      {!isRefineMode && (
         <>
           <textarea
             value={description}
@@ -155,33 +180,29 @@ export function AIPrefillBar({
                 handleGenerate();
               }
             }}
-            placeholder={
-              isEdit
-                ? `Describe the change you want — AI will update the fields for you.\n\nExample: "Lower the price to 60 CHF and make the description more concise."`
-                : `Describe what you want to create — AI will fill the form for you.\n\nExample: "I'm an artist selling original watercolour prints of Swiss landscapes, priced around 80 CHF each, shipping worldwide."`
-            }
-            disabled={isGenerating || disabled}
+            placeholder={`Describe what you want to create — AI will fill the form for you.\n\nExample: "I'm an artist selling original watercolour prints of Swiss landscapes, priced around 80 CHF each, shipping worldwide."`}
+            disabled={busy || disabled}
             rows={3}
             className="block w-full resize-none rounded-md border border-subtle bg-surface-page px-3 py-2 text-sm placeholder:text-fg-tertiary focus:border-interactive focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
           />
 
           <div className="flex items-center justify-between gap-2">
             {/* Example chips */}
-            {!isEdit && examples.length > 0 && !description && (
+            {examples.length > 0 && !description && (
               <div className="flex items-center gap-2 flex-wrap">
                 <div className="flex items-center gap-1 text-xs text-fg-tertiary">
                   <Lightbulb className="h-3 w-3" />
                   <span>Try:</span>
                 </div>
-                {examples.slice(0, 2).map((example, i) => (
+                {examples.slice(0, 2).map(example => (
                   <button
-                    key={i}
+                    key={example}
                     type="button"
                     onClick={() => {
                       setDescription(example);
                       setError(null);
                     }}
-                    disabled={isGenerating || disabled}
+                    disabled={busy || disabled}
                     className="rounded-sm bg-surface-page px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary"
                   >
                     {example.length > 45 ? `${example.slice(0, 45)}…` : example}
@@ -192,7 +213,7 @@ export function AIPrefillBar({
             <Button
               type="button"
               onClick={handleGenerate}
-              disabled={isGenerating || disabled || !description.trim()}
+              disabled={busy || disabled || !description.trim()}
               className="ml-auto shrink-0 gap-2 bg-fg-primary text-fg-inverted hover:bg-fg-primary/90"
             >
               {isGenerating ? (
@@ -211,40 +232,68 @@ export function AIPrefillBar({
         </>
       )}
 
-      {/* Refinement mode — shown after AI fills */}
-      {hasFilled && (
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={refineInput}
-            onChange={e => {
-              setRefineInput(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={e => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleRefine();
-              }
-            }}
-            placeholder='Tell AI what to change — e.g. "make the title shorter" or "increase the price"'
-            disabled={isRefining || disabled}
-            className="flex-1 rounded-md border border-subtle bg-surface-page px-3 py-2 text-sm placeholder:text-fg-tertiary focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-          />
-          <Button
-            type="button"
-            onClick={handleRefine}
-            disabled={isRefining || disabled || !refineInput.trim()}
-            className="shrink-0 gap-2 bg-fg-primary text-fg-inverted hover:bg-fg-primary/90"
-          >
-            {isRefining ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Sparkles className="h-4 w-4" />
-            )}
-            <span>Adjust</span>
-          </Button>
-        </div>
+      {/* Refine — the form has content, so the ask is "change it" */}
+      {isRefineMode && (
+        <>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={refineInput}
+              onChange={e => {
+                setRefineInput(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleRefine();
+                }
+              }}
+              placeholder='Tell AI what to change — e.g. "make the description longer and add a German version"'
+              disabled={busy || disabled}
+              className="flex-1 rounded-md border border-subtle bg-surface-page px-3 py-2 text-sm placeholder:text-fg-tertiary focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+            />
+            <Button
+              type="button"
+              onClick={handleRefine}
+              disabled={busy || disabled || refineInput.trim().length < 3}
+              className="shrink-0 gap-2 bg-fg-primary text-fg-inverted hover:bg-fg-primary/90"
+            >
+              {isRefining ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Sparkles className="h-4 w-4" />
+              )}
+              <span>Adjust</span>
+            </Button>
+          </div>
+
+          {/* One-click adjustments, filtered to what this form actually has */}
+          {adjustments.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              {adjustments.map(adjustment => (
+                <button
+                  key={adjustment.id}
+                  type="button"
+                  onClick={() => callAI(adjustment.instruction, 'refine')}
+                  disabled={busy || disabled}
+                  className="rounded-sm bg-surface-page px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary disabled:opacity-50"
+                >
+                  {adjustment.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Say what actually changed — the old bar reported success either way */}
+          {lastChanged !== null && !busy && (
+            <p className="text-xs text-fg-tertiary">
+              {lastChanged.length > 0
+                ? `Updated: ${lastChanged.map(labelFor).join(', ')}`
+                : 'No fields changed — try naming the field you want changed.'}
+            </p>
+          )}
+        </>
       )}
 
       {/* Error */}

--- a/src/components/create/AIPrefillBar.tsx
+++ b/src/components/create/AIPrefillBar.tsx
@@ -2,26 +2,37 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { Sparkles, Loader2, AlertCircle, Lightbulb, CheckCircle2, RefreshCw } from 'lucide-react';
+import { Sparkles, AlertCircle, CheckCircle2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
 import { API_ROUTES } from '@/config/api-routes';
 
-import Button from '@/components/ui/Button';
+import { AIFillPanel } from './AIFillPanel';
+import { AIRefinePanel } from './AIRefinePanel';
 import type { AIPrefillBarProps, AIPrefillResponse } from './types';
 import {
   getAdjustmentsForFields,
   getExampleDescriptions,
+  type AiAdjustment,
   type AiAssistIntent,
 } from '@/config/ai-form-assist';
 import type { EntityType } from '@/config/entity-registry';
 
 const EMPTY_FIELDS: NonNullable<AIPrefillBarProps['fields']> = [];
 
+/** Marks the free-text box as the in-flight request, so chips show their own spinner. */
+const TYPED_REQUEST = '__typed__';
+
+/**
+ * AI assistance for any entity form — fill an empty one, or change a filled one.
+ *
+ * Owns the request lifecycle only; the two surfaces render in AIFillPanel /
+ * AIRefinePanel.
+ */
 export function AIPrefillBar({
   entityType,
   onPrefill,
-  disabled,
+  disabled = false,
   existingData,
   mode = 'create',
   fields = EMPTY_FIELDS,
@@ -34,17 +45,16 @@ export function AIPrefillBar({
   const [description, setDescription] = useState(() =>
     mode === 'create' ? (searchParams.get('description') ?? '') : ''
   );
-  const [refineInput, setRefineInput] = useState('');
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [isRefining, setIsRefining] = useState(false);
+  const [instruction, setInstruction] = useState('');
+  const [pending, setPending] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [hasFilled, setHasFilled] = useState(false);
   const [lastChanged, setLastChanged] = useState<string[] | null>(null);
 
   const examples = getExampleDescriptions(entityType as EntityType);
 
-  // Adjustments are filtered against THIS form's fields, so a form without a
-  // description never offers to lengthen one.
+  // Filtered against THIS form's fields, so a form without a description never
+  // offers to lengthen one.
   const adjustments = useMemo(() => getAdjustmentsForFields(fields), [fields]);
 
   /**
@@ -53,7 +63,7 @@ export function AIPrefillBar({
    * once the AI has filled the form.
    */
   const isRefineMode = isEdit || hasFilled;
-  const busy = isGenerating || isRefining;
+  const busy = pending !== null;
 
   const labelFor = useCallback(
     (name: string) => fields.find(f => f.name === name)?.label ?? name,
@@ -61,9 +71,8 @@ export function AIPrefillBar({
   );
 
   const callAI = useCallback(
-    async (prompt: string, intent: AiAssistIntent) => {
-      const setter = intent === 'refine' ? setIsRefining : setIsGenerating;
-      setter(true);
+    async (prompt: string, intent: AiAssistIntent, requestId: string) => {
+      setPending(requestId);
       setError(null);
       setLastChanged(null);
 
@@ -85,7 +94,6 @@ export function AIPrefillBar({
         }
 
         const result: AIPrefillResponse = await response.json();
-
         if (!result.success) {
           throw new Error(result.error || 'Failed to generate form data');
         }
@@ -96,68 +104,89 @@ export function AIPrefillBar({
         setLastChanged(changedFields);
 
         if (intent === 'refine') {
-          setRefineInput('');
+          setInstruction('');
           if (changedFields.length === 0) {
             toast('Nothing changed', { description: 'Try naming the field you want changed.' });
           } else {
-            const count = changedFields.length;
-            toast.success(`Updated ${count} field${count > 1 ? 's' : ''}`);
+            toast.success(
+              `Updated ${changedFields.length} field${changedFields.length > 1 ? 's' : ''}`
+            );
           }
         } else {
-          toast.success('Form filled — review and adjust below', {
-            description: 'You can also tell AI what to change',
-          });
+          toast.success('Form filled — review and adjust below');
         }
       } catch (err) {
         logger.error('AI prefill error', err, 'AI');
         setError(err instanceof Error ? err.message : 'An unexpected error occurred');
       } finally {
-        setter(false);
+        setPending(null);
       }
     },
     [entityType, existingData, onPrefill]
   );
 
   const handleGenerate = useCallback(() => {
-    if (!description.trim() || description.trim().length < 10) {
+    if (description.trim().length < 10) {
       setError('Please describe what you want to create (at least 10 characters)');
       return;
     }
-    callAI(description, 'fill');
+    callAI(description, 'fill', TYPED_REQUEST);
   }, [description, callAI]);
 
   const handleRefine = useCallback(() => {
-    const instruction = refineInput.trim();
-    if (instruction.length < 3) {
+    if (instruction.trim().length < 3) {
       return;
     }
-    callAI(instruction, 'refine');
-  }, [refineInput, callAI]);
+    callAI(instruction, 'refine', TYPED_REQUEST);
+  }, [instruction, callAI]);
+
+  const handleAdjust = useCallback(
+    (adjustment: AiAdjustment) => callAI(adjustment.instruction, 'refine', adjustment.id),
+    [callAI]
+  );
+
+  const handleDescriptionChange = useCallback((value: string) => {
+    setDescription(value);
+    setError(null);
+  }, []);
+
+  const handleInstructionChange = useCallback((value: string) => {
+    setInstruction(value);
+    setError(null);
+  }, []);
 
   const handleReset = () => {
     setHasFilled(false);
     setDescription('');
-    setRefineInput('');
+    setInstruction('');
     setError(null);
     setLastChanged(null);
   };
 
+  const statusMessage =
+    busy || lastChanged === null
+      ? ''
+      : lastChanged.length > 0
+        ? `Updated: ${lastChanged.map(labelFor).join(', ')}`
+        : 'No fields changed — try naming the field you want changed.';
+
   return (
     <div className="mb-6 space-y-3 rounded-md border border-subtle bg-surface-raised/30 p-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <Sparkles className="h-4 w-4 text-fg-primary" />
+          <Sparkles className="h-4 w-4 shrink-0 text-fg-primary" />
           <span className="text-sm font-semibold text-fg-primary">
             {isEdit ? 'Edit with AI' : hasFilled ? 'AI filled the form' : 'Fill with AI'}
           </span>
-          {hasFilled && !isEdit && <CheckCircle2 className="h-4 w-4 text-status-positive" />}
+          {hasFilled && !isEdit && (
+            <CheckCircle2 className="h-4 w-4 shrink-0 text-status-positive" />
+          )}
         </div>
         {hasFilled && !isEdit && (
           <button
             type="button"
             onClick={handleReset}
-            className="flex items-center gap-1 text-xs text-fg-secondary hover:text-fg-primary"
+            className="flex min-h-11 shrink-0 items-center gap-1 px-1 text-xs text-fg-secondary hover:text-fg-primary"
           >
             <RefreshCw className="h-3 w-3" />
             Start over
@@ -165,141 +194,37 @@ export function AIPrefillBar({
         )}
       </div>
 
-      {/* Describe-and-fill — create only, until the AI has filled the form */}
-      {!isRefineMode && (
-        <>
-          <textarea
-            value={description}
-            onChange={e => {
-              setDescription(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={e => {
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                e.preventDefault();
-                handleGenerate();
-              }
-            }}
-            placeholder={`Describe what you want to create — AI will fill the form for you.\n\nExample: "I'm an artist selling original watercolour prints of Swiss landscapes, priced around 80 CHF each, shipping worldwide."`}
-            disabled={busy || disabled}
-            rows={3}
-            className="block w-full resize-none rounded-md border border-subtle bg-surface-page px-3 py-2 text-sm placeholder:text-fg-tertiary focus:border-interactive focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-          />
-
-          <div className="flex items-center justify-between gap-2">
-            {/* Example chips */}
-            {examples.length > 0 && !description && (
-              <div className="flex items-center gap-2 flex-wrap">
-                <div className="flex items-center gap-1 text-xs text-fg-tertiary">
-                  <Lightbulb className="h-3 w-3" />
-                  <span>Try:</span>
-                </div>
-                {examples.slice(0, 2).map(example => (
-                  <button
-                    key={example}
-                    type="button"
-                    onClick={() => {
-                      setDescription(example);
-                      setError(null);
-                    }}
-                    disabled={busy || disabled}
-                    className="rounded-sm bg-surface-page px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary"
-                  >
-                    {example.length > 45 ? `${example.slice(0, 45)}…` : example}
-                  </button>
-                ))}
-              </div>
-            )}
-            <Button
-              type="button"
-              onClick={handleGenerate}
-              disabled={busy || disabled || !description.trim()}
-              className="ml-auto shrink-0 gap-2 bg-fg-primary text-fg-inverted hover:bg-fg-primary/90"
-            >
-              {isGenerating ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <span>Filling form…</span>
-                </>
-              ) : (
-                <>
-                  <Sparkles className="h-4 w-4" />
-                  <span>Fill form</span>
-                </>
-              )}
-            </Button>
-          </div>
-        </>
+      {isRefineMode ? (
+        <AIRefinePanel
+          adjustments={adjustments}
+          onAdjust={handleAdjust}
+          instruction={instruction}
+          onInstructionChange={handleInstructionChange}
+          onSubmit={handleRefine}
+          pending={pending}
+          typedRequestId={TYPED_REQUEST}
+          disabled={disabled}
+        />
+      ) : (
+        <AIFillPanel
+          description={description}
+          onDescriptionChange={handleDescriptionChange}
+          examples={examples}
+          onSubmit={handleGenerate}
+          busy={busy}
+          disabled={disabled}
+        />
       )}
 
-      {/* Refine — the form has content, so the ask is "change it" */}
-      {isRefineMode && (
-        <>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={refineInput}
-              onChange={e => {
-                setRefineInput(e.target.value);
-                setError(null);
-              }}
-              onKeyDown={e => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  handleRefine();
-                }
-              }}
-              placeholder='Tell AI what to change — e.g. "make the description longer and add a German version"'
-              disabled={busy || disabled}
-              className="flex-1 rounded-md border border-subtle bg-surface-page px-3 py-2 text-sm placeholder:text-fg-tertiary focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-            />
-            <Button
-              type="button"
-              onClick={handleRefine}
-              disabled={busy || disabled || refineInput.trim().length < 3}
-              className="shrink-0 gap-2 bg-fg-primary text-fg-inverted hover:bg-fg-primary/90"
-            >
-              {isRefining ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Sparkles className="h-4 w-4" />
-              )}
-              <span>Adjust</span>
-            </Button>
-          </div>
+      {/* What actually changed — the old bar reported success either way.
+          A live region so it is announced, not merely visible. */}
+      <p role="status" aria-live="polite" className="text-xs text-fg-secondary empty:hidden">
+        {statusMessage}
+      </p>
 
-          {/* One-click adjustments, filtered to what this form actually has */}
-          {adjustments.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2">
-              {adjustments.map(adjustment => (
-                <button
-                  key={adjustment.id}
-                  type="button"
-                  onClick={() => callAI(adjustment.instruction, 'refine')}
-                  disabled={busy || disabled}
-                  className="rounded-sm bg-surface-page px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary disabled:opacity-50"
-                >
-                  {adjustment.label}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {/* Say what actually changed — the old bar reported success either way */}
-          {lastChanged !== null && !busy && (
-            <p className="text-xs text-fg-tertiary">
-              {lastChanged.length > 0
-                ? `Updated: ${lastChanged.map(labelFor).join(', ')}`
-                : 'No fields changed — try naming the field you want changed.'}
-            </p>
-          )}
-        </>
-      )}
-
-      {/* Error */}
       {error && (
         <div className="flex items-start gap-2 text-sm text-status-negative">
-          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
           <span>{error}</span>
         </div>
       )}

--- a/src/components/create/AIRefinePanel.tsx
+++ b/src/components/create/AIRefinePanel.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Sparkles, Loader2 } from 'lucide-react';
+import Button from '@/components/ui/Button';
+import { AIAssistChip } from './AIAssistChip';
+import type { AiAdjustment } from '@/config/ai-form-assist';
+
+interface AIRefinePanelProps {
+  /** Already filtered to what this form's fields support */
+  adjustments: AiAdjustment[];
+  onAdjust: (adjustment: AiAdjustment) => void;
+  instruction: string;
+  onInstructionChange: (value: string) => void;
+  onSubmit: () => void;
+  /** Which request is in flight — an adjustment id, or the typed-request marker */
+  pending: string | null;
+  typedRequestId: string;
+  disabled: boolean;
+}
+
+/**
+ * The populated-form surface: change what is already there.
+ *
+ * One-tap adjustments come FIRST and typing is the fallback. On a phone the
+ * point of opening this page is to get a listing published, not to compose
+ * instructions — so the fastest path to "better" should cost a single tap.
+ */
+export function AIRefinePanel({
+  adjustments,
+  onAdjust,
+  instruction,
+  onInstructionChange,
+  onSubmit,
+  pending,
+  typedRequestId,
+  disabled,
+}: AIRefinePanelProps) {
+  const isTyping = pending === typedRequestId;
+  const isBlocked = pending !== null || disabled;
+
+  return (
+    <div className="space-y-3">
+      {adjustments.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {adjustments.map(adjustment => (
+            <AIAssistChip
+              key={adjustment.id}
+              label={adjustment.label}
+              disabled={isBlocked}
+              isLoading={pending === adjustment.id}
+              onClick={() => onAdjust(adjustment)}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          type="text"
+          value={instruction}
+          onChange={e => onInstructionChange(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              onSubmit();
+            }
+          }}
+          placeholder="Or tell AI what else to change…"
+          disabled={isBlocked}
+          // text-base on mobile: anything smaller makes iOS zoom in on focus
+          className="min-h-11 flex-1 rounded-md border border-subtle bg-surface-page px-3 py-2 text-base placeholder:text-fg-tertiary focus:border-interactive focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 sm:text-sm"
+        />
+        <Button
+          type="button"
+          size="lg"
+          onClick={onSubmit}
+          disabled={isBlocked || instruction.trim().length < 3}
+          className="w-full gap-2 sm:w-auto"
+        >
+          {isTyping ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Sparkles className="h-4 w-4" />
+          )}
+          <span>{isTyping ? 'Adjusting…' : 'Adjust'}</span>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default AIRefinePanel;

--- a/src/components/create/EntityForm/hooks/useEntityFormState.ts
+++ b/src/components/create/EntityForm/hooks/useEntityFormState.ts
@@ -112,14 +112,20 @@ export function useEntityFormState<T extends Record<string, unknown>>({
   }, []);
 
   const handleAIPrefill = useCallback(
-    (data: Record<string, unknown>, confidence: Record<string, FieldConfidence>) => {
+    (
+      data: Record<string, unknown>,
+      confidence: Record<string, FieldConfidence>,
+      changedFields: string[]
+    ) => {
       setFormState(prev => ({
         ...prev,
         data: { ...prev.data, ...data } as T,
         isDirty: true,
       }));
-      const newFields = new Set<string>(Object.keys(data));
-      setAiGeneratedFields({ fields: newFields, confidence });
+      // Highlight only what the AI actually wrote. `data` carries the whole
+      // form (including the user's own untouched values), so keying off it
+      // flagged every field as AI-generated.
+      setAiGeneratedFields({ fields: new Set<string>(changedFields), confidence });
       window.scrollTo({ top: 0, behavior: 'smooth' });
     },
     []

--- a/src/components/create/EntityForm/index.tsx
+++ b/src/components/create/EntityForm/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useUserCurrency } from '@/hooks/useUserCurrency';
 import Loading from '@/components/Loading';
@@ -77,6 +77,13 @@ export function EntityForm<T extends Record<string, unknown>>({
   } = useEntityFormState({ config, initialValues, userCurrency, userId: user?.id, mode });
 
   const [createdEntity, setCreatedEntity] = useState<{ id: string; title: string } | null>(null);
+
+  // Flat field list for the AI bar: it offers only the adjustments this form's
+  // fields support, and names changed fields by their label.
+  const aiAssistFields = useMemo(
+    () => config.fieldGroups.flatMap(group => group.fields ?? []),
+    [config.fieldGroups]
+  );
 
   const handleFieldBlur = useCallback(
     (fieldName: string) => validateField(fieldName),
@@ -157,6 +164,7 @@ export function EntityForm<T extends Record<string, unknown>>({
         disabled={formState.isSubmitting}
         existingData={formState.data}
         mode={mode}
+        fields={aiAssistFields}
       />
 
       <FormFieldGroups

--- a/src/components/create/types.ts
+++ b/src/components/create/types.ts
@@ -376,9 +376,14 @@ export type FieldConfidence = number;
 export interface AIPrefillResponse {
   /** Whether the prefill was successful */
   success: boolean;
-  /** Generated field values */
+  /** Full set of form values to apply */
   data: Record<string, unknown>;
-  /** Confidence scores for each generated field (0-1) */
+  /**
+   * Fields the AI actually changed. Everything else in `data` is the user's
+   * own value carried through, so only these should be flagged as AI-written.
+   */
+  changedFields?: string[];
+  /** Confidence scores for each changed field (0-1) */
   confidence: Record<string, FieldConfidence>;
   /** Optional error message if unsuccessful */
   error?: string;
@@ -401,7 +406,11 @@ export interface AIPrefillBarProps {
   /** Entity type being created */
   entityType: string;
   /** Callback when AI generates field values */
-  onPrefill: (data: Record<string, unknown>, confidence: Record<string, FieldConfidence>) => void;
+  onPrefill: (
+    data: Record<string, unknown>,
+    confidence: Record<string, FieldConfidence>,
+    changedFields: string[]
+  ) => void;
   /** Whether form is currently submitting */
   disabled?: boolean;
   /** Existing form data (to preserve user input) */
@@ -412,6 +421,12 @@ export interface AIPrefillBarProps {
    * change you want" since the fields are already populated.
    */
   mode?: 'create' | 'edit';
+  /**
+   * The form's own fields. Drives which one-click adjustments are offered, so
+   * the bar suggests things this specific form can actually do (see
+   * `getAdjustmentsForFields`) and can name changed fields by their label.
+   */
+  fields?: Array<Pick<FieldConfig, 'name' | 'label' | 'type'>>;
 }
 
 /**

--- a/src/config/ai-form-assist.ts
+++ b/src/config/ai-form-assist.ts
@@ -71,8 +71,44 @@ export interface AiAdjustment {
   appliesTo?: AdjustmentScope;
 }
 
+/** A language a listing can be mirrored into, alongside the original text. */
+interface AiTranslationLanguage {
+  /** Chip label — "Add {label} version" */
+  label: string;
+  /** How the AI should be told to write it, including any spelling conventions */
+  instruction: string;
+}
+
 /**
- * The adjustments people actually ask for, most-frequent first.
+ * Languages offered as a one-click "add a translation" adjustment.
+ *
+ * Switzerland has four national languages, so which one is offered is a config
+ * decision, not something to bake into a component. Order is priority: the
+ * first is offered up front, the rest sit further down the chip list.
+ * German carries the house spelling rule (ss, never ß).
+ */
+export const AI_TRANSLATION_LANGUAGES: readonly AiTranslationLanguage[] = [
+  {
+    label: 'German',
+    instruction:
+      'German, using Swiss conventions: write "ss" instead of "ß", and keep the umlauts ä, ö and ü',
+  },
+  { label: 'French', instruction: 'French' },
+];
+
+function translationAdjustment(language: AiTranslationLanguage): AiAdjustment {
+  return {
+    id: `description-translate-${language.label.toLowerCase()}`,
+    label: `Add ${language.label} version`,
+    instruction: `Rewrite the description so it contains the original text first, then a blank line, then a faithful translation of the same text into ${language.instruction}. Keep both versions equally complete and do not add facts to either one.`,
+    appliesTo: { fieldNames: ['description'] },
+  };
+}
+
+const TRANSLATION_ADJUSTMENTS = AI_TRANSLATION_LANGUAGES.map(translationAdjustment);
+
+/**
+ * The adjustments people actually ask for, most-valuable first.
  *
  * Ordering is the display order; `AI_ADJUSTMENT_CHIP_LIMIT` caps how many a
  * form shows so the bar stays a bar and not a menu.
@@ -85,19 +121,34 @@ export const AI_ADJUSTMENTS: readonly AiAdjustment[] = [
       'Rewrite the description so it is substantially longer and more useful — at least three or four sentences. Cover what is offered, what makes it worth choosing, and what the buyer can expect. Keep every fact that is already there and do not invent new facts such as prices, dates, locations, credentials or guarantees.',
     appliesTo: { fieldNames: ['description'] },
   },
-  {
-    id: 'description-bilingual-de',
-    label: 'Add German version',
-    instruction:
-      'Rewrite the description so it contains the English text first, then a blank line, then a faithful German translation of the same text. Keep both versions equally complete. Use Swiss German spelling conventions: write "ss" instead of "ß", and keep the umlauts ä, ö and ü.',
-    appliesTo: { fieldNames: ['description'] },
-  },
+  // Primary translation language up front; the rest land after the staples.
+  ...TRANSLATION_ADJUSTMENTS.slice(0, 1),
   {
     id: 'description-shorter',
     label: 'Shorter description',
     instruction:
       'Tighten the description to two crisp sentences. Keep the concrete details and drop the filler. Do not remove any factual information such as prices, dates or what is included.',
     appliesTo: { fieldNames: ['description'] },
+  },
+  {
+    id: 'title-sharper',
+    label: 'Better title',
+    instruction:
+      'Rewrite the title so it is specific and scannable — what it is, for whom. Under 60 characters, no marketing filler, no trailing punctuation. Leave the other fields as they are.',
+    appliesTo: { fieldNames: ['title', 'name'] },
+  },
+  {
+    id: 'fill-blanks',
+    label: 'Fill in the blanks',
+    instruction:
+      'Fill in every field that is still empty, inferring sensible values from what is already filled in. Leave all fields that already have a value exactly as they are. Do not invent prices, dates or contact details — leave those empty if they are not implied by the rest of the form.',
+  },
+  {
+    id: 'tags-suggest',
+    label: 'Better tags',
+    instruction:
+      'Replace the tags with five to eight specific, lowercase keywords someone would actually search for to find this. No generic words like "quality" or "best".',
+    appliesTo: { fieldTypes: ['tags'] },
   },
   {
     id: 'tone-professional',
@@ -113,26 +164,7 @@ export const AI_ADJUSTMENTS: readonly AiAdjustment[] = [
       'Rewrite the free-text fields in a warmer, more personal tone — speak directly to the reader as "you". Keep all facts unchanged.',
     appliesTo: { fieldNames: ['description'] },
   },
-  {
-    id: 'title-sharper',
-    label: 'Better title',
-    instruction:
-      'Rewrite the title so it is specific and scannable — what it is, for whom. Under 60 characters, no marketing filler, no trailing punctuation. Leave the other fields as they are.',
-    appliesTo: { fieldNames: ['title', 'name'] },
-  },
-  {
-    id: 'tags-suggest',
-    label: 'Better tags',
-    instruction:
-      'Replace the tags with five to eight specific, lowercase keywords someone would actually search for to find this. No generic words like "quality" or "best".',
-    appliesTo: { fieldTypes: ['tags'] },
-  },
-  {
-    id: 'fill-blanks',
-    label: 'Fill in the blanks',
-    instruction:
-      'Fill in every field that is still empty, inferring sensible values from what is already filled in. Leave all fields that already have a value exactly as they are. Do not invent prices, dates or contact details — leave those empty if they are not implied by the rest of the form.',
-  },
+  ...TRANSLATION_ADJUSTMENTS.slice(1),
 ];
 
 /** How many adjustment chips a form shows at once. */

--- a/src/config/ai-form-assist.ts
+++ b/src/config/ai-form-assist.ts
@@ -1,0 +1,309 @@
+/**
+ * AI FORM ASSIST — CONFIG SSOT
+ *
+ * Everything the AI form filler shows or says that is *not* generic prompt
+ * plumbing lives here:
+ *
+ * - `AI_ADJUSTMENTS`  — the catalog of one-click refinements ("make the
+ *   description longer", "add a German version", …). Each entry declares which
+ *   fields it applies to, so a form only ever offers adjustments that make
+ *   sense for the fields it actually has.
+ * - `AI_FILL_EXAMPLES` — the "Try:" starter descriptions per entity type.
+ *
+ * Both used to be hardcoded switch statements inside the prompt builder, which
+ * meant entity types added to the registry silently got nothing. Keeping them
+ * here as data means the bar is form-aware by construction and new entities
+ * are one config entry, not a new `case`.
+ */
+
+import { ENTITY_REGISTRY, type EntityType } from '@/config/entity-registry';
+import type { FieldConfig, FieldInputType } from '@/components/create/types';
+
+// ==================== INTENT ====================
+
+/**
+ * What the user is asking the AI to do.
+ *
+ * - `fill`   — the form is (mostly) empty; generate values. Anything the user
+ *   already typed is protected and wins over the AI.
+ * - `refine` — the form already has content; *revise* it. The AI's output wins
+ *   for the fields it returns, because changing them is the whole point.
+ *
+ * This distinction is the SSOT for "who wins on conflict". Without it a refine
+ * request can never change anything, since every field it wants to rewrite is
+ * already non-empty.
+ */
+export type AiAssistIntent = 'fill' | 'refine';
+
+/**
+ * Fields the AI may overwrite even under intent `fill`.
+ *
+ * These carry template/defaults rather than user intent (a service form opens
+ * with a currency and often a placeholder rate), so protecting them means a
+ * description like "CHF 150 per hour" gets silently ignored. One list, used by
+ * both the prompt and the merge — they disagreed before, and the merge won.
+ */
+export const USER_OVERRIDABLE_FIELDS: readonly string[] = [
+  'price',
+  'currency',
+  'hourly_rate',
+  'fixed_price',
+];
+
+// ==================== ADJUSTMENTS ====================
+
+/** Which fields an adjustment is relevant to. Omit to always offer it. */
+interface AdjustmentScope {
+  /** Matches a field with any of these exact names */
+  fieldNames?: string[];
+  /** Matches a field of any of these input types */
+  fieldTypes?: FieldInputType[];
+}
+
+export interface AiAdjustment {
+  /** Stable identifier (used as React key and in tests) */
+  id: string;
+  /** Chip label — what the user reads */
+  label: string;
+  /** Sent to the AI verbatim as the refinement request */
+  instruction: string;
+  /** Only offered when the form has a matching field */
+  appliesTo?: AdjustmentScope;
+}
+
+/**
+ * The adjustments people actually ask for, most-frequent first.
+ *
+ * Ordering is the display order; `AI_ADJUSTMENT_CHIP_LIMIT` caps how many a
+ * form shows so the bar stays a bar and not a menu.
+ */
+export const AI_ADJUSTMENTS: readonly AiAdjustment[] = [
+  {
+    id: 'description-longer',
+    label: 'Longer description',
+    instruction:
+      'Rewrite the description so it is substantially longer and more useful — at least three or four sentences. Cover what is offered, what makes it worth choosing, and what the buyer can expect. Keep every fact that is already there and do not invent new facts such as prices, dates, locations, credentials or guarantees.',
+    appliesTo: { fieldNames: ['description'] },
+  },
+  {
+    id: 'description-bilingual-de',
+    label: 'Add German version',
+    instruction:
+      'Rewrite the description so it contains the English text first, then a blank line, then a faithful German translation of the same text. Keep both versions equally complete. Use Swiss German spelling conventions: write "ss" instead of "ß", and keep the umlauts ä, ö and ü.',
+    appliesTo: { fieldNames: ['description'] },
+  },
+  {
+    id: 'description-shorter',
+    label: 'Shorter description',
+    instruction:
+      'Tighten the description to two crisp sentences. Keep the concrete details and drop the filler. Do not remove any factual information such as prices, dates or what is included.',
+    appliesTo: { fieldNames: ['description'] },
+  },
+  {
+    id: 'tone-professional',
+    label: 'More professional',
+    instruction:
+      'Rewrite the free-text fields in a more professional, confident tone. No exclamation marks, no hype words like "amazing" or "revolutionary". Keep all facts unchanged.',
+    appliesTo: { fieldNames: ['description'] },
+  },
+  {
+    id: 'tone-warmer',
+    label: 'Friendlier tone',
+    instruction:
+      'Rewrite the free-text fields in a warmer, more personal tone — speak directly to the reader as "you". Keep all facts unchanged.',
+    appliesTo: { fieldNames: ['description'] },
+  },
+  {
+    id: 'title-sharper',
+    label: 'Better title',
+    instruction:
+      'Rewrite the title so it is specific and scannable — what it is, for whom. Under 60 characters, no marketing filler, no trailing punctuation. Leave the other fields as they are.',
+    appliesTo: { fieldNames: ['title', 'name'] },
+  },
+  {
+    id: 'tags-suggest',
+    label: 'Better tags',
+    instruction:
+      'Replace the tags with five to eight specific, lowercase keywords someone would actually search for to find this. No generic words like "quality" or "best".',
+    appliesTo: { fieldTypes: ['tags'] },
+  },
+  {
+    id: 'fill-blanks',
+    label: 'Fill in the blanks',
+    instruction:
+      'Fill in every field that is still empty, inferring sensible values from what is already filled in. Leave all fields that already have a value exactly as they are. Do not invent prices, dates or contact details — leave those empty if they are not implied by the rest of the form.',
+  },
+];
+
+/** How many adjustment chips a form shows at once. */
+export const AI_ADJUSTMENT_CHIP_LIMIT = 5;
+
+/** A field, reduced to what adjustment matching needs. */
+type MatchableField = Pick<FieldConfig, 'name' | 'type'>;
+
+function adjustmentApplies(adjustment: AiAdjustment, fields: MatchableField[]): boolean {
+  const scope = adjustment.appliesTo;
+  if (!scope) {
+    return true;
+  }
+  return fields.some(
+    field =>
+      scope.fieldNames?.includes(field.name) === true ||
+      scope.fieldTypes?.includes(field.type) === true
+  );
+}
+
+/**
+ * The adjustments worth offering for a specific form.
+ *
+ * This is what makes the bar form-aware: a wishlist with no tags field never
+ * offers "Better tags", and a form with no description never offers to
+ * lengthen one.
+ */
+export function getAdjustmentsForFields(
+  fields: MatchableField[],
+  limit: number = AI_ADJUSTMENT_CHIP_LIMIT
+): AiAdjustment[] {
+  return AI_ADJUSTMENTS.filter(adjustment => adjustmentApplies(adjustment, fields)).slice(0, limit);
+}
+
+/** Look up an adjustment's instruction by id (client sends the instruction). */
+export function getAdjustmentById(id: string): AiAdjustment | undefined {
+  return AI_ADJUSTMENTS.find(adjustment => adjustment.id === id);
+}
+
+// ==================== PER-ENTITY PROMPT INSTRUCTIONS ====================
+
+/**
+ * Rules the AI needs to fill a *specific* entity correctly — option values it
+ * must use verbatim, sentinel numbers, which of two price fields to set.
+ *
+ * Data, not a `switch`: an entity type with nothing special here simply has no
+ * entry, and adding one is a config line rather than a new branch in the
+ * prompt builder.
+ */
+export const AI_ENTITY_INSTRUCTIONS: Partial<Record<EntityType, string[]>> = {
+  product: [
+    'For product_type: Choose "physical" for tangible goods, "digital" for downloads/files, or "service" for service-based products.',
+    'For inventory_count: Use -1 for unlimited inventory, or a positive number for limited stock.',
+  ],
+  service: [
+    'For services: Provide either hourly_rate OR fixed_price (or both). Duration is in minutes.',
+  ],
+  event: ['For events: start_date is required. Use ISO format (YYYY-MM-DDTHH:mm).'],
+  loan: [
+    'For loans: original_amount is what you need to borrow in BTC. Interest rates are annual percentages (e.g., 5 for 5%).',
+  ],
+  investment: [
+    'For investments: target_amount is the total raise goal in BTC. minimum_investment is the minimum ticket size in BTC.',
+  ],
+  research: [
+    'For research: funding_goal_btc is the funding target. field and methodology must use the exact option values shown above (not labels).',
+  ],
+  wishlist: [
+    'For wishlists: type must be one of: general, birthday, wedding, baby_shower, graduation, personal. visibility: public, unlisted, or private.',
+  ],
+};
+
+/** Instruction that applies to every entity type. */
+export const AI_UNIVERSAL_INSTRUCTIONS: readonly string[] = [
+  'For Bitcoin prices: Express amounts in BTC as decimal values (e.g., 0.001 BTC). Never use satoshis. Common price points: 0.00005 BTC (~$5), 0.0003 BTC (~$30), 0.001 BTC (~$100).',
+];
+
+// ==================== STARTER EXAMPLES ====================
+
+/**
+ * "Try:" examples shown before the user has typed anything.
+ *
+ * Every entity type in the registry that can be created through a form should
+ * have an entry; `getExampleDescriptions` falls back to the registry's own
+ * description so a missing entry degrades to something useful rather than to
+ * the old placeholder text.
+ */
+export const AI_FILL_EXAMPLES: Partial<Record<EntityType, string[]>> = {
+  product: [
+    'Handmade ceramic mugs, CHF 45 each, glazed in small batches, ships from Zurich',
+    'Digital download of my Swiss landscape print collection, $15',
+    'Vintage hardware wallets, limited stock of 5 units, 0.005 BTC each',
+  ],
+  service: [
+    'Portrait and event photography, CHF 150 per hour, based in Zurich, travel possible',
+    'Web development and Lightning integration, from 0.01 BTC per project',
+    'One-to-one Bitcoin onboarding sessions, 90 minutes, remote',
+  ],
+  event: [
+    'Bitcoin meetup next Saturday evening at a cafe in Bern, free entry',
+    'Online workshop about the Lightning Network, January 15th at 7pm, 20 seats',
+    'Weekend hackathon with a 0.1 BTC prize pool',
+  ],
+  project: [
+    'Building an open-source Bitcoin wallet app, goal of 0.5 BTC',
+    'Documentary about Bitcoin adoption in Africa, three-month shoot',
+    'Community education programme for local merchants',
+  ],
+  cause: [
+    'Supporting Bitcoin education in underserved communities',
+    'Funding for open-source maintenance work',
+    'Help me replace the hardware wallet that was stolen',
+  ],
+  loan: [
+    'Need CHF 5,000 for 3 months to expand my repair shop',
+    'Looking to refinance an existing loan at a better rate',
+    'Small business loan for mining equipment, 0.1 BTC',
+  ],
+  investment: [
+    'Seeking 0.5 BTC equity investment for my app, revenue-share model',
+    'Raising 1 BTC for solar farm expansion, 8% annual return',
+    'Seed round, 0.25 BTC minimum ticket',
+  ],
+  research: [
+    'Bitcoin adoption study in emerging markets, goal 0.5 BTC',
+    'Computational biology research on protein folding, mixed methods',
+    'Economic impact of decentralised finance on local communities',
+  ],
+  wishlist: [
+    'Birthday wishlist for my 30th in June',
+    'Wedding registry — kitchen essentials and a honeymoon fund',
+    'Personal wishlist for books and electronics',
+  ],
+  asset: [
+    'Two-room flat in Basel available as loan collateral, valued around CHF 400,000',
+    'Professional camera kit available to rent by the day',
+    'Cargo bike I rent out to neighbours on weekends',
+  ],
+  ai_assistant: [
+    'An assistant that answers customer questions about my repair shop, CHF 5 per conversation',
+    'A research assistant that summarises Bitcoin news every morning',
+    'A bookkeeping assistant that categorises invoices for small businesses',
+  ],
+  group: [
+    'A Zurich Bitcoin builders collective with a shared treasury',
+    'A neighbourhood repair cooperative, membership by invitation',
+    'A small studio of three freelancers sharing project work',
+  ],
+  circle: [
+    'A weekly reading circle for Bitcoin books, open to anyone',
+    'A circle for parents in my neighbourhood organising childcare swaps',
+    'A circle of local makers sharing workshop space',
+  ],
+  document: [
+    'My skills, rates and the kind of work I want more of',
+    'Notes on my business goals for this year',
+    'Context about my clients and how I usually price projects',
+  ],
+};
+
+/**
+ * Starter examples for an entity type. Falls back to a prompt built from the
+ * registry so every entity type gets something concrete.
+ */
+export function getExampleDescriptions(entityType: EntityType): string[] {
+  const examples = AI_FILL_EXAMPLES[entityType];
+  if (examples && examples.length > 0) {
+    return examples;
+  }
+  const meta = ENTITY_REGISTRY[entityType];
+  return meta
+    ? [`Describe your ${meta.name.toLowerCase()} — ${meta.description.toLowerCase()}`]
+    : [];
+}

--- a/src/lib/ai/form-prefill-service.ts
+++ b/src/lib/ai/form-prefill-service.ts
@@ -8,6 +8,7 @@
 import type { EntityType } from '@/config/entity-registry';
 import { isValidEntityType } from '@/config/entity-registry';
 import type { AIPrefillResponse, EntityConfig } from '@/components/create/types';
+import { USER_OVERRIDABLE_FIELDS, type AiAssistIntent } from '@/config/ai-form-assist';
 import { logger } from '@/utils/logger';
 import {
   extractFieldDescriptions,
@@ -34,18 +35,84 @@ interface FormPrefillConfig {
   temperature?: number;
 }
 
+export interface FormPrefillRequest {
+  /** Entity type being filled (validated against the registry) */
+  entityType: string;
+  /** What the user typed: a description to fill from, or a change to apply */
+  description: string;
+  /** Form definition — supplies the field list the AI may write to */
+  entityConfig: EntityConfig;
+  /** Current form values */
+  existingData?: Record<string, unknown>;
+  /** Fill an empty form, or revise the values already in it. Default `fill`. */
+  intent?: AiAssistIntent;
+  /** Provider/model overrides */
+  config?: FormPrefillConfig;
+}
+
+/**
+ * Decide the final form values, and report which fields actually changed.
+ *
+ * This is the SSOT for "who wins on conflict", and it is why refinement used
+ * to silently do nothing: existing values unconditionally overwrote the AI's
+ * output, so a request to rewrite a non-empty description could never take
+ * effect.
+ *
+ * - `fill`   — the user's own input is protected; the AI only lands in gaps
+ *   (plus the price/currency fields, which carry template defaults rather than
+ *   user intent — see USER_OVERRIDABLE_FIELDS).
+ * - `refine` — the AI wins for the fields it returns, since changing them is
+ *   the entire request. Fields it omits keep their current values.
+ */
+export function mergePrefillResult(
+  aiData: Record<string, unknown>,
+  existingData: Record<string, unknown> | undefined,
+  intent: AiAssistIntent
+): { data: Record<string, unknown>; changedFields: string[] } {
+  const existing = existingData ?? {};
+
+  if (intent === 'refine') {
+    const changedFields = Object.keys(aiData).filter(
+      key => !valuesEqual(aiData[key], existing[key])
+    );
+    return { data: { ...existing, ...aiData }, changedFields };
+  }
+
+  const data: Record<string, unknown> = { ...aiData };
+  for (const [key, value] of Object.entries(existing)) {
+    const userProvided = value !== '' && value !== null && value !== undefined;
+    if (userProvided && !USER_OVERRIDABLE_FIELDS.includes(key)) {
+      data[key] = value;
+    }
+  }
+  const changedFields = Object.keys(aiData).filter(key => !valuesEqual(data[key], existing[key]));
+  return { data, changedFields };
+}
+
+/** Structural equality good enough for form values (scalars, arrays, plain objects). */
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return false;
+}
+
 /**
  * Server-side form prefill service
  *
  * This should be called from an API route, not directly from the client.
  */
-export async function generateFormPrefill(
-  entityType: string,
-  description: string,
-  entityConfig: EntityConfig,
-  existingData?: Record<string, unknown>,
-  config?: FormPrefillConfig
-): Promise<AIPrefillResponse> {
+export async function generateFormPrefill({
+  entityType,
+  description,
+  entityConfig,
+  existingData,
+  intent = 'fill',
+  config,
+}: FormPrefillRequest): Promise<AIPrefillResponse> {
   // Validate entity type
   if (!isValidEntityType(entityType)) {
     return {
@@ -73,13 +140,14 @@ export async function generateFormPrefill(
     const specialInstructions = getSpecialFieldInstructions(entityType as EntityType);
 
     // Build prompts
-    const systemPrompt = getSystemPrompt(entityType as EntityType);
+    const systemPrompt = getSystemPrompt(entityType as EntityType, intent);
     const userPrompt = getUserPrompt(
       entityType as EntityType,
       description,
       fieldsPrompt,
       specialInstructions,
-      existingData
+      existingData,
+      intent
     );
 
     // Determine provider: Groq first, OpenRouter fallback
@@ -123,7 +191,9 @@ export async function generateFormPrefill(
           { role: 'user', content: userPrompt },
         ],
         temperature: config?.temperature ?? 0.3,
-        max_tokens: config?.maxTokens ?? 1000,
+        // Headroom for genuinely written descriptions (and bilingual ones) —
+        // 1000 truncated the JSON mid-string on multi-field forms.
+        max_tokens: config?.maxTokens ?? 2000,
         ...(useGroq ? {} : { response_format: { type: 'json_object' } }),
       }),
     });
@@ -163,23 +233,20 @@ export async function generateFormPrefill(
       };
     }
 
-    // Merge with existing data (preserve user's input)
-    const mergedData = { ...parsed.data };
-    if (existingData) {
-      for (const [key, value] of Object.entries(existingData)) {
-        if (value !== '' && value !== null && value !== undefined) {
-          // User's existing data takes precedence
-          mergedData[key] = value;
-          // Mark preserved fields with high confidence
-          parsed.confidence[key] = 1.0;
-        }
-      }
-    }
+    const { data, changedFields } = mergePrefillResult(parsed.data, existingData, intent);
+
+    // Confidence is reported only for fields the AI actually changed — a
+    // preserved value is the user's, not an AI guess, and marking it 1.0 made
+    // the form highlight untouched fields as AI-generated.
+    const confidence = Object.fromEntries(
+      changedFields.map(field => [field, parsed.confidence[field] ?? 0.7])
+    );
 
     return {
       success: true,
-      data: mergedData,
-      confidence: parsed.confidence,
+      data,
+      changedFields,
+      confidence,
     };
   } catch (error) {
     logger.error('Form prefill error', error, 'AI');

--- a/src/lib/ai/prompts/form-prefill.ts
+++ b/src/lib/ai/prompts/form-prefill.ts
@@ -28,7 +28,7 @@ const WRITING_QUALITY_RULES = `WRITING QUALITY (this is where output usually fai
 - But DO write real prose for free-text fields. A description is written copy, not an echo of the title.
 - Bad: title "Photography", description "I offer photography." That is a failure. Write at least 3 full sentences a stranger would find useful: what this is, who it is for, and what to expect.
 - Never restate the title as the first sentence of the description.
-- Write plainly and specifically. No hype words ("amazing", "revolutionary", "world-class"), no exclamation marks, no emoji, no placeholder text like "Lorem" or "TBD".
+- Write plainly and specifically. No hype words ("amazing", "revolutionary", "world-class"), no exclamation marks, no emoji, and never leave filler or placeholder text in a field.
 - Write in the same language the user wrote in.`;
 
 const BITCOIN_RULES = `BITCOIN AND MONEY:

--- a/src/lib/ai/prompts/form-prefill.ts
+++ b/src/lib/ai/prompts/form-prefill.ts
@@ -1,39 +1,43 @@
 /**
  * Form Prefill Prompt Templates
  *
- * AI prompts for generating form field values from natural language descriptions.
+ * AI prompts for generating (intent `fill`) and revising (intent `refine`)
+ * form field values from natural language.
+ *
+ * The two intents need genuinely different prompts: filling means "extract
+ * what is stated and leave everything else alone", refining means "the user is
+ * asking you to change something that is already there". Sharing one prompt is
+ * why refinement used to be a no-op.
  */
 
 import type { EntityType } from '@/config/entity-registry';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
+import { USER_OVERRIDABLE_FIELDS, type AiAssistIntent } from '@/config/ai-form-assist';
 import { logger } from '@/utils/logger';
 
 /**
- * System prompt for form prefill AI
+ * Rules for anything the AI *writes* as prose, as opposed to *extracts* as fact.
+ *
+ * This block exists because "only output what you can confidently extract"
+ * produces descriptions like "I offer photography." for a service titled
+ * Photography — technically faithful, useless to a buyer. Facts must not be
+ * invented; sentences must still be written.
  */
-export function getSystemPrompt(entityType: EntityType): string {
-  const meta = ENTITY_REGISTRY[entityType];
-  const entityName = meta?.name || entityType;
+const WRITING_QUALITY_RULES = `WRITING QUALITY (this is where output usually fails — read carefully):
+- Facts and prose are different things. NEVER invent a FACT: prices, dates, locations, stock levels, delivery times, credentials, guarantees, contact details. If a fact is not in the user's text, leave that field out.
+- But DO write real prose for free-text fields. A description is written copy, not an echo of the title.
+- Bad: title "Photography", description "I offer photography." That is a failure. Write at least 3 full sentences a stranger would find useful: what this is, who it is for, and what to expect.
+- Never restate the title as the first sentence of the description.
+- Write plainly and specifically. No hype words ("amazing", "revolutionary", "world-class"), no exclamation marks, no emoji, no placeholder text like "Lorem" or "TBD".
+- Write in the same language the user wrote in.`;
 
-  return `You are a helpful assistant for OrangeCat, an AI-powered platform for economic activity.
-
-Your task is to extract structured data from a user's natural language description to help them create a ${entityName} listing.
-
-IMPORTANT CONTEXT:
+const BITCOIN_RULES = `BITCOIN AND MONEY:
 - OrangeCat settles payments in Bitcoin/Lightning; fiat currencies are for pricing and display only
 - Express Bitcoin amounts in BTC (e.g., 0.001 BTC) EVERYWHERE — in prices and in any title/description text. NEVER write "sats" or "satoshis"; rephrase to BTC even if the user's description used sats.
-- Keep fiat prices in their original currency (CHF, USD, EUR, etc.)
-- Price examples: "0.001 BTC", "CHF 50", "$25", "€100"
+- Keep fiat prices in the currency the user mentioned — do not convert
+- Price examples: "0.001 BTC", "CHF 50", "$25", "€100"`;
 
-RULES:
-1. Only output valid JSON - no markdown, no explanations
-2. Only include fields you can confidently extract from the description
-3. Include a "confidence" object with scores (0-1) for each field
-4. Do not make up information not in the description
-5. For unclear values, omit them rather than guess
-6. Keep prices in the currency the user mentioned — do not convert
-
-OUTPUT FORMAT:
+const OUTPUT_FORMAT = `OUTPUT FORMAT:
 {
   "data": {
     "field_name": "value",
@@ -44,20 +48,86 @@ OUTPUT FORMAT:
     ...
   }
 }`;
+
+/**
+ * System prompt for form prefill / refinement
+ */
+export function getSystemPrompt(entityType: EntityType, intent: AiAssistIntent = 'fill'): string {
+  const meta = ENTITY_REGISTRY[entityType];
+  const entityName = meta?.name || entityType;
+
+  const task =
+    intent === 'refine'
+      ? `The user already has a filled-in ${entityName} form and is asking you to CHANGE it. Apply the change they describe and return the updated values.
+
+REVISION RULES:
+1. The instruction describes a change to make. Make it — never return the current values unchanged.
+2. Return a field ONLY if its value should change. Omit every field that stays the same.
+3. Return complete replacement values, never diffs, fragments or instructions.
+4. Change only what the instruction implies. Do not quietly rewrite unrelated fields.
+5. Never shorten, truncate or downgrade a field you were not asked to change.`
+      : `Extract structured data from the user's natural language description to help them create a ${entityName} listing.
+
+RULES:
+1. Only include fields you can confidently derive from the description
+2. Do not make up factual information that is not in the description
+3. For unclear values, omit them rather than guess`;
+
+  return `You are the form-filling assistant for OrangeCat, an AI-powered platform for economic activity.
+
+${task}
+
+ALWAYS:
+- Output valid JSON only — no markdown, no explanations
+- Include a "confidence" object with a score (0-1) for every field you return
+
+${WRITING_QUALITY_RULES}
+
+${BITCOIN_RULES}
+
+${OUTPUT_FORMAT}`;
+}
+
+/** Drop empty/absent values so prompts only carry real content. */
+function nonEmptyEntries(data?: Record<string, unknown>): Record<string, unknown> {
+  if (!data) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(data).filter(([, v]) => v !== '' && v !== null && v !== undefined)
+  );
 }
 
 /**
- * Build the user prompt with field definitions and description
+ * Build the user prompt with field definitions and the user's request
  */
 export function getUserPrompt(
   entityType: EntityType,
   userDescription: string,
   fieldsDescription: string,
   specialInstructions: string,
-  existingData?: Record<string, unknown>
+  existingData?: Record<string, unknown>,
+  intent: AiAssistIntent = 'fill'
 ): string {
   const meta = ENTITY_REGISTRY[entityType];
   const entityName = meta?.name || entityType;
+  const currentValues = nonEmptyEntries(existingData);
+  const special = specialInstructions ? `\nSpecial instructions:\n${specialInstructions}\n` : '';
+
+  if (intent === 'refine') {
+    return `I am editing my ${entityName} listing.
+
+CURRENT FORM VALUES:
+${JSON.stringify(currentValues, null, 2)}
+
+THE CHANGE I WANT:
+"${userDescription}"
+
+Available fields for this ${entityName}:
+${fieldsDescription}
+${special}
+Apply my change to the current values. Output ONLY valid JSON with "data" and "confidence" objects, containing only the fields whose values should change.`;
+  }
 
   let prompt = `I want to create a ${entityName} listing.
 
@@ -66,19 +136,17 @@ Here's my description:
 
 Available fields for this ${entityName}:
 ${fieldsDescription}
+${special}`;
 
-${specialInstructions ? `Special instructions:\n${specialInstructions}\n` : ''}`;
-
-  if (existingData && Object.keys(existingData).length > 0) {
+  if (Object.keys(currentValues).length > 0) {
     // Price and currency are always overridable — if the user mentions them in their description,
     // the AI should pick them up rather than keeping template defaults.
-    const userOverridableFields = new Set(['price', 'currency', 'hourly_rate', 'fixed_price']);
-    const nonEmptyData = Object.entries(existingData).filter(
-      ([k, v]) => v !== '' && v !== null && v !== undefined && !userOverridableFields.has(k)
+    const preserved = Object.fromEntries(
+      Object.entries(currentValues).filter(([k]) => !USER_OVERRIDABLE_FIELDS.includes(k))
     );
-    if (nonEmptyData.length > 0) {
+    if (Object.keys(preserved).length > 0) {
       prompt += `\nPreserve these existing values (do not overwrite):
-${JSON.stringify(Object.fromEntries(nonEmptyData), null, 2)}\n`;
+${JSON.stringify(preserved, null, 2)}\n`;
     }
   }
 
@@ -164,69 +232,5 @@ export function parseAIResponse(
   } catch (error) {
     logger.error('Failed to parse AI response', error, 'AI');
     return null;
-  }
-}
-
-/**
- * Get example descriptions for different entity types (for UI hints)
- */
-export function getExampleDescriptions(entityType: EntityType): string[] {
-  switch (entityType) {
-    case 'product':
-      return [
-        'I want to sell handmade ceramic mugs for CHF 45 each',
-        'Digital download of my artwork collection, $15',
-        'Vintage hardware wallets, limited stock of 5 units, 0.005 BTC each',
-      ];
-    case 'service':
-      return [
-        'Consulting sessions, CHF 150/hour',
-        'Web development services starting at 0.01 BTC',
-        'Lightning Network integration help, 2 hour minimum',
-      ];
-    case 'event':
-      return [
-        'Bitcoin meetup next Saturday at the local cafe',
-        'Online workshop about Lightning Network, January 15th at 7pm',
-        'Hackathon weekend event with 0.1 BTC prize pool',
-      ];
-    case 'project':
-      return [
-        'Building an open-source Bitcoin wallet app, goal of 0.5 BTC',
-        'Documentary about Bitcoin adoption in Africa',
-        'Community education program for local merchants',
-      ];
-    case 'cause':
-      return [
-        'Supporting Bitcoin education in underserved communities',
-        'Funding for open-source development',
-        'Help me replace my hardware wallet that was stolen',
-      ];
-    case 'loan':
-      return [
-        'Need CHF 5,000 for 3 months to expand my business',
-        'Looking to refinance my existing loan at a better rate',
-        'Small business loan for mining equipment, 0.1 BTC',
-      ];
-    case 'investment':
-      return [
-        'Seeking 0.5 BTC in equity investment for my app, revenue-share model',
-        'Raising 1 BTC for solar farm expansion, 8% annual return',
-        'Looking for seed funding 0.25 BTC minimum investment',
-      ];
-    case 'research':
-      return [
-        'Bitcoin adoption study in emerging markets, goal 0.5 BTC',
-        'Computational biology research on protein folding, mixed methods',
-        'Economic impact of decentralized finance on local communities',
-      ];
-    case 'wishlist':
-      return [
-        'Birthday wishlist for my 30th in June',
-        'Wedding registry — we need kitchen essentials and a honeymoon fund',
-        'Personal wishlist for books and electronics',
-      ];
-    default:
-      return ['Describe what you want to create...'];
   }
 }

--- a/src/lib/ai/schema-to-prompt.ts
+++ b/src/lib/ai/schema-to-prompt.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EntityType } from '@/config/entity-registry';
+import { AI_ENTITY_INSTRUCTIONS, AI_UNIVERSAL_INSTRUCTIONS } from '@/config/ai-form-assist';
 import type { FieldConfig, FieldGroup } from '@/components/create/types';
 
 /**
@@ -147,55 +148,12 @@ export function formatFieldsForPrompt(descriptions: FieldDescription[]): string 
 }
 
 /**
- * Get common field names that typically need special handling
+ * Per-entity rules the AI needs to fill this form correctly.
+ *
+ * The content lives in `@/config/ai-form-assist` (AI_ENTITY_INSTRUCTIONS) —
+ * this is just the lookup, so adding an entity type never means adding a
+ * branch here.
  */
 export function getSpecialFieldInstructions(entityType: EntityType): string {
-  const instructions: string[] = [];
-
-  // Bitcoin-specific instructions
-  instructions.push(
-    'For Bitcoin prices: Express amounts in BTC as decimal values (e.g., 0.001 BTC). Never use satoshis. Common price points: 0.00005 BTC (~$5), 0.0003 BTC (~$30), 0.001 BTC (~$100).'
-  );
-
-  // Entity-specific instructions
-  switch (entityType) {
-    case 'product':
-      instructions.push(
-        'For product_type: Choose "physical" for tangible goods, "digital" for downloads/files, or "service" for service-based products.'
-      );
-      instructions.push(
-        'For inventory_count: Use -1 for unlimited inventory, or a positive number for limited stock.'
-      );
-      break;
-    case 'service':
-      instructions.push(
-        'For services: Provide either hourly_rate OR fixed_price (or both). Duration is in minutes.'
-      );
-      break;
-    case 'event':
-      instructions.push('For events: start_date is required. Use ISO format (YYYY-MM-DDTHH:mm).');
-      break;
-    case 'loan':
-      instructions.push(
-        'For loans: original_amount is what you need to borrow in BTC. Interest rates are annual percentages (e.g., 5 for 5%).'
-      );
-      break;
-    case 'investment':
-      instructions.push(
-        'For investments: target_amount is the total raise goal in BTC. minimum_investment is the minimum ticket size in BTC.'
-      );
-      break;
-    case 'research':
-      instructions.push(
-        'For research: funding_goal_btc is the funding target. field and methodology must use the exact option values shown above (not labels).'
-      );
-      break;
-    case 'wishlist':
-      instructions.push(
-        'For wishlists: type must be one of: general, birthday, wedding, baby_shower, graduation, personal. visibility: public, unlisted, or private.'
-      );
-      break;
-  }
-
-  return instructions.join('\n');
+  return [...AI_UNIVERSAL_INSTRUCTIONS, ...(AI_ENTITY_INSTRUCTIONS[entityType] ?? [])].join('\n');
 }

--- a/src/services/cat/tool-executor.ts
+++ b/src/services/cat/tool-executor.ts
@@ -134,11 +134,11 @@ INSTRUCTIONS (hard constraints):
           return;
         }
         try {
-          const prefill = await generateFormPrefill(
-            offer.entityType,
-            offer.description,
-            entityConfig
-          );
+          const prefill = await generateFormPrefill({
+            entityType: offer.entityType,
+            description: offer.description,
+            entityConfig,
+          });
           if (!prefill.success) {
             return;
           }
@@ -319,7 +319,7 @@ Explain this to the user in plain language: which provider is healthy, degraded,
     }
 
     try {
-      const prefill = await generateFormPrefill(entityType, description, entityConfig);
+      const prefill = await generateFormPrefill({ entityType, description, entityConfig });
       if (!prefill.success) {
         onToolCall?.({
           id: toolCall.id,


### PR DESCRIPTION
## The bug

The AI form filler could never change a field that already had a value.

Two layers enforced the same rule:

- `generateFormPrefill` overwrote every AI value with the existing form value whenever it was non-empty
- `getUserPrompt` told the model *"Preserve these existing values (do not overwrite)"*

So refinement on create only ever filled gaps, and **"Edit with AI" was a no-op by construction** — on an edit page every field is already populated. Typing *"make description longer and in english and german"* into Adjust did nothing, and the bar reported success anyway.

## The fix

An explicit **intent** is now the SSOT for who wins on conflict:

| intent | behaviour |
|---|---|
| `fill` | protects what the user typed (previous behaviour) |
| `refine` | the AI wins for the fields it returns; omitted fields keep their current values |

Edit mode starts in refine mode, since every field there is populated.

## Also in this PR

**Writing quality.** `"Only output what you can confidently extract"` is why title *Photography* produced description *"I offer photography."* The prompt now separates **facts** (never invent prices, dates, locations, credentials) from **prose** (write 3+ real sentences, never restate the title), and names that exact failure as a counter-example. `max_tokens` 1000 → 2000 so longer/bilingual copy stops truncating mid-JSON.

**Form-aware quick adjustments.** One-click chips — Longer description, Add German version, Shorter, More professional, Friendlier tone, Better title, Better tags, Fill in the blanks. Each declares which fields it applies to and is filtered against the form's real `fieldGroups`, so a form without a tags field never offers "Better tags".

**Honest feedback.** The bar now reports what actually changed (`Updated: Description, Tags`) instead of claiming success either way, and only fields the AI wrote are highlighted as AI-generated — previously the whole form lit up, because the response carried every field.

**SSOT / config-driven.** `getExampleDescriptions` and `getSpecialFieldInstructions` were `switch` statements covering 9 and 7 of 15 entity types; everything else silently got nothing. Both are now data in `src/config/ai-form-assist.ts` with a registry-derived fallback, so a new entity type is a config entry rather than a new `case`. `USER_OVERRIDABLE_FIELDS` is one list read by both the prompt and the merge — they disagreed before, and the merge silently won (the AI could never set a price the user described).

`generateFormPrefill` now takes an options object instead of 5 positional params.

## Verification

- `npm run type-check` — clean
- `npm run test:unit` — **1256/1256 pass** (pre-commit and pre-push gates both green)
- 27 new unit tests in `__tests__/unit/lib/ai-form-assist.test.ts` covering the merge policy in both intents, adjustment filtering, and that no entity type falls through to an empty example list

Not exercised against a live model — the merge policy and config are unit-tested; prompt-quality changes are reviewable but unmeasured.

## Known gap (not addressed)

The bar is SSOT across all entity create/edit forms (it lives in `EntityForm`), but a few long forms aren't entity forms and so don't get it: `TaskFormFields`, `ProposalFormFields`, `WalletForm`, group settings. Wiring those up requires generalizing the prefill API from "registry entity types" to "any declared form schema" — it currently resolves fields via `getEntityConfig(entityType)`. That's a design step, not a wiring change, so it's left out rather than special-cased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
