### PR TITLE
fix(profile): stop empty coordinates silently blocking every profile save

### DIFF
--- a/__tests__/unit/profile-coordinate-validation.test.ts
+++ b/__tests__/unit/profile-coordinate-validation.test.ts
@@ -1,0 +1,76 @@
+import { profileSchema, coerceCoordinate, normalizeProfileData } from '@/lib/validation/base';
+
+/**
+ * Regression for the silent profile-save failure: the location UI registers
+ * latitude/longitude as hidden text inputs, so react-hook-form reads their
+ * value as the string "" when no coordinate is set. Before the fix, the raw
+ * `z.number()` rejected "" with "Expected number, received string", which
+ * blocked handleSubmit for EVERY profile without coordinates — with no visible
+ * error (the hidden inputs render no FormMessage, so the "Save Profile" button
+ * silently did nothing).
+ *
+ * Fix: coerce the coordinate at the source (ProfileLocationSection registers
+ * the inputs with `setValueAs: coerceCoordinate`, so the resolver never sees
+ * "") and defend the server path (`normalizeProfileData` runs the same
+ * coercion so "" never reaches the numeric DB column). The schema keeps its
+ * clean `number | null | undefined` type.
+ */
+describe('coerceCoordinate', () => {
+  it('maps empty / blank / null / undefined to null', () => {
+    expect(coerceCoordinate('')).toBeNull();
+    expect(coerceCoordinate('   ')).toBeNull();
+    expect(coerceCoordinate(null)).toBeNull();
+    expect(coerceCoordinate(undefined)).toBeNull();
+  });
+
+  it('passes real numbers through and parses numeric strings', () => {
+    expect(coerceCoordinate(47.3769)).toBe(47.3769);
+    expect(coerceCoordinate('8.5417')).toBe(8.5417);
+  });
+
+  it('maps NaN and non-numeric junk to null', () => {
+    expect(coerceCoordinate(Number.NaN)).toBeNull();
+    expect(coerceCoordinate('not-a-number')).toBeNull();
+  });
+});
+
+describe('normalizeProfileData — coordinates never reach the DB as ""', () => {
+  it('maps empty / blank coordinates to null', () => {
+    const out = normalizeProfileData({
+      username: 'x',
+      latitude: '',
+      longitude: '   ',
+    }) as Record<string, unknown>;
+    expect(out.latitude).toBeNull();
+    expect(out.longitude).toBeNull();
+  });
+
+  it('passes real numeric coordinates through untouched', () => {
+    const out = normalizeProfileData({
+      username: 'x',
+      latitude: 47.3769,
+      longitude: 8.5417,
+    }) as Record<string, unknown>;
+    expect(out.latitude).toBe(47.3769);
+    expect(out.longitude).toBe(8.5417);
+  });
+});
+
+describe('profileSchema — the server path saves a bare profile with empty coords', () => {
+  it('accepts the normalized bare-profile payload (empty coords → null)', () => {
+    // The editor submits "" for unset lat/long; the server runs it through
+    // normalizeProfileData before parse, which is what must succeed end to end.
+    const bareForm = {
+      username: 'fresh-maker',
+      name: '',
+      bio: '',
+      latitude: '',
+      longitude: '',
+      website: '',
+      contact_email: 'fresh@example.com',
+      current_status: '',
+      help_wanted: [],
+    };
+    expect(profileSchema.safeParse(normalizeProfileData(bareForm)).success).toBe(true);
+  });
+});

