### PR TITLE
fix(payments): stop fabricating an expiry for on-chain payments

### DIFF
--- a/__tests__/unit/api/payment-reconcile-cron.test.ts
+++ b/__tests__/unit/api/payment-reconcile-cron.test.ts
@@ -37,14 +37,19 @@ jest.mock('@/domain/payments/paymentFlowService', () => ({
 
 const candidates: Array<Record<string, unknown>> = [];
 const polled: string[] = [];
+const orFilters: string[] = [];
 
 jest.mock('@/lib/supabase/admin', () => ({
   getAdminClient: () => ({
     from: () => {
       const builder: Record<string, unknown> = {};
-      for (const m of ['select', 'in', 'or', 'order']) {
+      for (const m of ['select', 'in', 'order']) {
         builder[m] = jest.fn(() => builder);
       }
+      builder.or = jest.fn((filter: string) => {
+        orFilters.push(filter);
+        return builder;
+      });
       builder.limit = jest.fn(() => Promise.resolve({ data: candidates, error: null }));
       builder.update = jest.fn(() => builder);
       builder.eq = jest.fn((_col: string, id: string) => {
@@ -80,6 +85,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   candidates.length = 0;
   polled.length = 0;
+  orFilters.length = 0;
   process.env.CRON_SECRET = 'right-secret';
   reconcileMock.mockResolvedValue({ status: STATUS.PAYMENT_INTENTS.INVOICE_READY, paid_at: null });
 });
@@ -94,6 +100,27 @@ describe('payment reconciliation sweep', () => {
   it('rejects a wrong secret', async () => {
     const res = await GET(request('wrong'));
     expect((res as unknown as { status: number }).status).toBe(401);
+  });
+
+  it('keeps watching on-chain intents, bounded by a horizon instead of a fake expiry', async () => {
+    await GET(request());
+
+    expect(orFilters).toHaveLength(1);
+    const filter = orFilters[0];
+
+    // On-chain is swept — it never reaches a terminal status, so the sweep is
+    // the only thing that will ever notice a late confirmation.
+    expect(filter).toContain('payment_method.eq.onchain');
+
+    // ...but not forever: the clause carries a created_at cutoff, so abandoned
+    // QRs stop costing mempool.space calls without the record ever claiming
+    // that no money arrived.
+    const cutoff = filter.match(/onchain[^)]*created_at\.gte\.([^,)]+)/)?.[1];
+    expect(cutoff).toBeDefined();
+
+    const ageDays = (Date.now() - new Date(cutoff as string).getTime()) / 86_400_000;
+    expect(ageDays).toBeGreaterThan(29);
+    expect(ageDays).toBeLessThan(31);
   });
 
   it('no-ops cleanly when nothing is pending', async () => {

--- a/__tests__/unit/domain/payments/intentExpiry.test.ts
+++ b/__tests__/unit/domain/payments/intentExpiry.test.ts
@@ -1,0 +1,69 @@
+/**
+ * `expires_at` means "can a new payment still be made?" — a fact about the
+ * rail. These tests pin that meaning, because conflating it with "how long we
+ * watch" is what silently loses on-chain money: a fabricated deadline makes the
+ * record terminal, the reconciliation sweep skips terminal rows, and a late
+ * payment settles with no notification, no contribution row, no funding total.
+ */
+
+import {
+  resolveIntentExpiry,
+  expiresInSecondsFrom,
+  LIGHTNING_FALLBACK_EXPIRY_MS,
+} from '@/domain/payments/intentExpiry';
+
+describe('resolveIntentExpiry', () => {
+  it('never expires an on-chain intent — a Bitcoin address keeps accepting money', () => {
+    expect(resolveIntentExpiry('onchain', null)).toBeNull();
+  });
+
+  it('ignores an expiry wrongly supplied for on-chain rather than trusting it', () => {
+    // Defence in depth: even if a caller invents a deadline, the rail has none.
+    const invented = new Date(Date.now() + 60_000).toISOString();
+    expect(resolveIntentExpiry('onchain', invented)).toBeNull();
+  });
+
+  it("keeps a Lightning invoice's own expiry — the bolt11 really does die", () => {
+    const stated = new Date(Date.now() + 900_000).toISOString();
+    expect(resolveIntentExpiry('lightning_address', stated)).toBe(stated);
+    expect(resolveIntentExpiry('nwc', stated)).toBe(stated);
+  });
+
+  it('falls back to an hour only when a Lightning provider stated no expiry', () => {
+    const before = Date.now();
+    const resolved = resolveIntentExpiry('nwc', null);
+    expect(resolved).not.toBeNull();
+
+    const deltaMs = new Date(resolved as string).getTime() - before;
+    expect(deltaMs).toBeGreaterThan(LIGHTNING_FALLBACK_EXPIRY_MS - 5_000);
+    expect(deltaMs).toBeLessThanOrEqual(LIGHTNING_FALLBACK_EXPIRY_MS + 5_000);
+  });
+
+  it('agrees across authenticated and account-free flows for the same rail', () => {
+    // The regression this replaces: authed on-chain never expired while public
+    // on-chain was handed an hour, so the same address behaved differently
+    // depending on who was paying.
+    expect(resolveIntentExpiry('onchain', null)).toBe(resolveIntentExpiry('onchain', null));
+    expect(resolveIntentExpiry('onchain', null)).toBeNull();
+  });
+});
+
+describe('expiresInSecondsFrom', () => {
+  it('returns null when there is no deadline, never 0', () => {
+    // 0 would render the payer's on-chain QR as already expired, telling them a
+    // perfectly valid address is dead.
+    expect(expiresInSecondsFrom(null)).toBeNull();
+  });
+
+  it('counts down to a real deadline', () => {
+    const inTenMinutes = new Date(Date.now() + 600_000).toISOString();
+    const secs = expiresInSecondsFrom(inTenMinutes);
+    expect(secs).toBeGreaterThan(595);
+    expect(secs).toBeLessThanOrEqual(600);
+  });
+
+  it('clamps a past deadline to 0 rather than going negative', () => {
+    const anHourAgo = new Date(Date.now() - 3_600_000).toISOString();
+    expect(expiresInSecondsFrom(anHourAgo)).toBe(0);
+  });
+});

--- a/src/app/api/cron/payment-reconcile/route.ts
+++ b/src/app/api/cron/payment-reconcile/route.ts
@@ -41,11 +41,35 @@ const SWEEPABLE_STATUSES = [
  * is genuinely undetectable, and guessing would be worse than the honest
  * buyer-confirms → recipient-confirms fallback that already handles it.
  */
-const DETECTABLE_RAILS = [
-  'and(payment_method.eq.nwc,payment_hash.not.is.null)',
-  'and(payment_method.eq.lightning_address,lnurl_verify_url.not.is.null)',
-  'and(payment_method.eq.onchain,onchain_address.not.is.null)',
-].join(',');
+/**
+ * How long we keep asking the chain about an unpaid on-chain intent.
+ *
+ * On-chain intents never expire — a Bitcoin address does not stop accepting
+ * money, so recording "expired" would assert something we cannot know (see
+ * domain/payments/intentExpiry). But non-terminal must not mean watched
+ * forever: without a horizon, every abandoned QR ever generated would be
+ * re-polled against mempool.space for the life of the platform.
+ *
+ * So the bound lives here, in the operational layer, where it means "we stopped
+ * asking" — not in the record, where it would mean "no money arrived". 30 days
+ * is far beyond any real confirmation delay, including a stuck fee market.
+ */
+const ONCHAIN_WATCH_HORIZON_DAYS = 30;
+
+/**
+ * Built per-tick because the on-chain clause carries a moving cutoff.
+ */
+function detectableRailsFilter(): string {
+  const horizon = new Date(
+    Date.now() - ONCHAIN_WATCH_HORIZON_DAYS * 24 * 60 * 60 * 1000
+  ).toISOString();
+
+  return [
+    'and(payment_method.eq.nwc,payment_hash.not.is.null)',
+    'and(payment_method.eq.lightning_address,lnurl_verify_url.not.is.null)',
+    `and(payment_method.eq.onchain,onchain_address.not.is.null,created_at.gte.${horizon})`,
+  ].join(',');
+}
 
 const BATCH_SIZE = 25;
 /** Leave headroom under the systemd unit's 120s curl timeout. */
@@ -61,7 +85,7 @@ async function pickCandidates(admin: SupabaseClient, limit: number): Promise<Pay
     .from(DATABASE_TABLES.PAYMENT_INTENTS)
     .select('*')
     .in('status', SWEEPABLE_STATUSES)
-    .or(DETECTABLE_RAILS)
+    .or(detectableRailsFilter())
     .order('last_polled_at', { ascending: true, nullsFirst: true })
     .limit(limit);
 

--- a/src/components/payment/PaymentQRCode.tsx
+++ b/src/components/payment/PaymentQRCode.tsx
@@ -60,6 +60,7 @@ export function PaymentQRCode({
   }, [expiresInSeconds]);
 
   const isLightning = qrData.startsWith('LN') || qrData.startsWith('ln');
+  const isOnchain = qrData.startsWith('bitcoin:');
   const copyText = isLightning ? qrData.toLowerCase() : qrData;
 
   const handleCopy = () => void copy(copyText);
@@ -106,6 +107,16 @@ export function PaymentQRCode({
         >
           <Timer className="h-3 w-3" />
           {secondsLeft <= 0 ? 'Invoice expired' : `Expires in ${formatCountdown(secondsLeft)}`}
+        </p>
+      )}
+
+      {/* No countdown on-chain, because there is no deadline to count down to.
+          Say so, rather than leaving the payer to wonder whether the QR went
+          stale — a Bitcoin address keeps accepting payment indefinitely. */}
+      {expiresInSeconds === undefined && isOnchain && (
+        <p className="flex items-center gap-1 text-xs text-fg-tertiary">
+          <Timer className="h-3 w-3" />
+          No deadline — this address stays valid
         </p>
       )}
 

--- a/src/domain/payments/intentExpiry.ts
+++ b/src/domain/payments/intentExpiry.ts
@@ -1,0 +1,77 @@
+/**
+ * What `payment_intents.expires_at` actually means.
+ *
+ * It answers exactly one question: **can a NEW payment still be made?** That is
+ * a fact about the rail, not about how long OrangeCat feels like watching.
+ *
+ * For Lightning the two coincide — a BOLT11 invoice is cryptographically dead
+ * after its expiry, so "can't pay" and "stop watching" become true at the same
+ * instant. For on-chain they do not: a Bitcoin address never stops accepting
+ * money. Money can land in ten minutes or ten days (slow wallet, fee-bump, an
+ * exchange withdrawal queue), and it lands in the recipient's wallet whatever
+ * our database says.
+ *
+ * Conflating the two is how money goes missing. A fabricated on-chain deadline
+ * makes the record terminal, the reconciliation sweep skips terminal rows, and
+ * a late payment then settles with no record at all: no recipient notification,
+ * no contribution row, funding totals frozen at zero. That is precisely the
+ * failure the sweep exists to prevent, surviving in the one rail where it is
+ * most likely — because on-chain is the slow rail.
+ *
+ * Bounding what we watch is a separate, legitimate concern. It belongs in the
+ * sweeper (see the on-chain watch horizon in /api/cron/payment-reconcile),
+ * where "we stopped asking" stays an operational choice rather than a claim
+ * written into the record that no payment arrived.
+ */
+
+import type { PaymentMethod } from './types';
+
+/**
+ * Fallback deadline for rails that DO expire, used only if the provider did not
+ * state one. Both Lightning paths set an explicit expiry today, so this is a
+ * safety net rather than a live default.
+ */
+export const LIGHTNING_FALLBACK_EXPIRY_MS = 60 * 60 * 1000;
+
+/**
+ * Which rails have a deadline at all. Exhaustive by construction: adding a
+ * payment method fails the build here until someone decides whether money can
+ * still arrive after the clock runs out.
+ */
+const RAIL_HAS_DEADLINE: Record<PaymentMethod, boolean> = {
+  nwc: true,
+  lightning_address: true,
+  // A Bitcoin address is valid forever — there is no moment after which paying
+  // it stops working, so there is no honest expiry to record.
+  onchain: false,
+};
+
+/**
+ * The single decision of when (or whether) an intent expires, shared by every
+ * creation path. Authenticated checkout and the account-free support/tip flows
+ * must not disagree about the same rail — they did before this existed: authed
+ * on-chain never expired while public on-chain was given an hour.
+ */
+export function resolveIntentExpiry(
+  method: PaymentMethod,
+  invoiceExpiresAt: string | null
+): string | null {
+  if (!RAIL_HAS_DEADLINE[method]) {
+    return null;
+  }
+  return invoiceExpiresAt ?? new Date(Date.now() + LIGHTNING_FALLBACK_EXPIRY_MS).toISOString();
+}
+
+/**
+ * Countdown for the payer's QR, or null when there is nothing to count down to.
+ *
+ * Null must stay null all the way to the UI: coercing "no deadline" to 0 would
+ * render an on-chain QR as already expired, telling the payer their perfectly
+ * valid address is dead.
+ */
+export function expiresInSecondsFrom(expiresAt: string | null): number | null {
+  if (!expiresAt) {
+    return null;
+  }
+  return Math.max(0, Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000));
+}

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -20,6 +20,7 @@ import { convertToBTC } from '@/services/currency/rates';
 import type { CurrencyCode } from '@/config/currencies';
 import { resolveSellerWallet, getSellerUserId } from './walletResolutionService';
 import { generateInvoice } from './invoiceGenerationService';
+import { resolveIntentExpiry, expiresInSecondsFrom } from './intentExpiry';
 import {
   checkNWCPaymentStatus,
   checkOnchainPaymentStatus,
@@ -51,8 +52,6 @@ const METHOD_LABELS: Record<string, string> = {
   lightning_address: 'Lightning Address',
   onchain: 'On-chain Bitcoin',
 };
-
-const PUBLIC_SUPPORT_EXPIRY_MS = 60 * 60 * 1000;
 
 function hashPublicStatusToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
@@ -116,7 +115,7 @@ export async function initiatePayment(
           ? STATUS.PAYMENT_INTENTS.INVOICE_READY
           : STATUS.PAYMENT_INTENTS.CREATED,
       description,
-      expires_at: invoice.expires_at,
+      expires_at: resolveIntentExpiry(wallet.method, invoice.expires_at),
     })
     .select()
     .single();
@@ -175,11 +174,8 @@ export async function initiatePayment(
     contribution = data;
   }
 
-  // 8. Calculate expires_in_seconds
-  let expiresInSeconds: number | null = null;
-  if (invoice.expires_at) {
-    expiresInSeconds = Math.floor((new Date(invoice.expires_at).getTime() - Date.now()) / 1000);
-  }
+  // 8. Countdown for the payer — null on rails that never expire (on-chain).
+  const expiresInSeconds = expiresInSecondsFrom(paymentIntent.expires_at);
 
   return {
     payment_intent: paymentIntent,
@@ -231,8 +227,7 @@ export async function initiatePublicSupport(
   const description = `Support: ${entityTitle}`;
   const invoice = await generateInvoice(wallet, amountBtc, description);
   const token = randomBytes(32).toString('base64url');
-  const expiresAt =
-    invoice.expires_at ?? new Date(Date.now() + PUBLIC_SUPPORT_EXPIRY_MS).toISOString();
+  const expiresAt = resolveIntentExpiry(wallet.method, invoice.expires_at);
   const admin = getAdminClient() as unknown as SupabaseClient;
 
   const { data: paymentIntent, error: paymentError } = await admin
@@ -282,10 +277,7 @@ export async function initiatePublicSupport(
     throw new Error('Failed to create public contribution');
   }
 
-  const expiresInSeconds = Math.max(
-    0,
-    Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000)
-  );
+  const expiresInSeconds = expiresInSecondsFrom(expiresAt);
 
   return {
     payment_intent: {
@@ -322,8 +314,7 @@ export async function initiateTip(
   const description = `Tip for ${recipientName}`;
   const invoice = await generateInvoice(wallet, amountBtc, description);
   const token = randomBytes(32).toString('base64url');
-  const expiresAt =
-    invoice.expires_at ?? new Date(Date.now() + PUBLIC_SUPPORT_EXPIRY_MS).toISOString();
+  const expiresAt = resolveIntentExpiry(wallet.method, invoice.expires_at);
   const admin = getAdminClient() as unknown as SupabaseClient;
 
   const { data: paymentIntent, error: paymentError } = await admin
@@ -357,10 +348,7 @@ export async function initiateTip(
     throw new Error('Failed to create tip payment intent');
   }
 
-  const expiresInSeconds = Math.max(
-    0,
-    Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000)
-  );
+  const expiresInSeconds = expiresInSecondsFrom(expiresAt);
 
   return {
     payment_intent: {

--- a/supabase/migrations/20260731080000_unexpire_onchain_intents.sql
+++ b/supabase/migrations/20260731080000_unexpire_onchain_intents.sql
@@ -1,0 +1,42 @@
+-- On-chain payment intents must not carry a deadline.
+--
+-- `expires_at` answers one question: can a NEW payment still be made? For
+-- Lightning that is real — a BOLT11 invoice is cryptographically dead after its
+-- expiry. For on-chain it is not: a Bitcoin address never stops accepting
+-- money, and money sent to it reaches the recipient whatever this database
+-- says.
+--
+-- The account-free support and tip flows nonetheless stamped every on-chain
+-- intent with a one-hour deadline (the authenticated flow did not — the same
+-- rail behaved differently depending on who was paying). That fabricated
+-- deadline is how on-chain money goes missing: the reconciliation sweep skips
+-- terminal rows, so a payment confirming after the hour settles with no record
+-- at all — no recipient notification, no contribution row, funding totals
+-- frozen at zero. On-chain is the slow rail, so it is the one most likely to
+-- confirm late.
+--
+-- The code now records NULL for on-chain (domain/payments/intentExpiry.ts) and
+-- bounds observation in the sweeper instead, where "we stopped asking" stays an
+-- operational choice rather than a claim that no money arrived. This corrects
+-- the rows written under the old rule.
+--
+-- Deliberately narrow: `paid_at IS NULL` guarantees no settled payment is ever
+-- touched, and only the expiry the old rule invented is undone.
+
+-- migration-safety: data-fix only — no schema change; restores non-terminal
+-- state for unpaid on-chain intents and clears an expiry that was never true.
+
+UPDATE payment_intents
+SET status = 'invoice_ready',
+    expires_at = NULL
+WHERE payment_method = 'onchain'
+  AND status = 'expired'
+  AND paid_at IS NULL;
+
+-- Any surviving on-chain intent (including future ones already created under
+-- the old code path) loses the invented deadline too.
+UPDATE payment_intents
+SET expires_at = NULL
+WHERE payment_method = 'onchain'
+  AND expires_at IS NOT NULL
+  AND paid_at IS NULL;


### PR DESCRIPTION
## The bug

`expires_at` was answering two questions at once. It should answer one: **can a NEW payment still be made?** That is a fact about the rail, not about how long OrangeCat feels like watching.

For Lightning the two coincide — a BOLT11 invoice is cryptographically dead after its expiry, so "can't pay" and "stop watching" become true at the same instant. For on-chain they do not. **A Bitcoin address never stops accepting money**, and money sent to it reaches the recipient whatever our database says.

`generateOnchainInvoice` already knew this and returned `expires_at: null` ("address is valid forever"). But `initiatePublicSupport` and `initiateTip` overrode that null with a one-hour deadline, while `initiatePayment` did not — so the same address behaved differently depending on whether the payer had an account.

**That fabricated deadline is how on-chain money goes missing.** It makes the record terminal → the reconciliation sweep (#503) skips terminal rows → a payment confirming after the hour settles with no record at all: no recipient notification, no contribution row, funding totals frozen at zero. Exactly the failure #503 exists to prevent, surviving in the rail where it is *most* likely, because on-chain is the slow rail (fee-bumps, exchange withdrawal queues, a stuck fee market).

Production already contained one such row — an on-chain tip stamped with a 1-hour expiry it should never have had, then expired by the sweep.

## The fix

**`src/domain/payments/intentExpiry.ts`** — one decision of when an intent expires, shared by all three creation paths so authed and account-free flows cannot disagree about the same rail again. Exhaustive over `PaymentMethod`, so adding a rail fails the build until someone decides whether money can still arrive after the clock runs out.

`expiresInSecondsFrom` keeps "no deadline" as `null` rather than `0` — `0` would render a valid on-chain QR as **already expired**, telling the payer a live address is dead.

**Sweeper** — on-chain intents are now never terminal, so something else must bound cost, or every abandoned QR ever generated gets re-polled against mempool.space forever. That bound is a 30-day watch horizon on `created_at`, and it lives in the operational layer deliberately: there it means *"we stopped asking"*. In the record it would mean *"no money arrived"* — which we cannot know, and must not claim.

**Migration** — undoes the invented expiry on existing unpaid on-chain rows. Narrow by construction: `paid_at IS NULL` can never touch a settled payment.

**QR** — says "No deadline — this address stays valid" on-chain, instead of silently omitting the countdown and leaving the payer wondering whether the code went stale.

## Verification

- PostgREST filter validated **against the production database** with a positive and negative control: a 2020 horizon returns the real on-chain row, a `now` horizon returns none — so the clause genuinely discriminates rather than merely parsing.
- Checked the surfaces affected by rows staying non-terminal: the cleanup cron does not touch `payment_intents`, and the only intent-listing endpoint filters on `buyer_confirmed`, which on-chain never enters.
- 62 payment/tip tests pass, including new ones pinning that on-chain expiry stays null even if a caller supplies one, and that "no deadline" survives to the UI as null.
- Type-check clean; ESLint 0 errors.

## Still unproven

No payment has ever reached `paid` in production. Every piece is tested and the sweep is verified running, but only a real payment closes that loop end to end.
