### PR TITLE
fix(ai-form): accept the short instructions the Adjust button already allows

### DIFF
--- a/__tests__/unit/api/ai-form-prefill-input-length.test.ts
+++ b/__tests__/unit/api/ai-form-prefill-input-length.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The AI form-assist input floor must depend on the intent.
+ *
+ * Regression guard for a dead end users hit on the Create/Edit forms: the
+ * "Adjust" button enabled at 3 characters while the API rejected anything
+ * under 10, so the most natural way to ask for a small change — "shorter",
+ * "longer", "in german" — failed with "Description must be at least 10
+ * characters". Two hardcoded numbers in two files, drifted apart.
+ *
+ * Both ends now read AI_ASSIST_MIN_INPUT_LENGTH. These tests lock the
+ * behaviour that number exists to produce.
+ */
+
+import { POST } from '@/app/api/ai/form-prefill/route';
+import { generateFormPrefill } from '@/lib/ai/form-prefill-service';
+import { AI_ASSIST_MIN_INPUT_LENGTH, AI_ADJUSTMENTS } from '@/config/ai-form-assist';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+// withAuth wraps the handler in a real Supabase session lookup; the request
+// itself is what this suite is about, so authentication is stubbed through.
+jest.mock('@/lib/api/withAuth', () => ({
+  withAuth:
+    (handler: (req: unknown) => Promise<unknown>) =>
+    (req: unknown): Promise<unknown> =>
+      handler(Object.assign(req as object, { user: { id: 'test-user' }, supabase: {} })),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimitWriteAsync: jest.fn().mockResolvedValue({ success: true }),
+  retryAfterSeconds: () => 0,
+}));
+
+// The response helpers wrap NextResponse, which needs the Next runtime; the
+// established convention in route tests is to stub them.
+jest.mock('@/lib/api/standardResponse', () => ({
+  apiValidationError: jest.fn((error: string) => ({ status: 400, error })),
+  apiBadRequest: jest.fn((error: string) => ({ status: 400, error })),
+  apiRateLimited: jest.fn(() => ({ status: 429 })),
+  apiInternalError: jest.fn(() => ({ status: 500 })),
+}));
+
+jest.mock('next/server', () => ({
+  NextResponse: { json: (body: unknown) => ({ status: 200, body }) },
+}));
+
+jest.mock('@/lib/ai/form-prefill-service', () => ({
+  generateFormPrefill: jest.fn(),
+}));
+
+const mockedPrefill = generateFormPrefill as jest.MockedFunction<typeof generateFormPrefill>;
+
+const BASE = {
+  entityType: 'service',
+  existingData: { title: 'Photography', description: 'I offer photography.' },
+};
+
+/** Call the route the way the browser does, minus the transport. */
+function post(body: Record<string, unknown>): Promise<{ status: number }> {
+  return (POST as unknown as (req: unknown) => Promise<{ status: number }>)({
+    json: async () => body,
+  });
+}
+
+describe('POST /api/ai/form-prefill — input length depends on intent', () => {
+  beforeEach(() => {
+    mockedPrefill.mockReset();
+    mockedPrefill.mockResolvedValue({
+      success: true,
+      data: { description: 'A longer, more useful description.' },
+      confidence: { description: 0.9 },
+      changedFields: ['description'],
+    });
+  });
+
+  // The exact words that used to fail. All are under the fill floor.
+  it.each(['shorter', 'longer', 'in german', 'add tags'])(
+    'accepts the short instruction %p when refining',
+    async instruction => {
+      expect(instruction.length).toBeLessThan(AI_ASSIST_MIN_INPUT_LENGTH.fill);
+
+      const response = await post({ ...BASE, description: instruction, intent: 'refine' });
+
+      expect(response.status).toBe(200);
+      expect(mockedPrefill).toHaveBeenCalledWith(
+        expect.objectContaining({ description: instruction, intent: 'refine' })
+      );
+    }
+  );
+
+  it('still demands a real description when filling an empty form', async () => {
+    const response = await post({ ...BASE, description: 'shorter', intent: 'fill' });
+
+    expect(response.status).toBe(400);
+    expect(mockedPrefill).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the fill floor when no intent is sent', async () => {
+    const response = await post({ ...BASE, description: 'shorter' });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects an instruction below the refine floor', async () => {
+    const tooShort = 'x'.repeat(AI_ASSIST_MIN_INPUT_LENGTH.refine - 1);
+
+    const response = await post({ ...BASE, description: tooShort, intent: 'refine' });
+
+    expect(response.status).toBe(400);
+    expect(mockedPrefill).not.toHaveBeenCalled();
+  });
+
+  it('does not count surrounding whitespace towards the floor', async () => {
+    const response = await post({ ...BASE, description: '   a   ', intent: 'refine' });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('accepts every one-click adjustment instruction', async () => {
+    for (const adjustment of AI_ADJUSTMENTS) {
+      const response = await post({
+        ...BASE,
+        description: adjustment.instruction,
+        intent: 'refine',
+      });
+      expect(response.status).toBe(200);
+    }
+  });
+});
+
+describe('AI_ASSIST_MIN_INPUT_LENGTH', () => {
+  it('lets a refinement be shorter than a from-scratch description', () => {
+    // A refinement is an instruction about a form that is already full; a fill
+    // has to carry all the substance itself.
+    expect(AI_ASSIST_MIN_INPUT_LENGTH.refine).toBeLessThan(AI_ASSIST_MIN_INPUT_LENGTH.fill);
+    expect(AI_ASSIST_MIN_INPUT_LENGTH.refine).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/ai/form-prefill/route.ts
+++ b/src/app/api/ai/form-prefill/route.ts
@@ -23,20 +23,37 @@ import { getEntityConfig } from '@/config/entity-configs/get-config';
 import { isValidEntityType, type EntityType } from '@/config/entity-registry';
 import { logger } from '@/utils/logger';
 import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { AI_ASSIST_MIN_INPUT_LENGTH } from '@/config/ai-form-assist';
 
 /**
  * Request validation schema
  */
-const requestSchema = z.object({
-  entityType: z.string().min(1, 'Entity type is required'),
-  description: z.string().min(10, 'Description must be at least 10 characters'),
-  existingData: z.record(z.unknown()).optional(),
-  /**
-   * `fill` protects what the user already typed; `refine` lets the AI rewrite
-   * it. A refine request that arrives as `fill` can never change anything.
-   */
-  intent: z.enum(['fill', 'refine']).default('fill'),
-});
+const requestSchema = z
+  .object({
+    entityType: z.string().min(1, 'Entity type is required'),
+    description: z.string().min(1, 'Description is required'),
+    existingData: z.record(z.unknown()).optional(),
+    /**
+     * `fill` protects what the user already typed; `refine` lets the AI rewrite
+     * it. A refine request that arrives as `fill` can never change anything.
+     */
+    intent: z.enum(['fill', 'refine']).default('fill'),
+  })
+  // The floor depends on the intent — a refinement is an instruction, not a
+  // description, and "shorter" says everything it needs to in seven characters.
+  .superRefine((value, ctx) => {
+    const min = AI_ASSIST_MIN_INPUT_LENGTH[value.intent];
+    if (value.description.trim().length < min) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['description'],
+        message:
+          value.intent === 'refine'
+            ? `Describe the change you want (at least ${min} characters)`
+            : `Description must be at least ${min} characters`,
+      });
+    }
+  });
 
 /**
  * POST /api/ai/form-prefill

--- a/src/components/create/AIPrefillBar.tsx
+++ b/src/components/create/AIPrefillBar.tsx
@@ -11,6 +11,7 @@ import { AIFillPanel } from './AIFillPanel';
 import { AIRefinePanel } from './AIRefinePanel';
 import type { AIPrefillBarProps, AIPrefillResponse } from './types';
 import {
+  AI_ASSIST_MIN_INPUT_LENGTH,
   getAdjustmentsForFields,
   getExampleDescriptions,
   type AiAdjustment,
@@ -126,15 +127,16 @@ export function AIPrefillBar({
   );
 
   const handleGenerate = useCallback(() => {
-    if (description.trim().length < 10) {
-      setError('Please describe what you want to create (at least 10 characters)');
+    const min = AI_ASSIST_MIN_INPUT_LENGTH.fill;
+    if (description.trim().length < min) {
+      setError(`Please describe what you want to create (at least ${min} characters)`);
       return;
     }
     callAI(description, 'fill', TYPED_REQUEST);
   }, [description, callAI]);
 
   const handleRefine = useCallback(() => {
-    if (instruction.trim().length < 3) {
+    if (instruction.trim().length < AI_ASSIST_MIN_INPUT_LENGTH.refine) {
       return;
     }
     callAI(instruction, 'refine', TYPED_REQUEST);

--- a/src/components/create/AIRefinePanel.tsx
+++ b/src/components/create/AIRefinePanel.tsx
@@ -3,7 +3,7 @@
 import { Sparkles, Loader2 } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import { AIAssistChip } from './AIAssistChip';
-import type { AiAdjustment } from '@/config/ai-form-assist';
+import { AI_ASSIST_MIN_INPUT_LENGTH, type AiAdjustment } from '@/config/ai-form-assist';
 
 interface AIRefinePanelProps {
   /** Already filtered to what this form's fields support */
@@ -74,7 +74,7 @@ export function AIRefinePanel({
           type="button"
           size="lg"
           onClick={onSubmit}
-          disabled={isBlocked || instruction.trim().length < 3}
+          disabled={isBlocked || instruction.trim().length < AI_ASSIST_MIN_INPUT_LENGTH.refine}
           className="w-full gap-2 sm:w-auto"
         >
           {isTyping ? (

--- a/src/config/ai-form-assist.ts
+++ b/src/config/ai-form-assist.ts
@@ -50,6 +50,24 @@ export const USER_OVERRIDABLE_FIELDS: readonly string[] = [
   'fixed_price',
 ];
 
+/**
+ * Shortest input each intent accepts, enforced identically on client and server.
+ *
+ * The two floors differ because the two inputs differ: `fill` takes a
+ * description of a thing that does not exist yet and needs real substance to
+ * work from, while `refine` takes an instruction about a form that is already
+ * full — and "shorter", "longer" and "in german" are all perfectly clear at
+ * well under ten characters.
+ *
+ * One number per intent, in one place: the button and the API used to disagree
+ * (enabled at 3, rejected under 10), so the most natural way to ask for a small
+ * change failed with "Description must be at least 10 characters".
+ */
+export const AI_ASSIST_MIN_INPUT_LENGTH: Record<AiAssistIntent, number> = {
+  fill: 10,
+  refine: 3,
+};
+
 // ==================== ADJUSTMENTS ====================
 
 /** Which fields an adjustment is relevant to. Omit to always offer it. */


### PR DESCRIPTION
## The bug

Typing a short instruction into the AI adjust box on any create/edit form failed:

> **"shorter"** → `Description must be at least 10 characters`

The **Adjust** button enables at 3 characters. The API rejected anything under 10. So the shortest, most natural way to ask for a change — `shorter`, `longer`, `in german`, `add tags` — was the one way that could never work, and the error text talked about a "description" when the user had written an instruction.

Two hardcoded numbers, in two files, that had drifted apart:

| Where | Floor |
|---|---|
| `AIRefinePanel` — Adjust button | `< 3` |
| `AIPrefillBar` — Fill button | `< 10` |
| `route.ts` — API, **both intents** | `< 10` |

## The fix

The floor is a property of the **intent**, not of the endpoint. A `fill` carries all the substance itself and needs real input; a `refine` is an instruction about a form that is already full.

`AI_ASSIST_MIN_INPUT_LENGTH` now states both floors once in the config SSOT (`src/config/ai-form-assist.ts`, alongside `AiAssistIntent` and `USER_OVERRIDABLE_FIELDS`), and the button, the panel and the route schema all read it. They can no longer disagree — which is the actual fix, since the numbers agreeing today is not what keeps them agreeing.

The route's flat `.min(10)` becomes a `.superRefine` that picks the floor by intent, and refine gets its own wording: *"Describe the change you want (at least 3 characters)"*.

## Verification

- New route test covers the exact words that used to fail, both floors, whitespace trimming, the no-intent default, and asserts **every** one-click `AI_ADJUSTMENTS` instruction is accepted.
- **Confirmed the test fails against the old code** — 4 failures with the flat floor restored, 10/10 pass with the fix. A regression lock that can't fail is worthless.
- `type-check` clean, eslint clean on changed files, 157 tests pass across `__tests__/unit/api/`, `ai-form-assist`, and `components/create/`.

## Context

Follow-on to #499, which fixed the deeper bug in this area (refine could never change a filled field). This closes the remaining client/server mismatch that #499 left in place. Supersedes #498, closed as duplicate.
