### PR TITLE
feat(ai): BYOK image generation in the shared image picker

### DIFF
--- a/src/app/api/ai/images/generate/route.ts
+++ b/src/app/api/ai/images/generate/route.ts
@@ -1,0 +1,120 @@
+/**
+ * AI image generation — BYOK-ONLY.
+ *
+ * GET  — capability probe: does this user have a valid key from an
+ *        image-capable provider (IMAGE_PROVIDER_RUNTIME)?
+ * POST — generate an image from a prompt with the USER'S OWN key, persist it
+ *        to storage, return a stable public URL.
+ *
+ * The platform free pool (Groq/OpenRouter text models) is NEVER used here and
+ * checkPlatformUsage/incrementPlatformUsage are deliberately absent: image
+ * generation only ever spends the user's own credits, so it cannot drain the
+ * platform quota. Only the generic write rate limit applies.
+ */
+
+import type { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import { createRateLimitResponse, rateLimitWriteAsync } from '@/lib/rate-limit';
+import { apiBadRequest, apiError, apiInternalError, apiSuccess } from '@/lib/api/standardResponse';
+import { createApiKeyService } from '@/services/ai/api-key-service';
+import { IMAGE_PROVIDER_RUNTIME, getImageProviderRuntime } from '@/config/ai-provider-runtime';
+import { generateImageWithKey } from '@/services/images/generate';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { STORAGE_BUCKETS } from '@/config/database-tables';
+import { logger } from '@/utils/logger';
+
+const bodySchema = z.object({
+  prompt: z.string().trim().min(3).max(1000),
+});
+
+const MIME_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+};
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+  try {
+    const keys = await createApiKeyService(supabase).getKeys(user.id);
+    const capable = keys.find(k => k.is_valid && k.provider in IMAGE_PROVIDER_RUNTIME);
+    return apiSuccess({
+      canGenerate: Boolean(capable),
+      provider: capable?.provider ?? null,
+    }) as NextResponse;
+  } catch (error) {
+    logger.error('images/generate capability probe failed', error, 'ImagesAPI');
+    return apiInternalError('Could not check image generation availability.');
+  }
+});
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+  try {
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return createRateLimitResponse(rl) as NextResponse;
+    }
+
+    const parsed = bodySchema.safeParse(await (request as NextRequest).json().catch(() => ({})));
+    if (!parsed.success) {
+      return apiBadRequest('Invalid request', parsed.error.flatten());
+    }
+    const { prompt } = parsed.data;
+
+    // First image-capable key in the user's own fallback-chain order.
+    const keys = await createApiKeyService(supabase).listDecryptedKeysOrdered(user.id);
+    const imageKey = keys.find(k => k.provider in IMAGE_PROVIDER_RUNTIME);
+    if (!imageKey) {
+      return apiError(
+        'Image generation needs your own OpenAI or xAI API key. Add one in Settings → AI.',
+        'NO_IMAGE_KEY',
+        400
+      );
+    }
+
+    const runtime = getImageProviderRuntime(imageKey.provider);
+    if (!runtime) {
+      return apiInternalError('Image provider is not configured.');
+    }
+
+    const result = await generateImageWithKey({
+      apiKey: imageKey.key,
+      baseUrl: runtime.baseUrl,
+      model: runtime.defaultImageModel,
+      prompt,
+    });
+    if (!result.ok) {
+      return apiError(`Image generation failed: ${result.error}`, 'UPSTREAM_ERROR', 502);
+    }
+
+    // Persist a stable copy — provider URLs/base64 are ephemeral. The admin
+    // client bypasses RLS, so the path MUST be scoped to the authenticated
+    // user id (mirrors the browser cover-upload path convention).
+    const ext = MIME_EXT[result.image.mimeType] ?? 'png';
+    const path = `${user.id}/ai-gen_${Date.now()}.${ext}`;
+    const admin = getAdminClient();
+    const { error: uploadError } = await admin.storage
+      .from(STORAGE_BUCKETS.BANNERS)
+      .upload(path, result.image.bytes, {
+        contentType: result.image.mimeType,
+        cacheControl: '31536000',
+        upsert: false,
+      });
+    if (uploadError) {
+      logger.error('Generated image upload failed', { error: uploadError }, 'ImagesAPI');
+      return apiInternalError('Could not save the generated image. Please try again.');
+    }
+
+    const { data: urlData } = admin.storage.from(STORAGE_BUCKETS.BANNERS).getPublicUrl(path);
+    return apiSuccess({
+      url: urlData.publicUrl,
+      provider: imageKey.provider,
+      model: runtime.defaultImageModel,
+    }) as NextResponse;
+  } catch (error) {
+    logger.error('images/generate failed', error, 'ImagesAPI');
+    return apiInternalError('Could not generate an image right now. Please try again.');
+  }
+});

