### PR TITLE
feat(payments): reconcile settled payments nobody was watching

### DIFF
--- a/__tests__/unit/api/payment-reconcile-cron.test.ts
+++ b/__tests__/unit/api/payment-reconcile-cron.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Payment reconciliation sweep — the backstop that makes OrangeCat's record of
+ * money converge with reality when nobody's browser is open.
+ *
+ * What matters here is not "does it call an API" but the selection and safety
+ * rules: it must be authenticated, must ask the SAME detection path the browser
+ * uses, must stamp intents before asking (so a hanging rail can't block the
+ * queue forever), and must survive one rail failing.
+ */
+
+import { GET } from '@/app/api/cron/payment-reconcile/route';
+import { reconcilePaymentIntent } from '@/domain/payments/paymentFlowService';
+import { STATUS } from '@/config/database-constants';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+// The response helpers wrap NextResponse, which needs the Next runtime; the
+// established convention in route tests is to stub them (see projects-id-api).
+jest.mock('@/lib/api/standardResponse', () => ({
+  apiSuccess: jest.fn((data: unknown) => ({
+    status: 200,
+    json: async () => ({ success: true, data }),
+  })),
+  apiUnauthorized: jest.fn(() => ({
+    status: 401,
+    json: async () => ({ success: false }),
+  })),
+  apiInternalError: jest.fn(() => ({
+    status: 500,
+    json: async () => ({ success: false }),
+  })),
+}));
+jest.mock('@/domain/payments/paymentFlowService', () => ({
+  reconcilePaymentIntent: jest.fn(),
+}));
+
+const candidates: Array<Record<string, unknown>> = [];
+const polled: string[] = [];
+
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: () => ({
+    from: () => {
+      const builder: Record<string, unknown> = {};
+      for (const m of ['select', 'in', 'or', 'order']) {
+        builder[m] = jest.fn(() => builder);
+      }
+      builder.limit = jest.fn(() => Promise.resolve({ data: candidates, error: null }));
+      builder.update = jest.fn(() => builder);
+      builder.eq = jest.fn((_col: string, id: string) => {
+        polled.push(id);
+        return Promise.resolve({ error: null });
+      });
+      return builder;
+    },
+  }),
+}));
+
+const reconcileMock = reconcilePaymentIntent as jest.MockedFunction<typeof reconcilePaymentIntent>;
+
+/**
+ * The jest env has no global web Request; the route only reads the
+ * authorization header, so a minimal stub keeps this test env-free (same
+ * approach as cronAuth.test.ts).
+ */
+function request(secret: string | null = 'right-secret'): Request {
+  return {
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'authorization' && secret !== null ? `Bearer ${secret}` : null,
+    },
+  } as unknown as Request;
+}
+
+async function body(res: unknown) {
+  return (await (res as { json: () => Promise<{ data?: Record<string, number> }> }).json());
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  candidates.length = 0;
+  polled.length = 0;
+  process.env.CRON_SECRET = 'right-secret';
+  reconcileMock.mockResolvedValue({ status: STATUS.PAYMENT_INTENTS.INVOICE_READY, paid_at: null });
+});
+
+describe('payment reconciliation sweep', () => {
+  it('rejects an unauthenticated caller', async () => {
+    const res = await GET(request(null));
+    expect((res as unknown as { status: number }).status).toBe(401);
+    expect(reconcileMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong secret', async () => {
+    const res = await GET(request('wrong'));
+    expect((res as unknown as { status: number }).status).toBe(401);
+  });
+
+  it('no-ops cleanly when nothing is pending', async () => {
+    const res = await GET(request());
+    expect((await body(res)).data).toMatchObject({ scanned: 0, settled: 0 });
+    expect(reconcileMock).not.toHaveBeenCalled();
+  });
+
+  it('counts a payment that settled with nobody watching', async () => {
+    candidates.push({ id: 'pi-1', payment_method: 'lightning_address' });
+    reconcileMock.mockResolvedValue({
+      status: STATUS.PAYMENT_INTENTS.PAID,
+      paid_at: new Date().toISOString(),
+    });
+
+    const res = await GET(request());
+
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+    expect((await body(res)).data).toMatchObject({ scanned: 1, settled: 1 });
+  });
+
+  it('stamps an intent BEFORE asking, so a hanging rail cannot block the queue', async () => {
+    candidates.push({ id: 'pi-slow', payment_method: 'nwc' });
+    reconcileMock.mockImplementation(async () => {
+      // By the time the rail is asked, the stamp must already be written.
+      expect(polled).toContain('pi-slow');
+      return { status: STATUS.PAYMENT_INTENTS.INVOICE_READY, paid_at: null };
+    });
+
+    await GET(request());
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps sweeping when one rail throws', async () => {
+    candidates.push({ id: 'pi-bad', payment_method: 'nwc' }, { id: 'pi-good', payment_method: 'nwc' });
+    reconcileMock
+      .mockRejectedValueOnce(new Error('provider down'))
+      .mockResolvedValueOnce({
+        status: STATUS.PAYMENT_INTENTS.PAID,
+        paid_at: new Date().toISOString(),
+      });
+
+    const res = await GET(request());
+
+    expect(reconcileMock).toHaveBeenCalledTimes(2);
+    expect((await body(res)).data).toMatchObject({ scanned: 2, settled: 1 });
+  });
+});

--- a/src/app/api/cron/payment-reconcile/route.ts
+++ b/src/app/api/cron/payment-reconcile/route.ts
@@ -1,0 +1,162 @@
+/**
+ * GET /api/cron/payment-reconcile — converge OrangeCat's record of money with
+ * reality, without depending on anyone's browser being open.
+ *
+ * OrangeCat is non-custodial: the invoice belongs to the recipient's wallet, so
+ * the truth about a payment lives at their provider or on the chain. Our
+ * `payment_intents` row is a cache of someone else's fact, and caches must be
+ * reconciled — nothing pushes settlement to us.
+ *
+ * Until this existed, the only thing that ever asked was the payer's open tab.
+ * Pay, close the tab, and the sats landed while our record stayed
+ * `invoice_ready` forever: the recipient never got their notification, and for
+ * entity funding no contribution row was written, so the totals stayed at zero.
+ *
+ * This is a BACKSTOP, not the primary path — the browser's 3s poll still covers
+ * the common case. It therefore optimises for certainty, not latency: run every
+ * minute, take a bounded batch, ask the same detection path the browser uses.
+ */
+
+import { verifyCronSecret } from '@/lib/api/cronAuth';
+import { apiSuccess, apiUnauthorized, apiInternalError } from '@/lib/api/standardResponse';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { STATUS } from '@/config/database-constants';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { reconcilePaymentIntent } from '@/domain/payments/paymentFlowService';
+import type { PaymentIntent } from '@/domain/payments/types';
+import { logger } from '@/utils/logger';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** Non-terminal statuses — the only ones worth asking about. */
+const SWEEPABLE_STATUSES = [
+  STATUS.PAYMENT_INTENTS.CREATED,
+  STATUS.PAYMENT_INTENTS.INVOICE_READY,
+  STATUS.PAYMENT_INTENTS.PENDING_CONFIRMATION,
+];
+
+/**
+ * Only rails that can be checked without human input.
+ *
+ * A bare Lightning address (no LUD-21 verify URL) is deliberately excluded: it
+ * is genuinely undetectable, and guessing would be worse than the honest
+ * buyer-confirms → recipient-confirms fallback that already handles it.
+ */
+const DETECTABLE_RAILS = [
+  'and(payment_method.eq.nwc,payment_hash.not.is.null)',
+  'and(payment_method.eq.lightning_address,lnurl_verify_url.not.is.null)',
+  'and(payment_method.eq.onchain,onchain_address.not.is.null)',
+].join(',');
+
+const BATCH_SIZE = 25;
+/** Leave headroom under the systemd unit's 120s curl timeout. */
+const BUDGET_MS = 45_000;
+
+/**
+ * Least-recently-asked first (never-asked first of all). With a bare LIMIT the
+ * same oldest intents would be re-polled every tick while newer ones starved;
+ * this ordering is self-balancing and bounds calls to third-party rails.
+ */
+async function pickCandidates(admin: SupabaseClient, limit: number): Promise<PaymentIntent[]> {
+  const { data, error } = await admin
+    .from(DATABASE_TABLES.PAYMENT_INTENTS)
+    .select('*')
+    .in('status', SWEEPABLE_STATUSES)
+    .or(DETECTABLE_RAILS)
+    .order('last_polled_at', { ascending: true, nullsFirst: true })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`Failed to select reconciliation candidates: ${error.message}`);
+  }
+  return (data ?? []) as PaymentIntent[];
+}
+
+/**
+ * Stamped BEFORE asking, so a rail that hangs or errors rotates to the back of
+ * the queue instead of blocking every later intent on the next tick.
+ */
+async function markPolled(admin: SupabaseClient, id: string): Promise<void> {
+  const { error } = await admin
+    .from(DATABASE_TABLES.PAYMENT_INTENTS)
+    .update({ last_polled_at: new Date().toISOString() })
+    .eq('id', id);
+  if (error) {
+    logger.warn('Failed to stamp last_polled_at', { paymentIntentId: id, error }, 'PaymentSweep');
+  }
+}
+
+export async function GET(request: Request) {
+  if (!verifyCronSecret(request)) {
+    return apiUnauthorized();
+  }
+
+  const startedAt = Date.now();
+  try {
+    const admin = getAdminClient() as unknown as SupabaseClient;
+    const candidates = await pickCandidates(admin, BATCH_SIZE);
+
+    if (candidates.length === 0) {
+      return apiSuccess({ scanned: 0, settled: 0, expired: 0, ranAt: new Date().toISOString() });
+    }
+
+    let scanned = 0;
+    let settled = 0;
+    let expired = 0;
+    let skippedForBudget = 0;
+
+    for (const intent of candidates) {
+      if (Date.now() - startedAt > BUDGET_MS) {
+        // Whatever is left keeps its old last_polled_at, so the next tick takes
+        // it first. Never silently pretend the batch was fully covered.
+        skippedForBudget = candidates.length - scanned;
+        break;
+      }
+
+      await markPolled(admin, intent.id);
+      scanned += 1;
+
+      try {
+        // The SAME path the payer's browser runs. Settlement side-effects are
+        // exactly-once (claimPaidTransition), so overlapping with a live poll
+        // is safe by construction.
+        const result = await reconcilePaymentIntent(admin, intent);
+        if (result.status === STATUS.PAYMENT_INTENTS.PAID) {
+          settled += 1;
+          logger.info(
+            'Reconciliation settled a payment nobody was watching',
+            { paymentIntentId: intent.id, method: intent.payment_method },
+            'PaymentSweep'
+          );
+        } else if (result.status === STATUS.PAYMENT_INTENTS.EXPIRED) {
+          expired += 1;
+        }
+      } catch (error) {
+        // One unreachable rail must not abort the sweep.
+        logger.warn(
+          'Reconciliation check failed for one intent',
+          { paymentIntentId: intent.id, error },
+          'PaymentSweep'
+        );
+      }
+    }
+
+    if (skippedForBudget > 0) {
+      logger.info(
+        'Reconciliation sweep hit its time budget',
+        { scanned, skippedForBudget },
+        'PaymentSweep'
+      );
+    }
+
+    return apiSuccess({
+      scanned,
+      settled,
+      expired,
+      skippedForBudget,
+      ranAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    logger.error('Payment reconciliation sweep failed', { error }, 'PaymentSweep');
+    return apiInternalError('Reconciliation sweep failed');
+  }
+}

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -496,10 +496,13 @@ async function refreshPaymentStatus(
     return { status: pi.status, paid_at: pi.paid_at };
   }
 
-  if (pi.expires_at && new Date(pi.expires_at) < new Date()) {
-    await updatePaymentStatus(supabase, pi.id, STATUS.PAYMENT_INTENTS.EXPIRED);
-    return { status: STATUS.PAYMENT_INTENTS.EXPIRED, paid_at: null };
-  }
+  // NOTE: expiry is evaluated AFTER asking the rail, at the end of this
+  // function. Declaring "expired" first meant a payment that landed in the last
+  // seconds before expiry — with nobody polling at that moment — was recorded as
+  // expired even though the money had arrived in the recipient's wallet. The
+  // invoice deadline governs whether a NEW payment can be made; it says nothing
+  // about whether one already was, and verify endpoints still report settled
+  // afterwards. Ask first, expire only on a genuine no.
 
   if (pi.payment_method === 'nwc' && pi.payment_hash) {
     const paid = await checkNWCPaymentStatus(supabase, pi);
@@ -532,7 +535,27 @@ async function refreshPaymentStatus(
     }
   }
 
+  // The rail says no payment arrived. Only now is expiry the truth.
+  if (pi.expires_at && new Date(pi.expires_at) < new Date()) {
+    await updatePaymentStatus(supabase, pi.id, STATUS.PAYMENT_INTENTS.EXPIRED);
+    return { status: STATUS.PAYMENT_INTENTS.EXPIRED, paid_at: null };
+  }
+
   return { status: pi.status, paid_at: pi.paid_at };
+}
+
+/**
+ * Reconcile one payment intent against its rail — the single detection path,
+ * shared by the payer's browser poll and the background sweep.
+ *
+ * Deliberately NOT a second implementation: a copy would drift, and then two
+ * parts of the product would disagree about whether money arrived.
+ */
+export async function reconcilePaymentIntent(
+  supabase: SupabaseClient,
+  pi: PaymentIntent
+): Promise<PaymentStatusResult> {
+  return refreshPaymentStatus(supabase, pi);
 }
 
 /**

--- a/supabase/migrations/20260729160000_payment_intents_last_polled_at.sql
+++ b/supabase/migrations/20260729160000_payment_intents_last_polled_at.sql
@@ -1,0 +1,27 @@
+-- Reconciliation scheduling for payment intents.
+--
+-- OrangeCat is non-custodial, so settlement is observed rather than owned: we
+-- learn a payment happened by asking the recipient's rail (LUD-21 verify, an
+-- NWC relay, the chain). Until now the only thing that ever asked was the
+-- payer's open browser tab — close it after paying and the money arrived while
+-- OrangeCat's record stayed at `invoice_ready` forever: no recipient
+-- notification, and no contribution row, so funding totals never moved.
+--
+-- A background sweep fixes that, but it needs fair scheduling. With only a
+-- LIMIT, the same oldest intents would be re-polled every tick while newer ones
+-- starved (head-of-line blocking) and third-party rails got hammered.
+-- `last_polled_at` + `ORDER BY last_polled_at NULLS FIRST` makes selection
+-- self-balancing: never-checked intents go first, then least-recently-checked.
+--
+-- The index is partial and matches the sweep predicate exactly, so it stays
+-- tiny — terminal intents (the overwhelming majority over time) are not in it.
+
+ALTER TABLE public.payment_intents
+  ADD COLUMN IF NOT EXISTS last_polled_at timestamptz;
+
+COMMENT ON COLUMN public.payment_intents.last_polled_at IS
+  'When a reconciliation sweep last asked the payment rail about this intent. NULL = never asked.';
+
+CREATE INDEX IF NOT EXISTS payment_intents_reconcile_idx
+  ON public.payment_intents (last_polled_at ASC NULLS FIRST)
+  WHERE status NOT IN ('paid', 'expired', 'failed', 'buyer_confirmed');


### PR DESCRIPTION
Second of two changes closing the gap between "money arrived" and "OrangeCat recorded it". Builds on #501 (exactly-once settlement), which must land first.

## The gap

Settlement detection only ever ran inside a status poll, and the only caller was the payer's open browser tab. Pay, close the tab, and the sats are in the recipient's wallet while our record sits at `invoice_ready` forever — no recipient notification, and for entity funding no contribution row, so the totals stay at zero. No cron swept anything; I verified the scheduled jobs were cleanup, email-cleanup, webhook-worker and weekly-digest.

## Design

Non-custody means settlement is **observed, never owned** — `payment_intents` is a cache of a fact that lives in the recipient's wallet, and caches must be reconciled because nothing pushes to us.

- **One detection path.** The sweep calls `reconcilePaymentIntent` → the same `refreshPaymentStatus` the browser uses. A second implementation would drift, and then two parts of the product would disagree about whether money arrived — the same failure mode as the wallets-page lie.
- **Only auto-detectable rails**: NWC with a payment hash, Lightning address *with* a LUD-21 verify URL, or on-chain. A bare Lightning address is genuinely undetectable; guessing is worse than its existing buyer-confirms → recipient-confirms fallback.
- **Fair scheduling, not just a batch cap.** New `last_polled_at` + `ORDER BY … NULLS FIRST` (migration applied to the box, partial index matching the sweep predicate). A bare `LIMIT` would re-poll the same oldest intents every tick while newer ones starved and third-party rails got hammered. Stamped *before* asking, so a hanging provider rotates to the back of the queue.
- **Bounded**: batch of 25, time budget under the systemd unit's 120s curl timeout; skipped intents keep their old stamp and go first next tick. It reports `skippedForBudget` rather than pretending full coverage.
- It's a **backstop, not the primary path** — the browser's 3s poll still handles the common case — so it optimises for certainty, not latency.

## Bonus fix

Expiry was evaluated **before** asking the rail, so a payment landing in the final seconds before expiry (with nobody polling) was recorded as *expired* even though the money arrived. The deadline governs whether a *new* payment can be made, not whether one already was. Now: ask first, expire only on a genuine no.

## Tests
6 new: auth rejection, empty sweep, settles-an-unwatched-payment, stamp-before-ask, and one failing rail not aborting the sweep.

## Deploy note
Needs a systemd timer on the box (`orangecat-cron@payment-reconcile`) — I'll install it after merge and verify the endpoint live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)