--- a/src/components/profile/sections/ProfileLocationSection.tsx
+++ b/src/components/profile/sections/ProfileLocationSection.tsx
@@ -20,6 +20,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { ProfileLocationSectionProps } from '../types';
+import { coerceCoordinate } from '@/lib/validation/base';
 
 export function ProfileLocationSection({
   form,
@@ -150,8 +151,11 @@ export function ProfileLocationSection({
       <input type="hidden" {...form.register('location_country')} />
       <input type="hidden" {...form.register('location_city')} />
       <input type="hidden" {...form.register('location_zip')} />
-      <input type="hidden" {...form.register('latitude')} />
-      <input type="hidden" {...form.register('longitude')} />
+      {/* Numeric coords: coerce the hidden input's string ("" when unset) to a
+          number|null so the resolver's z.number() never sees "" — which would
+          silently block the whole save. */}
+      <input type="hidden" {...form.register('latitude', { setValueAs: coerceCoordinate })} />
+      <input type="hidden" {...form.register('longitude', { setValueAs: coerceCoordinate })} />
       <input type="hidden" {...form.register('location_context')} />
     </>
   );

--- a/src/lib/validation/base.ts
+++ b/src/lib/validation/base.ts
@@ -127,6 +127,23 @@ export const optionalText = (maxLen?: number) => {
 export const optionalUrl = () => z.string().url().optional().nullable().or(z.literal(''));
 
 /**
+ * Coerce a coordinate value (latitude/longitude) to a number, or null when it
+ * is empty/blank/NaN. The location UI registers these as hidden text inputs, so
+ * an unset coordinate arrives as the string "" (or a numeric string once set).
+ * Used by `normalizeProfileData` to guarantee "" never reaches the numeric DB
+ * column, and available for the input layer to coerce at the source.
+ */
+export const coerceCoordinate = (val: unknown): number | null => {
+  if (val === '' || val === null || val === undefined) return null;
+  if (typeof val === 'number') return Number.isNaN(val) ? null : val;
+  if (typeof val === 'string') {
+    const n = Number(val.trim());
+    return val.trim() === '' || Number.isNaN(n) ? null : n;
+  }
+  return null;
+};
+
+/**
  * Zod schema for Lightning address validation
  * Use this in any schema that accepts Lightning addresses
  */
@@ -296,6 +313,14 @@ export function normalizeProfileData(data: unknown): ProfileData {
   if (!normalized.name || (typeof normalized.name === 'string' && normalized.name.trim() === '')) {
     normalized.name = normalized.username;
   }
+
+  // Coordinates arrive as "" from the hidden lat/long inputs when unset — map
+  // that (and any blank/NaN/numeric-string) to a number or null so it never
+  // reaches the numeric DB column as "". Defends the server path; the input
+  // layer (ProfileLocationSection) also coerces so the client resolver, which
+  // validates raw form values against z.number(), never sees "".
+  if ('latitude' in normalized) normalized.latitude = coerceCoordinate(normalized.latitude);
+  if ('longitude' in normalized) normalized.longitude = coerceCoordinate(normalized.longitude);
 
   // Auto-add https:// to website if protocol is missing
   if (normalized.website && typeof normalized.website === 'string') {


### PR DESCRIPTION
## What

Fixes a **silent, total profile-save failure**: for any profile without precise coordinates (the common case), clicking **Save Profile** did nothing — no request, no toast, no field error.

## Root cause

`ProfileLocationSection` registers `latitude`/`longitude` as hidden text `<input>`s, so react-hook-form hydrates their value as the string `""` when no coordinate is set. The schema types them `z.number()`, and since zodResolver validates the RAW form values, `""` fails with *"Expected number, received string"* — on fields that render no `FormMessage`, so the rejection was invisible and `handleSubmit` never reached `onSubmit`.

Diagnosed live on prod by extracting RHF's `control._formState.errors` from the React fiber: exactly `latitude`/`longitude` `invalid_type` with `_formValues.latitude === ""`.

## Fix (source + server guard; schema type unchanged)

- `coerceCoordinate()` in `src/lib/validation/base.ts` (SSOT): `""`/blank/NaN/non-numeric → `null`, numeric strings → number.
- The hidden inputs register with `setValueAs: coerceCoordinate`, so the resolver never sees `""`.
- `normalizeProfileData` applies the same coercion server-side, so `""` can never reach the numeric DB column from any client.
- Deliberately **not** widening the Zod schema (`.or(z.literal(''))` ripples the output type into `ScalableProfile`/Resolver typings; `z.preprocess` widens input to `unknown` and breaks `UseFormReturn` — both variants failed type-check and were discarded).

## Verified

- `type-check` 0 · lint 0 errors · new regression suite 6/6 (coercion, server path, full bare-profile payload)
- Browser E2E on prod after deploy: will confirm Save fires PUT → 200 → persists for a fresh bare profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)