### PR TITLE
fix(payments): never hand an xpub to a payer as if it were an address

### DIFF
--- a/__tests__/unit/domain/payments/payableOnchainAddress.test.ts
+++ b/__tests__/unit/domain/payments/payableOnchainAddress.test.ts
@@ -1,0 +1,88 @@
+/**
+ * An extended public key is not a payment address.
+ *
+ * `address_or_xpub` holds either, and nothing in this codebase derives an
+ * address from an xpub — `bip32` and `bitcoinjs-lib` are dependencies that no
+ * module imports. Before this, an xpub-only wallet resolved to
+ * `method: 'onchain'` with the xpub as the address, so the payer was shown
+ * `bitcoin:xpub6...` — a QR no wallet can pay — while the product reported the
+ * seller as ready to receive. The wallets page recommends xpubs, so following
+ * our own advice was the way to break receiving.
+ */
+
+import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+jest.mock('@/domain/payments/encryptionService', () => ({ decrypt: (v: string) => v }));
+
+/** Minimal stub of the chained select used by resolveUserWallet. */
+function clientReturning(wallets: Array<Record<string, unknown>>): SupabaseClient {
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'eq']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  let orderCalls = 0;
+  builder.order = jest.fn(() => {
+    orderCalls += 1;
+    // Second .order() resolves the query.
+    return orderCalls >= 2 ? Promise.resolve({ data: wallets, error: null }) : builder;
+  });
+  return { from: () => builder } as unknown as SupabaseClient;
+}
+
+const XPUB =
+  'xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz';
+const ADDRESS = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+
+describe('on-chain payment address resolution', () => {
+  it('refuses to hand an xpub to the payer as if it were an address', async () => {
+    const resolved = await resolveUserWallet(
+      clientReturning([{ id: 'w1', address_or_xpub: XPUB, wallet_type: 'xpub', is_primary: true }]),
+      'user-1'
+    );
+
+    // No payment method at all is the honest answer — the same one the owner's
+    // receive status gives — rather than an unpayable bitcoin: URI.
+    expect(resolved).toBeNull();
+  });
+
+  it('still resolves a real address', async () => {
+    const resolved = await resolveUserWallet(
+      clientReturning([
+        { id: 'w1', address_or_xpub: ADDRESS, wallet_type: 'onchain', is_primary: true },
+      ]),
+      'user-1'
+    );
+
+    expect(resolved).toMatchObject({ method: 'onchain', onchain_address: ADDRESS });
+  });
+
+  it('skips an xpub wallet to reach a payable one behind it', async () => {
+    // The fallback branch used to take wallets[0] unconditionally, so an xpub
+    // sitting first shadowed a perfectly good address further down.
+    const resolved = await resolveUserWallet(
+      clientReturning([
+        { id: 'w1', address_or_xpub: XPUB, wallet_type: 'xpub', is_primary: true },
+        { id: 'w2', address_or_xpub: ADDRESS, wallet_type: 'general', is_primary: false },
+      ]),
+      'user-1'
+    );
+
+    expect(resolved).toMatchObject({ method: 'onchain', wallet_id: 'w2' });
+  });
+
+  it('prefers Lightning over an on-chain address, unchanged', async () => {
+    const resolved = await resolveUserWallet(
+      clientReturning([
+        { id: 'w1', address_or_xpub: ADDRESS, wallet_type: 'onchain', is_primary: true },
+        { id: 'w2', lightning_address: 'mao@orangecat.ch', wallet_type: 'lightning' },
+      ]),
+      'user-1'
+    );
+
+    expect(resolved).toMatchObject({ method: 'lightning_address' });
+  });
+});

--- a/src/domain/payments/walletResolutionService.ts
+++ b/src/domain/payments/walletResolutionService.ts
@@ -12,6 +12,7 @@ import { DATABASE_TABLES } from '@/config/database-tables';
 import { getEntityMetadata, type EntityType } from '@/config/entity-registry';
 import { getAdminClient } from '@/lib/supabase/admin';
 import { decrypt } from './encryptionService';
+import { detectWalletType } from '@/types/wallet';
 import type { ResolvedWallet } from './types';
 import { logger } from '@/utils/logger';
 
