### PR TITLE
feat: Cat spend caps + machine-payable v1 payments (agent buy loop)

### DIFF
--- a/__tests__/unit/api/v1-payments.test.ts
+++ b/__tests__/unit/api/v1-payments.test.ts
@@ -1,0 +1,220 @@
+/**
+ * /api/v1/payments — machine-payable contract tests
+ *
+ * Covers: OpenAPI spec generation includes the payment paths, and the POST
+ * route's auth/scope/visibility gates (the parts that differ from the
+ * session-only internal route it wraps).
+ */
+
+import { POST } from '@/app/api/v1/payments/route';
+import { resolveRequestAuth } from '@/lib/api/resolveRequestAuth';
+import { initiatePayment } from '@/domain/payments';
+import type { NextRequest } from 'next/server';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/lib/api/resolveRequestAuth', () => ({
+  ...jest.requireActual('@/lib/api/resolveRequestAuth'),
+  resolveRequestAuth: jest.fn(),
+}));
+
+// NextResponse is unavailable in the jest env — repo convention is to mock the
+// response helpers with plain status/json shims (see projects-id-api.test.ts).
+jest.mock('@/lib/api/standardResponse', () => ({
+  apiSuccess: jest.fn((data: unknown, opts?: { status?: number }) => ({
+    status: opts?.status ?? 200,
+    json: async () => ({ success: true, data }),
+  })),
+  apiUnauthorized: jest.fn(() => ({
+    status: 401,
+    json: async () => ({ success: false, error: { message: 'Unauthorized' } }),
+  })),
+  apiForbidden: jest.fn((message = 'Forbidden') => ({
+    status: 403,
+    json: async () => ({ success: false, error: { message } }),
+  })),
+  apiNotFound: jest.fn((message = 'Not found') => ({
+    status: 404,
+    json: async () => ({ success: false, error: { message } }),
+  })),
+  apiBadRequest: jest.fn((message = 'Bad request') => ({
+    status: 400,
+    json: async () => ({ success: false, error: { message } }),
+  })),
+  apiRateLimited: jest.fn(() => ({
+    status: 429,
+    json: async () => ({ success: false, error: { message: 'Rate limited' } }),
+  })),
+  apiInternalError: jest.fn((message = 'Internal error') => ({
+    status: 500,
+    json: async () => ({ success: false, error: { message } }),
+  })),
+}));
+
+jest.mock('@/domain/payments', () => ({
+  initiatePayment: jest.fn(),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimitWriteAsync: jest.fn().mockResolvedValue({ success: true }),
+  rateLimitIntegrationKeyWrite: jest.fn().mockResolvedValue({ success: true }),
+  rateLimitIntegrationKeyRead: jest.fn().mockResolvedValue({ success: true }),
+  retryAfterSeconds: jest.fn().mockReturnValue(30),
+}));
+
+// Public client controls the anonymous-visibility gate for key auth.
+const mockPublicMaybeSingle = jest.fn();
+jest.mock('@/lib/supabase/public', () => ({
+  createPublicClient: jest.fn(() => ({
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: mockPublicMaybeSingle,
+    })),
+  })),
+}));
+
+jest.mock('@/lib/supabase/server', () => ({
+  createServerClient: jest.fn(async () => ({ _kind: 'session-client' })),
+}));
+
+jest.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: jest.fn(() => ({ _kind: 'admin-client' })),
+}));
+
+const mockResolveRequestAuth = resolveRequestAuth as jest.Mock;
+const mockInitiatePayment = initiatePayment as jest.Mock;
+
+const ENTITY_ID = '11111111-2222-3333-4444-555555555555';
+
+function makeRequest(body: unknown): NextRequest {
+  return {
+    headers: new Headers(),
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+function keyAuth(scopes: string[]) {
+  return {
+    userId: 'buyer-1',
+    boundActorId: 'actor-1',
+    source: 'integration_key',
+    integrationKeyId: 'key-1',
+    scopes,
+    isTest: false,
+  };
+}
+
+describe('POST /api/v1/payments', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPublicMaybeSingle.mockResolvedValue({ data: { id: ENTITY_ID } });
+    mockInitiatePayment.mockResolvedValue({
+      payment_intent: { id: 'pi-1', status: 'invoice_ready' },
+      qr_data: 'lightning:lnbc…',
+      method_label: 'Lightning',
+      expires_in_seconds: 600,
+    });
+  });
+
+  it('returns 401 without auth', async () => {
+    mockResolveRequestAuth.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ entity_type: 'product', entity_id: ENTITY_ID }));
+
+    expect(res.status).toBe(401);
+    expect(mockInitiatePayment).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the key lacks payments.write', async () => {
+    mockResolveRequestAuth.mockResolvedValue(keyAuth(['products.write']));
+
+    const res = await POST(makeRequest({ entity_type: 'product', entity_id: ENTITY_ID }));
+
+    expect(res.status).toBe(403);
+    expect(mockInitiatePayment).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for key auth when the entity is not publicly visible', async () => {
+    mockResolveRequestAuth.mockResolvedValue(keyAuth(['payments.write']));
+    mockPublicMaybeSingle.mockResolvedValue({ data: null });
+
+    const res = await POST(makeRequest({ entity_type: 'product', entity_id: ENTITY_ID }));
+
+    expect(res.status).toBe(404);
+    expect(mockInitiatePayment).not.toHaveBeenCalled();
+  });
+
+  it('creates a payment for key auth on a public entity, attributed to the key user', async () => {
+    mockResolveRequestAuth.mockResolvedValue(keyAuth(['payments.write']));
+
+    const res = await POST(makeRequest({ entity_type: 'product', entity_id: ENTITY_ID }));
+
+    expect(res.status).toBe(201);
+    expect(mockInitiatePayment).toHaveBeenCalledWith(
+      expect.objectContaining({ _kind: 'admin-client' }),
+      'buyer-1',
+      expect.objectContaining({ entity_type: 'product', entity_id: ENTITY_ID })
+    );
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.payment_intent.id).toBe('pi-1');
+  });
+
+  it('skips the anonymous-visibility gate for session auth (RLS covers it)', async () => {
+    mockResolveRequestAuth.mockResolvedValue({
+      userId: 'buyer-1',
+      boundActorId: null,
+      source: 'session',
+      integrationKeyId: null,
+      scopes: ['*'],
+      isTest: false,
+    });
+
+    const res = await POST(makeRequest({ entity_type: 'product', entity_id: ENTITY_ID }));
+
+    expect(res.status).toBe(201);
+    expect(mockPublicMaybeSingle).not.toHaveBeenCalled();
+    expect(mockInitiatePayment).toHaveBeenCalledWith(
+      expect.objectContaining({ _kind: 'session-client' }),
+      'buyer-1',
+      expect.anything()
+    );
+  });
+
+  it('maps known domain errors to a safe 400', async () => {
+    mockResolveRequestAuth.mockResolvedValue(keyAuth(['payments.write']));
+    mockInitiatePayment.mockRejectedValue(new Error('Cannot purchase your own entity'));
+
+    const res = await POST(makeRequest({ entity_type: 'product', entity_id: ENTITY_ID }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(JSON.stringify(body)).toContain('You cannot pay for your own entity');
+  });
+
+  it('rejects an invalid body with 400 before touching the domain', async () => {
+    mockResolveRequestAuth.mockResolvedValue(keyAuth(['payments.write']));
+
+    const res = await POST(makeRequest({ entity_type: 'nope', entity_id: 'not-a-uuid' }));
+
+    expect(res.status).toBe(400);
+    expect(mockInitiatePayment).not.toHaveBeenCalled();
+  });
+});
+
+describe('OpenAPI spec — payment paths', () => {
+  it('includes the machine-payable loop endpoints', async () => {
+    // Imported lazily so the route-level mocks above don't interfere.
+    const { getOpenApiSpec } = jest.requireActual('@/lib/openapi/generator') as {
+      getOpenApiSpec: () => { paths: Record<string, Record<string, unknown>> };
+    };
+    const spec = getOpenApiSpec();
+
+    expect(spec.paths['/api/v1/payments']?.post).toBeDefined();
+    expect(spec.paths['/api/v1/payments/{id}']?.get).toBeDefined();
+    expect(spec.paths['/api/v1/payments/public']?.post).toBeDefined();
+  });
+});