--- a/src/components/articles/ImageSuggestPicker.tsx
+++ b/src/components/articles/ImageSuggestPicker.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Search, Loader2, X, ImageOff } from 'lucide-react';
+import { Search, Loader2, X, ImageOff, Sparkles } from 'lucide-react';
 import { suggestArticleImages } from '@/services/articles/image-client';
+import ImageGeneratePanel from '@/components/images/ImageGeneratePanel';
 import type { StockImage } from '@/services/images/types';
 import { cn } from '@/lib/utils';
 
 /**
- * AI image picker: on open it turns the given text into concrete search terms
- * and shows royalty-free (CC0 / public-domain) candidates; the user can also
- * search manually or click a suggested term. Picking one hands back the
+ * AI image picker with two modes: Search (Openverse CC0/public-domain, AI
+ * turns the given text into search terms) and Generate (the user's OWN
+ * OpenAI/xAI key — see ImageGeneratePanel). Picking either way hands back a
  * full-res URL. Used for article covers, inline article images, and the
  * timeline post composer.
  */
@@ -26,6 +27,7 @@ export default function ImageSuggestPicker({
   onPick: (image: StockImage) => void;
   onClose: () => void;
 }) {
+  const [mode, setMode] = useState<'search' | 'generate'>('search');
   const [images, setImages] = useState<StockImage[]>([]);
   const [queries, setQueries] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -68,98 +70,137 @@ export default function ImageSuggestPicker({
         </button>
       </div>
 
-      <form
-        onSubmit={e => {
-          e.preventDefault();
-          if (manual.trim()) {
-            void load(manual.trim());
-          }
-        }}
-        className="mb-2 flex gap-2"
-      >
-        <div className="relative flex-1">
-          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-fg-tertiary" />
-          <input
-            type="text"
-            value={manual}
-            onChange={e => setManual(e.target.value)}
-            placeholder="Search free images…"
-            aria-label="Search images"
-            className="w-full rounded-md border border-default bg-surface-page py-1.5 pl-8 pr-3 text-sm text-fg-primary placeholder:text-fg-tertiary focus:border-accent-warm focus:outline-none"
-          />
-        </div>
+      <div className="mb-2 flex gap-1.5" role="tablist" aria-label="Image source">
         <button
-          type="submit"
-          disabled={!manual.trim() || loading}
-          className="rounded-md border border-default px-3 py-1.5 text-sm font-medium text-fg-primary transition-colors hover:bg-surface-raised disabled:opacity-50"
+          type="button"
+          role="tab"
+          aria-selected={mode === 'search'}
+          onClick={() => setMode('search')}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors',
+            mode === 'search'
+              ? 'border-default bg-surface-raised font-medium text-fg-primary'
+              : 'border-subtle text-fg-secondary hover:border-default hover:text-fg-primary'
+          )}
         >
-          Search
+          <Search className="h-3.5 w-3.5" />
+          Search free photos
         </button>
-      </form>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'generate'}
+          onClick={() => setMode('generate')}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors',
+            mode === 'generate'
+              ? 'border-default bg-surface-raised font-medium text-fg-primary'
+              : 'border-subtle text-fg-secondary hover:border-default hover:text-fg-primary'
+          )}
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+          Generate
+        </button>
+      </div>
 