@@ -215,6 +216,31 @@ interface WalletRow {
 }
 
 /**
+ * The on-chain address a payer can actually send to, or null if there isn't one.
+ *
+ * `address_or_xpub` holds either. An extended public key is NOT a payment
+ * address: it is the key you derive addresses FROM, and nothing in this
+ * codebase derives (bip32 and bitcoinjs-lib are dependencies, but no module
+ * imports them). Handing an xpub to the payer produces `bitcoin:xpub6...`, a QR
+ * that no wallet can pay — while the UI reports the seller as ready to receive.
+ *
+ * Refusing to receive is worse for the user than a broken QR only if the QR
+ * works. This one never does, so say so instead: an xpub-only wallet resolves
+ * to no payment method, the same answer the owner's own receive status gives.
+ *
+ * The real fix is per-intent derivation from the xpub, which would also make
+ * on-chain detection sound (a never-reused address identifies its payment
+ * unambiguously; a static one cannot). That is a feature, not a guard.
+ */
+function toPayableOnchainAddress(value?: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return detectWalletType(trimmed) === 'address' ? trimmed : null;
+}
+
+/**
  * Pick the best payment method from a SINGLE wallet row.
  * Priority: NWC > Lightning Address > On-chain. Returns null if the wallet has
  * no usable payment detail (or its NWC URI fails to decrypt).
@@ -237,8 +263,9 @@ function pickMethodFromWallet(wallet: WalletRow): ResolvedWallet | null {
     };
   }
 
-  if (wallet.address_or_xpub) {
-    return { method: 'onchain', wallet_id: wallet.id, onchain_address: wallet.address_or_xpub };
+  const onchainAddress = toPayableOnchainAddress(wallet.address_or_xpub);
+  if (onchainAddress) {
+    return { method: 'onchain', wallet_id: wallet.id, onchain_address: onchainAddress };
   }
 
   return null;
@@ -335,23 +362,28 @@ export async function resolveUserWallet(
 
   // Check for on-chain address
   const onchainWallet = wallets.find(
-    w => w.address_or_xpub && (w.wallet_type === 'onchain' || w.wallet_type === 'both')
+    w =>
+      toPayableOnchainAddress(w.address_or_xpub) &&
+      (w.wallet_type === 'onchain' || w.wallet_type === 'both')
   );
   if (onchainWallet) {
     return {
       method: 'onchain',
       wallet_id: onchainWallet.id,
-      onchain_address: onchainWallet.address_or_xpub!,
+      onchain_address: toPayableOnchainAddress(onchainWallet.address_or_xpub)!,
     };
   }
 
-  // Fallback: use first wallet's address_or_xpub if available
-  const fallback = wallets[0];
-  if (fallback.address_or_xpub) {
+  // Fallback: the first wallet holding a payable address. This is where an
+  // xpub-only wallet used to leak through — the branch above filters on
+  // wallet_type, but this one never did, so `bitcoin:xpub6...` reached the
+  // payer as a QR no wallet could pay.
+  const fallback = wallets.find(w => toPayableOnchainAddress(w.address_or_xpub));
+  if (fallback) {
     return {
       method: 'onchain',
       wallet_id: fallback.id,
-      onchain_address: fallback.address_or_xpub,
+      onchain_address: toPayableOnchainAddress(fallback.address_or_xpub)!,
     };
   }
 


### PR DESCRIPTION
Found while investigating a **false settlement that fired in production** minutes after #511 deployed. Full incident write-up below, because the fix here is only one of the three things it exposed.

## The fix in this PR

`wallets.address_or_xpub` holds either kind of value, and both on-chain resolution branches passed it through verbatim as the payment address. But an extended public key **is not an address** — it is the key you derive addresses *from*, and nothing in this codebase derives: `bip32` and `bitcoinjs-lib` are declared dependencies that no module imports.

So an xpub-only wallet resolved to `method: 'onchain'` with the xpub as the address, and the payer got `bitcoin:xpub6...` — a QR no wallet can pay — while the product reported the seller as ready to receive. **The wallets page recommends extended public keys**, so following our own advice was the way to break receiving.

`toPayableOnchainAddress` now gates both sites on `detectWalletType`. An xpub-only wallet resolves to no payment method, which is the honest answer and the same one the owner's receive status already gives. Refusing to receive only looks worse than a broken QR if the QR works; this one never did.

The **fallback branch** is where it actually leaked: the `wallet_type` branch above it filtered correctly, but the fallback took `wallets[0]` unconditionally, so an xpub sitting first both produced an unpayable URI *and* shadowed a good address further down. It now picks the first payable wallet.

## Incident: the sweep reported money that never arrived

Minutes after #511 removed the fabricated on-chain expiry, the reconciliation sweep marked an on-chain tip **paid** and sent the recipient a "You received a tip: 0.0001 BTC" notification.

Nobody had paid it. The intent's address was `bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq` — the **BIP173 specification example address**, sitting in a row labelled "Audit Wallet 1783190948061" (test-data pollution). That address is public and receives constant unrelated traffic, and `checkOnchainPaymentStatus` matches on `(address, amount, since created_at)` — so a stranger's transaction satisfied it.

**Corrected in production:** intent set to `failed` with `paid_at` cleared, false notification deleted. Blast radius was that one notification — no contribution row, no webhook (verified). The intent is now terminal, so the sweep no longer matches strangers' transactions against it.

**My change did not create this path**, but it did remove the accidental one-hour cap that had been limiting its blast radius. Stated plainly because it's the honest accounting.

## The part that needs your decision (not fixed here)

On-chain matching by `(address, amount, time window)` is **only sound if the address is unique to the payment**. With a reused static address you cannot distinguish "someone paid my invoice" from "someone paid me for something else" — the address's uniqueness *is* the payment's identifier. That is what per-invoice derivation from an xpub exists for, and `bip32`/`bitcoinjs-lib` are already in `package.json`, suggesting it was intended and never built.

Building derivation would fix both problems at once: xpub wallets become genuinely usable, and every intent gets a never-reused address that identifies its payment unambiguously. But it is a feature with real money implications (gap limit, address indexing, change detection), not a guard I should slip in unilaterally.

Until then, on-chain auto-detection remains best-effort against a reused address. I deliberately did **not** add an "inactive wallet ⇒ don't settle" guard: deactivating a wallet doesn't un-receive money, so that would risk suppressing a *real* settlement — the opposite failure.

## Verification

- 80 payment/wallet/tip tests pass, including 4 new ones covering the xpub cases and confirming Lightning priority is unchanged.
- Type-check clean.