--- a/__tests__/unit/cat/action-executor-columns.test.ts
+++ b/__tests__/unit/cat/action-executor-columns.test.ts
@@ -22,6 +22,7 @@ import { DATABASE_TABLES } from '@/config/database-tables';
 jest.mock('@/services/cat/permission-service', () => ({
   CatPermissionService: jest.fn().mockImplementation(() => ({
     checkPermission: jest.fn().mockResolvedValue({ allowed: true, requiresConfirmation: false }),
+    checkSpendCaps: jest.fn().mockResolvedValue({ allowed: true }),
   })),
 }));
 

--- a/__tests__/unit/cat/spend-caps.test.ts
+++ b/__tests__/unit/cat/spend-caps.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Cat spend caps — enforcement tests
+ *
+ * cat_permissions.max_btc_per_action existed since baseline but was never read
+ * (the "exists but not wired" class). These tests pin the enforcement added in
+ * July 2026: per-action cap + daily BTC budget, checked in the permission
+ * service and enforced by the executor on both the direct and the
+ * confirm-pending paths.
+ */
+
+import { CatPermissionService, effectiveSpendCaps } from '@/services/cat/permission-service';
+import { CatActionExecutor } from '@/services/cat/action-executor';
+import { DATABASE_TABLES } from '@/config/database-tables';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+// Executor tests control permission behavior per-test via this mock instance.
+const mockPermissionService = {
+  checkPermission: jest.fn(),
+  checkSpendCaps: jest.fn(),
+};
+jest.mock('@/services/cat/permission-service', () => {
+  const actual = jest.requireActual('@/services/cat/permission-service');
+  return {
+    ...actual,
+    CatPermissionService: jest.fn().mockImplementation(() => mockPermissionService),
+  };
+});
+
+// Keep the executor tests light — no real handlers (they import wallet/NWC code).
+const mockSendPaymentHandler = jest.fn();
+jest.mock('@/services/cat/handlers', () => ({
+  ACTION_HANDLERS: {
+    get send_payment() {
+      return mockSendPaymentHandler;
+    },
+  },
+}));
+
+const USER_ID = 'user-1';
+const ACTOR_ID = 'actor-1';
+
+// ── effectiveSpendCaps (pure) ────────────────────────────────────────────────
+
+describe('effectiveSpendCaps', () => {
+  it('returns nulls when no rows define caps', () => {
+    expect(effectiveSpendCaps([])).toEqual({ maxBtcPerAction: null, maxBtcPerDay: null });
+    expect(effectiveSpendCaps([{ max_btc_per_action: null, max_btc_per_day: null }])).toEqual({
+      maxBtcPerAction: null,
+      maxBtcPerDay: null,
+    });
+  });
+
+  it('takes the stricter (lower) cap when both specific and category rows define one', () => {
+    const rows = [
+      { max_btc_per_action: 0.01, max_btc_per_day: 0.05 },
+      { max_btc_per_action: 0.002, max_btc_per_day: 0.1 },
+    ];
+    expect(effectiveSpendCaps(rows)).toEqual({ maxBtcPerAction: 0.002, maxBtcPerDay: 0.05 });
+  });
+
+  it('ignores null/absent values on one row while using the other', () => {
+    const rows = [
+      { max_btc_per_action: null },
+      { max_btc_per_action: 0.001, max_btc_per_day: 0.01 },
+    ];
+    expect(effectiveSpendCaps(rows)).toEqual({ maxBtcPerAction: 0.001, maxBtcPerDay: 0.01 });
+  });
+});
+
+// ── CatPermissionService.checkSpendCaps ──────────────────────────────────────
+
+/**
+ * Thenable query-builder mock keyed by table: awaiting the chain resolves with
+ * the configured rows for that table.
+ */
+function buildCapsSupabase(config: {
+  permissionRows: Record<string, unknown>[];
+  logRows?: { amount_btc: number | null }[];
+}) {
+  const neqCalls: unknown[][] = [];
+  const makeChain = (table: string) => {
+    const rows =
+      table === DATABASE_TABLES.CAT_PERMISSIONS ? config.permissionRows : (config.logRows ?? []);
+    const chain: Record<string, unknown> = {};
+    for (const method of ['select', 'eq', 'in', 'gte', 'order', 'limit']) {
+      chain[method] = jest.fn().mockReturnValue(chain);
+    }
+    chain.neq = jest.fn((...args: unknown[]) => {
+      neqCalls.push(args);
+      return chain;
+    });
+    chain.then = (resolve: (value: { data: unknown }) => unknown) =>
+      Promise.resolve(resolve({ data: rows }));
+    return chain;
+  };
+  return {
+    from: jest.fn((table: string) => makeChain(table)),
+    _neqCalls: neqCalls,
+  };
+}
+
+// checkSpendCaps tests need the REAL service class, not the module mock above.
+const { CatPermissionService: RealPermissionService } = jest.requireActual(
+  '@/services/cat/permission-service'
+) as { CatPermissionService: typeof CatPermissionService };
+
+describe('CatPermissionService.checkSpendCaps', () => {
+  it('allows non-payment actions without querying permissions', async () => {
+    const supabase = buildCapsSupabase({ permissionRows: [] });
+    const service = new RealPermissionService(supabase as never);
+
+    const result = await service.checkSpendCaps(USER_ID, 'create_product', 0.5);
+
+    expect(result.allowed).toBe(true);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('allows payment actions with no amount (handler validates separately)', async () => {
+    const supabase = buildCapsSupabase({ permissionRows: [] });
+    const service = new RealPermissionService(supabase as never);
+
+    const result = await service.checkSpendCaps(USER_ID, 'send_payment', null);
+
+    expect(result.allowed).toBe(true);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('denies a payment above the per-action cap with an actionable reason', async () => {
+    const supabase = buildCapsSupabase({
+      permissionRows: [{ action_id: '*', max_btc_per_action: 0.001, max_btc_per_day: null }],
+    });
+    const service = new RealPermissionService(supabase as never);
+
+    const result = await service.checkSpendCaps(USER_ID, 'send_payment', 0.002);
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('per-action cap of 0.001 BTC');
+  });
+
+  it('allows a payment exactly at the per-action cap', async () => {
+    const supabase = buildCapsSupabase({
+      permissionRows: [{ action_id: '*', max_btc_per_action: 0.001, max_btc_per_day: null }],
+    });
+    const service = new RealPermissionService(supabase as never);
+
+    const result = await service.checkSpendCaps(USER_ID, 'send_payment', 0.001);
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it('denies when the payment would exceed the daily budget, reporting remaining', async () => {
+    const supabase = buildCapsSupabase({
+      permissionRows: [{ action_id: '*', max_btc_per_action: null, max_btc_per_day: 0.01 }],
+      logRows: [{ amount_btc: 0.004 }, { amount_btc: 0.004 }],
+    });
+    const service = new RealPermissionService(supabase as never);
+
+    const result = await service.checkSpendCaps(USER_ID, 'send_payment', 0.005);
+
+    expect(result.allowed).toBe(false);
+    expect(result.spentTodayBtc).toBeCloseTo(0.008, 8);
+    expect(result.reason).toContain('daily budget of 0.01 BTC');
+  });
+
+  it('allows within the daily budget and excludes the caller in-flight log row', async () => {
+    const supabase = buildCapsSupabase({
+      permissionRows: [{ action_id: '*', max_btc_per_day: 0.01 }],
+      logRows: [{ amount_btc: 0.004 }],
+    });
+    const service = new RealPermissionService(supabase as never);
+
+    const result = await service.checkSpendCaps(USER_ID, 'send_payment', 0.005, {
+      excludeLogId: 'log-42',
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(supabase._neqCalls).toEqual([['id', 'log-42']]);
+  });
+});
+
+// ── Executor wiring ──────────────────────────────────────────────────────────
+
+function buildExecutorSupabase() {
+  const insertsByTable: Record<string, unknown[]> = {};
+  const updatesByTable: Record<string, unknown[]> = {};
+  const makeChain = (table: string) => {
+    const chain: Record<string, unknown> = {};
+    chain.insert = jest.fn((payload: unknown) => {
+      (insertsByTable[table] ??= []).push(payload);
+      return chain;
+    });
+    chain.update = jest.fn((payload: unknown) => {
+      (updatesByTable[table] ??= []).push(payload);
+      return chain;
+    });
+    for (const method of ['select', 'eq', 'in', 'gte', 'neq', 'order', 'limit']) {
+      chain[method] = jest.fn().mockReturnValue(chain);
+    }
+    chain.single = jest.fn().mockResolvedValue({ data: { id: 'log-1' }, error: null });
+    chain.maybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+    chain.then = (resolve: (value: { data: unknown }) => unknown) =>
+      Promise.resolve(resolve({ data: [] }));
+    return chain;
+  };
+  return {
+    from: jest.fn((table: string) => makeChain(table)),
+    _insertsByTable: insertsByTable,
+    _updatesByTable: updatesByTable,
+  };
+}
+
+describe('CatActionExecutor spend-cap enforcement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPermissionService.checkPermission.mockResolvedValue({
+      allowed: true,
+      requiresConfirmation: false,
+    });
+    mockSendPaymentHandler.mockResolvedValue({ success: true, data: { status: 'paid' } });
+  });
+
+  it('denies an over-cap payment before creating a pending action or log row', async () => {
+    mockPermissionService.checkSpendCaps.mockResolvedValue({
+      allowed: false,
+      reason: 'Amount 0.5 BTC exceeds your per-action cap of 0.001 BTC.',
+    });
+    const supabase = buildExecutorSupabase();
+    const executor = new CatActionExecutor(supabase as never);
+
+    const result = await executor.executeAction(USER_ID, ACTOR_ID, {
+      actionId: 'send_payment',
+      parameters: { amount_btc: 0.5, recipient: 'alice@getalby.com' },
+    });
+
+    expect(result.status).toBe('denied');
+    expect(result.error).toContain('per-action cap');
+    expect(supabase._insertsByTable[DATABASE_TABLES.CAT_PENDING_ACTIONS]).toBeUndefined();
+    expect(supabase._insertsByTable[DATABASE_TABLES.CAT_ACTION_LOG]).toBeUndefined();
+    expect(mockSendPaymentHandler).not.toHaveBeenCalled();
+  });
+
+  it('re-checks caps at execution time (backstop) and logs the denial', async () => {
+    // Early check passes; budget is consumed before execution → backstop denies.
+    mockPermissionService.checkSpendCaps
+      .mockResolvedValueOnce({ allowed: true })
+      .mockResolvedValueOnce({ allowed: false, reason: 'daily budget exceeded' });
+    const supabase = buildExecutorSupabase();
+    const executor = new CatActionExecutor(supabase as never);
+
+    const result = await executor.executeAction(USER_ID, ACTOR_ID, {
+      actionId: 'send_payment',
+      parameters: { amount_btc: 0.005, recipient: 'alice@getalby.com' },
+    });
+
+    expect(result.status).toBe('denied');
+    expect(mockSendPaymentHandler).not.toHaveBeenCalled();
+    // The backstop excludes the freshly-created log row from the budget sum
+    expect(mockPermissionService.checkSpendCaps).toHaveBeenLastCalledWith(
+      USER_ID,
+      'send_payment',
+      0.005,
+      { excludeLogId: 'log-1' }
+    );
+    // Audit trail: the log row is marked failed with the denial reason
+    const logUpdates = supabase._updatesByTable[DATABASE_TABLES.CAT_ACTION_LOG] as {
+      status: string;
+      error_message: string | null;
+    }[];
+    expect(logUpdates?.at(-1)?.status).toBe('failed');
+    expect(logUpdates?.at(-1)?.error_message).toBe('daily budget exceeded');
+  });
+
+  it('executes a payment within caps', async () => {
+    mockPermissionService.checkSpendCaps.mockResolvedValue({ allowed: true });
+    const supabase = buildExecutorSupabase();
+    const executor = new CatActionExecutor(supabase as never);
+
+    const result = await executor.executeAction(USER_ID, ACTOR_ID, {
+      actionId: 'send_payment',
+      parameters: { amount_btc: 0.0005, recipient: 'alice@getalby.com' },
+    });
+
+    expect(result.status).toBe('completed');
+    expect(mockSendPaymentHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/api/AGENTS.md
+++ b/docs/api/AGENTS.md
@@ -1,0 +1,98 @@
+# Buying on OrangeCat as a machine
+
+OrangeCat entities — products, services, projects, causes — are payable by
+any client that can speak HTTP and pay a Lightning invoice. No browser, no
+account requirement, no scraping. This page is the whole loop.
+
+**Base URL**: `https://orangecat.ch/api/v1` · **Spec**: `GET /api/v1/openapi.json`
+(live OpenAPI 3.1, generated from the server's own validation schemas) ·
+**Discovery**: `GET /api/v1`
+
+## Auth: two modes
+
+1. **Integration key** — minted by a user at Settings → Integrations. Send
+   `X-OrangeCat-Key: ock_…` (or `Authorization: Bearer ock_…`). The key is
+   bound to one actor and carries scopes; payments need `payments.write` /
+   `payments.read` (or the `*` wildcard). Payments are attributed to the
+   key's user as buyer.
+2. **No auth at all** — the `/payments/public` flow. Anonymous, IP
+   rate-limited, settlement verified via a per-payment bearer token.
+
+## The loop
+
+### 1. Discover
+
+```bash
+# Semantic search across public entities (no auth)
+curl 'https://orangecat.ch/api/v1/search?q=handmade+ceramics&limit=5'
+
+# Or list a specific entity type
+curl 'https://orangecat.ch/api/v1/products?limit=20'
+```
+
+### 2. Quote
+
+```bash
+curl 'https://orangecat.ch/api/v1/products/<entity_id>'
+# → price_btc, title, description — decide whether to buy
+```
+
+### 3. Pay
+
+With a key (attributed purchase / contribution):
+
+```bash
+curl -X POST 'https://orangecat.ch/api/v1/payments' \
+  -H 'X-OrangeCat-Key: ock_…' \
+  -H 'Content-Type: application/json' \
+  -d '{"entity_type": "product", "entity_id": "<entity_id>"}'
+# → { payment_intent: { id, bolt11, status: "invoice_ready", … }, qr_data, expires_in_seconds }
+```
+
+Without an account:
+
+```bash
+curl -X POST 'https://orangecat.ch/api/v1/payments/public' \
+  -H 'Content-Type: application/json' \
+  -d '{"entity_type": "project", "entity_id": "<entity_id>", "amount_btc": 0.0002}'
+# → additionally returns status_token — keep it, it is the only credential
+```
+
+Pay the returned `bolt11` with any Lightning wallet (NWC `pay_invoice`,
+LND, CLN, an exchange withdrawal — anything that pays bolt11).
+
+Contribution-pattern entities (project, cause, …) require `amount_btc`;
+fixed-price entities (product, service) take the listed price and ignore it.
+
+### 4. Verify
+
+```bash
+# Key flow
+curl 'https://orangecat.ch/api/v1/payments/<intent_id>' \
+  -H 'X-OrangeCat-Key: ock_…'
+
+# Account-less flow
+curl 'https://orangecat.ch/api/v1/payments/public/<intent_id>' \
+  -H 'X-Payment-Token: <status_token>'
+```
+
+Poll until `status` is terminal. **`paid` means settled** — the server
+re-checks the invoice against the receiving wallet (NWC lookup / LNURL
+verify) on every read; it is not a client claim. `expired` / `failed` are
+the give-up states. Respect `expires_in_seconds` from step 3 — invoices are
+not payable forever.
+
+Sellers can also subscribe to the `payment.settled` webhook instead of
+polling (Settings → Integrations → Webhooks).
+
+## Rules of the road
+
+- **Idempotency**: entity-create endpoints accept an `Idempotency-Key`
+  header. Payment creation does not yet — treat a timeout as unknown and
+  reconcile via status polling, don't blind-retry the POST.
+- **Rate limits**: per key for authenticated calls, per IP for the public
+  flow. Back off on 429 using the `Retry-After` header.
+- **Sandbox**: keys minted with the test flag (`ock_test_…`) create
+  sandbox-flagged entities; live payment flows use live keys.
+- **Conventions** (error envelope, versioning): see
+  [`CONVENTIONS.md`](CONVENTIONS.md).

--- a/src/app/(authenticated)/dashboard/cat/permissions/SpendCapsCard.tsx
+++ b/src/app/(authenticated)/dashboard/cat/permissions/SpendCapsCard.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState } from 'react';
+import { Wallet } from 'lucide-react';
+import { toast } from 'sonner';
+import { API_ROUTES } from '@/config/api-routes';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import type { SpendCaps } from './types';
+
+interface SpendCapsCardProps {
+  caps: SpendCaps;
+  disabled: boolean;
+  onSaved: (caps: SpendCaps) => void;
+}
+
+/** Parse a cap input: empty = no cap (null), otherwise a positive BTC decimal. */
+function parseCap(value: string): number | null | undefined {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined; // invalid
+  }
+  return parsed;
+}
+
+export function SpendCapsCard({ caps, disabled, onSaved }: SpendCapsCardProps) {
+  const { formatAmountBtc } = useDisplayCurrency();
+  const [perAction, setPerAction] = useState(caps.maxBtcPerAction?.toString() ?? '');
+  const [perDay, setPerDay] = useState(caps.maxBtcPerDay?.toString() ?? '');
+  const [saving, setSaving] = useState(false);
+
+  const parsedPerAction = parseCap(perAction);
+  const parsedPerDay = parseCap(perDay);
+  const invalid = parsedPerAction === undefined || parsedPerDay === undefined;
+  const dirty =
+    (parsedPerAction ?? null) !== caps.maxBtcPerAction ||
+    (parsedPerDay ?? null) !== caps.maxBtcPerDay;
+
+  const save = async () => {
+    if (invalid) {
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch(API_ROUTES.CAT.PERMISSIONS, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          actionId: '*',
+          category: 'payments',
+          requiresConfirmation: true,
+          maxBtcPerAction: parsedPerAction,
+          maxBtcPerDay: parsedPerDay,
+        }),
+      });
+      const json = await res.json();
+      if (json.success && json.data?.spendCaps) {
+        onSaved(json.data.spendCaps);
+        toast.success('Spending caps updated');
+      } else {
+        toast.error(json.error?.message || 'Failed to update spending caps');
+      }
+    } catch {
+      toast.error('Failed to update spending caps');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="bg-surface-base rounded-lg border border-default p-4">
+      <div className="flex items-center gap-2 mb-1">
+        <Wallet className="h-4 w-4 text-fg-secondary" />
+        <h3 className="font-semibold text-fg-primary">Spending caps</h3>
+      </div>
+      <p className="text-sm text-fg-secondary mb-4">
+        Hard limits on what Cat can pay, even after you confirm. Leave empty for no cap.
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="text-sm font-medium text-fg-primary">Max per payment (BTC)</span>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step="0.00000001"
+            min="0"
+            placeholder="No cap"
+            value={perAction}
+            onChange={e => setPerAction(e.target.value)}
+            disabled={disabled || saving}
+            className="mt-1"
+          />
+          {typeof parsedPerAction === 'number' && (
+            <span className="mt-1 block text-xs text-fg-tertiary">
+              ≈ {formatAmountBtc(parsedPerAction)}
+            </span>
+          )}
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-fg-primary">Daily budget (BTC)</span>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step="0.00000001"
+            min="0"
+            placeholder="No cap"
+            value={perDay}
+            onChange={e => setPerDay(e.target.value)}
+            disabled={disabled || saving}
+            className="mt-1"
+          />
+          {typeof parsedPerDay === 'number' && (
+            <span className="mt-1 block text-xs text-fg-tertiary">
+              ≈ {formatAmountBtc(parsedPerDay)}
+            </span>
+          )}
+        </label>
+      </div>
+      {invalid && (
+        <p className="mt-2 text-sm text-status-negative">Caps must be positive BTC amounts.</p>
+      )}
+      <div className="mt-4 flex justify-end">
+        <Button size="sm" onClick={save} disabled={disabled || saving || invalid || !dirty}>
+          {saving ? 'Saving…' : 'Save caps'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(authenticated)/dashboard/cat/permissions/page.tsx
+++ b/src/app/(authenticated)/dashboard/cat/permissions/page.tsx
@@ -12,6 +12,7 @@ import { TooltipProvider } from '@/components/ui/Tooltip';
 import type { PermissionData } from './types';
 import { PermissionStats } from './PermissionStats';
 import { CategoryRow } from './CategoryRow';
+import { SpendCapsCard } from './SpendCapsCard';
 import { PermissionPresets } from './PermissionPresets';
 import { PermissionInfo } from './PermissionInfo';
 
@@ -193,16 +194,24 @@ export default function CatPermissionsPage() {
 
           <div className="space-y-4">
             {summary.categories.map(cat => (
-              <CategoryRow
-                key={cat.category}
-                cat={cat}
-                actions={availableActions.filter(a => a.category === cat.category)}
-                isExpanded={expandedCategories.has(cat.category)}
-                saving={saving}
-                onToggleExpanded={toggleExpanded}
-                onToggleCategory={toggleCategory}
-                onToggleAction={toggleAction}
-              />
+              <div key={cat.category} className="space-y-4">
+                <CategoryRow
+                  cat={cat}
+                  actions={availableActions.filter(a => a.category === cat.category)}
+                  isExpanded={expandedCategories.has(cat.category)}
+                  saving={saving}
+                  onToggleExpanded={toggleExpanded}
+                  onToggleCategory={toggleCategory}
+                  onToggleAction={toggleAction}
+                />
+                {cat.category === 'payments' && cat.enabled && (
+                  <SpendCapsCard
+                    caps={data.spendCaps}
+                    disabled={saving !== null}
+                    onSaved={caps => setData(prev => (prev ? { ...prev, spendCaps: caps } : prev))}
+                  />
+                )}
+              </div>
             ))}
           </div>
 

--- a/src/app/(authenticated)/dashboard/cat/permissions/types.ts
+++ b/src/app/(authenticated)/dashboard/cat/permissions/types.ts
@@ -22,6 +22,11 @@ export interface CategorySummary {
   enabledActionCount: number;
 }
 
+export interface SpendCaps {
+  maxBtcPerAction: number | null;
+  maxBtcPerDay: number | null;
+}
+
 export interface PermissionData {
   summary: {
     categories: CategorySummary[];
@@ -31,4 +36,5 @@ export interface PermissionData {
   };
   availableActions: Action[];
   categories: Category[];
+  spendCaps: SpendCaps;
 }

--- a/src/app/api/cat/permissions/route.ts
+++ b/src/app/api/cat/permissions/route.ts
@@ -31,8 +31,10 @@ const grantPermissionSchema = z.object({
   actionId: z.string().min(1),
   category: categorySchema,
   requiresConfirmation: z.boolean().optional(),
-  dailyLimit: z.number().int().positive().optional(),
-  maxSatsPerAction: z.number().int().positive().optional(),
+  // Limits/caps: omitted = leave unchanged, null = clear. BTC decimals, not sats.
+  dailyLimit: z.number().int().positive().nullable().optional(),
+  maxBtcPerAction: z.number().positive().nullable().optional(),
+  maxBtcPerDay: z.number().positive().nullable().optional(),
 });
 
 const revokePermissionSchema = z.object({
@@ -60,7 +62,9 @@ export const GET = withAuth(async (request: AuthenticatedRequest) => {
       ...value,
     }));
 
-    return apiSuccess({ summary, availableActions, categories });
+    const spendCaps = await permissionService.getSpendCaps(user.id);
+
+    return apiSuccess({ summary, availableActions, categories, spendCaps });
   } catch (error) {
     logger.error('Get cat permissions error', error, 'CatPermissionsAPI');
     return apiInternalError('Failed to get permissions');
@@ -81,8 +85,7 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       return apiBadRequest('Invalid request', parseResult.error.errors);
     }
 
-    const { actionId, category, requiresConfirmation, dailyLimit, maxSatsPerAction } =
-      parseResult.data;
+    const { actionId, category, requiresConfirmation, ...rawLimits } = parseResult.data;
 
     if (actionId !== '*') {
       const action = CAT_ACTIONS[actionId];
@@ -94,21 +97,39 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       }
     }
 
+    // Preserve omitted-vs-null semantics: only forward keys the client sent.
+    const limits: {
+      dailyLimit?: number | null;
+      maxBtcPerAction?: number | null;
+      maxBtcPerDay?: number | null;
+    } = {};
+    if ('dailyLimit' in body) {
+      limits.dailyLimit = rawLimits.dailyLimit ?? null;
+    }
+    if ('maxBtcPerAction' in body) {
+      limits.maxBtcPerAction = rawLimits.maxBtcPerAction ?? null;
+    }
+    if ('maxBtcPerDay' in body) {
+      limits.maxBtcPerDay = rawLimits.maxBtcPerDay ?? null;
+    }
+
     const permissionService = createPermissionService(supabase);
     if (actionId === '*') {
       await permissionService.grantCategory(user.id, category as ActionCategory, {
         requiresConfirmation: requiresConfirmation ?? true,
-        dailyLimit,
+        ...limits,
       });
     } else {
       await permissionService.grantPermission(user.id, actionId, category as ActionCategory, {
         requiresConfirmation: requiresConfirmation ?? true,
-        dailyLimit,
-        maxSatsPerAction,
+        ...limits,
       });
     }
 
-    return apiSuccess({ summary: await permissionService.getPermissionSummary(user.id) });
+    return apiSuccess({
+      summary: await permissionService.getPermissionSummary(user.id),
+      spendCaps: await permissionService.getSpendCaps(user.id),
+    });
   } catch (error) {
     logger.error('Grant cat permission error', error, 'CatPermissionsAPI');
     return apiInternalError('Failed to grant permission');

--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -13,6 +13,7 @@ import {
   apiRateLimited,
 } from '@/lib/api/standardResponse';
 import { initiatePayment } from '@/domain/payments';
+import { mapKnownPaymentError } from '@/domain/payments/knownPaymentErrors';
 import { paymentCreateSchema } from '@/lib/validation/finance';
 import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { logger } from '@/utils/logger';
@@ -54,21 +55,9 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
     logger.error('Payment initiation failed', { error });
 
     // Return safe, user-friendly errors for known domain error patterns
-    const knownErrors: Record<string, string> = {
-      'no wallet': 'Seller has no payment method configured',
-      'own entity': 'You cannot pay for your own entity',
-      'no price': 'This entity has no price set',
-      'Amount is required': 'Payment amount is required for contributions',
-      'owner not found': 'This listing is no longer available.',
-      'LNURL-pay endpoint': 'Seller Lightning Address is unreachable. Try again later.',
-      'outside allowed range': 'Payment amount is outside the allowed range for this seller.',
-      'LNURL callback': 'Lightning Address invoice request failed. Try again later.',
-      'not a pay request': 'Seller Lightning Address is not configured correctly.',
-    };
-    for (const [pattern, safeMessage] of Object.entries(knownErrors)) {
-      if (message.includes(pattern)) {
-        return apiBadRequest(safeMessage);
-      }
+    const safeMessage = mapKnownPaymentError(message);
+    if (safeMessage) {
+      return apiBadRequest(safeMessage);
     }
 
     return apiInternalError('Failed to initiate payment');

--- a/src/app/api/v1/README.md
+++ b/src/app/api/v1/README.md
@@ -70,6 +70,19 @@ handlers currently require a session).
 | `/api/v1/assets`      | POST   | Create an asset              |
 | `/api/v1/wishlists`   | POST   | Create a wishlist            |
 
+### Payments (the machine-payable loop)
+
+| Endpoint                       | Method | Auth                     | What it does                                              |
+| ------------------------------ | ------ | ------------------------ | --------------------------------------------------------- |
+| `/api/v1/payments`             | POST   | key (`payments.write`)   | Create a payment intent + Lightning invoice for an entity |
+| `/api/v1/payments/{id}`        | GET    | key (`payments.read`)    | Live settlement status (NWC lookup / LNURL verify)        |
+| `/api/v1/payments/public`      | POST   | none (IP rate-limited)   | Account-less payment; returns invoice + status token      |
+| `/api/v1/payments/public/{id}` | GET    | `X-Payment-Token` header | Status polling for account-less payments                  |
+
+Together with entity list/get and `/api/v1/search`, this closes the agent
+buy loop: **discover → quote → pay → verify**. The full walkthrough with
+curl examples lives in [`docs/api/AGENTS.md`](../../../docs/api/AGENTS.md).
+
 ### Publish bus
 
 | Endpoint                   | Method | What it does                                          |

--- a/src/app/api/v1/payments/[id]/route.ts
+++ b/src/app/api/v1/payments/[id]/route.ts
@@ -1,0 +1,78 @@
+/**
+ * GET /api/v1/payments/{id} — Payment status (machine-payable contract)
+ *
+ * The verify half of the agent loop: poll until `status` is `paid` (auto
+ * settlement detection via NWC lookup / LNURL verify) or `expired`/`failed`.
+ * Only the buyer or seller of the intent can read it.
+ *
+ * Accepts integration keys (`payments.read` scope) and session auth.
+ */
+
+import { NextRequest } from 'next/server';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  apiSuccess,
+  apiUnauthorized,
+  apiForbidden,
+  apiNotFound,
+  apiInternalError,
+  apiRateLimited,
+} from '@/lib/api/standardResponse';
+import { resolveRequestAuth, hasScope } from '@/lib/api/resolveRequestAuth';
+import { checkPaymentStatus } from '@/domain/payments';
+import { createServerClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { rateLimitIntegrationKeyRead, retryAfterSeconds } from '@/lib/rate-limit';
+import { validateUUID, getValidationError } from '@/lib/api/validation';
+import { logger } from '@/utils/logger';
+
+const PAYMENTS_READ_SCOPE = 'payments.read';
+
+export async function GET(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const idValidation = getValidationError(validateUUID(id, 'payment ID'));
+  if (idValidation) {
+    return idValidation;
+  }
+
+  try {
+    const auth = await resolveRequestAuth(request);
+    if (!auth) {
+      return apiUnauthorized();
+    }
+    if (!hasScope(auth.scopes, PAYMENTS_READ_SCOPE)) {
+      return apiForbidden('This key is not allowed to read payments.');
+    }
+
+    // Polling endpoint — per-key read bucket keeps a runaway agent from
+    // starving the user's other keys. Session reads are unmetered (parity
+    // with the internal status route).
+    if (auth.source === 'integration_key' && auth.integrationKeyId) {
+      const rl = await rateLimitIntegrationKeyRead(auth.integrationKeyId);
+      if (!rl.success) {
+        return apiRateLimited('Too many status checks. Please slow down.', retryAfterSeconds(rl));
+      }
+    }
+
+    // checkPaymentStatus enforces buyer/seller access itself, so the
+    // service-role client is safe for sessionless callers.
+    const supabase =
+      auth.source === 'session'
+        ? ((await createServerClient()) as unknown as SupabaseClient)
+        : (createAdminClient() as unknown as SupabaseClient);
+
+    const result = await checkPaymentStatus(supabase, id, auth.userId);
+    return apiSuccess(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Status check failed';
+    logger.error('v1 payment status check failed', { error });
+
+    if (message.includes('not found')) {
+      return apiNotFound('Payment not found');
+    }
+    if (message.includes('Access denied')) {
+      return apiForbidden('Access denied');
+    }
+    return apiInternalError('Failed to check payment status');
+  }
+}

--- a/src/app/api/v1/payments/route.ts
+++ b/src/app/api/v1/payments/route.ts
@@ -1,0 +1,113 @@
+/**
+ * POST /api/v1/payments — Initiate a payment (machine-payable contract)
+ *
+ * The authenticated buy half of the agent loop: discover (GET /api/v1/<entity>,
+ * /api/v1/search) → pay (here: creates a payment intent + Lightning invoice)
+ * → verify (GET /api/v1/payments/{id} until status=paid).
+ *
+ * Accepts integration keys (`payments.write` scope) and session auth — same
+ * dual-auth contract as the rest of /api/v1. For the account-less flow use
+ * POST /api/v1/payments/public instead.
+ */
+
+import { NextRequest } from 'next/server';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  apiSuccess,
+  apiBadRequest,
+  apiUnauthorized,
+  apiForbidden,
+  apiNotFound,
+  apiInternalError,
+  apiRateLimited,
+} from '@/lib/api/standardResponse';
+import { resolveRequestAuth, hasScope } from '@/lib/api/resolveRequestAuth';
+import { initiatePayment } from '@/domain/payments';
+import { mapKnownPaymentError } from '@/domain/payments/knownPaymentErrors';
+import { paymentCreateSchema } from '@/lib/validation/finance';
+import { getEntityMetadata } from '@/config/entity-registry';
+import { createServerClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { createPublicClient } from '@/lib/supabase/public';
+import {
+  rateLimitWriteAsync,
+  rateLimitIntegrationKeyWrite,
+  retryAfterSeconds,
+} from '@/lib/rate-limit';
+import { logger } from '@/utils/logger';
+
+const PAYMENTS_WRITE_SCOPE = 'payments.write';
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await resolveRequestAuth(request);
+    if (!auth) {
+      return apiUnauthorized();
+    }
+    if (!hasScope(auth.scopes, PAYMENTS_WRITE_SCOPE)) {
+      logger.warn('Scope denied for payments.write', {
+        userId: auth.userId,
+        source: auth.source,
+        integrationKeyId: auth.integrationKeyId,
+      });
+      return apiForbidden('This key is not allowed to initiate payments.');
+    }
+
+    const rl =
+      auth.source === 'integration_key' && auth.integrationKeyId
+        ? await rateLimitIntegrationKeyWrite(auth.integrationKeyId)
+        : await rateLimitWriteAsync(auth.userId);
+    if (!rl.success) {
+      return apiRateLimited('Too many payment requests. Please slow down.', retryAfterSeconds(rl));
+    }
+
+    const body = await request.json();
+    const result = paymentCreateSchema.safeParse(body);
+    if (!result.success) {
+      return apiBadRequest('Invalid input', result.error.errors);
+    }
+    const validated = result.data;
+
+    // Session callers read through their own RLS (public rows + own rows).
+    // Key/OIDC callers carry no Supabase session, so writes go through the
+    // service-role client (authz enforced above — the entityPostHandler
+    // pattern). To keep visibility semantics equivalent, gate on the entity
+    // being anonymously readable first: a key can only pay for public listings.
+    let supabase: SupabaseClient;
+    if (auth.source === 'session') {
+      supabase = (await createServerClient()) as unknown as SupabaseClient;
+    } else {
+      const meta = getEntityMetadata(validated.entity_type);
+      const { data: visibleEntity } = await createPublicClient()
+        .from(meta.tableName)
+        .select('id')
+        .eq('id', validated.entity_id)
+        .maybeSingle();
+      if (!visibleEntity) {
+        return apiNotFound('Entity not found');
+      }
+      supabase = createAdminClient() as unknown as SupabaseClient;
+    }
+
+    const paymentResult = await initiatePayment(supabase, auth.userId, {
+      entity_type: validated.entity_type,
+      entity_id: validated.entity_id,
+      amount_btc: validated.amount_btc,
+      message: validated.message,
+      is_anonymous: validated.is_anonymous,
+      shipping_address_id: validated.shipping_address_id,
+      buyer_note: validated.buyer_note,
+    });
+
+    return apiSuccess(paymentResult, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Payment initiation failed';
+    logger.error('v1 payment initiation failed', { error });
+
+    const safeMessage = mapKnownPaymentError(message);
+    if (safeMessage) {
+      return apiBadRequest(safeMessage);
+    }
+    return apiInternalError('Failed to initiate payment');
+  }
+}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -30,6 +30,18 @@ export const CHANGELOG_TAGS: Record<ChangelogTag, { label: string }> = {
 /** Newest first. */
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-07-31',
+    tag: 'feature',
+    title: 'Spending caps for Cat, and payments any machine can make',
+    summary:
+      'Two guardrails-and-rails updates: hard Bitcoin spending limits on Cat payment actions, and a documented API loop so any agent or script can discover, buy, and verify settlement.',
+    items: [
+      'Set a max-per-payment cap and a daily Bitcoin budget in Cat → Permissions; Cat cannot exceed them even after you confirm.',
+      'New public API endpoints: create a payment for any public listing and poll it until it settles — with an integration key or no account at all.',
+      'The full machine-buying walkthrough is in the live API spec at /api/v1/openapi.json.',
+    ],
+  },
+  {
     date: '2026-07-29',
     tag: 'feature',
     title: 'Your Cat learns from real outcomes',

--- a/src/config/public-api.ts
+++ b/src/config/public-api.ts
@@ -47,10 +47,27 @@ export const PUBLIC_API_INTEGRATION_SCOPE_TOKENS = [
   'timeline.write',
   'stakeholders.read',
   'stakeholders.write',
+  'payments.read',
+  'payments.write',
 ] as const;
 
 /** Non-entity v1 endpoints (publish bus, stakeholder graph, discovery, …). */
 export const PUBLIC_API_INTEGRATION_ENDPOINTS = [
+  {
+    name: 'payments',
+    methods: ['POST'] as const,
+    endpoint: `${PUBLIC_API_BASE}/payments`,
+  },
+  {
+    name: 'payments.status',
+    methods: ['GET'] as const,
+    endpoint: `${PUBLIC_API_BASE}/payments/{id}`,
+  },
+  {
+    name: 'payments.public',
+    methods: ['POST'] as const,
+    endpoint: `${PUBLIC_API_BASE}/payments/public`,
+  },
   {
     name: 'timeline.publish',
     methods: ['POST'] as const,

--- a/src/domain/payments/knownPaymentErrors.ts
+++ b/src/domain/payments/knownPaymentErrors.ts
@@ -1,0 +1,28 @@
+/**
+ * Known payment-domain error patterns → safe client-facing messages.
+ *
+ * Shared by the internal /api/payments route and the public /api/v1/payments
+ * contract so both surfaces translate domain errors identically without
+ * leaking internals.
+ */
+const KNOWN_PAYMENT_ERRORS: Record<string, string> = {
+  'no wallet': 'Seller has no payment method configured',
+  'own entity': 'You cannot pay for your own entity',
+  'no price': 'This entity has no price set',
+  'Amount is required': 'Payment amount is required for contributions',
+  'owner not found': 'This listing is no longer available.',
+  'LNURL-pay endpoint': 'Seller Lightning Address is unreachable. Try again later.',
+  'outside allowed range': 'Payment amount is outside the allowed range for this seller.',
+  'LNURL callback': 'Lightning Address invoice request failed. Try again later.',
+  'not a pay request': 'Seller Lightning Address is not configured correctly.',
+};
+
+/** Returns the safe message for a known domain error, or null for unknown errors. */
+export function mapKnownPaymentError(message: string): string | null {
+  for (const [pattern, safeMessage] of Object.entries(KNOWN_PAYMENT_ERRORS)) {
+    if (message.includes(pattern)) {
+      return safeMessage;
+    }
+  }
+  return null;
+}

--- a/src/lib/openapi/registerV1Routes.ts
+++ b/src/lib/openapi/registerV1Routes.ts
@@ -35,6 +35,7 @@ import {
   assetSchema,
   wishlistSchema,
 } from '@/lib/validation';
+import { paymentCreateSchema, publicSupportCreateSchema } from '@/lib/validation/finance';
 
 /**
  * Map public entity types to their request-body Zod schemas. Adding a
@@ -258,6 +259,141 @@ export function registerV1Routes(): void {
       },
     });
   }
+
+  // Payments — the machine-payable loop: discover (entity GET / search) →
+  // pay (POST /payments) → verify (GET /payments/{id} until status=paid).
+  const paymentIntentSchema = z
+    .object({
+      id: z.string().uuid(),
+      status: z
+        .enum([
+          'created',
+          'invoice_ready',
+          'paid',
+          'expired',
+          'failed',
+          'buyer_confirmed',
+          'pending_confirmation',
+        ])
+        .openapi({
+          description:
+            '`paid` is settlement — detected automatically via NWC lookup or LNURL verify. `buyer_confirmed` is an unverified manual claim awaiting recipient confirmation.',
+        }),
+      amount_btc: z.number().openapi({ description: 'Amount in BTC (decimal).' }),
+      bolt11: z.string().nullable().openapi({ description: 'Lightning invoice to pay.' }),
+      onchain_address: z.string().nullable(),
+      expires_at: z.string().datetime().nullable(),
+    })
+    .catchall(z.unknown())
+    .openapi('PaymentIntent');
+
+  const paymentCreateResponseSchema = z
+    .object({
+      payment_intent: paymentIntentSchema,
+      qr_data: z.string().openapi({ description: 'String to render as a payment QR code.' }),
+      method_label: z.string(),
+      expires_in_seconds: z.number().nullable(),
+    })
+    .catchall(z.unknown())
+    .openapi('PaymentCreateResponse');
+
+  openApiRegistry.registerPath({
+    method: 'post',
+    path: `${PUBLIC_API_BASE}/payments`,
+    summary: 'Initiate a payment for an entity',
+    description:
+      'Creates a payment intent and a Lightning invoice (or on-chain address) for a publicly visible entity — a fixed-price purchase creates an order, a contribution supports a project/cause. Requires the `payments.write` scope. Poll GET /api/v1/payments/{id} until `status` is `paid`. Account-less callers should use POST /api/v1/payments/public instead.',
+    tags: ['Payments'],
+    security: [{ IntegrationKey: [] }],
+    request: {
+      body: {
+        required: true,
+        content: { 'application/json': { schema: paymentCreateSchema.openapi('PaymentCreate') } },
+      },
+    },
+    responses: {
+      201: {
+        description: 'Payment intent created; pay the returned invoice.',
+        content: {
+          'application/json': {
+            schema: apiSuccessSchema(paymentCreateResponseSchema, 'PaymentCreateSuccess'),
+          },
+        },
+      },
+      ...COMMON_ERROR_RESPONSES,
+    },
+  });
+
+  openApiRegistry.registerPath({
+    method: 'get',
+    path: `${PUBLIC_API_BASE}/payments/{id}`,
+    summary: 'Check payment status (settlement verification)',
+    description:
+      'Returns the live status of a payment intent — NWC lookup / LNURL verify runs on read, so `paid` here means settled, not claimed. Only the buyer or seller can read an intent. Requires the `payments.read` scope.',
+    tags: ['Payments'],
+    security: [{ IntegrationKey: [] }],
+    request: {
+      params: z.object({ id: z.string().uuid().openapi({ description: 'Payment intent id.' }) }),
+    },
+    responses: {
+      200: {
+        description: 'Current payment status.',
+        content: {
+          'application/json': {
+            schema: apiSuccessSchema(paymentIntentSchema, 'PaymentStatusSuccess'),
+          },
+        },
+      },
+      401: COMMON_ERROR_RESPONSES[401],
+      403: COMMON_ERROR_RESPONSES[403],
+      404: COMMON_ERROR_RESPONSES[404],
+      429: COMMON_ERROR_RESPONSES[429],
+      500: COMMON_ERROR_RESPONSES[500],
+    },
+  });
+
+  openApiRegistry.registerPath({
+    method: 'post',
+    path: `${PUBLIC_API_BASE}/payments/public`,
+    summary: 'Initiate an account-less payment',
+    description:
+      'Anonymous support flow: no auth required. Returns the invoice plus a bearer `status_token`; poll GET /api/v1/payments/public/{id} with the `X-Payment-Token` header to verify settlement. Rate limited per IP.',
+    tags: ['Payments'],
+    request: {
+      body: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: publicSupportCreateSchema.openapi('PublicPaymentCreate'),
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: 'Payment intent created; pay the invoice, keep the status token.',
+        content: {
+          'application/json': {
+            schema: apiSuccessSchema(
+              paymentCreateResponseSchema
+                .extend({
+                  status_token: z.string().openapi({
+                    description:
+                      'Bearer token for status polling — the only credential for this intent. Not recoverable if lost.',
+                  }),
+                })
+                .openapi('PublicPaymentCreateResponse'),
+              'PublicPaymentCreateSuccess'
+            ),
+          },
+        },
+      },
+      400: COMMON_ERROR_RESPONSES[400],
+      404: COMMON_ERROR_RESPONSES[404],
+      429: COMMON_ERROR_RESPONSES[429],
+      500: COMMON_ERROR_RESPONSES[500],
+    },
+  });
 
   // Publish bus — not an entity create, so registered explicitly. External
   // clients (FleetCrown) land a build event on a project's wall; idempotent +

--- a/src/services/cat/action-executor.ts
+++ b/src/services/cat/action-executor.ts
@@ -100,6 +100,23 @@ export class CatActionExecutor {
       };
     }
 
+    // 2b. Enforce BTC spend caps early so the user isn't asked to confirm a
+    // payment that will be denied anyway. performAction re-checks as the
+    // enforcement backstop (caps/budget can change between propose and confirm).
+    const spendCheck = await this.permissionService.checkSpendCaps(
+      userId,
+      actionId,
+      this.extractBtcAmount(action, parameters)
+    );
+    if (!spendCheck.allowed) {
+      return {
+        success: false,
+        actionId,
+        status: 'denied',
+        error: spendCheck.reason || 'Spend cap exceeded',
+      };
+    }
+
     // 3. If confirmation required, create pending action
     if (permission.requiresConfirmation) {
       const pendingAction = await this.createPendingAction(
@@ -289,6 +306,28 @@ export class CatActionExecutor {
 
     if (logError) {
       logger.error('Failed to create action log', { error: logError }, 'CatActionExecutor');
+    }
+
+    // Spend-cap backstop: this is the single choke point both the direct and the
+    // confirm-pending paths go through. Denials are logged for the audit trail.
+    const spendCheck = await this.permissionService.checkSpendCaps(
+      userId,
+      action.id,
+      this.extractBtcAmount(action, parameters),
+      { excludeLogId: logEntry?.id }
+    );
+    if (!spendCheck.allowed) {
+      const reason = spendCheck.reason || 'Spend cap exceeded';
+      if (logEntry) {
+        await this.updateActionLog(logEntry.id, 'failed', null, reason);
+      }
+      return {
+        success: false,
+        actionId: action.id,
+        status: 'denied',
+        error: reason,
+        logId: logEntry?.id,
+      };
     }
 
     const handler = ACTION_HANDLERS[action.id];

--- a/src/services/cat/permission-service.ts
+++ b/src/services/cat/permission-service.ts
@@ -24,6 +24,7 @@ interface CatPermission {
   requires_confirmation: boolean; // Override: always confirm even if action doesn't require it
   daily_limit?: number; // Max executions per day (null = unlimited)
   max_btc_per_action?: number; // Max BTC per payment action (decimal, e.g. 0.001)
+  max_btc_per_day?: number; // Max total BTC across payment actions per day
   created_at: string;
   updated_at: string;
 }
@@ -34,6 +35,18 @@ interface PermissionCheck {
   requiresConfirmation: boolean;
   dailyUsage?: number;
   dailyLimit?: number;
+}
+
+export interface SpendCaps {
+  maxBtcPerAction: number | null;
+  maxBtcPerDay: number | null;
+}
+
+export interface SpendCapCheck {
+  allowed: boolean;
+  reason?: string;
+  /** BTC already spent (or in flight) today across payment actions. */
+  spentTodayBtc?: number;
 }
 
 interface UserPermissionSummary {
@@ -59,6 +72,23 @@ const DEFAULT_PERMISSIONS: Partial<Record<ActionCategory, boolean>> = {
   organization: false,
   settings: false,
 };
+
+/**
+ * Combine caps from the matched permission rows (specific action + category '*').
+ * The stricter (lower) non-null cap wins. Exported for tests.
+ */
+export function effectiveSpendCaps(
+  rows: { max_btc_per_action?: number | null; max_btc_per_day?: number | null }[]
+): SpendCaps {
+  const min = (values: (number | null | undefined)[]): number | null => {
+    const present = values.filter((v): v is number => typeof v === 'number' && v > 0);
+    return present.length > 0 ? Math.min(...present) : null;
+  };
+  return {
+    maxBtcPerAction: min(rows.map(r => r.max_btc_per_action)),
+    maxBtcPerDay: min(rows.map(r => r.max_btc_per_day)),
+  };
+}
 
 // ==================== SERVICE ====================
 
@@ -153,6 +183,104 @@ export class CatPermissionService {
   }
 
   /**
+   * Enforce BTC spend caps for a payment action.
+   *
+   * Caps live on cat_permissions rows: the matched specific-action row and/or the
+   * category-wide ('*') payments row. When both define a cap the stricter (lower)
+   * one wins. Daily spend is derived from cat_action_log.amount_btc — rows still
+   * 'executing' count toward the budget (a crash mid-payment may still have
+   * settled, so we fail safe).
+   */
+  async checkSpendCaps(
+    userId: string,
+    actionId: string,
+    amountBtc: number | null,
+    options: { excludeLogId?: string } = {}
+  ): Promise<SpendCapCheck> {
+    const action = CAT_ACTIONS[actionId];
+    if (!action || action.category !== 'payments' || !amountBtc || amountBtc <= 0) {
+      return { allowed: true };
+    }
+
+    const { data: rows } = await this.supabase
+      .from(DATABASE_TABLES.CAT_PERMISSIONS)
+      .select('action_id, max_btc_per_action, max_btc_per_day')
+      .eq('user_id', userId)
+      .eq('category', action.category)
+      .in('action_id', [actionId, '*']);
+
+    const caps = effectiveSpendCaps(rows ?? []);
+
+    if (caps.maxBtcPerAction !== null && amountBtc > caps.maxBtcPerAction) {
+      return {
+        allowed: false,
+        reason: `Amount ${amountBtc} BTC exceeds your per-action cap of ${caps.maxBtcPerAction} BTC. Raise the cap in Cat → Permissions if intended.`,
+      };
+    }
+
+    if (caps.maxBtcPerDay !== null) {
+      const spentTodayBtc = await this.getDailySpendBtc(userId, options.excludeLogId);
+      if (spentTodayBtc + amountBtc > caps.maxBtcPerDay) {
+        const remaining = Math.max(0, caps.maxBtcPerDay - spentTodayBtc);
+        return {
+          allowed: false,
+          reason: `This payment would exceed your daily budget of ${caps.maxBtcPerDay} BTC (${remaining} BTC remaining today).`,
+          spentTodayBtc,
+        };
+      }
+      return { allowed: true, spentTodayBtc };
+    }
+
+    return { allowed: true };
+  }
+
+  /**
+   * BTC spent (or in flight) today across all payment actions, from the action log.
+   */
+  async getDailySpendBtc(userId: string, excludeLogId?: string): Promise<number> {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    let query = this.supabase
+      .from(DATABASE_TABLES.CAT_ACTION_LOG)
+      .select('amount_btc')
+      .eq('user_id', userId)
+      .eq('category', 'payments')
+      .in('status', ['executing', 'completed'])
+      .gte('created_at', today.toISOString());
+
+    // The caller's own in-flight log row must not count against its budget check.
+    if (excludeLogId) {
+      query = query.neq('id', excludeLogId);
+    }
+
+    const { data } = await query;
+
+    return (data ?? []).reduce(
+      (sum: number, row: { amount_btc: number | null }) => sum + (row.amount_btc ?? 0),
+      0
+    );
+  }
+
+  /**
+   * Current spend caps for the payments category (the '*' row — what the UI edits).
+   */
+  async getSpendCaps(userId: string): Promise<SpendCaps> {
+    const { data } = await this.supabase
+      .from(DATABASE_TABLES.CAT_PERMISSIONS)
+      .select('max_btc_per_action, max_btc_per_day')
+      .eq('user_id', userId)
+      .eq('category', 'payments')
+      .eq('action_id', '*')
+      .maybeSingle();
+
+    return {
+      maxBtcPerAction: data?.max_btc_per_action ?? null,
+      maxBtcPerDay: data?.max_btc_per_day ?? null,
+    };
+  }
+
+  /**
    * Get daily usage count for an action
    */
   async getDailyUsage(userId: string, actionId: string): Promise<number> {
@@ -178,27 +306,36 @@ export class CatPermissionService {
     category: ActionCategory,
     options: {
       requiresConfirmation?: boolean;
-      dailyLimit?: number;
-      maxSatsPerAction?: number;
+      dailyLimit?: number | null;
+      maxBtcPerAction?: number | null;
+      maxBtcPerDay?: number | null;
     } = {}
   ): Promise<CatPermission> {
+    const record: Record<string, unknown> = {
+      user_id: userId,
+      action_id: actionId,
+      category,
+      granted: true,
+      requires_confirmation: options.requiresConfirmation ?? true,
+      updated_at: new Date().toISOString(),
+    };
+    // Limits/caps: omitted = leave as-is (a grant toggle must not wipe them);
+    // explicit null = clear.
+    if ('dailyLimit' in options) {
+      record.daily_limit = options.dailyLimit;
+    }
+    if ('maxBtcPerAction' in options) {
+      record.max_btc_per_action = options.maxBtcPerAction;
+    }
+    if ('maxBtcPerDay' in options) {
+      record.max_btc_per_day = options.maxBtcPerDay;
+    }
+
     const { data, error } = await this.supabase
       .from(DATABASE_TABLES.CAT_PERMISSIONS)
-      .upsert(
-        {
-          user_id: userId,
-          action_id: actionId,
-          category,
-          granted: true,
-          requires_confirmation: options.requiresConfirmation ?? true,
-          daily_limit: options.dailyLimit ?? null,
-          max_btc_per_action: options.maxSatsPerAction ?? null,
-          updated_at: new Date().toISOString(),
-        },
-        {
-          onConflict: 'user_id,action_id,category',
-        }
-      )
+      .upsert(record, {
+        onConflict: 'user_id,action_id,category',
+      })
       .select()
       .single();
 
@@ -241,7 +378,12 @@ export class CatPermissionService {
   async grantCategory(
     userId: string,
     category: ActionCategory,
-    options: { requiresConfirmation?: boolean; dailyLimit?: number } = {}
+    options: {
+      requiresConfirmation?: boolean;
+      dailyLimit?: number | null;
+      maxBtcPerAction?: number | null;
+      maxBtcPerDay?: number | null;
+    } = {}
   ): Promise<void> {
     await this.grantPermission(userId, '*', category, options);
   }

--- a/supabase/migrations/20260731100000_cat_permissions_max_btc_per_day.sql
+++ b/supabase/migrations/20260731100000_cat_permissions_max_btc_per_day.sql
@@ -1,0 +1,8 @@
+-- Daily BTC spend budget for Cat payment actions.
+-- max_btc_per_action existed since baseline but was never enforced; enforcement
+-- lands in the same change as this column. Spent-per-day is derived from
+-- cat_action_log.amount_btc (no new bookkeeping state).
+
+ALTER TABLE public.cat_permissions
+  ADD COLUMN IF NOT EXISTS max_btc_per_day numeric(18, 8)
+    CHECK (max_btc_per_day IS NULL OR max_btc_per_day > 0);


### PR DESCRIPTION
## Agent spend caps + the machine-payable buy loop

Implements the two remaining builds from the agents field report (after the outcome loop, PR #504): safety rails for the agent that spends, and a payment API any machine can drive.

### 1. Cat spending caps — wiring a control that existed but did nothing

`cat_permissions.max_btc_per_action` has existed since baseline and was **written by the API but never read by any code** — the same "exists but not wired" class as the dead audit trail fixed in #504. Now enforced, plus a real daily budget:

- `CatPermissionService.checkSpendCaps`: per-action cap + daily BTC budget. When both a specific-action row and the category `*` row define a cap, the stricter one wins.
- Daily spend is **derived** from `cat_action_log.amount_btc` (executing + completed rows) — zero new bookkeeping state, same philosophy as the track record. The caller's own in-flight log row is excluded from its budget check.
- Enforced twice in the executor: early in `executeAction` (users aren't asked to confirm a doomed payment) and as a backstop in `performAction` — the single choke point both the direct and confirm-pending paths cross, so a cap lowered *after* a proposal still applies at confirm time. Denials are logged to the audit trail.
- **Latent unit bug fixed**: the API accepted the cap as `maxSatsPerAction` (`.int()`) but stored it raw into the `NUMERIC(18,8)` BTC column — a client sending "100 sats" would have stored a 100 **BTC** cap. Renamed to `maxBtcPerAction` (BTC decimals; no external callers existed). Caps semantics: omitted = unchanged, `null` = clear — so grant toggles no longer wipe limits.
- New migration `20260731100000_cat_permissions_max_btc_per_day.sql` (CD applies it on deploy).
- Spending-caps editor on the payments category row in Cat → Permissions (semantic tokens, fiat equivalent via `useDisplayCurrency`).

### 2. Machine-payable API — closing the agent buy loop under /api/v1

Discovery already accepted integration keys (entity list/get, `/v1/search`); payment creation and settlement polling didn't. Now:

- `POST /api/v1/payments` — dual-auth (ock_ key with `payments.write`, or session), per-key rate bucket, wraps `initiatePayment`. Key callers are gated on the entity being **anonymously visible** before the service-role write, so keys can't reach non-public listings.
- `GET /api/v1/payments/{id}` — settlement status (`payments.read`). `paid` is verified against the receiving wallet (NWC lookup / LNURL verify), not claimed.
- OpenAPI: both paths registered + the previously **unregistered** anonymous `/payments/public` flow; `payments.read`/`payments.write` scopes and endpoints added to the `public-api.ts` SSOT (discovery output + key-minting UI pick them up automatically).
- `docs/api/AGENTS.md`: the whole discover → quote → pay → verify loop with curl examples; v1 README updated.
- `knownPaymentErrors` extracted — internal and v1 routes translate domain errors identically (DRY, second consumer).

### Deliberately NOT in here: assistant spending wallets

The field report's "agent spending" half for `ai_assistant` entities is deferred with a reason, not just an ops blocker: assistants currently have **no autonomous action runtime** — they answer chats. Budget tables for an agent that cannot act would be state without behavior, the exact dead-pipeline class #504 cleaned up. Prerequisite is a product decision on an assistant action loop; Cat (which *does* act) now has the spend rails from part 1.

### Verified

- `npm run verify` green locally (tsc, lint, full test suite, docs scan, route audit).
- 20 new tests: cap combination + service checks + executor wiring (12), v1 route auth/scope/visibility gates + OpenAPI spec pin (8).
- Existing 94-test executor column suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
