### PR TITLE
feat(cat): global, page-aware Cat launcher on every app page

### DIFF
--- a/src/components/ai-chat/GlobalCatLauncher.tsx
+++ b/src/components/ai-chat/GlobalCatLauncher.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Cat, X, Maximize2 } from 'lucide-react';
+import { ModernChatPanel } from '@/components/ai-chat/ModernChatPanel/index';
+import { describePageForCat } from '@/config/cat-page-context';
+import { ROUTES } from '@/config/routes';
+import { cn } from '@/lib/utils';
+
+/**
+ * Global Cat launcher — a floating button on every app page that opens Cat as a
+ * slide-over, WITHOUT leaving the page. Because it lives on top of the current
+ * page, it passes that page (and its entity, if any) to Cat, so "summarise this
+ * project" / "who's asking about this?" work in context. The full history +
+ * settings still live at the Cat hub, one click away via the expand button.
+ *
+ * Mounted once in AppShell; the parent decides when to render it (authed app
+ * surfaces only, never the Cat hub itself).
+ */
+export default function GlobalCatLauncher() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  // Keep the drawer's conversation across open/close within a session, so
+  // reopening resumes the thread instead of starting cold.
+  const [conversationId, setConversationId] = useState<string | null>(null);
+
+  const page = describePageForCat(pathname);
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  return (
+    <>
+      {/* Floating launcher — clears the mobile bottom nav (pb-20) on small screens. */}
+      {!open && (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label="Ask Cat"
+          className="fixed bottom-20 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-accent-warm text-white shadow-lg transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-warm focus-visible:ring-offset-2 md:bottom-6 md:right-6"
+          title="Ask Cat about this page"
+        >
+          <Cat className="h-6 w-6" />
+        </button>
+      )}
+
+      {open && (
+        <>
+          {/* Backdrop (mobile emphasis; desktop keeps the page visible behind). */}
+          <div
+            className="fixed inset-0 z-40 bg-black/40 sm:bg-black/20"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
+
+          <aside
+            role="dialog"
+            aria-label="Cat"
+            className={cn(
+              'fixed inset-y-0 right-0 z-50 flex w-full flex-col bg-surface-page shadow-2xl',
+              'sm:w-[420px] sm:border-l sm:border-default'
+            )}
+          >
+            <header className="flex items-center justify-between border-b border-default px-4 py-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-accent-warm/10 text-accent-warm">
+                  <Cat className="h-4 w-4" />
+                </span>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-fg-primary">Cat</p>
+                  {page?.label && (
+                    <p className="truncate text-xs text-fg-tertiary">Looking at {page.label}</p>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                <Link
+                  href={ROUTES.DASHBOARD.CAT}
+                  onClick={() => setOpen(false)}
+                  className="flex h-8 w-8 items-center justify-center rounded-md text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary"
+                  title="Open the full Cat"
+                  aria-label="Open the full Cat page"
+                >
+                  <Maximize2 className="h-4 w-4" />
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  className="flex h-8 w-8 items-center justify-center rounded-md text-fg-secondary transition-colors hover:bg-surface-raised hover:text-fg-primary"
+                  aria-label="Close Cat"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            </header>
+
+            <div className="oc-chat-layout min-h-0 flex-1">
+              <ModernChatPanel
+                variant="focus"
+                conversationId={conversationId}
+                onConversationCreated={setConversationId}
+                pageContext={page}
+                className="min-h-0 flex-1"
+              />
+            </div>
+          </aside>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
@@ -5,6 +5,7 @@ import { API_ROUTES } from '@/config/api-routes';
 import { isCatHubPath } from '@/config/routes';
 import { useUserCurrency } from '@/hooks/useUserCurrency';
 import { STORAGE_KEYS } from '@/config/storage-keys';
+import type { CatPageDescriptor } from '@/config/cat-page-context';
 import type {
   Message,
   CatAction,
@@ -80,6 +81,12 @@ interface UseChatMessagesOptions {
    * so the owner can adopt it (highlight in the rail, route later sends to it).
    */
   onConversationCreated?: (id: string) => void;
+  /**
+   * The page the user is currently on, when Cat runs as a global overlay. Sent
+   * with each message so Cat knows what the user is looking at. Omitted on the
+   * standalone Cat hub (there is no "page behind" it).
+   */
+  pageContext?: CatPageDescriptor | null;
 }
 
 /** Create a conversation row on the server; null on failure (send falls back to default). */
@@ -104,6 +111,7 @@ export function useChatMessages({
   onMessageSent,
   onConversationStarted,
   onConversationCreated,
+  pageContext,
 }: UseChatMessagesOptions) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -118,6 +126,9 @@ export function useChatMessages({
   onConversationStartedRef.current = onConversationStarted;
   const onConversationCreatedRef = useRef(onConversationCreated);
   onConversationCreatedRef.current = onConversationCreated;
+  // Live page context — read at send time so navigating with Cat open stays current.
+  const pageContextRef = useRef(pageContext);
+  pageContextRef.current = pageContext;
   const preferredCurrency = useUserCurrency();
 
   // Conversation created lazily on the first send of a fresh draft. `pending`
@@ -199,6 +210,8 @@ export function useChatMessages({
             preferredCurrency,
             locale: readLocale(),
             lastVisitedPath: readLastVisitedPath(),
+            currentPath: pageContextRef.current?.path,
+            currentEntity: pageContextRef.current?.entity,
             conversationId: activeConversationId ?? undefined,
           }),
           signal: abortController.signal,

--- a/src/components/ai-chat/ModernChatPanel/index.tsx
+++ b/src/components/ai-chat/ModernChatPanel/index.tsx
@@ -45,6 +45,8 @@ interface ModernChatPanelProps {
   onConversationStarted?: () => void;
   /** Fires when the first send of a fresh draft created a conversation — adopt it. */
   onConversationCreated?: (id: string) => void;
+  /** Current page the user is on (global overlay) so Cat is page-aware. */
+  pageContext?: import('@/config/cat-page-context').CatPageDescriptor | null;
   className?: string;
 }
 
@@ -59,6 +61,7 @@ export function ModernChatPanel({
   conversationId,
   onConversationStarted,
   onConversationCreated,
+  pageContext,
   className,
 }: ModernChatPanelProps = {}) {
   const router = useRouter();
@@ -113,6 +116,7 @@ export function ModernChatPanel({
     },
     onConversationStarted,
     onConversationCreated,
+    pageContext,
   });
 
   const { suggestions, hasContext, isLoadingSuggestions } = useSuggestions();

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -3,7 +3,8 @@
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
-import { getRouteChrome, getRouteSurface } from '@/config/routes';
+import { getRouteChrome, getRouteSurface, isCatHubPath } from '@/config/routes';
+import GlobalCatLauncher from '@/components/ai-chat/GlobalCatLauncher';
 import { STORAGE_KEYS } from '@/config/storage-keys';
 import { Header } from './Header';
 import { Sidebar } from '@/components/sidebar/Sidebar';
@@ -176,6 +177,12 @@ export function AppShell({ children }: AppShellProps) {
 
       {/* Mobile Bottom Navigation - Context-aware (handles its own visibility) */}
       <MobileBottomNav />
+
+      {/* Global Cat — reachable from any authenticated app page, page-context-aware.
+          Hidden on the Cat hub itself (it IS Cat there). */}
+      {isAppSurface && isAuthReady && user && !isCatHubPath(pathname ?? '/') && (
+        <GlobalCatLauncher />
+      )}
     </div>
   );
 }

--- a/src/config/cat-page-context.ts
+++ b/src/config/cat-page-context.ts
@@ -1,0 +1,90 @@
+/**
+ * Page → Cat context: turns the URL the user is currently on into a small,
+ * safe descriptor Cat can reason about ("they're looking at project abc123").
+ * This is what makes the global Cat launcher page-AWARE instead of generic —
+ * open it on a project and Cat knows the project, open it on an article and it
+ * knows the article. Client- and server-safe (no imports beyond types).
+ *
+ * Deliberately conservative: we only claim an entity for routes we recognise,
+ * and never treat create/edit sub-routes as an entity ref.
+ */
+
+export interface CatPageEntity {
+  /** Entity kind, e.g. 'project', 'article', 'profile'. */
+  type: string;
+  /** The id or slug from the URL. */
+  ref: string;
+}
+
+export interface CatPageDescriptor {
+  /** The absolute in-app path (same-origin). */
+  path: string;
+  /** Human phrase for UI ("a project", "your dashboard"). */
+  label?: string;
+  /** Recognised entity when the path is an entity view. */
+  entity?: CatPageEntity;
+}
+
+/** Sub-route segments that are actions, not entity refs. */
+const RESERVED_REFS = new Set(['new', 'create', 'edit', 'settings']);
+
+interface Pattern {
+  re: RegExp;
+  type: string;
+  label: string;
+}
+
+// Ordered most-specific first. `([^/]+)` captures the id/slug.
+const ENTITY_PATTERNS: Pattern[] = [
+  { re: /^\/projects\/([^/]+)/, type: 'project', label: 'a project' },
+  { re: /^\/profiles\/([^/]+)/, type: 'profile', label: "a member's profile" },
+  { re: /^\/(?:articles|blog)\/([^/]+)/, type: 'article', label: 'an article' },
+  { re: /^\/groups\/([^/]+)/, type: 'group', label: 'a group' },
+  { re: /^\/events\/([^/]+)/, type: 'event', label: 'an event' },
+  { re: /^\/causes\/([^/]+)/, type: 'cause', label: 'a cause' },
+  { re: /^\/assets\/([^/]+)/, type: 'asset', label: 'an asset' },
+];
+
+// Non-entity areas worth naming so Cat knows the surface the user is on.
+const AREA_LABELS: Array<{ re: RegExp; label: string }> = [
+  { re: /^\/dashboard\/store/, label: 'your store' },
+  { re: /^\/dashboard\/wallet/, label: 'your wallet' },
+  { re: /^\/dashboard(\/|$)/, label: 'your dashboard' },
+  { re: /^\/discover/, label: 'the discover feed' },
+  { re: /^\/timeline/, label: 'the timeline' },
+  { re: /^\/search/, label: 'search' },
+  { re: /^\/settings/, label: 'your settings' },
+  { re: /^\/pricing/, label: 'the pricing page' },
+];
+
+/**
+ * Describe the current page for Cat. Returns undefined for anything that isn't a
+ * safe same-origin path (so callers can simply skip sending page context).
+ */
+export function describePageForCat(pathname: string | null | undefined): CatPageDescriptor | null {
+  if (!pathname || !pathname.startsWith('/')) {
+    return null;
+  }
+  const path = pathname.slice(0, 200);
+
+  for (const p of ENTITY_PATTERNS) {
+    const m = path.match(p.re);
+    if (m) {
+      const ref = decodeURIComponent(m[1]);
+      const isEntity = !RESERVED_REFS.has(ref.toLowerCase());
+      return {
+        path,
+        label: isEntity ? p.label : `creating ${p.label}`,
+        entity: isEntity ? { type: p.type, ref } : undefined,
+      };
+    }
+  }
+
+  for (const a of AREA_LABELS) {
+    if (a.re.test(path)) {
+      return { path, label: a.label };
+    }
+  }
+
+  return { path };
+}

--- a/src/services/ai/context-sections.ts
+++ b/src/services/ai/context-sections.ts
@@ -90,7 +90,14 @@ export function renderCurrentSession(r: FullUserContext['runtime']): string | nu
   lines.push(
     `**Locale**: ${r.locale} — reply in the language and conventions of this locale unless the user writes in another language.`
   );
-  if (r.lastVisitedPath) {
+  if (r.currentPath) {
+    const entity = r.currentEntity
+      ? ` — a ${r.currentEntity.type} (ref \`${r.currentEntity.ref}\`)`
+      : '';
+    lines.push(
+      `**Currently viewing**: \`${r.currentPath}\`${entity}. The user opened you WHILE on this page — if their question is about it ("this", "here", "them"), ground your answer in it. Use your lookup/search tools to pull the specifics of that ${r.currentEntity ? r.currentEntity.type : 'page'} rather than guessing.`
+    );
+  } else if (r.lastVisitedPath) {
     lines.push(
       `**Just came from**: \`${r.lastVisitedPath}\` — if relevant to their question, reference what's on that page.`
     );

--- a/src/services/ai/document-context-types.ts
+++ b/src/services/ai/document-context-types.ts
@@ -210,6 +210,14 @@ export interface RuntimeContext {
    */
   lastVisitedPath?: string;
   /**
+   * The page the user is looking at RIGHT NOW, when Cat is opened as a global
+   * overlay on top of a page (not the standalone Cat hub). Makes Cat aware of
+   * "this project / this article" the user is currently viewing.
+   */
+  currentPath?: string;
+  /** The entity the current page is about, if recognised (type + id/slug). */
+  currentEntity?: { type: string; ref: string };
+  /**
    * Live BTC exchange-rate snapshot so Cat quotes real numbers for BTC⇄fiat
    * conversions instead of recalling a stale rate from training data.
    */

--- a/src/services/ai/document-context.ts
+++ b/src/services/ai/document-context.ts
@@ -243,6 +243,10 @@ export interface RuntimeContextHints {
   locale?: string;
   /** Same-origin path of the page user came from. Stripped if it looks unsafe. */
   lastVisitedPath?: string;
+  /** Same-origin path of the page the user is on NOW (global Cat overlay). */
+  currentPath?: string;
+  /** Entity the current page is about, if the client recognised one. */
+  currentEntity?: { type: string; ref: string };
 }
 
 /**
@@ -267,6 +271,24 @@ function sanitizeLastVisitedPath(path: string | undefined): string | undefined {
   return path;
 }
 
+/**
+ * Sanitize the client-supplied "currently viewing" entity. Both fields are short
+ * and URL-safe; anything else is dropped rather than fed to Cat.
+ */
+function sanitizeCurrentEntity(
+  entity: { type?: unknown; ref?: unknown } | undefined
+): { type: string; ref: string } | undefined {
+  if (!entity || typeof entity.type !== 'string' || typeof entity.ref !== 'string') {
+    return undefined;
+  }
+  const type = entity.type.trim().slice(0, 32);
+  const ref = entity.ref.trim().slice(0, 120);
+  if (!/^[a-z_]+$/i.test(type) || !ref) {
+    return undefined;
+  }
+  return { type, ref };
+}
+
 async function fetchRuntimeContextForCat(
   supabase: AnySupabaseClient,
   userId: string,
@@ -289,6 +311,8 @@ async function fetchRuntimeContextForCat(
       : 'en-US';
 
   const lastVisitedPath = sanitizeLastVisitedPath(hints?.lastVisitedPath);
+  const currentPath = sanitizeLastVisitedPath(hints?.currentPath);
+  const currentEntity = currentPath ? sanitizeCurrentEntity(hints?.currentEntity) : undefined;
 
   // Current actor: for Tier 1 we always use the individual actor. Group-context
   // switching plumbs through later (Tier 5), with its own server-side validation
@@ -335,6 +359,8 @@ async function fetchRuntimeContextForCat(
     locale,
     currentActor,
     lastVisitedPath,
+    currentPath,
+    currentEntity,
     btcRate,
   };
 }

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -58,6 +58,9 @@ export const catChatBodySchema = z.object({
   preferredCurrency: z.string().max(8).optional(),
   locale: z.string().max(20).optional(),
   lastVisitedPath: z.string().max(200).optional(),
+  /** The page the user is on right now (global Cat overlay), + its entity if any. */
+  currentPath: z.string().max(200).optional(),
+  currentEntity: z.object({ type: z.string().max(32), ref: z.string().max(120) }).optional(),
 });
 
 export type CatChatBody = z.infer<typeof catChatBodySchema>;
@@ -194,6 +197,8 @@ export async function orchestrateCatChat(
     preferredCurrency,
     locale,
     lastVisitedPath,
+    currentPath,
+    currentEntity,
     conversationId: requestedConversationId,
   } = body;
 
@@ -237,6 +242,8 @@ export async function orchestrateCatChat(
       preferredCurrency,
       locale,
       lastVisitedPath,
+      currentPath,
+      currentEntity,
     }),
     recallMemories(supabase, user.id, message),
   ]);
@@ -522,7 +529,6 @@ export async function orchestrateCatChat(
       },
     });
     return applyRateLimitHeaders(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       new Response(readable, {
         status: 200,
         headers: {


### PR DESCRIPTION
Answers two gaps George raised about Cat: it wasn't reachable from most pages, and it never knew *what page you were on*.

## Before
- Cat lived at exactly one URL (`/dashboard/cat`) — you had to navigate away to use it, contradicting its own charter ("The Cat is the interface").
- Even there, the only page signal was a `lastVisitedPath` breadcrumb (the page you were on *before* Cat). It never knew the entity you were actually looking at → answers felt generic.

## After
- **Global launcher** — a floating Cat button mounted once in `AppShell`, on every authenticated app page (hidden on the Cat hub itself). Opens Cat as a slide-over **without leaving the page**; an expand button jumps to the full hub. Keeps its conversation across open/close within a session. (evig's corner chat is admin-only and context-blind — this is deliberately better on both counts.)
- **Page-aware** — `describePageForCat()` (new SSOT) turns the live pathname into a safe descriptor: *"a project (ref abc123)"*, *"an article (ref my-slug)"*, *"your dashboard"*. Sent with every message and plumbed through the whole pipeline:
  `useChatMessages` → chat schema → `RuntimeContextHints` → `RuntimeContext` → a **"Currently viewing"** line in the system prompt (which supersedes the weaker "Just came from"). Server sanitises both fields; unknown paths degrade to path-only, so Cat never fabricates a page.

Net: "summarise this project" / "who's asking about this?" now work in context from anywhere.

## Notes
- The chat panel is only mounted while the drawer is open (no background fetches when closed).
- New optional schema fields are backward-compatible; old clients keep working.

## Verification
- `tsc` **0 errors**, eslint **clean**, `audit:routes` **clean**, **1243/1243** unit tests pass. Page-descriptor parsing validated across entity/create/area/unknown routes.
- ⚠️ **Not** exercised E2E against the production DB (sandbox can't reach `supabase.orangecat.ch`) — the drawer render + live page-context grounding are best smoke-tested on a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)