### PR TITLE
feat(ai): OpenRouter image generation — the default BYOK key can now generate

### DIFF
--- a/__tests__/unit/images/generate.test.ts
+++ b/__tests__/unit/images/generate.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Pins the provider wire contracts for BYOK image generation — the shapes we
+ * cannot exercise against live keys from CI: the OpenAI-style
+ * /images/generations response (b64_json + the gpt-image response_format
+ * quirk) and OpenRouter's chat-modalities data-URI response.
+ */
+
+import { IMAGE_PROVIDER_RUNTIME, getImageProviderRuntime } from '@/config/ai-provider-runtime';
+import { generateImageWithKey } from '@/services/images/generate';
+
+// jsdom's AbortSignal may lack the static timeout() helper Node provides.
+if (typeof AbortSignal.timeout !== 'function') {
+  (AbortSignal as unknown as { timeout: (ms: number) => AbortSignal }).timeout = () =>
+    new AbortController().signal;
+}
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3]);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('IMAGE_PROVIDER_RUNTIME', () => {
+  it('every declared provider resolves to a base URL and model', () => {
+    for (const providerId of Object.keys(IMAGE_PROVIDER_RUNTIME)) {
+      const runtime = getImageProviderRuntime(providerId);
+      expect(runtime).not.toBeNull();
+      expect(runtime!.baseUrl).toMatch(/^https:\/\//);
+      expect(runtime!.defaultImageModel.length).toBeGreaterThan(0);
+      expect(['images', 'chat']).toContain(runtime!.api);
+    }
+  });
+
+  it('openrouter carries its own base URL (not in PROVIDER_RUNTIME)', () => {
+    expect(getImageProviderRuntime('openrouter')?.baseUrl).toBe('https://openrouter.ai/api/v1');
+  });
+
+  it('returns null for non-image providers', () => {
+    expect(getImageProviderRuntime('groq')).toBeNull();
+    expect(getImageProviderRuntime('deepseek')).toBeNull();
+  });
+});
+
+describe('generateImageWithKey — images endpoint', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('decodes b64_json and sniffs PNG, omitting response_format for gpt-image models', async () => {
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(jsonResponse({ data: [{ b64_json: PNG_BYTES.toString('base64') }] }));
+
+    const result = await generateImageWithKey({
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-image-1',
+      prompt: 'a cat',
+      api: 'images',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.image.mimeType).toBe('image/png');
+      expect(Buffer.from(result.image.bytes)).toEqual(PNG_BYTES);
+    }
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.openai.com/v1/images/generations');
+    const body = JSON.parse(init.body as string);
+    expect(body.response_format).toBeUndefined();
+  });
+
+  it('requests b64_json for non-gpt-image models and sniffs JPEG', async () => {
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(jsonResponse({ data: [{ b64_json: JPEG_BYTES.toString('base64') }] }));
+
+    const result = await generateImageWithKey({
+      apiKey: 'xai-test',
+      baseUrl: 'https://api.x.ai/v1',
+      model: 'grok-2-image',
+      prompt: 'a cat',
+      api: 'images',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.image.mimeType).toBe('image/jpeg');
+    }
+    const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body.response_format).toBe('b64_json');
+  });
+
+  it('surfaces the provider error message on failure', async () => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(jsonResponse({ error: { message: 'billing hard limit reached' } }, 400));
+
+    const result = await generateImageWithKey({
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-image-1',
+      prompt: 'a cat',
+      api: 'images',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'billing hard limit reached' });
+  });
+});
+
+describe('generateImageWithKey — chat modalities (OpenRouter)', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('asks for image modality and decodes the data-URI response', async () => {
+    const dataUri = `data:image/png;base64,${PNG_BYTES.toString('base64')}`;
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        jsonResponse({ choices: [{ message: { images: [{ image_url: { url: dataUri } }] } }] })
+      );
+
+    const result = await generateImageWithKey({
+      apiKey: 'sk-or-test',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'google/gemini-3.1-flash-image',
+      prompt: 'a cat',
+      api: 'chat',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.image.mimeType).toBe('image/png');
+      expect(Buffer.from(result.image.bytes)).toEqual(PNG_BYTES);
+    }
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://openrouter.ai/api/v1/chat/completions');
+    const body = JSON.parse(init.body as string);
+    expect(body.modalities).toEqual(['image', 'text']);
+    expect(body.messages).toEqual([{ role: 'user', content: 'a cat' }]);
+  });
+
+  it('errors when the model answers with text only', async () => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(jsonResponse({ choices: [{ message: { content: 'I cannot' } }] }));
+
+    const result = await generateImageWithKey({
+      apiKey: 'sk-or-test',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'google/gemini-3.1-flash-image',
+      prompt: 'a cat',
+      api: 'chat',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('no image');
+    }
+  });
+});

