### PR TITLE
fix(db): make cat_action write policies idempotent — unblocks all deploys

### DIFF
--- a/supabase/migrations/20260729133000_cat_action_write_policies.sql
+++ b/supabase/migrations/20260729133000_cat_action_write_policies.sql
@@ -14,12 +14,22 @@
 -- Both tables are strictly owner-scoped (user_id = auth.uid()), matching the
 -- existing SELECT policies and the platform convention (see cat_memories).
 
+-- Idempotent: at least one of these policies already existed on the box, so the
+-- bare CREATE aborted the transaction and blocked EVERY deploy (the migration
+-- runner rolls back and refuses to swap the release). Postgres has no
+-- CREATE POLICY IF NOT EXISTS, so drop-then-create is the repo convention
+-- (see 20260711000000_loan_offers_select_policy_recursion_fix). Safe to
+-- re-run, and correct on a fresh database.
+
+DROP POLICY IF EXISTS "Users can insert own cat action log" ON public.cat_action_log;
 CREATE POLICY "Users can insert own cat action log" ON public.cat_action_log
   FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));
 
+DROP POLICY IF EXISTS "Users can update own cat action log" ON public.cat_action_log;
 CREATE POLICY "Users can update own cat action log" ON public.cat_action_log
   FOR UPDATE USING (user_id = (SELECT auth.uid()))
   WITH CHECK (user_id = (SELECT auth.uid()));
 
+DROP POLICY IF EXISTS "Users can insert own pending cat actions" ON public.cat_pending_actions;
 CREATE POLICY "Users can insert own pending cat actions" ON public.cat_pending_actions
   FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));


### PR DESCRIPTION
CD has been failing for every merge to main at the migration step:

```
→ applying 20260729133000_cat_action_write_policies.sql
ERROR: policy "Users can insert own cat action log" for table "cat_action_log" already exists
ERROR: migrations failed — aborting deploy (live release untouched)
```

The policies already exist on the box, but the migration was never recorded as applied (the runner rolls the transaction back on failure), so every subsequent deploy retries it and aborts. Production is safe but frozen on the previous release — nothing merged since has shipped.

Postgres has no `CREATE POLICY IF NOT EXISTS`, so each `CREATE` is now preceded by `DROP POLICY IF EXISTS`, the pattern already used in `20260711000000_loan_offers_select_policy_recursion_fix`. Re-runnable, and still correct on a fresh database.

Editing rather than superseding: this migration never applied, so it is pending rather than immutable — and a follow-up migration would not help, since the failing one runs first and would still abort.

Found while shipping #499, which is merged but could not deploy because of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)