### PR TITLE
feat(timeline): bring AI editing to short posts + replies

### DIFF
--- a/src/app/api/ai/writing/revise/route.ts
+++ b/src/app/api/ai/writing/revise/route.ts
@@ -30,6 +30,8 @@ const bodySchema = z.object({
   title: z.string().trim().max(300).optional(),
   topic: z.string().trim().max(300).optional(),
   instruction: z.string().trim().max(300).optional(),
+  /** 'post' (short) vs 'article' (long-form, default) — changes framing + length. */
+  kind: z.enum(['post', 'article']).optional(),
 });
 
 const AI_UNAVAILABLE =
@@ -47,7 +49,7 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
     if (!parsed.success) {
       return apiBadRequest('Invalid request', parsed.error.flatten());
     }
-    const { action, text, tone, title, topic, instruction } = parsed.data;
+    const { action, text, tone, title, topic, instruction, kind } = parsed.data;
 
     // Title suggestions return a list; everything else returns transformed text.
     if (action === 'title') {
@@ -78,6 +80,7 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       title,
       topic,
       instruction,
+      kind,
     });
     if (!result) {
       return apiError(AI_UNAVAILABLE, 'AI_UNAVAILABLE', 503) as NextResponse;

--- a/src/components/timeline/PostAiEditMenu.tsx
+++ b/src/components/timeline/PostAiEditMenu.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { Wand2, Loader2, ChevronDown } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
+} from '@/components/ui/dropdown-menu';
+import { reviseArticleText } from '@/services/articles/ai-client';
+import type { ReviseAction, TonePreset } from '@/services/cat/writing-types';
+import { TIMELINE_SURFACE } from '@/config/timeline';
+import { cn } from '@/lib/utils';
+
+const TONES: { key: TonePreset; label: string }[] = [
+  { key: 'casual', label: 'More casual' },
+  { key: 'formal', label: 'More formal' },
+  { key: 'punchy', label: 'More punchy' },
+  { key: 'warm', label: 'Warmer' },
+];
+
+/**
+ * "Improve" menu for something the user has ALREADY typed into a post/reply
+ * composer — the short-form counterpart to the article editor's Ask-AI strip
+ * (previously buried in the article editor only). Rewrites the whole post text
+ * in place, kept post-short + voice-matched by the revise engine (kind:'post').
+ * Fails soft: a transient inline note, never a blocking error.
+ */
+export default function PostAiEditMenu({
+  text,
+  onRevised,
+  disabled,
+}: {
+  text: string;
+  onRevised: (text: string) => void;
+  disabled?: boolean;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const blocked = busy || disabled || !text.trim();
+
+  async function run(action: Exclude<ReviseAction, 'continue' | 'outline'>, tone?: TonePreset) {
+    if (blocked) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await reviseArticleText({ action, text, tone, kind: 'post' });
+      onRevised(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not edit that. Try again.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const item = 'cursor-pointer text-sm text-fg-primary focus:bg-surface-raised';
+
+  return (
+    <div className="inline-flex items-center gap-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            disabled={blocked}
+            className={cn(TIMELINE_SURFACE.chip, 'gap-1.5')}
+            title="Improve what you've written with AI"
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wand2 className="h-4 w-4" />}
+            {busy ? 'Editing…' : 'Improve'}
+            <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-52">
+          <DropdownMenuItem className={item} onSelect={() => run('improve')}>
+            Improve the writing
+          </DropdownMenuItem>
+          <DropdownMenuItem className={item} onSelect={() => run('tighten')}>
+            Make it tighter
+          </DropdownMenuItem>
+          <DropdownMenuItem className={item} onSelect={() => run('expand')}>
+            Add a bit more
+          </DropdownMenuItem>
+          <DropdownMenuItem className={item} onSelect={() => run('grammar')}>
+            Fix grammar &amp; spelling
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-fg-tertiary">Change tone</DropdownMenuLabel>
+          {TONES.map(t => (
+            <DropdownMenuItem key={t.key} className={item} onSelect={() => run('tone', t.key)}>
+              {t.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {error && <span className="text-xs text-status-negative">{error}</span>}
+    </div>
+  );
+}

--- a/src/components/timeline/PostCard.tsx
+++ b/src/components/timeline/PostCard.tsx
@@ -17,6 +17,7 @@ import { cn } from '@/lib/utils';
 import { Check } from 'lucide-react';
 import { usePostCardActions } from './usePostCardActions';
 import ReplyAiButton from './ReplyAiButton';
+import PostAiEditMenu from './PostAiEditMenu';
 import { TIMELINE_SURFACE } from '@/config/timeline';
 
 interface PostCardProps {
@@ -206,13 +207,22 @@ export function PostCard({
                     disabled={isReplying}
                     autoFocus
                   />
-                  <div className="flex items-center justify-between gap-2 mt-2">
-                    <ReplyAiButton
-                      parentText={event.description || event.title || ''}
-                      parentAuthor={event.actor?.username || event.actor?.name}
-                      onDraft={setReplyText}
-                      disabled={isReplying}
-                    />
+                  <div className="flex flex-wrap items-center justify-between gap-2 mt-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <ReplyAiButton
+                        parentText={event.description || event.title || ''}
+                        parentAuthor={event.actor?.username || event.actor?.name}
+                        onDraft={setReplyText}
+                        disabled={isReplying}
+                      />
+                      {replyText.trim() && (
+                        <PostAiEditMenu
+                          text={replyText}
+                          onRevised={setReplyText}
+                          disabled={isReplying}
+                        />
+                      )}
+                    </div>
                     <Button
                       onClick={handleReplySubmit}
                       disabled={!replyText.trim() || isReplying}

--- a/src/components/timeline/TimelineComposer.tsx
+++ b/src/components/timeline/TimelineComposer.tsx
@@ -25,6 +25,7 @@ import {
 } from './ComposerShared';
 import PostAiButton from './PostAiButton';
 import ReplyAiButton from './ReplyAiButton';
+import PostAiEditMenu from './PostAiEditMenu';
 
 export interface TimelineComposerProps {
   targetOwnerId?: string;
@@ -205,6 +206,13 @@ const TimelineComposer = React.memo(function TimelineComposer({
                   parentText={parentPostText}
                   parentAuthor={parentAuthorName}
                   onDraft={postComposer.setContent}
+                  disabled={postComposer.isPosting}
+                />
+              )}
+              {postComposer.content.trim() && (
+                <PostAiEditMenu
+                  text={postComposer.content}
+                  onRevised={postComposer.setContent}
                   disabled={postComposer.isPosting}
                 />
               )}

--- a/src/services/articles/ai-client.ts
+++ b/src/services/articles/ai-client.ts
@@ -78,6 +78,8 @@ export function reviseArticleText(opts: {
   title?: string;
   topic?: string;
   instruction?: string;
+  /** 'post' for short timeline posts (short + length-clamped); default 'article'. */
+  kind?: 'post' | 'article';
 }): Promise<string> {
   return postJson<{ result: string }>('/api/ai/writing/revise', opts).then(d => d.result);
 }

--- a/src/services/cat/writing-revise.ts
+++ b/src/services/cat/writing-revise.ts
@@ -13,6 +13,7 @@
 
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { ARTICLE_LIMITS } from '@/config/articles';
+import { TIMELINE_CONTENT_LIMITS } from '@/config/timeline';
 import { callPlatformJson, parseJsonLoose } from './platform-llm';
 import { GROUNDING_RULES, buildVoiceContext } from './writing-context';
 import type { ReviseAction, TonePreset } from './writing-types';
@@ -40,12 +41,31 @@ const ACTION_INSTRUCTIONS: Record<Exclude<ReviseAction, 'tone' | 'outline'>, str
 
 const REVISE_SYSTEM_PREAMBLE = `You are the writing companion inside OrangeCat, editing a long-form article the user is writing. You transform the user's OWN text — you never lecture, never add meta-commentary, never wrap the result in quotes or code fences. Return only the revised prose as Markdown.`;
 
+/**
+ * Short-post preamble. The same actions (improve/tighten/tone…) apply, but the
+ * output must stay a short social post — never balloon into an article. Used
+ * when the composer is a timeline post/reply rather than the article editor.
+ */
+function preambleForKind(kind: ReviseKind): string {
+  if (kind === 'post') {
+    return `You are the writing companion inside OrangeCat, editing a SHORT social post (tweet-length) the user is writing. You transform the user's OWN text — never lecture, never add meta-commentary, never wrap it in quotes or code fences, no Markdown headings or lists. Keep it a short post under ${TIMELINE_CONTENT_LIMITS.post} characters; NEVER expand it into an essay. Return only the post text.`;
+  }
+  return REVISE_SYSTEM_PREAMBLE;
+}
+
+function bodyLimitForKind(kind: ReviseKind): number {
+  return kind === 'post' ? TIMELINE_CONTENT_LIMITS.post : ARTICLE_LIMITS.body;
+}
+
 /** Clamp text sent to the model — a runaway body shouldn't blow the token budget. */
 const MAX_INPUT_CHARS = 8000;
 
 function clampInput(text: string): string {
   return text.length > MAX_INPUT_CHARS ? text.slice(0, MAX_INPUT_CHARS) : text;
 }
+
+/** Whether we're editing a long-form article body or a short timeline post. */
+export type ReviseKind = 'post' | 'article';
 
 export interface ReviseInput {
   action: ReviseAction;
@@ -59,6 +79,8 @@ export interface ReviseInput {
   topic?: string;
   /** Optional free-form steer ("make it less salesy"). */
   instruction?: string;
+  /** Long-form article (default) vs a short post — changes framing + length clamp. */
+  kind?: ReviseKind;
 }
 
 /**
@@ -84,14 +106,15 @@ export async function reviseText(
       ? TONE_INSTRUCTIONS[input.tone ?? 'casual']
       : ACTION_INSTRUCTIONS[input.action];
 
+  const kind = input.kind ?? 'article';
   const { recentBlob } = await buildVoiceContext(supabase, userId);
-  const system = `${REVISE_SYSTEM_PREAMBLE}
+  const system = `${preambleForKind(kind)}
 
 TASK: ${directive}
 ${input.instruction ? `The user also asked: ${input.instruction}\n` : ''}
 ${GROUNDING_RULES}
 
-Output ONLY JSON: {"result":"the revised markdown"}.`;
+Output ONLY JSON: {"result":"the revised ${kind === 'post' ? 'post' : 'markdown'}"}.`;
 
   const user = `${input.title ? `Article title: ${input.title}\n` : ''}The author's recent posts (their voice — match it):
 ${recentBlob}
@@ -107,10 +130,10 @@ Return the ${input.action === 'continue' ? 'continuation' : 'revised text'} as J
   const parsed = parseJsonLoose<{ result?: unknown }>(raw);
   const result = typeof parsed?.result === 'string' ? parsed.result.trim() : '';
   if (!result) {
-    logger.warn('writing-revise: empty result', { action: input.action }, 'WritingRevise');
+    logger.warn('writing-revise: empty result', { action: input.action, kind }, 'WritingRevise');
     return null;
   }
-  return result.slice(0, ARTICLE_LIMITS.body);
+  return result.slice(0, bodyLimitForKind(kind));
 }
 
 async function outlineForTopic(


### PR DESCRIPTION
Edge-fix #4 from the AI audit: the in-editor AI edit actions were buried in the long-form **article** editor only — short-post authors (most users) never saw them.

## What's new
- **PostAiEditMenu** — an "Improve" dropdown (improve / tighten / add a bit more / fix grammar / change tone) that rewrites whatever you've already typed, **in place**. Shows once the composer has content, in **both**:
  - the post composer (`TimelineComposer` — top-level posts *and* detail-page replies), and
  - the inline `PostCard` reply box.
- Complements the existing "write for me" (`PostAiButton`) and "AI reply" (`ReplyAiButton`) with **"improve what I wrote."**

## Backend
- The revise engine/route/client gain an optional `kind: 'post' | 'article'` (default `article`, backward-compatible). For posts it swaps the "long-form article" framing for a short-post one and **clamps the result to the post limit**, so an edit never balloons a tweet into an essay.
- Reuses the existing `/api/ai/writing/revise` endpoint — no new surface.

## Verification
- `tsc` **0 errors**, eslint clean, `audit:routes` clean, unit tests green. Validated against Groq that `kind:'post'` keeps output short (a 128-char post → ~125 chars after "improve", voice preserved).
- Not exercised E2E vs prod DB (sandbox limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)