### PR TITLE
feat(timeline): attach AI-suggested free images to short posts

### DIFF
--- a/src/components/articles/ImageSuggestPicker.tsx
+++ b/src/components/articles/ImageSuggestPicker.tsx
@@ -7,10 +7,11 @@ import type { StockImage } from '@/services/images/types';
 import { cn } from '@/lib/utils';
 
 /**
- * AI image picker: on open it turns the article into concrete search terms and
- * shows royalty-free (CC0 / public-domain) candidates; the user can also search
- * manually or click a suggested term. Picking one hands back the full-res URL.
- * Used for both the cover and inline body images.
+ * AI image picker: on open it turns the given text into concrete search terms
+ * and shows royalty-free (CC0 / public-domain) candidates; the user can also
+ * search manually or click a suggested term. Picking one hands back the
+ * full-res URL. Used for article covers, inline article images, and the
+ * timeline post composer.
  */
 export default function ImageSuggestPicker({
   title,

--- a/src/components/timeline/PostContent.tsx
+++ b/src/components/timeline/PostContent.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { ArrowRight, ExternalLink } from 'lucide-react';
-import { TimelineDisplayEvent } from '@/types/timeline';
+import { TimelineDisplayEvent, getPostImage } from '@/types/timeline';
 import { renderMarkdownToReact } from '@/utils/markdown';
 import { TIMELINE_SURFACE } from '@/config/timeline';
 import { getExternalAttribution } from '@/config/external-publish';
@@ -53,6 +53,9 @@ export function PostContent({ event }: PostContentProps) {
 
   // Threads-like: never show separate titles; keep posts conversational
   const _shouldShowTitle = false;
+
+  // Attached image (metadata.image, set via the composer's Openverse picker).
+  const postImage = getPostImage(event.metadata);
 
   return (
     <div className="space-y-2">
@@ -238,22 +241,24 @@ export function PostContent({ event }: PostContentProps) {
         </div>
       )}
 
-      {/* FUTURE: Add media rendering (images, videos, embeds) — requires media upload pipeline and storage bucket setup before attachments can be displayed */}
-      {(() => {
-        const attachments =
-          (event.metadata?.attachments as Array<{ type: string; filename: string }>) || [];
-        return attachments.length > 0 ? (
-          <div className="mt-3 space-y-2">
-            {attachments.map((attachment: { type: string; filename: string }, index: number) => (
-              <div key={index} className="rounded-md bg-surface-raised p-4">
-                <p className="text-sm text-fg-secondary">
-                  Media attachment: {attachment.type} - {attachment.filename}
-                </p>
-              </div>
-            ))}
-          </div>
-        ) : null;
-      })()}
+      {/* Attached image — plain <img>: Openverse hosts aren't in next/image remotePatterns */}
+      {postImage && !isRepost && (
+        <figure className="mt-3">
+          {/* eslint-disable-next-line @next/next/no-img-element -- external (Openverse) host */}
+          <img
+            src={postImage.url}
+            alt={postImage.alt || ''}
+            loading="lazy"
+            className="max-h-[28rem] w-auto max-w-full rounded-lg border border-subtle object-contain"
+          />
+          {postImage.credit && (
+            <figcaption className="mt-1 text-2xs text-fg-tertiary">
+              {postImage.credit}
+              {postImage.license ? ` · ${postImage.license.toUpperCase()}` : ''}
+            </figcaption>
+          )}
+        </figure>
+      )}
     </div>
   );
 }

--- a/src/components/timeline/TimelineComposer.tsx
+++ b/src/components/timeline/TimelineComposer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { Globe, Lock } from 'lucide-react';
+import { Globe, ImagePlus, Lock, X } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import { usePostComposer } from '@/hooks/usePostComposerNew';
 import { useContentEditableEditor } from '@/hooks/useContentEditableEditor';
@@ -26,6 +26,8 @@ import {
 import PostAiButton from './PostAiButton';
 import ReplyAiButton from './ReplyAiButton';
 import PostAiEditMenu from './PostAiEditMenu';
+import ImageSuggestPicker from '@/components/articles/ImageSuggestPicker';
+import type { StockImage } from '@/services/images/types';
 
 export interface TimelineComposerProps {
   targetOwnerId?: string;
@@ -63,6 +65,7 @@ const TimelineComposer = React.memo(function TimelineComposer({
 }: TimelineComposerProps) {
   const { user, profile } = useAuth();
   const [showProjects, setShowProjects] = useState(false);
+  const [showImagePicker, setShowImagePicker] = useState(false);
   const [isOnline, setIsOnline] = useState(true);
 
   useEffect(() => {
@@ -134,6 +137,20 @@ const TimelineComposer = React.memo(function TimelineComposer({
     setShowProjects(true);
   }, []);
 
+  const handlePickImage = useCallback(
+    (img: StockImage) => {
+      postComposer.setImage({
+        url: img.fullUrl,
+        alt: img.title,
+        credit: img.creator,
+        license: img.license,
+        source_url: img.sourceUrl,
+      });
+      setShowImagePicker(false);
+    },
+    [postComposer]
+  );
+
   const isButtonDisabled = useMemo(
     () =>
       !postComposer.content.trim() ||
@@ -194,6 +211,38 @@ const TimelineComposer = React.memo(function TimelineComposer({
             />
           )}
 
+          {postComposer.image && (
+            <div className="relative mt-3 inline-block max-w-full">
+              {/* eslint-disable-next-line @next/next/no-img-element -- external (Openverse) host, not in next/image remotePatterns */}
+              <img
+                src={postComposer.image.url}
+                alt={postComposer.image.alt}
+                className="max-h-56 max-w-full rounded-lg border border-subtle object-cover"
+              />
+              <button
+                type="button"
+                onClick={() => postComposer.setImage(null)}
+                disabled={postComposer.isPosting}
+                aria-label="Remove image"
+                className="absolute right-2 top-2 rounded-full border border-subtle bg-surface-base/90 p-1 text-fg-primary transition-colors hover:bg-surface-base"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          )}
+
+          {showImagePicker && !postComposer.image && (
+            <div className="mt-3">
+              <ImageSuggestPicker
+                title=""
+                body={postComposer.content}
+                heading="Add an image"
+                onPick={handlePickImage}
+                onClose={() => setShowImagePicker(false)}
+              />
+            </div>
+          )}
+
           <ComposerMessages error={postComposer.error} success={postComposer.postSuccess} />
 
           <div className="mt-4 flex items-center justify-between border-t border-subtle pt-3">
@@ -216,6 +265,21 @@ const TimelineComposer = React.memo(function TimelineComposer({
                   disabled={postComposer.isPosting}
                 />
               )}
+              <button
+                type="button"
+                onClick={() => setShowImagePicker(v => !v)}
+                disabled={postComposer.isPosting}
+                className={cn(
+                  TIMELINE_SURFACE.chip,
+                  (showImagePicker || postComposer.image) && TIMELINE_SURFACE.chipActive,
+                  'gap-1.5'
+                )}
+                title="Add a free image (AI-suggested from your post)"
+                aria-expanded={showImagePicker}
+              >
+                <ImagePlus className="h-4 w-4" />
+                Image
+              </button>
               {!simpleMode && <TextFormatToolbar onFormat={handleFormat} />}
 
               {!simpleMode && allowProjectSelection && postComposer.userProjects.length > 0 && (

--- a/src/hooks/usePostComposerNew.ts
+++ b/src/hooks/usePostComposerNew.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { logger } from '@/utils/logger';
 import { useAuth } from '@/hooks/useAuth';
-import type { TimelineVisibility, TimelineDisplayEvent } from '@/types/timeline';
+import type { TimelineVisibility, TimelineDisplayEvent, PostImageMeta } from '@/types/timeline';
 import { usePostDraft } from '@/hooks/usePostDraft';
 import { fetchUserProjects, type UserProject } from '@/services/timeline/utils/post-composer';
 import { usePostSubmission } from './usePostSubmission';
@@ -29,6 +29,8 @@ interface PostComposerState {
   setVisibility: (visibility: TimelineVisibility) => void;
   selectedProjects: string[];
   setSelectedProjects: (projects: string[]) => void;
+  image: PostImageMeta | null;
+  setImage: (image: PostImageMeta | null) => void;
   userProjects: UserProject[];
   loadingProjects: boolean;
   isPosting: boolean;
@@ -64,6 +66,7 @@ export function usePostComposer(options: PostComposerOptions = {}): PostComposer
   const [content, setContent] = useState('');
   const [visibility, setVisibility] = useState<TimelineVisibility>(defaultVisibility || 'public');
   const [selectedProjects, setSelectedProjects] = useState<string[]>([]);
+  const [image, setImage] = useState<PostImageMeta | null>(null);
   const [userProjects, setUserProjects] = useState<UserProject[]>([]);
   const [loadingProjects, setLoadingProjects] = useState(false);
 
@@ -97,6 +100,7 @@ export function usePostComposer(options: PostComposerOptions = {}): PostComposer
   const clearFormState = useCallback(() => {
     setContent('');
     setSelectedProjects([]);
+    setImage(null);
   }, []);
 
   const {
@@ -117,6 +121,7 @@ export function usePostComposer(options: PostComposerOptions = {}): PostComposer
     visibility,
     selectedProjects,
     parentEventId,
+    image: image ?? undefined,
     onOptimisticUpdate,
     onSuccess,
     contentValid,
@@ -154,6 +159,8 @@ export function usePostComposer(options: PostComposerOptions = {}): PostComposer
     setVisibility,
     selectedProjects,
     setSelectedProjects,
+    image,
+    setImage,
     userProjects,
     loadingProjects,
     isPosting,

--- a/src/hooks/usePostSubmission.ts
+++ b/src/hooks/usePostSubmission.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { logger } from '@/utils/logger';
 import { TimelineVisibility } from '@/types/timeline';
-import type { TimelineDisplayEvent } from '@/types/timeline';
+import type { TimelineDisplayEvent, PostImageMeta } from '@/types/timeline';
 import {
   formatPostError,
   submitPost,
@@ -25,6 +25,7 @@ interface UsePostSubmissionOptions {
   visibility: TimelineVisibility;
   selectedProjects: string[];
   parentEventId: string | undefined;
+  image: PostImageMeta | undefined;
   onOptimisticUpdate: ((event: TimelineDisplayEvent) => void) | undefined;
   onSuccess: ((event?: TimelineDisplayEvent) => void) | undefined;
   contentValid: boolean;
@@ -41,6 +42,7 @@ export function usePostSubmission({
   visibility,
   selectedProjects,
   parentEventId,
+  image,
   onOptimisticUpdate,
   onSuccess,
   contentValid,
@@ -78,6 +80,7 @@ export function usePostSubmission({
         visibility,
         selectedProjects,
         parentEventId,
+        image,
         onOptimisticUpdate,
       });
       if (!result.success) {
@@ -104,6 +107,7 @@ export function usePostSubmission({
     visibility,
     selectedProjects,
     parentEventId,
+    image,
     onOptimisticUpdate,
     onSuccess,
     clearDraft,
@@ -124,6 +128,7 @@ export function usePostSubmission({
           visibility,
           selectedProjects,
           parentEventId,
+          image,
           onOptimisticUpdate,
         });
         setError(null);
@@ -168,6 +173,7 @@ export function usePostSubmission({
     selectedProjects,
     subjectType,
     subjectId,
+    image,
     onOfflineQueued,
   ]);
 

--- a/src/services/timeline/utils/post-composer.ts
+++ b/src/services/timeline/utils/post-composer.ts
@@ -9,7 +9,7 @@ import { ENTITY_STATUS } from '@/config/database-constants';
 import { TIMELINE_CONTENT_LIMITS } from '@/config/timeline';
 import { timelineService } from '@/services/timeline';
 import { offlineQueueService } from '@/lib/offline-queue';
-import type { TimelineSubjectType, TimelineDisplayEvent } from '@/types/timeline';
+import type { TimelineSubjectType, TimelineDisplayEvent, PostImageMeta } from '@/types/timeline';
 import {
   getEventIcon,
   getEventDisplayType,
@@ -67,6 +67,7 @@ interface CreateOptimisticEventParams {
   visibility: TimelineVisibility;
   selectedProjects: string[];
   parentEventId?: string;
+  image?: PostImageMeta;
 }
 
 /**
@@ -74,8 +75,16 @@ interface CreateOptimisticEventParams {
  * before the server confirms the post creation.
  */
 function createOptimisticEvent(params: CreateOptimisticEventParams): TimelineDisplayEvent {
-  const { user, content, subjectType, subjectId, visibility, selectedProjects, parentEventId } =
-    params;
+  const {
+    user,
+    content,
+    subjectType,
+    subjectId,
+    visibility,
+    selectedProjects,
+    parentEventId,
+    image,
+  } = params;
 
   const optimisticId = `optimistic-${Date.now()}-${Math.random()}`;
   const now = new Date().toISOString();
@@ -108,6 +117,7 @@ function createOptimisticEvent(params: CreateOptimisticEventParams): TimelineDis
       cross_posted_projects: selectedProjects.length > 0 ? selectedProjects : undefined,
       is_optimistic: true,
       is_reply: !!parentEventId,
+      ...(image ? { image } : {}),
     },
     parentEventId,
     eventTimestamp: now,
@@ -247,6 +257,7 @@ interface PostSubmitOptions {
   visibility: TimelineVisibility;
   selectedProjects: string[];
   parentEventId?: string;
+  image?: PostImageMeta;
   onOptimisticUpdate?: (event: TimelineDisplayEvent) => void;
 }
 
@@ -268,6 +279,7 @@ export async function submitPost(options: PostSubmitOptions): Promise<PostSubmit
     visibility,
     selectedProjects,
     parentEventId,
+    image,
     onOptimisticUpdate,
   } = options;
 
@@ -289,6 +301,7 @@ export async function submitPost(options: PostSubmitOptions): Promise<PostSubmit
     visibility,
     selectedProjects,
     parentEventId,
+    image,
   });
   onOptimisticUpdate?.(optimisticEvent);
 
@@ -310,7 +323,7 @@ export async function submitPost(options: PostSubmitOptions): Promise<PostSubmit
         title,
         description: postContent,
         visibility,
-        metadata: { is_user_post: true, is_reply: true },
+        metadata: { is_user_post: true, is_reply: true, ...(image ? { image } : {}) },
         parentEventId,
       })
     : await timelineService.createEventWithVisibility({
@@ -321,7 +334,11 @@ export async function submitPost(options: PostSubmitOptions): Promise<PostSubmit
         title,
         description: postContent,
         visibility,
-        metadata: { is_user_post: true, cross_posted_count: selectedProjects.length },
+        metadata: {
+          is_user_post: true,
+          cross_posted_count: selectedProjects.length,
+          ...(image ? { image } : {}),
+        },
         timelineContexts,
       });
 
@@ -347,6 +364,7 @@ export async function queueOfflinePost(options: PostSubmitOptions): Promise<void
     visibility,
     selectedProjects,
     parentEventId,
+    image,
     onOptimisticUpdate,
   } = options;
 
@@ -365,6 +383,7 @@ export async function queueOfflinePost(options: PostSubmitOptions): Promise<void
         is_user_post: true,
         cross_posted: subjectId && subjectId !== user.id,
         cross_posted_projects: selectedProjects.length > 0 ? selectedProjects : undefined,
+        ...(image ? { image } : {}),
       },
     },
     user.id
@@ -379,6 +398,7 @@ export async function queueOfflinePost(options: PostSubmitOptions): Promise<void
       visibility,
       selectedProjects,
       parentEventId,
+      image,
     });
     offlineEvent.id = `offline-${Date.now()}`;
     offlineEvent.metadata = {

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -111,6 +111,28 @@ export type TimelineSubjectType =
  */
 export type TimelineVisibility = 'public' | 'followers' | 'private';
 
+/**
+ * Image attached to a short post, stored verbatim at `metadata.image`
+ * (snake_case to match the other metadata keys). Sourced from the CC0/PD
+ * Openverse picker, so a remote URL — no upload pipeline involved.
+ */
+export interface PostImageMeta {
+  url: string;
+  alt: string;
+  /** Creator attribution shown under the image when present. */
+  credit: string | null;
+  license: string | null;
+  source_url: string | null;
+}
+
+/** SSOT reader for `metadata.image` — every render surface goes through this. */
+export function getPostImage(metadata: Record<string, any> | undefined): PostImageMeta | null {
+  const img = metadata?.image;
+  return img && typeof img === 'object' && typeof img.url === 'string' && img.url
+    ? (img as PostImageMeta)
+    : null;
+}
+
 // ==================== CORE TIMELINE EVENT ====================
 
 /**
@@ -157,7 +179,7 @@ export interface TimelineEvent {
   updatedAt: string;
 
   // Metadata
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   metadata?: Record<string, any>;
   tags?: string[];
 
@@ -202,7 +224,7 @@ interface TimelineEmbed {
   url: string;
   title?: string;
   thumbnail?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   metadata?: Record<string, any>;
 }
 
@@ -388,7 +410,7 @@ export interface CreateTimelineEventRequest {
   quantity?: number;
   visibility?: TimelineVisibility;
   isFeatured?: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   metadata?: Record<string, any>;
   tags?: string[];
   parentEventId?: string;
@@ -402,7 +424,7 @@ export interface TimelineEventResponse {
   success: boolean;
   event?: TimelineEvent | TimelineDisplayEvent;
   error?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   metadata?: Record<string, any>;
 }
 
@@ -428,7 +450,7 @@ export interface TimelineEventDb extends Omit<
   event_timestamp: string;
   created_at: string;
   updated_at: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   metadata?: Record<string, any>;
   tags?: string[];
   parent_event_id?: string;


### PR DESCRIPTION
## What

Closes the deferred item from the AI-helpfulness arc (#496/#500/#502/#506): **AI image search now works on short timeline posts**, not just articles.

- **Composer**: new `Image` chip opens the existing Openverse picker (`ImageSuggestPicker`) — AI turns the post text into search terms, all results CC0/public-domain. Selected image shows as a preview with a remove button.
- **Storage**: one image per post at `metadata.image` (`{url, alt, credit, license, source_url}`), persisted verbatim by the `create_post_with_visibility` RPC — **zero migrations**. `PostImageMeta` + `getPostImage()` in `src/types/timeline.ts` are the SSOT for the shape.
- **Flow**: image travels through online submit (posts *and* replies), the optimistic event (visible instantly), and the offline queue. `EditPostModal` already preserves untouched metadata, so editing text keeps the image.
- **Feed**: `PostContent` renders the image (plain `<img>` — Openverse hosts aren't in `next/image` remotePatterns, same as article images) with creator/license attribution; replaced the dead `attachments` placeholder stub.

## Why this shape

The recon showed everything needed already exists: the picker and `/api/ai/images/suggest` route are post-agnostic, and `timeline_events.metadata` jsonb is written verbatim — so a full upload pipeline (buckets, moderation, size limits) isn't required for the AI-image use case. File upload can layer on later by reusing the banners-bucket helper if wanted.

## Verification

- `tsc --noEmit` — 0 errors
- eslint on touched files — 0 errors (5 pre-existing warnings on main, unrelated)
- `npm run audit:routes` — clean
- jest — **1300/1300 tests pass**
- Not E2E'd against prod DB (sandbox can't reach it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)