-      {queries.length > 0 && (
-        <div className="mb-2 flex flex-wrap gap-1.5">
-          {queries.map(q => (
-            <button
-              key={q}
-              type="button"
-              onClick={() => {
-                setManual(q);
-                void load(q);
-              }}
-              className="rounded-full border border-subtle px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:border-default hover:text-fg-primary"
-            >
-              {q}
-            </button>
-          ))}
-        </div>
-      )}
-
-      {loading ? (
-        <div className="flex items-center justify-center gap-2 py-10 text-sm text-fg-tertiary">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Finding images…
-        </div>
-      ) : error ? (
-        <p className="py-6 text-center text-xs text-status-negative">{error}</p>
-      ) : images.length === 0 ? (
-        <div className="flex flex-col items-center gap-1.5 py-8 text-center text-fg-tertiary">
-          <ImageOff className="h-6 w-6" />
-          <p className="text-xs">No images found. Try a different search term.</p>
-        </div>
+      {mode === 'generate' ? (
+        <ImageGeneratePanel initialPrompt={title || body} onPick={onPick} />
       ) : (
-        <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-          {images.map(img => (
-            <li key={img.id}>
-              <button
-                type="button"
-                onClick={() => onPick(img)}
-                className={cn(
-                  'group block w-full overflow-hidden rounded-md border border-subtle transition-colors hover:border-accent-warm'
-                )}
-                title={img.creator ? `${img.title} · ${img.creator}` : img.title}
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={img.thumbUrl}
-                  alt={img.title}
-                  loading="lazy"
-                  className="aspect-[4/3] w-full bg-surface-page object-cover"
-                />
-                <span className="block truncate px-1.5 py-1 text-left text-2xs text-fg-tertiary">
-                  {img.creator
-                    ? `${img.creator} · ${img.license.toUpperCase()}`
-                    : img.license.toUpperCase()}
-                </span>
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
+        <>
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              if (manual.trim()) {
+                void load(manual.trim());
+              }
+            }}
+            className="mb-2 flex gap-2"
+          >
+            <div className="relative flex-1">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-fg-tertiary" />
+              <input
+                type="text"
+                value={manual}
+                onChange={e => setManual(e.target.value)}
+                placeholder="Search free images…"
+                aria-label="Search images"
+                className="w-full rounded-md border border-default bg-surface-page py-1.5 pl-8 pr-3 text-sm text-fg-primary placeholder:text-fg-tertiary focus:border-accent-warm focus:outline-none"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={!manual.trim() || loading}
+              className="rounded-md border border-default px-3 py-1.5 text-sm font-medium text-fg-primary transition-colors hover:bg-surface-raised disabled:opacity-50"
+            >
+              Search
+            </button>
+          </form>
 
-      <p className="mt-2 text-2xs text-fg-tertiary">
-        Free to use (CC0 / public domain) via Openverse.
-      </p>
+          {queries.length > 0 && (
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {queries.map(q => (
+                <button
+                  key={q}
+                  type="button"
+                  onClick={() => {
+                    setManual(q);
+                    void load(q);
+                  }}
+                  className="rounded-full border border-subtle px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:border-default hover:text-fg-primary"
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-sm text-fg-tertiary">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Finding images…
+            </div>
+          ) : error ? (
+            <p className="py-6 text-center text-xs text-status-negative">{error}</p>
+          ) : images.length === 0 ? (
+            <div className="flex flex-col items-center gap-1.5 py-8 text-center text-fg-tertiary">
+              <ImageOff className="h-6 w-6" />
+              <p className="text-xs">No images found. Try a different search term.</p>
+            </div>
+          ) : (
+            <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {images.map(img => (
+                <li key={img.id}>
+                  <button
+                    type="button"
+                    onClick={() => onPick(img)}
+                    className={cn(
+                      'group block w-full overflow-hidden rounded-md border border-subtle transition-colors hover:border-accent-warm'
+                    )}
+                    title={img.creator ? `${img.title} · ${img.creator}` : img.title}
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={img.thumbUrl}
+                      alt={img.title}
+                      loading="lazy"
+                      className="aspect-[4/3] w-full bg-surface-page object-cover"
+                    />
+                    <span className="block truncate px-1.5 py-1 text-left text-2xs text-fg-tertiary">
+                      {img.creator
+                        ? `${img.creator} · ${img.license.toUpperCase()}`
+                        : img.license.toUpperCase()}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <p className="mt-2 text-2xs text-fg-tertiary">
+            Free to use (CC0 / public domain) via Openverse.
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/images/ImageGeneratePanel.tsx
+++ b/src/components/images/ImageGeneratePanel.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Key, Loader2, Sparkles } from 'lucide-react';
+import { fetchImageGenCapability, generateImage } from '@/services/images/generate-client';
+import type { StockImage } from '@/services/images/types';
+import { ROUTES } from '@/config/routes';
+
+/**
+ * BYOK image generation panel for the shared image picker. Probes capability
+ * on open; without an image-capable key it shows a Settings → AI pointer
+ * instead of a dead form. Generation runs on the user's own key only.
+ */
+export default function ImageGeneratePanel({
+  initialPrompt = '',
+  onPick,
+}: {
+  initialPrompt?: string;
+  onPick: (image: StockImage) => void;
+}) {
+  const [capability, setCapability] = useState<{
+    canGenerate: boolean;
+    provider: string | null;
+  } | null>(null);
+  const [prompt, setPrompt] = useState(initialPrompt.slice(0, 300));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{ url: string; prompt: string } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchImageGenCapability().then(cap => {
+      if (!cancelled) {
+        setCapability(cap);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleGenerate() {
+    const trimmed = prompt.trim();
+    if (!trimmed || busy) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const generated = await generateImage(trimmed);
+      setResult({ url: generated.url, prompt: trimmed });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not generate an image. Please try again.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (capability === null) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-10 text-sm text-fg-tertiary">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Checking your AI keys…
+      </div>
+    );
+  }
+
+  if (!capability.canGenerate) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-8 text-center">
+        <Sparkles className="h-6 w-6 text-fg-tertiary" />
+        <p className="max-w-xs text-sm text-fg-secondary">
+          Image generation runs on your own AI key — the free OrangeCat pool is text-only.
+        </p>
+        <Link
+          href={ROUTES.SETTINGS_AI}
+          className="inline-flex items-center gap-1.5 rounded-md bg-accent-warm px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-accent-warm/90"
+        >
+          <Key className="h-3.5 w-3.5" />
+          Add an OpenAI or xAI key
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <textarea
+        value={prompt}
+        onChange={e => setPrompt(e.target.value)}
+        rows={3}
+        maxLength={1000}
+        placeholder="Describe the image you want…"
+        aria-label="Image prompt"
+        disabled={busy}
+        className="w-full rounded-md border border-default bg-surface-page px-3 py-2 text-sm text-fg-primary placeholder:text-fg-tertiary focus:border-accent-warm focus:outline-none disabled:opacity-50"
+      />
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleGenerate}
+          disabled={!prompt.trim() || busy}
+          className="inline-flex items-center gap-1.5 rounded-md bg-accent-warm px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-accent-warm/90 disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+          {busy ? 'Generating… ~30s' : result ? 'Generate again' : 'Generate'}
+        </button>
+        {error && <span className="text-xs text-status-negative">{error}</span>}
+      </div>
+
+      {result && !busy && (
+        <div className="space-y-2">
+          {/* eslint-disable-next-line @next/next/no-img-element -- freshly generated, stored on our own storage host */}
+          <img
+            src={result.url}
+            alt={result.prompt}
+            className="max-h-64 w-auto max-w-full rounded-md border border-subtle object-contain"
+          />
+          <button
+            type="button"
+            onClick={() =>
+              onPick({
+                id: `gen-${Date.now()}`,
+                thumbUrl: result.url,
+                fullUrl: result.url,
+                title: result.prompt,
+                creator: null,
+                license: 'ai-generated',
+                sourceUrl: null,
+              })
+            }
+            className="inline-flex items-center gap-1.5 rounded-md border border-default px-3 py-1.5 text-sm font-medium text-fg-primary transition-colors hover:bg-surface-raised"
+          >
+            Use this image
+          </button>
+        </div>
+      )}
+
+      <p className="text-2xs text-fg-tertiary">
+        Generated with your own {capability.provider === 'xai' ? 'xAI' : 'OpenAI'} key and labeled
+        AI-generated.
+      </p>
+    </div>
+  );
+}

--- a/src/components/timeline/PostContent.tsx
+++ b/src/components/timeline/PostContent.tsx
@@ -251,10 +251,9 @@ export function PostContent({ event }: PostContentProps) {
             loading="lazy"
             className="max-h-[28rem] w-auto max-w-full rounded-lg border border-subtle object-contain"
           />
-          {postImage.credit && (
+          {(postImage.credit || postImage.license) && (
             <figcaption className="mt-1 text-2xs text-fg-tertiary">
-              {postImage.credit}
-              {postImage.license ? ` · ${postImage.license.toUpperCase()}` : ''}
+              {[postImage.credit, postImage.license?.toUpperCase()].filter(Boolean).join(' · ')}
             </figcaption>
           )}
         </figure>

--- a/src/config/ai-provider-runtime.ts
+++ b/src/config/ai-provider-runtime.ts
@@ -53,3 +53,34 @@ export function getProviderRuntime(providerId: string): ProviderRuntimeConfig | 
 export function isOpenAICompatibleProvider(providerId: string): boolean {
   return providerId in PROVIDER_RUNTIME;
 }
+
+// ---------------------------------------------------------------------------
+// Image generation (BYOK-only)
+// ---------------------------------------------------------------------------
+
+export interface ImageProviderRuntimeConfig {
+  /** Model used for image generation when the user hasn't picked one. */
+  defaultImageModel: string;
+}
+
+/**
+ * Providers whose keys can also generate images via the OpenAI-compatible
+ * POST {baseUrl}/images/generations endpoint (base URL comes from
+ * PROVIDER_RUNTIME above — same provider, same key).
+ *
+ * BYOK-only by design: the platform free pool is text-only and must never
+ * pay for image generation. OpenRouter is deliberately absent — its image
+ * output rides /chat/completions with a different response shape.
+ */
+export const IMAGE_PROVIDER_RUNTIME: Record<string, ImageProviderRuntimeConfig> = {
+  openai: { defaultImageModel: 'gpt-image-1' },
+  xai: { defaultImageModel: 'grok-2-image' },
+};
+
+export function getImageProviderRuntime(
+  providerId: string
+): (ImageProviderRuntimeConfig & ProviderRuntimeConfig) | null {
+  const image = IMAGE_PROVIDER_RUNTIME[providerId];
+  const base = PROVIDER_RUNTIME[providerId];
+  return image && base ? { ...base, ...image } : null;
+}

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -91,6 +91,7 @@ export const API_ROUTES = {
   },
   AI: {
     FORM_PREFILL: '/api/ai/form-prefill',
+    IMAGES_GENERATE: '/api/ai/images/generate',
   },
   AUTH: {
     CALLBACK: '/api/auth/callback',

--- a/src/services/images/generate-client.ts
+++ b/src/services/images/generate-client.ts
@@ -1,0 +1,45 @@
+/**
+ * Browser client for BYOK image generation. Same thin-fetch style as
+ * suggestArticleImages: unwrap { success, data } or throw a friendly Error.
+ */
+
+import { API_ROUTES } from '@/config/api-routes';
+
+export interface ImageGenCapability {
+  canGenerate: boolean;
+  provider: string | null;
+}
+
+export interface GeneratedImageRef {
+  url: string;
+  provider: string;
+  model: string;
+}
+
+async function unwrap<T>(res: Response, fallback: string): Promise<T> {
+  const json = await res.json().catch(() => null);
+  if (!res.ok || !json?.success) {
+    const err = json?.error;
+    const message = (typeof err === 'string' ? err : err?.message) || fallback;
+    throw new Error(message);
+  }
+  return json.data as T;
+}
+
+export async function fetchImageGenCapability(): Promise<ImageGenCapability> {
+  try {
+    const res = await fetch(API_ROUTES.AI.IMAGES_GENERATE);
+    return await unwrap<ImageGenCapability>(res, 'unavailable');
+  } catch {
+    // A failed probe just means "treat as not available" — never block the UI.
+    return { canGenerate: false, provider: null };
+  }
+}
+
+export function generateImage(prompt: string): Promise<GeneratedImageRef> {
+  return fetch(API_ROUTES.AI.IMAGES_GENERATE, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt }),
+  }).then(res => unwrap<GeneratedImageRef>(res, 'Could not generate an image. Please try again.'));
+}

--- a/src/services/images/generate.ts
+++ b/src/services/images/generate.ts
@@ -1,0 +1,105 @@
+/**
+ * Server-side image generation against a user's OWN provider key
+ * (OpenAI-compatible POST {baseUrl}/images/generations). BYOK-only — this is
+ * never called with a platform key; see IMAGE_PROVIDER_RUNTIME.
+ */
+
+import { logger } from '@/utils/logger';
+
+const GENERATION_TIMEOUT_MS = 90_000;
+
+export interface GeneratedImage {
+  bytes: Uint8Array;
+  mimeType: string;
+}
+
+export type GenerateImageResult =
+  | { ok: true; image: GeneratedImage }
+  | { ok: false; error: string };
+
+/** Sniff the actual format — providers return PNG, JPEG, or WebP. */
+function sniffMimeType(bytes: Uint8Array): string {
+  if (bytes[0] === 0x89 && bytes[1] === 0x50) {
+    return 'image/png';
+  }
+  if (bytes[0] === 0xff && bytes[1] === 0xd8) {
+    return 'image/jpeg';
+  }
+  if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[8] === 0x57) {
+    return 'image/webp';
+  }
+  return 'image/png';
+}
+
+export async function generateImageWithKey(opts: {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  prompt: string;
+}): Promise<GenerateImageResult> {
+  const { apiKey, baseUrl, model, prompt } = opts;
+
+  try {
+    const response = await fetch(`${baseUrl}/images/generations`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        prompt,
+        n: 1,
+        // gpt-image-* rejects response_format (it always returns base64);
+        // dall-e / grok default to ephemeral URLs unless asked for base64.
+        ...(model.startsWith('gpt-image') ? {} : { response_format: 'b64_json' }),
+      }),
+      signal: AbortSignal.timeout(GENERATION_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      const providerMessage = body?.error?.message || `provider returned ${response.status}`;
+      logger.warn(
+        'Image generation failed upstream',
+        { status: response.status, model, providerMessage },
+        'ImageGen'
+      );
+      return { ok: false, error: providerMessage };
+    }
+
+    const json = (await response.json().catch(() => null)) as {
+      data?: Array<{ b64_json?: string; url?: string }>;
+    } | null;
+    const first = json?.data?.[0];
+
+    if (first?.b64_json) {
+      const bytes = new Uint8Array(Buffer.from(first.b64_json, 'base64'));
+      return { ok: true, image: { bytes, mimeType: sniffMimeType(bytes) } };
+    }
+
+    // Some providers ignore response_format and hand back an ephemeral URL —
+    // fetch it now so the caller can persist a stable copy.
+    if (first?.url) {
+      const download = await fetch(first.url, {
+        signal: AbortSignal.timeout(GENERATION_TIMEOUT_MS),
+      });
+      if (!download.ok) {
+        return { ok: false, error: 'could not download the generated image' };
+      }
+      const bytes = new Uint8Array(await download.arrayBuffer());
+      return { ok: true, image: { bytes, mimeType: sniffMimeType(bytes) } };
+    }
+
+    return { ok: false, error: 'provider returned no image' };
+  } catch (error) {
+    const timedOut = error instanceof Error && error.name === 'TimeoutError';
+    logger.warn('Image generation request failed', { model, error: String(error) }, 'ImageGen');
+    return {
+      ok: false,
+      error: timedOut ? 'generation timed out — try a simpler prompt' : 'request failed',
+    };
+  }
+}


### PR DESCRIPTION
## What

Users can now put a photo in a post (or article) **two ways**: search real CC0 images (existing Openverse flow) or **generate one — if they have the right model**. The shared `ImageSuggestPicker` gains `Search free photos | Generate` tabs, so posts, article covers, and inline article images all get generation at once.

## How

- **BYOK-only by construction.** `IMAGE_PROVIDER_RUNTIME` (in `ai-provider-runtime.ts`, next to the existing chat runtime SSOT) declares which providers can generate: `openai` (`gpt-image-1`) and `xai` (`grok-2-image`) — both already supported key providers with the same base URLs and the OpenAI-compatible `POST /images/generations` shape. The platform free pool (text-only Groq/OpenRouter) is never called and platform quota is never touched; only the generic write rate limit applies.
- **New route `/api/ai/images/generate`**: `GET` = capability probe (does the user have a valid image-capable key); `POST` = resolve the first image-capable key in the user's own chain order (`listDecryptedKeysOrdered`), generate (90s timeout, handles `b64_json` and ephemeral-URL responses, sniffs actual mime), then persist to the banners bucket at `${user.id}/ai-gen_*` via the admin client for a **stable public URL** — provider outputs are ephemeral.
- **UI**: `ImageGeneratePanel` — prompt box prefilled from the post/article text, busy state ("Generating… ~30s"), preview + "Use this image" / "Generate again". Without a capable key it shows an honest explainer + "Add an OpenAI or xAI key" → Settings → AI instead of a dead form.
- **Honest labeling**: generated picks carry `license: 'ai-generated'`, so the feed caption reads **AI-GENERATED**. The caption now also shows license without a creator (CC0 search images were previously unlabeled).

## Verification

- `tsc --noEmit` 0 errors · eslint clean · `npm run audit:routes` clean · **1301/1301 tests**
- Not exercised against a live OpenAI/xAI key or prod DB from this sandbox — the request/response shapes follow the providers' documented `/images/generations` contract, and all failure paths degrade to friendly inline errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)