--- a/src/app/api/ai/images/generate/route.ts
+++ b/src/app/api/ai/images/generate/route.ts
@@ -68,7 +68,7 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
     const imageKey = keys.find(k => k.provider in IMAGE_PROVIDER_RUNTIME);
     if (!imageKey) {
       return apiError(
-        'Image generation needs your own OpenAI or xAI API key. Add one in Settings → AI.',
+        'Image generation needs your own API key (OpenRouter, OpenAI, or xAI). Add one in Settings → AI.',
         'NO_IMAGE_KEY',
         400
       );
@@ -84,6 +84,7 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       baseUrl: runtime.baseUrl,
       model: runtime.defaultImageModel,
       prompt,
+      api: runtime.api,
     });
     if (!result.ok) {
       return apiError(`Image generation failed: ${result.error}`, 'UPSTREAM_ERROR', 502);

--- a/src/components/images/ImageGeneratePanel.tsx
+++ b/src/components/images/ImageGeneratePanel.tsx
@@ -6,6 +6,7 @@ import { Key, Loader2, Sparkles } from 'lucide-react';
 import { fetchImageGenCapability, generateImage } from '@/services/images/generate-client';
 import type { StockImage } from '@/services/images/types';
 import { ROUTES } from '@/config/routes';
+import { getAIProvider } from '@/data/aiProviders';
 
 /**
  * BYOK image generation panel for the shared image picker. Probes capability
@@ -78,7 +79,7 @@ export default function ImageGeneratePanel({
           className="inline-flex items-center gap-1.5 rounded-md bg-accent-warm px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-accent-warm/90"
         >
           <Key className="h-3.5 w-3.5" />
-          Add an OpenAI or xAI key
+          Add a key (OpenRouter, OpenAI, or xAI)
         </Link>
       </div>
     );
@@ -138,7 +139,8 @@ export default function ImageGeneratePanel({
       )}
 
       <p className="text-2xs text-fg-tertiary">
-        Generated with your own {capability.provider === 'xai' ? 'xAI' : 'OpenAI'} key and labeled
+        Generated with your own{' '}
+        {getAIProvider(capability.provider ?? '')?.name ?? capability.provider} key and labeled
         AI-generated.
       </p>
     </div>

--- a/src/config/ai-provider-runtime.ts
+++ b/src/config/ai-provider-runtime.ts
@@ -61,26 +61,40 @@ export function isOpenAICompatibleProvider(providerId: string): boolean {
 export interface ImageProviderRuntimeConfig {
   /** Model used for image generation when the user hasn't picked one. */
   defaultImageModel: string;
+  /**
+   * How the provider exposes image output: the OpenAI-style
+   * POST {baseUrl}/images/generations, or a /chat/completions call with
+   * `modalities: ['image','text']` (OpenRouter's shape).
+   */
+  api: 'images' | 'chat';
+  /** Only needed when the provider isn't in PROVIDER_RUNTIME (OpenRouter). */
+  baseUrl?: string;
 }
 
 /**
- * Providers whose keys can also generate images via the OpenAI-compatible
- * POST {baseUrl}/images/generations endpoint (base URL comes from
- * PROVIDER_RUNTIME above — same provider, same key).
+ * Providers whose keys can also generate images. Base URL comes from
+ * PROVIDER_RUNTIME above unless overridden — same provider, same key.
  *
  * BYOK-only by design: the platform free pool is text-only and must never
- * pay for image generation. OpenRouter is deliberately absent — its image
- * output rides /chat/completions with a different response shape.
+ * pay for image generation.
  */
 export const IMAGE_PROVIDER_RUNTIME: Record<string, ImageProviderRuntimeConfig> = {
-  openai: { defaultImageModel: 'gpt-image-1' },
-  xai: { defaultImageModel: 'grok-2-image' },
+  openai: { defaultImageModel: 'gpt-image-1', api: 'images' },
+  xai: { defaultImageModel: 'grok-2-image', api: 'images' },
+  openrouter: {
+    defaultImageModel: 'google/gemini-3.1-flash-image',
+    api: 'chat',
+    baseUrl: 'https://openrouter.ai/api/v1',
+  },
 };
 
 export function getImageProviderRuntime(
   providerId: string
-): (ImageProviderRuntimeConfig & ProviderRuntimeConfig) | null {
+): (ImageProviderRuntimeConfig & { baseUrl: string }) | null {
   const image = IMAGE_PROVIDER_RUNTIME[providerId];
-  const base = PROVIDER_RUNTIME[providerId];
-  return image && base ? { ...base, ...image } : null;
+  if (!image) {
+    return null;
+  }
+  const baseUrl = image.baseUrl ?? PROVIDER_RUNTIME[providerId]?.baseUrl;
+  return baseUrl ? { ...image, baseUrl } : null;
 }

