### PR TITLE
fix(payments): make settlement side-effects exactly-once

### DIFF
--- a/__tests__/unit/domain/payments/buyerConfirmPayment.test.ts
+++ b/__tests__/unit/domain/payments/buyerConfirmPayment.test.ts
@@ -43,10 +43,15 @@ function makeSupabase(opts: {
   intent: Record<string, unknown> | null;
   statusUpdateError?: unknown;
 }) {
-  const awaitQueue: Array<{ error: unknown }> = [{ error: opts.statusUpdateError ?? null }];
+  // The status flip is now a claim: it returns the row when this caller won it.
+  const awaitQueue: Array<{ data?: unknown; error: unknown }> = [
+    opts.statusUpdateError
+      ? { data: null, error: opts.statusUpdateError }
+      : { data: [{ id: PI_ID }], error: null },
+  ];
 
   const builder: Record<string, unknown> = {};
-  for (const m of ['select', 'update', 'eq', 'in']) {
+  for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
     builder[m] = jest.fn(() => builder);
   }
   builder.single = jest.fn(() => Promise.resolve({ data: opts.intent, error: null }));

--- a/__tests__/unit/domain/payments/exactlyOncePaid.test.ts
+++ b/__tests__/unit/domain/payments/exactlyOncePaid.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Settlement side-effects run exactly once, no matter how many observers see
+ * the same payment.
+ *
+ * OrangeCat is non-custodial, so it never owns the fact of payment — it learns
+ * about it by asking (the payer's browser polling every 3s, a background sweep,
+ * the recipient confirming). Several observers can therefore report the same
+ * settlement at the same moment. The transition to `paid` is a conditional
+ * UPDATE, so exactly one of them wins, and only the winner may run the
+ * side-effects: inventory decrement, Supporter grant, notification, webhook.
+ *
+ * A lost race must be a silent no-op — NOT a second notification, and above all
+ * NOT a second inventory decrement (that oversells real stock).
+ */
+
+import { checkPaymentStatus } from '@/domain/payments/paymentFlowService';
+import { STATUS } from '@/config/database-constants';
+import { checkOnchainPaymentStatus } from '@/domain/payments/paymentStatusService';
+import { NotificationDispatcher } from '@/services/notifications/dispatcher';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/lib/email/send-seller-notification', () => ({
+  sendSellerPaymentNotification: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/services/notifications/dispatcher', () => ({
+  NotificationDispatcher: { dispatch: jest.fn().mockResolvedValue(undefined) },
+}));
+jest.mock('@/domain/payments/paymentStatusService', () => ({
+  checkNWCPaymentStatus: jest.fn(),
+  checkOnchainPaymentStatus: jest.fn(),
+}));
+
+const onchainMock = checkOnchainPaymentStatus as jest.Mock;
+const dispatchMock = NotificationDispatcher.dispatch as jest.Mock;
+
+const PI_ID = 'pi-race';
+const SELLER = 'seller-1';
+
+const intent = {
+  id: PI_ID,
+  buyer_id: 'buyer-1',
+  seller_id: SELLER,
+  status: STATUS.PAYMENT_INTENTS.INVOICE_READY,
+  payment_method: 'onchain',
+  intent_kind: 'purchase',
+  onchain_address: 'bc1qxyz',
+  entity_type: 'product',
+  entity_id: 'prod-1',
+  amount_btc: 0.01,
+  description: 'Product: Blue Mug',
+  paid_at: null,
+  expires_at: null,
+};
+
+/**
+ * @param claimWon whether the conditional paid-transition matched a row. false
+ *        models "another observer already settled this one microsecond ago":
+ *        PostgREST returns an empty array, no error.
+ */
+function makeSupabase(claimWon: boolean) {
+  const rpc = jest.fn(() => Promise.resolve({ error: null }));
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
+  builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve({ data: claimWon ? [{ id: PI_ID }] : [], error: null }).then(resolve, reject);
+  return { from: jest.fn(() => builder), rpc } as never;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  onchainMock.mockResolvedValue('confirmed');
+});
+
+describe('exactly-once settlement', () => {
+  it('runs the side-effects when this observer wins the transition', async () => {
+    const supabase = makeSupabase(true);
+    const res = await checkPaymentStatus(supabase, PI_ID, SELLER);
+
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs NO side-effects when another observer already settled it', async () => {
+    const supabase = makeSupabase(false);
+    const res = await checkPaymentStatus(supabase, PI_ID, SELLER);
+
+    // The payment really is paid — the caller must still be told so.
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
+    // ...but nothing may fire a second time.
+    expect(dispatchMock).not.toHaveBeenCalled();
+    // Above all: no second inventory decrement (that would oversell).
+    expect((supabase as unknown as { rpc: jest.Mock }).rpc).not.toHaveBeenCalled();
+  });
+
+  it('notifies once when two observers report the same payment concurrently', async () => {
+    // First caller claims the row; the second finds it already paid.
+    let claimed = false;
+    const rpc = jest.fn(() => Promise.resolve({ error: null }));
+    const builder: Record<string, unknown> = {};
+    for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
+      builder[m] = jest.fn(() => builder);
+    }
+    builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
+    builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) => {
+      const won = !claimed;
+      claimed = true;
+      return Promise.resolve({ data: won ? [{ id: PI_ID }] : [], error: null }).then(
+        resolve,
+        reject
+      );
+    };
+    const supabase = { from: jest.fn(() => builder), rpc } as never;
+
+    await Promise.all([
+      checkPaymentStatus(supabase, PI_ID, SELLER),
+      checkPaymentStatus(supabase, PI_ID, SELLER),
+    ]);
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/unit/domain/payments/handlePaymentConfirmed.test.ts
+++ b/__tests__/unit/domain/payments/handlePaymentConfirmed.test.ts
@@ -56,9 +56,13 @@ const onchainIntent = {
  *   [ intent status update, order update ].  rpc() resolves cleanly.
  */
 function makeSupabase(orderUpdateError: unknown) {
-  const awaitQueue: Array<{ error: unknown }> = [{ error: null }, { error: orderUpdateError }];
+  // [ paid-transition claim (returns the row = we won), order update ]
+  const awaitQueue: Array<{ data?: unknown; error: unknown }> = [
+    { data: [{ id: PI_ID }], error: null },
+    { error: orderUpdateError },
+  ];
   const builder: Record<string, unknown> = {};
-  for (const m of ['select', 'update', 'eq', 'in']) {
+  for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
     builder[m] = jest.fn(() => builder);
   }
   builder.single = jest.fn(() => Promise.resolve({ data: onchainIntent, error: null }));
@@ -89,12 +93,14 @@ const tipIntent = {
 /** Builder returning `intent`; the tip path only awaits ONE update (mark paid). */
 function makeSupabaseReturning(intent: unknown) {
   const builder: Record<string, unknown> = {};
-  for (const m of ['select', 'update', 'eq', 'in']) {
+  for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
     builder[m] = jest.fn(() => builder);
   }
   builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
+  // Awaited writes resolve as a won claim (the conditional paid-transition
+  // returns the row it updated).
   builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
-    Promise.resolve({ error: null }).then(resolve, reject);
+    Promise.resolve({ data: [{ id: PI_ID }], error: null }).then(resolve, reject);
   const rpc = jest.fn(() => Promise.resolve({ error: null }));
   return { from: jest.fn(() => builder), rpc } as never;
 }

--- a/__tests__/unit/domain/payments/lnurlVerify.test.ts
+++ b/__tests__/unit/domain/payments/lnurlVerify.test.ts
@@ -93,15 +93,17 @@ describe('checkPaymentStatus — lightning_address + verify URL', () => {
   function makeSupabase(intent: Record<string, unknown>) {
     const update = jest.fn();
     const builder: Record<string, unknown> = {};
-    for (const m of ['select', 'update', 'eq', 'in']) {
+    for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
       builder[m] = jest.fn((...args: unknown[]) => {
         if (m === 'update') update(...args);
         return builder;
       });
     }
     builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
+    // The paid transition is a conditional UPDATE … .neq('status','paid').select('id'):
+    // a returned row means THIS caller won the claim and owns the side-effects.
     builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
-      Promise.resolve({ error: null }).then(resolve, reject);
+      Promise.resolve({ data: [{ id: intent.id }], error: null }).then(resolve, reject);
     return { client: { from: jest.fn(() => builder) } as never, update };
   }
 

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -702,7 +702,49 @@ async function updatePaymentStatus(
 }
 
 /**
+ * Claim the transition to `paid`, exactly once.
+ *
+ * Settlement is observed, never owned: OrangeCat is non-custodial, so the truth
+ * lives in the recipient's wallet and we learn about it by asking (a browser
+ * poll, a background sweep, a recipient confirming). Any number of observers
+ * may therefore report the same payment at the same moment.
+ *
+ * A plain `UPDATE … SET status='paid'` let every one of them proceed to the
+ * side-effects: inventory would be decremented twice (overselling), Supporter
+ * plans granted twice, the recipient notified twice, webhooks fanned twice.
+ *
+ * The row's own status is the lock. A conditional update is atomic in Postgres,
+ * so exactly one caller can move a not-yet-paid intent to paid, and only that
+ * caller is entitled to run the settlement side-effects.
+ *
+ * @returns true when THIS caller won the transition; false when someone else
+ *          already settled it (a safe, silent no-op).
+ */
+async function claimPaidTransition(
+  supabase: SupabaseClient,
+  paymentIntentId: string
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from(DATABASE_TABLES.PAYMENT_INTENTS)
+    .update({ status: STATUS.PAYMENT_INTENTS.PAID, paid_at: new Date().toISOString() })
+    .eq('id', paymentIntentId)
+    .neq('status', STATUS.PAYMENT_INTENTS.PAID)
+    .select('id');
+
+  // Same reasoning as updatePaymentStatus: a swallowed error here would leave
+  // money state diverging from reality while the caller reports success.
+  if (error) {
+    logger.error('Failed to claim paid transition', { paymentIntentId, error });
+    throw new Error('Failed to update payment status');
+  }
+
+  return (data?.length ?? 0) > 0;
+}
+
+/**
  * Handle side-effects when a payment is confirmed as paid.
+ *
+ * Runs at most once per payment intent — see {@link claimPaidTransition}.
  */
 async function handlePaymentConfirmed(
   supabase: SupabaseClient,
@@ -712,8 +754,18 @@ async function handlePaymentConfirmed(
   const entityType = paymentIntent.entity_type as EntityType;
   const entityId = paymentIntent.entity_id;
 
-  // Mark payment intent as paid
-  await updatePaymentStatus(supabase, piId, 'paid');
+  // Mark payment intent as paid — and only continue if we were the observer
+  // that actually moved it there. Losing the race means another poller (or the
+  // recipient's confirmation) already ran every side-effect below.
+  const claimed = await claimPaidTransition(supabase, piId);
+  if (!claimed) {
+    logger.info(
+      'Payment already settled by another observer — skipping duplicate side-effects',
+      { paymentIntentId: piId },
+      'paymentFlowService'
+    );
+    return;
+  }
 
   // A tip is a person-to-person gift with no entity — none of the entity-scoped
   // side-effects below apply (and getEntityMetadata would throw on a null type).


### PR DESCRIPTION
First of two changes closing the gap between "money arrived" and "OrangeCat recorded it". This one is pure money-safety and stands on its own.

## The problem

`handlePaymentConfirmed` marked an intent paid with an unconditional `UPDATE`, then ran the side-effects. Nothing bound the side-effects to *winning* that transition, so every concurrent observer ran them:

- inventory decremented twice → **overselling real stock**
- Supporter plan granted twice
- recipient notified twice
- `payment.settled` webhook fanned twice

Two browser tabs polling the same payment already trigger this today. It gets worse the moment a second observer exists.

## The fix

The row's own status is the lock:

```sql
UPDATE payment_intents SET status='paid', paid_at=now()
WHERE id=$1 AND status <> 'paid' RETURNING id
```

Atomic in Postgres — exactly one caller can move a not-yet-paid intent to paid, and only that caller runs the side-effects. A lost race is a silent, logged no-op, and the caller still reports `PAID` because the payment really did settle.

(Different shape from the advisory lock PR #490 used for Cat Credits: that guarded a multi-row ledger append; this guards one row's status, so a conditional update is the right primitive.)

## Why it lands first

It's a precondition for the reconciliation sweeper. Adding a second observer *before* this would double the double-fire surface instead of closing the gap.

## Tests
3 new: winner runs side-effects exactly once; loser runs none (explicitly asserting no second inventory decrement); two concurrent observers produce one notification. Existing payment mocks updated for the returning-row contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)