### PR TITLE
feat(ai-form): AI assist for any declared form — tasks + proposals, config-driven

### DIFF
--- a/__tests__/unit/lib/ai-assist-any-form.test.ts
+++ b/__tests__/unit/lib/ai-assist-any-form.test.ts
@@ -1,0 +1,185 @@
+/**
+ * AI form assist beyond registry entities — target resolution, output
+ * sanitizing, and the standalone form catalog (tasks, proposals).
+ *
+ * These lock the contract that made the assist bar generalizable: any form is
+ * a resolved target (name + declared fields + instructions), and AI output is
+ * coerced against those declared fields before it ever reaches a form.
+ */
+
+import { resolveAiAssistTarget } from '@/lib/ai/assist-target';
+import { sanitizeAiFields } from '@/lib/ai/sanitize-ai-fields';
+import { AI_ASSIST_FORMS } from '@/config/ai-assist-forms';
+import { getExampleDescriptions } from '@/config/ai-form-assist';
+import { ENTITY_TYPES } from '@/config/entity-registry';
+import { applyTaskAiData } from '@/app/(authenticated)/dashboard/tasks/task-form-types';
+import type { TaskFormData } from '@/app/(authenticated)/dashboard/tasks/task-form-types';
+import type { FieldConfig } from '@/components/create/types';
+
+describe('AI_ASSIST_FORMS — the standalone form catalog', () => {
+  it('never collides with an entity type (entity registry resolves first)', () => {
+    for (const formId of Object.keys(AI_ASSIST_FORMS)) {
+      expect(ENTITY_TYPES).not.toContain(formId);
+    }
+  });
+
+  it('declares complete forms: name, fields, and starter examples', () => {
+    for (const form of Object.values(AI_ASSIST_FORMS)) {
+      expect(form.name).toBeTruthy();
+      expect(form.fields.length).toBeGreaterThan(0);
+      expect(form.examples.length).toBeGreaterThan(0);
+      for (const field of form.fields) {
+        expect(field.name).toBeTruthy();
+        expect(field.label).toBeTruthy();
+        if (field.type === 'select' || field.type === 'radio') {
+          expect(field.options?.length).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it('has a textarea in every form — the bar exists for prose-heavy forms', () => {
+    for (const form of Object.values(AI_ASSIST_FORMS)) {
+      expect(form.fields.some(field => field.type === 'textarea')).toBe(true);
+    }
+  });
+});
+
+describe('resolveAiAssistTarget — one resolver for every form kind', () => {
+  it('resolves an entity type through the registry', () => {
+    const target = resolveAiAssistTarget('service');
+    expect(target).not.toBeNull();
+    expect(target?.name).toBe('Service');
+    expect(target?.fields.length).toBeGreaterThan(0);
+    expect(target?.instructions.length).toBeGreaterThan(0);
+  });
+
+  it('resolves a standalone assist form', () => {
+    const target = resolveAiAssistTarget('task');
+    expect(target).not.toBeNull();
+    expect(target?.name).toBe('Task');
+    expect(target?.fields.map(field => field.name)).toContain('task_type');
+  });
+
+  it('resolves the proposal form with its own instructions on top of universal ones', () => {
+    const target = resolveAiAssistTarget('proposal');
+    expect(target?.instructions.join('\n')).toContain('treasury');
+  });
+
+  it('returns null for an unknown form type', () => {
+    expect(resolveAiAssistTarget('nonsense')).toBeNull();
+    expect(resolveAiAssistTarget('')).toBeNull();
+  });
+});
+
+describe('sanitizeAiFields — declared fields are enforced, not requested', () => {
+  const fields: FieldConfig[] = [
+    { name: 'title', label: 'Title', type: 'text' },
+    {
+      name: 'category',
+      label: 'Category',
+      type: 'select',
+      options: [
+        { value: 'cleaning', label: 'Cleaning' },
+        { value: 'it', label: 'IT' },
+      ],
+    },
+    { name: 'estimated_minutes', label: 'Minutes', type: 'number', min: 1, max: 480 },
+    { name: 'tags', label: 'Tags', type: 'tags' },
+    { name: 'is_public', label: 'Public', type: 'boolean' },
+  ];
+
+  it('maps a select answered with its label back to the option value', () => {
+    expect(sanitizeAiFields({ category: 'Cleaning' }, fields)).toEqual({ category: 'cleaning' });
+  });
+
+  it('drops a select value that matches no option', () => {
+    expect(sanitizeAiFields({ category: 'gardening' }, fields)).toEqual({});
+  });
+
+  it('coerces numeric strings and drops out-of-range numbers', () => {
+    expect(sanitizeAiFields({ estimated_minutes: '45' }, fields)).toEqual({
+      estimated_minutes: 45,
+    });
+    expect(sanitizeAiFields({ estimated_minutes: 9999 }, fields)).toEqual({});
+  });
+
+  it('accepts tags as an array or a comma-separated string', () => {
+    expect(sanitizeAiFields({ tags: ['a', ' b '] }, fields)).toEqual({ tags: ['a', 'b'] });
+    expect(sanitizeAiFields({ tags: 'a, b' }, fields)).toEqual({ tags: ['a', 'b'] });
+  });
+
+  it('coerces boolean strings', () => {
+    expect(sanitizeAiFields({ is_public: 'true' }, fields)).toEqual({ is_public: true });
+    expect(sanitizeAiFields({ is_public: 'maybe' }, fields)).toEqual({});
+  });
+
+  it('passes undeclared fields through untouched (companion values like currency)', () => {
+    expect(sanitizeAiFields({ currency: 'CHF' }, fields)).toEqual({ currency: 'CHF' });
+  });
+
+  it('renders a number handed to a text field instead of losing it', () => {
+    expect(sanitizeAiFields({ title: 2026 }, fields)).toEqual({ title: '2026' });
+  });
+});
+
+describe('getExampleDescriptions — standalone forms get starters too', () => {
+  it('returns the declared examples for task and proposal', () => {
+    expect(getExampleDescriptions('task')).toEqual(AI_ASSIST_FORMS.task.examples);
+    expect(getExampleDescriptions('proposal')).toEqual(AI_ASSIST_FORMS.proposal.examples);
+  });
+
+  it('returns nothing for an unknown form instead of a fake fallback', () => {
+    expect(getExampleDescriptions('nonsense')).toEqual([]);
+  });
+});
+
+describe('applyTaskAiData — AI output lands safely in task form state', () => {
+  const base: TaskFormData = {
+    title: 'Old',
+    description: '',
+    instructions: '',
+    task_type: 'one_time',
+    schedule_cron: '',
+    schedule_human: '',
+    category: 'other',
+    tags: [],
+    priority: 'normal',
+    estimated_minutes: '',
+    project_id: 'keep-me',
+  };
+
+  it('applies valid values and keeps untouched state', () => {
+    const next = applyTaskAiData(base, {
+      title: 'Clean workshop',
+      task_type: 'recurring_scheduled',
+      schedule_human: 'Every Friday',
+      category: 'cleaning',
+      estimated_minutes: 45,
+      tags: ['workshop'],
+    });
+    expect(next.title).toBe('Clean workshop');
+    expect(next.task_type).toBe('recurring_scheduled');
+    expect(next.schedule_human).toBe('Every Friday');
+    expect(next.category).toBe('cleaning');
+    expect(next.estimated_minutes).toBe(45);
+    expect(next.tags).toEqual(['workshop']);
+    expect(next.project_id).toBe('keep-me');
+  });
+
+  it('rejects invalid enum values and malformed types', () => {
+    const next = applyTaskAiData(base, {
+      task_type: 'sometimes',
+      category: 42,
+      priority: 'asap',
+      estimated_minutes: 'soon',
+      tags: 'not-an-array',
+    });
+    expect(next).toEqual(base);
+  });
+
+  it('caps tags at the form limit of 10', () => {
+    const next = applyTaskAiData(base, { tags: Array.from({ length: 15 }, (_, i) => `t${i}`) });
+    expect(next.tags).toHaveLength(10);
+  });
+});

--- a/__tests__/unit/lib/ai-assist-any-form.test.ts
+++ b/__tests__/unit/lib/ai-assist-any-form.test.ts
@@ -9,6 +9,7 @@
 
 import { resolveAiAssistTarget } from '@/lib/ai/assist-target';
 import { sanitizeAiFields } from '@/lib/ai/sanitize-ai-fields';
+import { generateFormPrefill } from '@/lib/ai/form-prefill-service';
 import { AI_ASSIST_FORMS } from '@/config/ai-assist-forms';
 import { getExampleDescriptions } from '@/config/ai-form-assist';
 import { ENTITY_TYPES } from '@/config/entity-registry';
@@ -120,6 +121,47 @@ describe('sanitizeAiFields — declared fields are enforced, not requested', () 
 
   it('renders a number handed to a text field instead of losing it', () => {
     expect(sanitizeAiFields({ title: 2026 }, fields)).toEqual({ title: '2026' });
+  });
+});
+
+describe('generateFormPrefill — service floor follows the intent, like the route', () => {
+  // #508 lowered the ROUTE floor for refine to 3 but its test mocked this
+  // service, which still hard-rejected under 10 — so "shorter" passed the
+  // route and then died here. Both layers now read AI_ASSIST_MIN_INPUT_LENGTH.
+  const target = resolveAiAssistTarget('service');
+  const envKeys = ['GROQ_API_KEY', 'OPENROUTER_API_KEY'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    // No provider keys → a request that passes the length gate fails on
+    // provider config, proving the gate let it through without any network.
+    for (const key of envKeys) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterAll(() => {
+    for (const key of envKeys) {
+      if (saved[key] !== undefined) {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  it('does not reject a short refine instruction as "too short"', async () => {
+    const result = await generateFormPrefill({
+      target: target!,
+      description: 'shorter',
+      intent: 'refine',
+    });
+    expect(result.error).not.toMatch(/at least/);
+  });
+
+  it('still rejects a too-short fill description', async () => {
+    const result = await generateFormPrefill({ target: target!, description: 'hi' });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('at least 10');
   });
 });
 

--- a/src/app/(authenticated)/dashboard/tasks/TaskFormFields.tsx
+++ b/src/app/(authenticated)/dashboard/tasks/TaskFormFields.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import Button from '@/components/ui/Button';
 import { Save } from 'lucide-react';
 import {
@@ -8,6 +9,8 @@ import {
   TASK_CATEGORY_LABELS,
   PRIORITY_LABELS,
 } from '@/config/tasks';
+import { AI_ASSIST_FORMS } from '@/config/ai-assist-forms';
+import { AIPrefillBar } from '@/components/create/AIPrefillBar';
 import type { TaskFormData } from './task-form-types';
 
 interface TaskFormFieldsProps {
@@ -24,6 +27,10 @@ interface TaskFormFieldsProps {
   onRemoveTag: (tag: string) => void;
   onSubmit: (e: React.FormEvent) => void;
   onCancel: () => void;
+  /** When provided, the AI assist bar renders and applies its output here (see applyTaskAiData) */
+  onAIPrefill?: (data: Record<string, unknown>) => void;
+  /** Which AI-assist framing to use — matches the page the form is on */
+  aiMode?: 'create' | 'edit';
   showTaskTypeHint?: boolean;
   submitLabel?: string;
 }
@@ -55,11 +62,36 @@ export function TaskFormFields({
   onRemoveTag,
   onSubmit,
   onCancel,
+  onAIPrefill,
+  aiMode = 'create',
   showTaskTypeHint = false,
   submitLabel = 'Save',
 }: TaskFormFieldsProps) {
+  // The AI only sees (and reports on) the fields it is declared to write to.
+  const aiExistingData = useMemo(
+    () =>
+      Object.fromEntries(
+        AI_ASSIST_FORMS.task.fields.map(field => [
+          field.name,
+          (formData as unknown as Record<string, unknown>)[field.name],
+        ])
+      ),
+    [formData]
+  );
+
   return (
     <form onSubmit={onSubmit} className="p-6 space-y-4">
+      {onAIPrefill && (
+        <AIPrefillBar
+          formType="task"
+          mode={aiMode}
+          onPrefill={data => onAIPrefill(data)}
+          disabled={submitting}
+          existingData={aiExistingData}
+          fields={AI_ASSIST_FORMS.task.fields}
+        />
+      )}
+
       <div>
         <label className="block text-sm font-medium text-fg-primary mb-1">
           Title <span className="text-status-negative">*</span>

--- a/src/app/(authenticated)/dashboard/tasks/[id]/edit/page.tsx
+++ b/src/app/(authenticated)/dashboard/tasks/[id]/edit/page.tsx
@@ -25,6 +25,7 @@ export default function EditTaskPage() {
     errors,
     handleChange,
     handleEstimatedMinutesChange,
+    handleAIPrefill,
     handleAddTag,
     handleRemoveTag,
     handleSubmit,
@@ -64,6 +65,8 @@ export default function EditTaskPage() {
             submitting={submitting}
             onChange={handleChange}
             onEstimatedMinutesChange={handleEstimatedMinutesChange}
+            onAIPrefill={handleAIPrefill}
+            aiMode="edit"
             onAddTag={handleAddTag}
             onRemoveTag={handleRemoveTag}
             onSubmit={handleSubmit}

--- a/src/app/(authenticated)/dashboard/tasks/[id]/edit/useEditTaskForm.ts
+++ b/src/app/(authenticated)/dashboard/tasks/[id]/edit/useEditTaskForm.ts
@@ -5,7 +5,7 @@ import { logger } from '@/utils/logger';
 import { ROUTES } from '@/config/routes';
 import { API_ROUTES } from '@/config/api-routes';
 import type { Task } from '@/lib/schemas/tasks';
-import type { TaskFormData } from '../../task-form-types';
+import { applyTaskAiData, type TaskFormData } from '../../task-form-types';
 
 export function useEditTaskForm(taskId: string, enabled: boolean) {
   const router = useRouter();
@@ -75,6 +75,11 @@ export function useEditTaskForm(taskId: string, enabled: boolean) {
 
   const handleEstimatedMinutesChange = (value: number | '') => {
     setFormData(prev => (prev ? { ...prev, estimated_minutes: value } : null));
+  };
+
+  const handleAIPrefill = (data: Record<string, unknown>) => {
+    setFormData(prev => (prev ? applyTaskAiData(prev, data) : null));
+    setErrors({});
   };
 
   const handleAddTag = () => {
@@ -166,6 +171,7 @@ export function useEditTaskForm(taskId: string, enabled: boolean) {
     errors,
     handleChange,
     handleEstimatedMinutesChange,
+    handleAIPrefill,
     handleAddTag,
     handleRemoveTag,
     handleSubmit,

--- a/src/app/(authenticated)/dashboard/tasks/new/page.tsx
+++ b/src/app/(authenticated)/dashboard/tasks/new/page.tsx
@@ -21,6 +21,7 @@ export default function NewTaskPage() {
     errors,
     handleChange,
     handleEstimatedMinutesChange,
+    handleAIPrefill,
     handleAddTag,
     handleRemoveTag,
     handleSubmit,
@@ -56,6 +57,8 @@ export default function NewTaskPage() {
             submitting={submitting}
             onChange={handleChange}
             onEstimatedMinutesChange={handleEstimatedMinutesChange}
+            onAIPrefill={handleAIPrefill}
+            aiMode="create"
             onAddTag={handleAddTag}
             onRemoveTag={handleRemoveTag}
             onSubmit={handleSubmit}

--- a/src/app/(authenticated)/dashboard/tasks/new/useNewTaskForm.ts
+++ b/src/app/(authenticated)/dashboard/tasks/new/useNewTaskForm.ts
@@ -4,7 +4,13 @@ import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
 import { TASK_DEFAULTS } from '@/config/tasks';
 import { API_ROUTES } from '@/config/api-routes';
-import type { TaskFormData, TaskCategory, TaskType, Priority } from '../task-form-types';
+import {
+  applyTaskAiData,
+  type TaskFormData,
+  type TaskCategory,
+  type TaskType,
+  type Priority,
+} from '../task-form-types';
 
 const INITIAL_FORM_DATA: TaskFormData = {
   title: '',
@@ -44,6 +50,11 @@ export function useNewTaskForm() {
 
   const handleEstimatedMinutesChange = (value: number | '') => {
     setFormData(prev => ({ ...prev, estimated_minutes: value }));
+  };
+
+  const handleAIPrefill = (data: Record<string, unknown>) => {
+    setFormData(prev => applyTaskAiData(prev, data));
+    setErrors({});
   };
 
   const handleAddTag = () => {
@@ -129,6 +140,7 @@ export function useNewTaskForm() {
     errors,
     handleChange,
     handleEstimatedMinutesChange,
+    handleAIPrefill,
     handleAddTag,
     handleRemoveTag,
     handleSubmit,

--- a/src/app/(authenticated)/dashboard/tasks/task-form-types.ts
+++ b/src/app/(authenticated)/dashboard/tasks/task-form-types.ts
@@ -1,4 +1,11 @@
-import { TASK_CATEGORIES, TASK_TYPES, PRIORITIES } from '@/config/tasks';
+import {
+  TASK_CATEGORIES,
+  TASK_TYPES,
+  PRIORITIES,
+  TASK_TYPE_OPTIONS,
+  TASK_CATEGORY_OPTIONS,
+  PRIORITY_OPTIONS,
+} from '@/config/tasks';
 
 export type TaskCategory = (typeof TASK_CATEGORIES)[keyof typeof TASK_CATEGORIES];
 export type TaskType = (typeof TASK_TYPES)[keyof typeof TASK_TYPES];
@@ -16,4 +23,47 @@ export interface TaskFormData {
   priority: Priority;
   estimated_minutes: number | '';
   project_id: string;
+}
+
+/**
+ * Apply AI-generated values onto the task form state.
+ *
+ * The server already coerces values against the declared assist fields (see
+ * `sanitizeAiFields`); this is the last line of defense at the state boundary:
+ * only known fields land, enums must be valid option values, and anything
+ * malformed keeps the previous value instead of corrupting the form.
+ */
+export function applyTaskAiData(prev: TaskFormData, data: Record<string, unknown>): TaskFormData {
+  const next: TaskFormData = { ...prev };
+  if (typeof data.title === 'string') {
+    next.title = data.title;
+  }
+  if (typeof data.description === 'string') {
+    next.description = data.description;
+  }
+  if (typeof data.instructions === 'string') {
+    next.instructions = data.instructions;
+  }
+  if (typeof data.schedule_human === 'string') {
+    next.schedule_human = data.schedule_human;
+  }
+  if (typeof data.task_type === 'string' && TASK_TYPE_OPTIONS.includes(data.task_type as TaskType)) {
+    next.task_type = data.task_type as TaskType;
+  }
+  if (
+    typeof data.category === 'string' &&
+    TASK_CATEGORY_OPTIONS.includes(data.category as TaskCategory)
+  ) {
+    next.category = data.category as TaskCategory;
+  }
+  if (typeof data.priority === 'string' && PRIORITY_OPTIONS.includes(data.priority as Priority)) {
+    next.priority = data.priority as Priority;
+  }
+  if (typeof data.estimated_minutes === 'number' && Number.isFinite(data.estimated_minutes)) {
+    next.estimated_minutes = Math.round(data.estimated_minutes);
+  }
+  if (Array.isArray(data.tags)) {
+    next.tags = data.tags.filter((tag): tag is string => typeof tag === 'string').slice(0, 10);
+  }
+  return next;
 }

--- a/src/app/api/ai/form-prefill/route.ts
+++ b/src/app/api/ai/form-prefill/route.ts
@@ -2,11 +2,11 @@
  * AI Form Prefill API Endpoint
  *
  * Generates form field values from natural language descriptions using AI.
- * Used by the entity creation forms to prefill fields based on user descriptions.
+ * Serves every AI-assistable form: registry entities (product, service, …)
+ * and standalone declared forms (task, proposal) — see
+ * `resolveAiAssistTarget` for how a form type becomes a field list.
  *
  * POST /api/ai/form-prefill
- *
- * Created: 2025-01-20
  */
 
 import { z } from 'zod';
@@ -19,8 +19,7 @@ import {
 } from '@/lib/api/standardResponse';
 import { NextResponse } from 'next/server';
 import { generateFormPrefill } from '@/lib/ai/form-prefill-service';
-import { getEntityConfig } from '@/config/entity-configs/get-config';
-import { isValidEntityType, type EntityType } from '@/config/entity-registry';
+import { resolveAiAssistTarget } from '@/lib/ai/assist-target';
 import { logger } from '@/utils/logger';
 import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { AI_ASSIST_MIN_INPUT_LENGTH } from '@/config/ai-form-assist';
@@ -30,7 +29,10 @@ import { AI_ASSIST_MIN_INPUT_LENGTH } from '@/config/ai-form-assist';
  */
 const requestSchema = z
   .object({
-    entityType: z.string().min(1, 'Entity type is required'),
+    /** Entity type or standalone assist-form id ("service", "task", …) */
+    formType: z.string().min(1).optional(),
+    /** Legacy name for formType — kept so in-flight clients keep working */
+    entityType: z.string().min(1).optional(),
     description: z.string().min(1, 'Description is required'),
     existingData: z.record(z.unknown()).optional(),
     /**
@@ -38,6 +40,10 @@ const requestSchema = z
      * it. A refine request that arrives as `fill` can never change anything.
      */
     intent: z.enum(['fill', 'refine']).default('fill'),
+  })
+  .refine(body => body.formType || body.entityType, {
+    message: 'formType is required',
+    path: ['formType'],
   })
   // The floor depends on the intent — a refinement is an instruction, not a
   // description, and "shorter" says everything it needs to in seven characters.
@@ -79,24 +85,19 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
       return apiValidationError('Invalid request', parseResult.error.flatten().fieldErrors);
     }
 
-    const { entityType, description, existingData, intent } = parseResult.data;
+    const { description, existingData, intent } = parseResult.data;
+    const formType = parseResult.data.formType ?? parseResult.data.entityType ?? '';
 
-    // Validate entity type
-    if (!isValidEntityType(entityType)) {
-      return apiBadRequest(`Invalid entity type: ${entityType}`);
-    }
-
-    // Get entity configuration
-    const entityConfig = getEntityConfig(entityType as EntityType);
-    if (!entityConfig) {
-      return apiBadRequest(`No configuration found for entity type: ${entityType}`);
+    const target = resolveAiAssistTarget(formType);
+    if (!target) {
+      return apiBadRequest(`Unknown form type: ${formType}`);
     }
 
     logger.info(
       'AI form prefill request',
       {
         userId: user.id,
-        entityType,
+        formType,
         intent,
         descriptionLength: description.length,
       },
@@ -105,9 +106,8 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
 
     // Generate form prefill using AI
     const result = await generateFormPrefill({
-      entityType,
+      target,
       description,
-      entityConfig,
       existingData,
       intent,
     });
@@ -117,7 +117,7 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
         'AI form prefill failed',
         {
           userId: user.id,
-          entityType,
+          formType,
           error: result.error,
         },
         'AI'
@@ -130,7 +130,7 @@ export const POST = withAuth(async (req: AuthenticatedRequest) => {
       'AI form prefill success',
       {
         userId: user.id,
-        entityType,
+        formType,
         intent,
         fieldsChanged: result.changedFields?.length ?? 0,
       },

--- a/src/components/create/AIPrefillBar.tsx
+++ b/src/components/create/AIPrefillBar.tsx
@@ -17,7 +17,6 @@ import {
   type AiAdjustment,
   type AiAssistIntent,
 } from '@/config/ai-form-assist';
-import type { EntityType } from '@/config/entity-registry';
 
 const EMPTY_FIELDS: NonNullable<AIPrefillBarProps['fields']> = [];
 
@@ -31,7 +30,7 @@ const TYPED_REQUEST = '__typed__';
  * AIRefinePanel.
  */
 export function AIPrefillBar({
-  entityType,
+  formType,
   onPrefill,
   disabled = false,
   existingData,
@@ -52,7 +51,7 @@ export function AIPrefillBar({
   const [hasFilled, setHasFilled] = useState(false);
   const [lastChanged, setLastChanged] = useState<string[] | null>(null);
 
-  const examples = getExampleDescriptions(entityType as EntityType);
+  const examples = getExampleDescriptions(formType);
 
   // Filtered against THIS form's fields, so a form without a description never
   // offers to lengthen one.
@@ -82,7 +81,7 @@ export function AIPrefillBar({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            entityType,
+            formType,
             description: prompt.trim(),
             existingData,
             intent,
@@ -123,7 +122,7 @@ export function AIPrefillBar({
         setPending(null);
       }
     },
-    [entityType, existingData, onPrefill]
+    [formType, existingData, onPrefill]
   );
 
   const handleGenerate = useCallback(() => {

--- a/src/components/create/EntityForm/index.tsx
+++ b/src/components/create/EntityForm/index.tsx
@@ -159,7 +159,7 @@ export function EntityForm<T extends Record<string, unknown>>({
                     and have the fields filled instead of typing each one. On edit
                     the bar refines the existing values (it receives existingData). */}
       <AIPrefillBar
-        entityType={config.type}
+        formType={config.type}
         onPrefill={handleAIPrefill}
         disabled={formState.isSubmitting}
         existingData={formState.data}

--- a/src/components/create/types.ts
+++ b/src/components/create/types.ts
@@ -357,8 +357,8 @@ export interface UseTemplateSelectionReturn<T extends Record<string, unknown>> {
  * Request body for AI form prefill
  */
 export interface AIPrefillRequest {
-  /** Entity type to generate fields for */
-  entityType: string;
+  /** Form to generate fields for — an entity type or a declared assist-form id */
+  formType: string;
   /** User's natural language description */
   description: string;
   /** Any fields already filled (to preserve user input) */
@@ -403,8 +403,8 @@ export interface AIGeneratedFields {
  * Props for the AI prefill bar component
  */
 export interface AIPrefillBarProps {
-  /** Entity type being created */
-  entityType: string;
+  /** Form being filled — an entity type or a declared assist-form id (task, proposal) */
+  formType: string;
   /** Callback when AI generates field values */
   onPrefill: (
     data: Record<string, unknown>,

--- a/src/components/groups/proposals/CreateProposalDialog.tsx
+++ b/src/components/groups/proposals/CreateProposalDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { proposalSchema, type ProposalFormData } from '@/lib/validation/proposals';
 import {
@@ -22,7 +22,12 @@ import {
   type ProposalFieldType,
 } from '@/lib/entity-guidance/proposal-guidance';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { AIPrefillBar } from '@/components/create/AIPrefillBar';
+import { AI_ASSIST_FORMS } from '@/config/ai-assist-forms';
 import { ProposalFormFields } from './ProposalFormFields';
+
+/** Field names the AI may write — anything else it returns is ignored. */
+const PROPOSAL_AI_FIELD_NAMES = new Set(AI_ASSIST_FORMS.proposal.fields.map(field => field.name));
 
 interface CreateProposalDialogProps {
   open: boolean;
@@ -52,6 +57,24 @@ export function CreateProposalDialog({
       is_public: false,
     },
   });
+
+  // Live form values for the AI bar (useWatch, not form.watch — the latter is
+  // React-Compiler-incompatible).
+  const formValues = useWatch({ control: form.control });
+
+  // The server sanitizes values against the declared proposal fields; here we
+  // only route them into react-hook-form so validation and dirty state engage.
+  const handleAIPrefill = (data: Record<string, unknown>) => {
+    for (const [key, value] of Object.entries(data)) {
+      if (!PROPOSAL_AI_FIELD_NAMES.has(key) || value === null || value === undefined) {
+        continue;
+      }
+      form.setValue(key as keyof ProposalFormData, value as never, {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+    }
+  };
 
   const onSubmit = async (data: ProposalFormData) => {
     try {
@@ -112,6 +135,13 @@ export function CreateProposalDialog({
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-4">
           <div className="lg:col-span-2">
+            <AIPrefillBar
+              formType="proposal"
+              onPrefill={handleAIPrefill}
+              disabled={submitting}
+              existingData={formValues}
+              fields={AI_ASSIST_FORMS.proposal.fields}
+            />
             <ProposalFormFields
               form={form}
               activeField={activeField}

--- a/src/components/groups/proposals/ProposalFormFields.tsx
+++ b/src/components/groups/proposals/ProposalFormFields.tsx
@@ -95,12 +95,14 @@ export function ProposalFormFields({
           render={({ field }) => (
             <FormItem>
               <FormLabel>Type</FormLabel>
+              {/* Controlled (`value`, not `defaultValue`) — AI prefill sets this
+                  via form.setValue and the trigger must follow the form state. */}
               <Select
                 onValueChange={value => {
                   field.onChange(value);
                   setActiveField('proposal_type');
                 }}
-                defaultValue={field.value}
+                value={field.value}
                 onOpenChange={open => {
                   if (open) {
                     setActiveField('proposal_type');

--- a/src/config/ai-assist-forms.ts
+++ b/src/config/ai-assist-forms.ts
@@ -1,0 +1,162 @@
+/**
+ * AI-ASSISTABLE STANDALONE FORMS — CONFIG SSOT
+ *
+ * The AI form assist bar works off a declared field list. Entity forms get
+ * theirs from the entity registry / entity configs; the long forms that are
+ * NOT registry entities (tasks, group proposals) declare theirs here.
+ *
+ * One entry = one AI-fillable form. `resolveAiAssistTarget` checks the entity
+ * registry first and this catalog second, so a form id here must never collide
+ * with an EntityType.
+ *
+ * Field labels/options are derived from the same config SSOTs the forms
+ * themselves render from (TASK_TYPE_LABELS, PROPOSAL_TYPE_SELECT_OPTIONS, …),
+ * so the AI's view of a form can't drift from what the user sees.
+ *
+ * Deliberately absent:
+ * - WalletForm — its whole design is "paste one payment handle"; an AI cannot
+ *   invent an address, so there is nothing for it to write.
+ * - Group settings — two short fields and toggles; the bar would be bigger
+ *   than the form.
+ */
+
+import type { FieldConfig, SelectOption } from '@/components/create/types';
+import {
+  TASK_TYPE_LABELS,
+  TASK_CATEGORY_LABELS,
+  PRIORITY_LABELS,
+} from '@/config/tasks';
+import { PROPOSAL_TYPE_SELECT_OPTIONS } from '@/config/proposal-constants';
+
+export interface AiAssistFormConfig {
+  /** Human name used in prompts and log lines ("Task", "Proposal") */
+  name: string;
+  /** The fields the AI may write to — same FieldConfig shape as entity configs */
+  fields: FieldConfig[];
+  /** Form-specific prompt rules (option semantics, sentinel values, …) */
+  instructions?: string[];
+  /** "Try:" starter descriptions shown in the fill panel */
+  examples: string[];
+}
+
+/** A value→label record (the shape all our label SSOTs use) as select options. */
+function selectOptions(labels: Record<string, string>): SelectOption[] {
+  return Object.entries(labels).map(([value, label]) => ({ value, label }));
+}
+
+export const AI_ASSIST_FORMS = {
+  task: {
+    name: 'Task',
+    fields: [
+      { name: 'title', label: 'Title', type: 'text', required: true },
+      {
+        name: 'task_type',
+        label: 'Task Type',
+        type: 'select',
+        options: selectOptions(TASK_TYPE_LABELS),
+        required: true,
+      },
+      {
+        name: 'schedule_human',
+        label: 'Schedule',
+        type: 'text',
+        hint: 'When the task should happen, in plain words',
+        placeholder: 'Every Monday, Daily at 9 AM',
+      },
+      {
+        name: 'category',
+        label: 'Category',
+        type: 'select',
+        options: selectOptions(TASK_CATEGORY_LABELS),
+        required: true,
+      },
+      {
+        name: 'priority',
+        label: 'Priority',
+        type: 'select',
+        options: selectOptions(PRIORITY_LABELS),
+      },
+      {
+        name: 'estimated_minutes',
+        label: 'Estimated Time (Minutes)',
+        type: 'number',
+        min: 1,
+        max: 480,
+      },
+      { name: 'description', label: 'Description', type: 'textarea' },
+      {
+        name: 'instructions',
+        label: 'Instructions',
+        type: 'textarea',
+        hint: 'Step-by-step instructions for whoever does the task',
+      },
+      { name: 'tags', label: 'Tags', type: 'tags' },
+    ],
+    instructions: [
+      'For task_type: choose "recurring_scheduled" only when a fixed schedule is stated, and put that schedule into schedule_human in plain words (e.g. "Every Monday at 9 AM"). Otherwise leave schedule_human out.',
+      'For estimated_minutes: whole minutes between 1 and 480; set it only when a duration is stated or clearly implied.',
+      'For instructions: concrete steps, one per line. Only steps that follow from the description — do not invent tools, locations or products.',
+    ],
+    examples: [
+      'Clean the workshop every Friday afternoon, takes about 45 minutes',
+      'Fix the leaking tap in the kitchen — one-time, high priority',
+      'Restock printer paper whenever it runs low',
+    ],
+  },
+  proposal: {
+    name: 'Proposal',
+    fields: [
+      { name: 'title', label: 'Title', type: 'text', required: true },
+      { name: 'description', label: 'Description', type: 'textarea' },
+      {
+        name: 'proposal_type',
+        label: 'Type',
+        type: 'select',
+        options: PROPOSAL_TYPE_SELECT_OPTIONS,
+      },
+      {
+        name: 'voting_threshold',
+        label: 'Voting Threshold (%)',
+        type: 'number',
+        min: 1,
+        max: 100,
+        hint: 'Minimum percentage of yes votes required to pass',
+      },
+      {
+        name: 'voting_ends_at',
+        label: 'Voting End Date',
+        type: 'date',
+        hint: 'When voting closes',
+      },
+      {
+        name: 'amount_btc',
+        label: 'Amount (BTC)',
+        type: 'currency',
+        hint: 'Treasury proposals only — amount to spend',
+      },
+      {
+        name: 'recipient_address',
+        label: 'Recipient Bitcoin Address',
+        type: 'bitcoin_address',
+        hint: 'Treasury proposals only',
+      },
+    ],
+    instructions: [
+      'For proposal_type: use "treasury" only when the proposal spends group funds; only then may amount_btc and recipient_address be set. For every other type leave both out.',
+      'For voting_ends_at: set it only when an explicit calendar date is given. Never compute a date from relative phrases like "in one week" — leave it out instead.',
+      'Never set voting_threshold unless the description states one; the group default applies otherwise.',
+    ],
+    examples: [
+      'Spend 0.01 BTC from the treasury for new workshop tools, recipient bc1q…',
+      'Adopt a monthly member meetup, first Thursday each month',
+      'Make our project roadmap public on the group page',
+    ],
+  },
+} satisfies Record<string, AiAssistFormConfig>;
+
+export type AiAssistFormId = keyof typeof AI_ASSIST_FORMS;
+
+/** Untyped-key lookup for request handling (form ids arrive as strings). */
+export function getAssistFormConfig(formId: string): AiAssistFormConfig | undefined {
+  return (AI_ASSIST_FORMS as Record<string, AiAssistFormConfig>)[formId];
+}

--- a/src/config/ai-form-assist.ts
+++ b/src/config/ai-form-assist.ts
@@ -16,7 +16,8 @@
  * are one config entry, not a new `case`.
  */
 
-import { ENTITY_REGISTRY, type EntityType } from '@/config/entity-registry';
+import { ENTITY_REGISTRY, isValidEntityType, type EntityType } from '@/config/entity-registry';
+import { getAssistFormConfig } from '@/config/ai-assist-forms';
 import type { FieldConfig, FieldInputType } from '@/components/create/types';
 
 // ==================== INTENT ====================
@@ -344,16 +345,19 @@ export const AI_FILL_EXAMPLES: Partial<Record<EntityType, string[]>> = {
 };
 
 /**
- * Starter examples for an entity type. Falls back to a prompt built from the
- * registry so every entity type gets something concrete.
+ * Starter examples for any AI-assistable form — an entity type or a
+ * standalone assist form (task, proposal). Entity types without their own
+ * entry fall back to a prompt built from the registry so every one gets
+ * something concrete.
  */
-export function getExampleDescriptions(entityType: EntityType): string[] {
-  const examples = AI_FILL_EXAMPLES[entityType];
-  if (examples && examples.length > 0) {
-    return examples;
+export function getExampleDescriptions(formType: string): string[] {
+  if (isValidEntityType(formType)) {
+    const examples = AI_FILL_EXAMPLES[formType];
+    if (examples && examples.length > 0) {
+      return examples;
+    }
+    const meta = ENTITY_REGISTRY[formType];
+    return [`Describe your ${meta.name.toLowerCase()} — ${meta.description.toLowerCase()}`];
   }
-  const meta = ENTITY_REGISTRY[entityType];
-  return meta
-    ? [`Describe your ${meta.name.toLowerCase()} — ${meta.description.toLowerCase()}`]
-    : [];
+  return getAssistFormConfig(formType)?.examples ?? [];
 }

--- a/src/lib/ai/assist-target.ts
+++ b/src/lib/ai/assist-target.ts
@@ -1,0 +1,52 @@
+/**
+ * AI assist target resolution — the one place a form id becomes "what the AI
+ * may write to".
+ *
+ * A form type is either an EntityType (fields come from the entity config's
+ * fieldGroups) or a standalone form declared in `@/config/ai-assist-forms`
+ * (tasks, proposals). Everything downstream — prompts, sanitizing, merging —
+ * works off the resolved target and never needs to know which kind it was.
+ */
+
+import { getEntityConfig } from '@/config/entity-configs/get-config';
+import { isValidEntityType, ENTITY_REGISTRY } from '@/config/entity-registry';
+import { getAssistFormConfig } from '@/config/ai-assist-forms';
+import { AI_ENTITY_INSTRUCTIONS, AI_UNIVERSAL_INSTRUCTIONS } from '@/config/ai-form-assist';
+import type { FieldConfig } from '@/components/create/types';
+
+export interface AiAssistTarget {
+  /** The form id this resolved from (an EntityType or an assist-form id) */
+  id: string;
+  /** Human name used in prompts ("Service", "Task", "Proposal") */
+  name: string;
+  /** Fields the AI may write to */
+  fields: FieldConfig[];
+  /** Complete prompt instructions: universal rules + form-specific ones */
+  instructions: string[];
+}
+
+export function resolveAiAssistTarget(formType: string): AiAssistTarget | null {
+  if (isValidEntityType(formType)) {
+    const entityConfig = getEntityConfig(formType);
+    if (!entityConfig) {
+      return null;
+    }
+    return {
+      id: formType,
+      name: ENTITY_REGISTRY[formType].name,
+      fields: entityConfig.fieldGroups.flatMap(group => group.fields ?? []),
+      instructions: [...AI_UNIVERSAL_INSTRUCTIONS, ...(AI_ENTITY_INSTRUCTIONS[formType] ?? [])],
+    };
+  }
+
+  const form = getAssistFormConfig(formType);
+  if (!form) {
+    return null;
+  }
+  return {
+    id: formType,
+    name: form.name,
+    fields: form.fields,
+    instructions: [...AI_UNIVERSAL_INSTRUCTIONS, ...(form.instructions ?? [])],
+  };
+}

--- a/src/lib/ai/form-prefill-service.ts
+++ b/src/lib/ai/form-prefill-service.ts
@@ -6,7 +6,11 @@
  */
 
 import type { AIPrefillResponse } from '@/components/create/types';
-import { USER_OVERRIDABLE_FIELDS, type AiAssistIntent } from '@/config/ai-form-assist';
+import {
+  AI_ASSIST_MIN_INPUT_LENGTH,
+  USER_OVERRIDABLE_FIELDS,
+  type AiAssistIntent,
+} from '@/config/ai-form-assist';
 import { logger } from '@/utils/logger';
 import { extractFieldDescriptions, formatFieldsForPrompt } from './schema-to-prompt';
 import { getSystemPrompt, getUserPrompt, parseAIResponse } from './prompts/form-prefill';
@@ -106,13 +110,19 @@ export async function generateFormPrefill({
   intent = 'fill',
   config,
 }: FormPrefillRequest): Promise<AIPrefillResponse> {
-  // Validate description
-  if (!description || description.trim().length < 10) {
+  // Same per-intent floor as the API schema (AI_ASSIST_MIN_INPUT_LENGTH) — a
+  // hardcoded 10 here used to reject the short refine instructions ("shorter")
+  // the route had just accepted.
+  const minLength = AI_ASSIST_MIN_INPUT_LENGTH[intent];
+  if (!description || description.trim().length < minLength) {
     return {
       success: false,
       data: {},
       confidence: {},
-      error: 'Please provide a longer description (at least 10 characters)',
+      error:
+        intent === 'refine'
+          ? `Describe the change you want (at least ${minLength} characters)`
+          : `Please provide a longer description (at least ${minLength} characters)`,
     };
   }
 

--- a/src/lib/ai/form-prefill-service.ts
+++ b/src/lib/ai/form-prefill-service.ts
@@ -5,17 +5,13 @@
  * Processes natural language descriptions and generates structured form data.
  */
 
-import type { EntityType } from '@/config/entity-registry';
-import { isValidEntityType } from '@/config/entity-registry';
-import type { AIPrefillResponse, EntityConfig } from '@/components/create/types';
+import type { AIPrefillResponse } from '@/components/create/types';
 import { USER_OVERRIDABLE_FIELDS, type AiAssistIntent } from '@/config/ai-form-assist';
 import { logger } from '@/utils/logger';
-import {
-  extractFieldDescriptions,
-  formatFieldsForPrompt,
-  getSpecialFieldInstructions,
-} from './schema-to-prompt';
+import { extractFieldDescriptions, formatFieldsForPrompt } from './schema-to-prompt';
 import { getSystemPrompt, getUserPrompt, parseAIResponse } from './prompts/form-prefill';
+import { sanitizeAiFields } from './sanitize-ai-fields';
+import type { AiAssistTarget } from './assist-target';
 
 // Default models for form prefill (fast, good at JSON generation)
 const DEFAULT_GROQ_MODEL = 'llama-3.3-70b-versatile';
@@ -36,12 +32,10 @@ interface FormPrefillConfig {
 }
 
 export interface FormPrefillRequest {
-  /** Entity type being filled (validated against the registry) */
-  entityType: string;
+  /** What form is being filled — resolve via `resolveAiAssistTarget` */
+  target: AiAssistTarget;
   /** What the user typed: a description to fill from, or a change to apply */
   description: string;
-  /** Form definition — supplies the field list the AI may write to */
-  entityConfig: EntityConfig;
   /** Current form values */
   existingData?: Record<string, unknown>;
   /** Fill an empty form, or revise the values already in it. Default `fill`. */
@@ -106,23 +100,12 @@ function valuesEqual(a: unknown, b: unknown): boolean {
  * This should be called from an API route, not directly from the client.
  */
 export async function generateFormPrefill({
-  entityType,
+  target,
   description,
-  entityConfig,
   existingData,
   intent = 'fill',
   config,
 }: FormPrefillRequest): Promise<AIPrefillResponse> {
-  // Validate entity type
-  if (!isValidEntityType(entityType)) {
-    return {
-      success: false,
-      data: {},
-      confidence: {},
-      error: `Invalid entity type: ${entityType}`,
-    };
-  }
-
   // Validate description
   if (!description || description.trim().length < 10) {
     return {
@@ -134,15 +117,15 @@ export async function generateFormPrefill({
   }
 
   try {
-    // Extract field descriptions from the entity config
-    const fieldDescriptions = extractFieldDescriptions(entityConfig);
+    // Describe the declared fields for the prompt
+    const fieldDescriptions = extractFieldDescriptions(target.fields);
     const fieldsPrompt = formatFieldsForPrompt(fieldDescriptions);
-    const specialInstructions = getSpecialFieldInstructions(entityType as EntityType);
+    const specialInstructions = target.instructions.join('\n');
 
     // Build prompts
-    const systemPrompt = getSystemPrompt(entityType as EntityType, intent);
+    const systemPrompt = getSystemPrompt(target.name, intent);
     const userPrompt = getUserPrompt(
-      entityType as EntityType,
+      target.name,
       description,
       fieldsPrompt,
       specialInstructions,
@@ -233,7 +216,11 @@ export async function generateFormPrefill({
       };
     }
 
-    const { data, changedFields } = mergePrefillResult(parsed.data, existingData, intent);
+    // Enforce declared field types before merging — the prompt asks for option
+    // values / numbers / ISO dates, the sanitizer guarantees them.
+    const aiData = sanitizeAiFields(parsed.data, target.fields);
+
+    const { data, changedFields } = mergePrefillResult(aiData, existingData, intent);
 
     // Confidence is reported only for fields the AI actually changed — a
     // preserved value is the user's, not an AI guess, and marking it 1.0 made

--- a/src/lib/ai/prompts/form-prefill.ts
+++ b/src/lib/ai/prompts/form-prefill.ts
@@ -10,8 +10,6 @@
  * why refinement used to be a no-op.
  */
 
-import type { EntityType } from '@/config/entity-registry';
-import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { USER_OVERRIDABLE_FIELDS, type AiAssistIntent } from '@/config/ai-form-assist';
 import { logger } from '@/utils/logger';
 
@@ -50,15 +48,15 @@ const OUTPUT_FORMAT = `OUTPUT FORMAT:
 }`;
 
 /**
- * System prompt for form prefill / refinement
+ * System prompt for form prefill / refinement.
+ *
+ * `formName` is the resolved human name of whatever form is being filled — an
+ * entity ("Service") or a standalone form ("Task", "Proposal").
  */
-export function getSystemPrompt(entityType: EntityType, intent: AiAssistIntent = 'fill'): string {
-  const meta = ENTITY_REGISTRY[entityType];
-  const entityName = meta?.name || entityType;
-
+export function getSystemPrompt(formName: string, intent: AiAssistIntent = 'fill'): string {
   const task =
     intent === 'refine'
-      ? `The user already has a filled-in ${entityName} form and is asking you to CHANGE it. Apply the change they describe and return the updated values.
+      ? `The user already has a filled-in ${formName} form and is asking you to CHANGE it. Apply the change they describe and return the updated values.
 
 REVISION RULES:
 1. The instruction describes a change to make. Make it — never return the current values unchanged.
@@ -66,7 +64,7 @@ REVISION RULES:
 3. Return complete replacement values, never diffs, fragments or instructions.
 4. Change only what the instruction implies. Do not quietly rewrite unrelated fields.
 5. Never shorten, truncate or downgrade a field you were not asked to change.`
-      : `Extract structured data from the user's natural language description to help them create a ${entityName} listing.
+      : `Extract structured data from the user's natural language description to help them create a ${formName}.
 
 RULES:
 1. Only include fields you can confidently derive from the description
@@ -102,20 +100,18 @@ function nonEmptyEntries(data?: Record<string, unknown>): Record<string, unknown
  * Build the user prompt with field definitions and the user's request
  */
 export function getUserPrompt(
-  entityType: EntityType,
+  formName: string,
   userDescription: string,
   fieldsDescription: string,
   specialInstructions: string,
   existingData?: Record<string, unknown>,
   intent: AiAssistIntent = 'fill'
 ): string {
-  const meta = ENTITY_REGISTRY[entityType];
-  const entityName = meta?.name || entityType;
   const currentValues = nonEmptyEntries(existingData);
   const special = specialInstructions ? `\nSpecial instructions:\n${specialInstructions}\n` : '';
 
   if (intent === 'refine') {
-    return `I am editing my ${entityName} listing.
+    return `I am editing my ${formName}.
 
 CURRENT FORM VALUES:
 ${JSON.stringify(currentValues, null, 2)}
@@ -123,18 +119,18 @@ ${JSON.stringify(currentValues, null, 2)}
 THE CHANGE I WANT:
 "${userDescription}"
 
-Available fields for this ${entityName}:
+Available fields for this ${formName}:
 ${fieldsDescription}
 ${special}
 Apply my change to the current values. Output ONLY valid JSON with "data" and "confidence" objects, containing only the fields whose values should change.`;
   }
 
-  let prompt = `I want to create a ${entityName} listing.
+  let prompt = `I want to create a ${formName}.
 
 Here's my description:
 "${userDescription}"
 
-Available fields for this ${entityName}:
+Available fields for this ${formName}:
 ${fieldsDescription}
 ${special}`;
 

--- a/src/lib/ai/sanitize-ai-fields.ts
+++ b/src/lib/ai/sanitize-ai-fields.ts
@@ -1,0 +1,120 @@
+/**
+ * Coerce AI-returned form values against the form's declared fields.
+ *
+ * The prompt tells the model to use option *values*, ISO dates, numbers — but
+ * a prompt is a request, not a guarantee. This is the enforcement: a select
+ * answered with its label ("Cleaning") maps back to its value ("cleaning"),
+ * numbers arrive as numbers, tags as a string array, and a value that cannot
+ * be made valid is dropped rather than written into the form.
+ *
+ * Fields the AI returned that are NOT declared pass through untouched — some
+ * flows carry companion values (e.g. `currency` next to a price field) that
+ * the field list doesn't declare, and dropping them would regress those forms.
+ */
+
+import type { FieldConfig } from '@/components/create/types';
+
+function coerceNumber(value: unknown, field: FieldConfig): number | undefined {
+  const num = typeof value === 'number' ? value : Number(value);
+  if (typeof value === 'boolean' || value === '' || value === null || Number.isNaN(num)) {
+    return undefined;
+  }
+  if (field.min !== undefined && num < field.min) {
+    return undefined;
+  }
+  if (field.max !== undefined && num > field.max) {
+    return undefined;
+  }
+  return num;
+}
+
+function coerceSelect(value: unknown, field: FieldConfig): string | undefined {
+  if (typeof value !== 'string' || !field.options) {
+    return undefined;
+  }
+  const byValue = field.options.find(option => option.value === value);
+  if (byValue) {
+    return byValue.value;
+  }
+  // Models answer with the label often enough to be worth mapping back.
+  const byLabel = field.options.find(
+    option => option.label.toLowerCase() === value.trim().toLowerCase()
+  );
+  return byLabel?.value;
+}
+
+function coerceTags(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const tags = value.filter((tag): tag is string => typeof tag === 'string' && tag.trim() !== '');
+    return tags.length > 0 ? tags.map(tag => tag.trim()) : undefined;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value
+      .split(',')
+      .map(tag => tag.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+}
+
+function coerceBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return undefined;
+}
+
+function coerceValue(value: unknown, field: FieldConfig): unknown {
+  switch (field.type) {
+    case 'number':
+    case 'currency':
+      return coerceNumber(value, field);
+    case 'select':
+    case 'radio':
+      return coerceSelect(value, field);
+    case 'checkbox':
+    case 'boolean':
+      return coerceBoolean(value);
+    case 'tags':
+      return coerceTags(value);
+    default:
+      // Free-text-ish fields (text, textarea, date, url, …): strings pass,
+      // numbers are rendered, null passes (an explicit clear), rest dropped.
+      if (typeof value === 'number') {
+        return String(value);
+      }
+      return typeof value === 'string' || value === null ? value : undefined;
+  }
+}
+
+/**
+ * Validate/coerce `data` against `fields`. Declared fields are coerced to the
+ * declared type (invalid → dropped); undeclared fields pass through unchanged.
+ */
+export function sanitizeAiFields(
+  data: Record<string, unknown>,
+  fields: FieldConfig[]
+): Record<string, unknown> {
+  const byName = new Map(fields.map(field => [field.name, field]));
+  const result: Record<string, unknown> = {};
+
+  for (const [key, raw] of Object.entries(data)) {
+    const field = byName.get(key);
+    if (!field) {
+      result[key] = raw;
+      continue;
+    }
+    const coerced = coerceValue(raw, field);
+    if (coerced !== undefined) {
+      result[key] = coerced;
+    }
+  }
+
+  return result;
+}

--- a/src/lib/ai/schema-to-prompt.ts
+++ b/src/lib/ai/schema-to-prompt.ts
@@ -1,13 +1,11 @@
 /**
  * Schema to Prompt Utilities
  *
- * Converts Zod schemas and entity configurations to human-readable
- * field descriptions for AI prompts.
+ * Converts declared form fields (entity configs or standalone AI-assist
+ * forms) to human-readable field descriptions for AI prompts.
  */
 
-import type { EntityType } from '@/config/entity-registry';
-import { AI_ENTITY_INSTRUCTIONS, AI_UNIVERSAL_INSTRUCTIONS } from '@/config/ai-form-assist';
-import type { FieldConfig, FieldGroup } from '@/components/create/types';
+import type { FieldConfig } from '@/components/create/types';
 
 /**
  * Field description for AI prompt
@@ -102,22 +100,10 @@ function fieldConfigToDescription(field: FieldConfig): FieldDescription {
 }
 
 /**
- * Extract field descriptions from an entity config
+ * Extract field descriptions from a declared field list
  */
-export function extractFieldDescriptions(config: {
-  fieldGroups: FieldGroup[];
-}): FieldDescription[] {
-  const descriptions: FieldDescription[] = [];
-
-  for (const group of config.fieldGroups) {
-    if (group.fields) {
-      for (const field of group.fields) {
-        descriptions.push(fieldConfigToDescription(field));
-      }
-    }
-  }
-
-  return descriptions;
+export function extractFieldDescriptions(fields: FieldConfig[]): FieldDescription[] {
+  return fields.map(fieldConfigToDescription);
 }
 
 /**
@@ -145,15 +131,4 @@ export function formatFieldsForPrompt(descriptions: FieldDescription[]): string 
   }
 
   return lines.join('\n');
-}
-
-/**
- * Per-entity rules the AI needs to fill this form correctly.
- *
- * The content lives in `@/config/ai-form-assist` (AI_ENTITY_INSTRUCTIONS) —
- * this is just the lookup, so adding an entity type never means adding a
- * branch here.
- */
-export function getSpecialFieldInstructions(entityType: EntityType): string {
-  return [...AI_UNIVERSAL_INSTRUCTIONS, ...(AI_ENTITY_INSTRUCTIONS[entityType] ?? [])].join('\n');
 }

--- a/src/services/cat/tool-executor.ts
+++ b/src/services/cat/tool-executor.ts
@@ -8,7 +8,7 @@ import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { searchPlatform, type SearchType } from './platform-search';
 import { generateFormPrefill } from '@/lib/ai/form-prefill-service';
 import { generateOffers } from './offer-engine';
-import { getEntityConfig } from '@/config/entity-configs/get-config';
+import { resolveAiAssistTarget } from '@/lib/ai/assist-target';
 import { isValidEntityType, type EntityType } from '@/config/entity-registry';
 import { PREFILLABLE_ENTITY_TYPES } from './tool-use-detection';
 import { fetchWebsiteText, resolveRequestedUrl } from './website-analysis';
@@ -129,15 +129,14 @@ INSTRUCTIONS (hard constraints):
     let emitted = 0;
     await Promise.all(
       offers.map(async offer => {
-        const entityConfig = getEntityConfig(offer.entityType);
-        if (!entityConfig) {
+        const target = resolveAiAssistTarget(offer.entityType);
+        if (!target) {
           return;
         }
         try {
           const prefill = await generateFormPrefill({
-            entityType: offer.entityType,
+            target,
             description: offer.description,
-            entityConfig,
           });
           if (!prefill.success) {
             return;
@@ -303,8 +302,8 @@ Explain this to the user in plain language: which provider is healthy, degraded,
     }
 
     const entityType = requestedType as EntityType;
-    const entityConfig = getEntityConfig(entityType);
-    if (!entityConfig) {
+    const target = resolveAiAssistTarget(entityType);
+    if (!target) {
       onToolCall?.({
         id: toolCall.id,
         name: toolName,
@@ -319,7 +318,7 @@ Explain this to the user in plain language: which provider is healthy, degraded,
     }
 
     try {
-      const prefill = await generateFormPrefill({ entityType, description, entityConfig });
+      const prefill = await generateFormPrefill({ target, description });
       if (!prefill.success) {
         onToolCall?.({
           id: toolCall.id,


### PR DESCRIPTION
## What

The AI fill/refine bar (shipped in #499) only worked on registry entity forms, because the prefill API resolved its field list via `getEntityConfig(entityType)`. This generalizes the pipeline to **any declared form**, and wires the bar into the two remaining long prose-heavy forms: **task create/edit** and the **group proposal dialog**.

## How

- **New SSOT `src/config/ai-assist-forms.ts`** — standalone AI-fillable forms (`task`, `proposal`) declared as `FieldConfig` lists derived from the same label SSOTs the forms render from (`TASK_TYPE_LABELS`, `PROPOSAL_TYPE_SELECT_OPTIONS`, …), plus per-form prompt instructions and starter examples. Adding a form = one config entry.
- **One resolver, `resolveAiAssistTarget()`** — entity registry first, assist-form catalog second. The API route, the prefill service, and the Cat tool-executor all work off the resolved target; prompts take a form *name*, not an `EntityType`.
- **`sanitizeAiFields()`** — AI output is now coerced server-side against the declared fields before merging: select answered with its label maps back to the option value, numbers are range-checked, tags/booleans normalized, invalid values dropped. This hardens the existing entity forms too — a prompt is a request, not a guarantee.
- **Task form**: bar embedded in `TaskFormFields` (create *and* edit for free), applied through `applyTaskAiData` — enum-validated at the state boundary. One sentence like *"clean the workshop every Friday, ~45 min"* fills title, type, schedule, category, minutes.
- **Proposal dialog**: bar routes values through `form.setValue` (validate + dirty). Fixed a latent bug this exposed: the proposal-type Select was uncontrolled (`defaultValue`), so a programmatic type change updated form state without updating the trigger.
- **API**: accepts `formType`; `entityType` kept as a legacy alias so in-flight clients keep working across the deploy.

## Deliberately excluded

- **WalletForm** — its entire design is "paste one payment handle"; an AI cannot invent an address, so there is nothing for it to write.
- **Group settings** — two short fields and toggles; the bar would be bigger than the form.

## Verification

- `npm run verify` green on the rebased tree: docs scan, type-check, route audit, lint (0 errors), **1320/1320 tests** (19 new: resolver, sanitizer, catalog completeness, task applier).
- Self-review fixes included: `form.watch()` → `useWatch` (React Compiler compat), controlled Select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)