--- a/src/services/images/generate.ts
+++ b/src/services/images/generate.ts
@@ -1,7 +1,9 @@
 /**
- * Server-side image generation against a user's OWN provider key
- * (OpenAI-compatible POST {baseUrl}/images/generations). BYOK-only — this is
- * never called with a platform key; see IMAGE_PROVIDER_RUNTIME.
+ * Server-side image generation against a user's OWN provider key. Two call
+ * styles (see IMAGE_PROVIDER_RUNTIME): OpenAI-style POST
+ * {baseUrl}/images/generations, or OpenRouter's /chat/completions with
+ * `modalities: ['image','text']` returning data-URI images. BYOK-only —
+ * this is never called with a platform key.
  */
 
 import { logger } from '@/utils/logger';
@@ -32,6 +34,19 @@ function sniffMimeType(bytes: Uint8Array): string {
 }
 
 export async function generateImageWithKey(opts: {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  prompt: string;
+  api: 'images' | 'chat';
+}): Promise<GenerateImageResult> {
+  if (opts.api === 'chat') {
+    return generateViaChat(opts);
+  }
+  return generateViaImagesEndpoint(opts);
+}
+
+async function generateViaImagesEndpoint(opts: {
   apiKey: string;
   baseUrl: string;
   model: string;
@@ -97,6 +112,75 @@ export async function generateImageWithKey(opts: {
   } catch (error) {
     const timedOut = error instanceof Error && error.name === 'TimeoutError';
     logger.warn('Image generation request failed', { model, error: String(error) }, 'ImageGen');
+    return {
+      ok: false,
+      error: timedOut ? 'generation timed out — try a simpler prompt' : 'request failed',
+    };
+  }
+}
+
+/**
+ * OpenRouter shape: a normal chat completion asked for image output; the
+ * generated image comes back as a base64 data URI at
+ * choices[0].message.images[n].image_url.url.
+ */
+async function generateViaChat(opts: {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  prompt: string;
+}): Promise<GenerateImageResult> {
+  const { apiKey, baseUrl, model, prompt } = opts;
+
+  try {
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+        modalities: ['image', 'text'],
+      }),
+      signal: AbortSignal.timeout(GENERATION_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      const providerMessage = body?.error?.message || `provider returned ${response.status}`;
+      logger.warn(
+        'Image generation (chat) failed upstream',
+        { status: response.status, model, providerMessage },
+        'ImageGen'
+      );
+      return { ok: false, error: providerMessage };
+    }
+
+    const json = (await response.json().catch(() => null)) as {
+      choices?: Array<{ message?: { images?: Array<{ image_url?: { url?: string } }> } }>;
+    } | null;
+    const dataUri = json?.choices?.[0]?.message?.images?.[0]?.image_url?.url;
+    if (!dataUri) {
+      return { ok: false, error: 'model returned no image — try a different prompt' };
+    }
+
+    const base64 = dataUri.includes(',') ? dataUri.slice(dataUri.indexOf(',') + 1) : dataUri;
+    const bytes = new Uint8Array(Buffer.from(base64, 'base64'));
+    if (bytes.length === 0) {
+      return { ok: false, error: 'model returned an empty image' };
+    }
+    return { ok: true, image: { bytes, mimeType: sniffMimeType(bytes) } };
+  } catch (error) {
+    const timedOut = error instanceof Error && error.name === 'TimeoutError';
+    logger.warn(
+      'Image generation (chat) request failed',
+      { model, error: String(error) },
+      'ImageGen'
+    );
     return {
       ok: false,
       error: timedOut ? 'generation timed out — try a simpler prompt' : 'request failed',


### PR DESCRIPTION
## What

Follow-up to #513. OpenRouter is OrangeCat's **default** BYOK provider, so most key-holding users saw the Generate tab tell them to get a second (OpenAI/xAI) key. Now their existing OpenRouter key generates too.

## How

- `IMAGE_PROVIDER_RUNTIME` gains an `api: 'images' | 'chat'` discriminator and an optional `baseUrl` override (OpenRouter isn't in `PROVIDER_RUNTIME`). OpenAI/xAI unchanged on `/images/generations`; OpenRouter uses `/chat/completions` with `modalities: ['image','text']`.
- Default model `google/gemini-3.1-flash-image` — chosen from OpenRouter's **live model catalog** (current-gen GA slug, ~cheapest per image). Response is a base64 data URI at `choices[0].message.images[0].image_url.url`, decoded, mime-sniffed, and persisted to storage exactly like the other providers.
- UI: capability footer now names the provider from the `aiProviders` display SSOT; no-key CTA says "OpenRouter, OpenAI, or xAI".
- **New contract tests** (`__tests__/unit/images/generate.test.ts`, 8 tests) pin both wire shapes — b64_json + the gpt-image `response_format` quirk, and the OpenRouter data-URI path — since CI can't call live providers.

Still BYOK-only: platform free pool never called, platform quota never debited.

## Verification

tsc 0 errors · eslint clean · audit:routes clean · **1328/1328 tests** (8 new) · not exercised against a live key (shapes pinned by tests; errors surface inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)