### PR TITLE
feat(data-controls): memory consent toggle, account export, delete-all conversations

### DIFF
--- a/__tests__/unit/cat/memory-consent.test.ts
+++ b/__tests__/unit/cat/memory-consent.test.ts
@@ -1,0 +1,82 @@
+import { memoryConsentGranted } from '@/services/cat/memory';
+import { deleteAllConversations } from '@/services/cat/conversation-history';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+
+/**
+ * Data-controls P0: the memory consent toggle and delete-all conversations.
+ *
+ * memoryConsentGranted gates extractAndStoreMemories — its failure semantics
+ * matter: a missing preferences row or a failed read must default to TRUE
+ * (memory on), because silently disabling memory on a transient DB error would
+ * be a worse bug than the one the toggle solves. Only an explicit
+ * memory_enabled=false may turn it off.
+ */
+
+function supabaseReturning(row: unknown, error: unknown = null): AnySupabaseClient {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: row, error }),
+        }),
+      }),
+    }),
+  } as unknown as AnySupabaseClient;
+}
+
+describe('memoryConsentGranted', () => {
+  it('defaults to true when no preferences row exists', async () => {
+    expect(await memoryConsentGranted(supabaseReturning(null), 'u1')).toBe(true);
+  });
+
+  it('is true when memory_enabled is true', async () => {
+    expect(await memoryConsentGranted(supabaseReturning({ memory_enabled: true }), 'u1')).toBe(
+      true
+    );
+  });
+
+  it('is false ONLY on explicit memory_enabled=false', async () => {
+    expect(await memoryConsentGranted(supabaseReturning({ memory_enabled: false }), 'u1')).toBe(
+      false
+    );
+  });
+
+  it('defaults to true when the read throws (never silently disable on error)', async () => {
+    const throwing = {
+      from: () => {
+        throw new Error('db down');
+      },
+    } as unknown as AnySupabaseClient;
+    expect(await memoryConsentGranted(throwing, 'u1')).toBe(true);
+  });
+});
+
+describe('deleteAllConversations', () => {
+  it('deletes cat_conversations rows scoped to the user and reports success', async () => {
+    const calls: Array<{ table: string; column: string; value: string }> = [];
+    const supabase = {
+      from: (table: string) => ({
+        delete: () => ({
+          eq: async (column: string, value: string) => {
+            calls.push({ table, column, value });
+            return { error: null };
+          },
+        }),
+      }),
+    } as unknown as AnySupabaseClient;
+
+    expect(await deleteAllConversations(supabase, 'user-123')).toBe(true);
+    expect(calls).toEqual([{ table: 'cat_conversations', column: 'user_id', value: 'user-123' }]);
+  });
+
+  it('reports failure when the delete errors', async () => {
+    const supabase = {
+      from: () => ({
+        delete: () => ({
+          eq: async () => ({ error: { message: 'nope' } }),
+        }),
+      }),
+    } as unknown as AnySupabaseClient;
+    expect(await deleteAllConversations(supabase, 'user-123')).toBe(false);
+  });
+});

--- a/src/app/(authenticated)/settings/SettingsDataSection.tsx
+++ b/src/app/(authenticated)/settings/SettingsDataSection.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+/**
+ * SettingsDataSection — "Your data" controls on the account settings page.
+ *
+ * - Export my data: downloads everything the platform stores about the user as
+ *   JSON (GDPR / Swiss-DSG right of access; served by /api/account/export).
+ * - Delete all Cat conversations: bulk clear of chat history, with an inline
+ *   two-step confirm (same UX as CatMemoryManager's "Forget everything").
+ */
+
+import { useCallback, useState } from 'react';
+import { DatabaseBackup, Download, Loader2, MessageSquareX } from 'lucide-react';
+import { toast } from 'sonner';
+import Button from '@/components/ui/Button';
+import { logger } from '@/utils/logger';
+import { API_ROUTES, ACCOUNT_EXPORT_FILENAME } from '@/config/api-routes';
+
+export function SettingsDataSection() {
+  const [isExporting, setIsExporting] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
+
+  const handleExport = useCallback(async () => {
+    setIsExporting(true);
+    try {
+      const res = await fetch(API_ROUTES.ACCOUNT_EXPORT);
+      if (!res.ok) {
+        throw new Error(`export failed (${res.status})`);
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = ACCOUNT_EXPORT_FILENAME;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      toast.success('Your data export has been downloaded');
+    } catch (err) {
+      logger.error('Account export failed', err, 'Settings');
+      toast.error('Could not export your data. Try again.');
+    } finally {
+      setIsExporting(false);
+    }
+  }, []);
+
+  const handleClearConversations = useCallback(async () => {
+    setIsClearing(true);
+    try {
+      const res = await fetch(`${API_ROUTES.CAT.CONVERSATIONS}?all=true`, { method: 'DELETE' });
+      if (!res.ok) {
+        throw new Error(`delete failed (${res.status})`);
+      }
+      setConfirmClear(false);
+      toast.success('All Cat conversations deleted');
+    } catch (err) {
+      logger.error('Delete-all conversations failed', err, 'Settings');
+      toast.error('Could not delete conversations. Try again.');
+    } finally {
+      setIsClearing(false);
+    }
+  }, []);
+
+  return (
+    <div className="border-t border-default pt-10">
+      <h3 className="mb-4 flex items-center text-lg font-semibold text-fg-primary">
+        <DatabaseBackup className="mr-2 h-6 w-6" />
+        Your data
+      </h3>
+
+      <div className="space-y-4">
+        <div className="rounded-md border border-default bg-surface-raised/30 p-6">
+          <h4 className="mb-2 text-lg font-medium text-fg-primary">Export my data</h4>
+          <p className="mb-4 text-base text-fg-secondary">
+            Download a JSON file with the data we store about you — profile, Cat conversations and
+            memories, credit history, and preferences. It&apos;s your data; take it anywhere.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleExport}
+            disabled={isExporting}
+            className="px-6 py-2"
+          >
+            {isExporting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Preparing…
+              </>
+            ) : (
+              <>
+                <Download className="mr-2 h-4 w-4" /> Export my data
+              </>
+            )}
+          </Button>
+        </div>
+
+        <div className="rounded-md border border-default bg-surface-raised/30 p-6">
+          <h4 className="mb-2 text-lg font-medium text-fg-primary">Delete all Cat conversations</h4>
+          <p className="mb-4 text-base text-fg-secondary">
+            Permanently delete your entire Cat chat history. Memories Cat has saved are managed
+            separately in AI settings. This cannot be undone.
+          </p>
+          {confirmClear ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="mr-2 text-sm text-fg-primary">
+                Delete every conversation? This can&apos;t be undone.
+              </span>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setConfirmClear(false)}
+                disabled={isClearing}
+                className="px-4 py-2"
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="danger"
+                onClick={handleClearConversations}
+                disabled={isClearing}
+                className="px-4 py-2"
+              >
+                {isClearing ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Deleting…
+                  </>
+                ) : (
+                  'Yes, delete all'
+                )}
+              </Button>
+            </div>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setConfirmClear(true)}
+              className="px-6 py-2 text-status-negative hover:border-status-negative/40"
+            >
+              <MessageSquareX className="mr-2 h-4 w-4" /> Delete all conversations
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -41,6 +41,7 @@ export default function AISettingsPage() {
     deleteKey,
     setPrimaryKey,
     reorderKeys,
+    updatePreferences,
   } = useAISettings();
 
   if (!hydrated || authLoading) {
@@ -140,7 +141,13 @@ export default function AISettingsPage() {
         </section>
 
         {/* ── Memory ────────────────────────────────────────────────────── */}
-        <CatMemoryManager reloadKey={memoryReloadKey} />
+        <CatMemoryManager
+          reloadKey={memoryReloadKey}
+          memoryEnabled={preferences?.memory_enabled !== false}
+          onToggleMemory={async enabled => {
+            await updatePreferences({ memory_enabled: enabled });
+          }}
+        />
 
         {/* ── Import memory from another AI ──────────────────────────────── */}
         <CatMemoryImport onImported={() => setMemoryReloadKey(k => k + 1)} />

--- a/src/app/(authenticated)/settings/page.tsx
+++ b/src/app/(authenticated)/settings/page.tsx
@@ -11,6 +11,7 @@ import { SettingsEmailSection } from './SettingsEmailSection';
 import { SettingsPasswordSection } from './SettingsPasswordSection';
 import { SettingsSecuritySection } from './SettingsSecuritySection';
 import { SettingsDangerSection } from './SettingsDangerSection';
+import { SettingsDataSection } from './SettingsDataSection';
 import { SettingsModals } from './SettingsModals';
 
 const SETTINGS_SUB_PAGES: Array<{
@@ -114,6 +115,8 @@ export default function SettingsPage() {
               onViewRecoveryCodes={() => setShowRecoveryCodes(true)}
               onMFADisableComplete={refreshMFAStatus}
             />
+            <SettingsDataSection />
+
             <SettingsDangerSection isDeleting={isDeleting} onDelete={handleDeleteAccount} />
           </div>
         </div>

--- a/src/app/api/account/export/route.ts
+++ b/src/app/api/account/export/route.ts
@@ -1,0 +1,123 @@
+/**
+ * GET /api/account/export — download the user's data as JSON (data controls).
+ *
+ * GDPR / Swiss-DSG "export my data": one authenticated endpoint that returns
+ * the personal data the platform stores about the requesting user, as a
+ * downloadable JSON file. Reads go through the request-scoped (RLS) client, so
+ * the export can only ever contain rows the user is allowed to see.
+ *
+ * Scope (listed in the manifest so the file is honest about coverage):
+ * - profile, AI preferences, notification preferences
+ * - Cat: conversations, messages, memories (content — embedding vectors are
+ *   internal derivatives, not personal data), economic profile
+ * - credit ledger: entries + top-ups
+ * - user-to-user messages the USER sent (other participants' messages belong
+ *   to them and are not exported)
+ * Encrypted BYOK API keys are deliberately excluded.
+ */
+
+import { apiRateLimited, handleApiError } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { NextResponse } from 'next/server';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { ACCOUNT_EXPORT_FILENAME } from '@/config/api-routes';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+
+async function rows(
+  supabase: AnySupabaseClient,
+  table: string,
+  column: string,
+  userId: string,
+  select = '*'
+): Promise<unknown[]> {
+  const { data, error } = await supabase.from(table).select(select).eq(column, userId);
+  if (error) {
+    throw new Error(`Export failed reading ${table}: ${error.message}`);
+  }
+  return data ?? [];
+}
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+
+  // Heavy read — use the stricter write-tier limit to prevent hammering.
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many export requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
+  try {
+    const [
+      profile,
+      aiPreferences,
+      notificationPreferences,
+      catConversations,
+      catMessages,
+      catMemories,
+      economicProfile,
+      creditEntries,
+      creditTopups,
+      sentMessages,
+    ] = await Promise.all([
+      rows(supabase, DATABASE_TABLES.PROFILES, 'id', user.id),
+      rows(supabase, DATABASE_TABLES.USER_AI_PREFERENCES, 'user_id', user.id),
+      rows(supabase, DATABASE_TABLES.NOTIFICATION_PREFERENCES, 'user_id', user.id),
+      rows(supabase, DATABASE_TABLES.CAT_CONVERSATIONS, 'user_id', user.id),
+      rows(supabase, DATABASE_TABLES.CAT_MESSAGES, 'user_id', user.id),
+      rows(
+        supabase,
+        DATABASE_TABLES.CAT_MEMORIES,
+        'user_id',
+        user.id,
+        'id, content, source, source_conversation_id, created_at'
+      ),
+      rows(supabase, DATABASE_TABLES.USER_ECONOMIC_PROFILE, 'user_id', user.id),
+      rows(supabase, DATABASE_TABLES.CAT_CREDIT_ENTRIES, 'user_id', user.id),
+      rows(supabase, DATABASE_TABLES.CAT_CREDIT_TOPUPS, 'user_id', user.id),
+      rows(supabase, DATABASE_TABLES.MESSAGES, 'sender_id', user.id),
+    ]);
+
+    const payload = {
+      manifest: {
+        product: 'OrangeCat',
+        exported_at: new Date().toISOString(),
+        user_id: user.id,
+        scope: [
+          'profile',
+          'ai_preferences',
+          'notification_preferences',
+          'cat_conversations',
+          'cat_messages',
+          'cat_memories (content only — embedding vectors excluded)',
+          'economic_profile',
+          'credit_entries',
+          'credit_topups',
+          'sent_messages (only messages you sent; other participants’ messages are theirs)',
+        ],
+        excluded: ['encrypted BYOK API keys'],
+      },
+      profile,
+      ai_preferences: aiPreferences,
+      notification_preferences: notificationPreferences,
+      cat_conversations: catConversations,
+      cat_messages: catMessages,
+      cat_memories: catMemories,
+      economic_profile: economicProfile,
+      credit_entries: creditEntries,
+      credit_topups: creditTopups,
+      sent_messages: sentMessages,
+    };
+
+    return new NextResponse(JSON.stringify(payload, null, 2), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="${ACCOUNT_EXPORT_FILENAME}"`,
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/src/app/api/cat/conversations/route.ts
+++ b/src/app/api/cat/conversations/route.ts
@@ -1,12 +1,17 @@
 /**
  * Cat Conversations API
  *
- * GET  /api/cat/conversations  - List the user's conversations (rail)
- * POST /api/cat/conversations  - Start a new conversation, returns { id }
+ * GET    /api/cat/conversations           - List the user's conversations (rail)
+ * POST   /api/cat/conversations           - Start a new conversation, returns { id }
+ * DELETE /api/cat/conversations?all=true  - Delete ALL conversations (data controls)
  */
 
-import { listConversations, createConversation } from '@/services/cat/conversation-history';
-import { apiSuccess, apiRateLimited, handleApiError } from '@/lib/api/standardResponse';
+import {
+  listConversations,
+  createConversation,
+  deleteAllConversations,
+} from '@/services/cat/conversation-history';
+import { apiSuccess, apiError, apiRateLimited, handleApiError } from '@/lib/api/standardResponse';
 import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 
@@ -31,6 +36,32 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
   try {
     const id = await createConversation(supabase, user.id);
     return apiSuccess({ id });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const DELETE = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+
+  // Bulk-delete is explicit-opt-in via ?all=true — a bare DELETE on the
+  // collection must not wipe everything by accident. Single-conversation
+  // delete lives at /api/cat/conversations/[id].
+  if (request.nextUrl.searchParams.get('all') !== 'true') {
+    return apiError('Pass ?all=true to delete all conversations', 'VALIDATION_ERROR', 400);
+  }
+
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
+  try {
+    const ok = await deleteAllConversations(supabase, user.id);
+    if (!ok) {
+      return apiError('Failed to delete conversations', 'INTERNAL_ERROR', 500);
+    }
+    return apiSuccess({ success: true });
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/components/ai/CatMemoryManager.tsx
+++ b/src/components/ai/CatMemoryManager.tsx
@@ -25,9 +25,17 @@ interface Memory {
 interface CatMemoryManagerProps {
   /** Bump to force a reload — e.g. after an import adds new memories. */
   reloadKey?: number;
+  /** Consent state: is Cat allowed to store new memories? Omit to hide the toggle. */
+  memoryEnabled?: boolean;
+  /** Called with the new consent value when the user flips the toggle. */
+  onToggleMemory?: (enabled: boolean) => Promise<void> | void;
 }
 
-export function CatMemoryManager({ reloadKey = 0 }: CatMemoryManagerProps = {}) {
+export function CatMemoryManager({
+  reloadKey = 0,
+  memoryEnabled,
+  onToggleMemory,
+}: CatMemoryManagerProps = {}) {
   const [memories, setMemories] = useState<Memory[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -142,6 +150,32 @@ export function CatMemoryManager({ reloadKey = 0 }: CatMemoryManagerProps = {}) 
             Durable facts Cat has learned about you from your conversations, so it carries context
             across sessions. You control all of it — delete anything, anytime.
           </p>
+          {memoryEnabled !== undefined && onToggleMemory && (
+            <label className="mt-3 flex cursor-pointer items-center gap-3">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={memoryEnabled}
+                aria-label="Remember details from our conversations"
+                onClick={() => void onToggleMemory(!memoryEnabled)}
+                className={`relative h-6 w-11 shrink-0 rounded-full transition-colors ${
+                  memoryEnabled ? 'bg-accent-warm' : 'bg-surface-raised border border-default'
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                    memoryEnabled ? 'translate-x-[22px]' : 'translate-x-0.5'
+                  }`}
+                />
+              </button>
+              <span className="text-sm text-fg-primary">
+                Remember details from our conversations
+                <span className="block text-xs text-fg-tertiary">
+                  Off = Cat stops saving new memories. Existing ones stay until you delete them.
+                </span>
+              </span>
+            </label>
+          )}
         </div>
       </div>
 

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -168,6 +168,7 @@ export const API_ROUTES = {
     ACTIVITIES: (slug: string) => `${ENTITY_REGISTRY['group'].apiEndpoint}/${slug}/activities`,
   },
   JOBS: '/api/jobs',
+  ACCOUNT_EXPORT: '/api/account/export',
   DELETE_USER: '/api/delete-user',
   WAITLIST: '/api/waitlist',
   AI_ASSISTANTS: {
@@ -187,3 +188,6 @@ export const API_ROUTES = {
     RECEIVE_INFO: (id: string) => `/api/bookings/${id}/receive-info`,
   },
 } as const;
+
+/** Download filename served by API_ROUTES.ACCOUNT_EXPORT (and used by its UI button). */
+export const ACCOUNT_EXPORT_FILENAME = 'orangecat-account-export.json';

--- a/src/hooks/useAISettings.ts
+++ b/src/hooks/useAISettings.ts
@@ -22,6 +22,8 @@ export interface UserAIPreferences {
   onboarding_completed: boolean;
   onboarding_completed_at: string | null;
   onboarding_step: number;
+  /** Consent: may Cat extract + store memories from conversations? Gates extractAndStoreMemories. */
+  memory_enabled: boolean;
   /** The free platform default's position in the Cat fallback chain (0 = first). */
   platform_chain_position: number;
   cached_total_requests: number;

--- a/src/services/cat/conversation-history.ts
+++ b/src/services/cat/conversation-history.ts
@@ -12,7 +12,6 @@
  * - A conversation's title is auto-set from its first user message
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { DATABASE_TABLES } from '@/config/database-tables';
 
@@ -158,6 +157,23 @@ export async function deleteConversation(
     .from(DATABASE_TABLES.CAT_CONVERSATIONS)
     .delete()
     .eq('id', owned)
+    .eq('user_id', userId);
+  return !error;
+}
+
+/**
+ * Delete ALL of a user's Cat conversations (data-controls "delete all").
+ * Deleting the cat_conversations rows is sufficient — cat_messages has
+ * ON DELETE CASCADE on conversation_id, so messages go with them. Returns
+ * success.
+ */
+export async function deleteAllConversations(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<boolean> {
+  const { error } = await supabase
+    .from(DATABASE_TABLES.CAT_CONVERSATIONS)
+    .delete()
     .eq('user_id', userId);
   return !error;
 }

--- a/src/services/cat/memory.ts
+++ b/src/services/cat/memory.ts
@@ -172,9 +172,32 @@ function parseFacts(raw: string): string[] {
 }
 
 /**
+ * Consent gate: has this user turned memory off? Reads
+ * user_ai_preferences.memory_enabled (default true — a missing row or a
+ * failed read must never silently disable memory). Only consulted after the
+ * cheap guards pass, so it costs one indexed lookup per self-disclosure turn.
+ */
+export async function memoryConsentGranted(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<boolean> {
+  try {
+    const { data } = await supabase
+      .from(DATABASE_TABLES.USER_AI_PREFERENCES)
+      .select('memory_enabled')
+      .eq('user_id', userId)
+      .maybeSingle();
+    return (data as { memory_enabled?: boolean } | null)?.memory_enabled !== false;
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Distil durable facts from one exchange and store the new ones. Best-effort
  * and non-blocking — call without awaiting on the response path. Skips silently
- * when embeddings are off, the message isn't self-disclosure, or the LLM/DB
+ * when embeddings are off, the message isn't self-disclosure, the user has
+ * turned memory off (user_ai_preferences.memory_enabled), or the LLM/DB
  * fails. Dedupes against existing memories by vector similarity.
  */
 export async function extractAndStoreMemories(
@@ -187,6 +210,9 @@ export async function extractAndStoreMemories(
   model: string
 ): Promise<void> {
   if (!embeddingsEnabled() || !looksLikeSelfDisclosure(userMessage)) {
+    return;
+  }
+  if (!(await memoryConsentGranted(supabase, userId))) {
     return;
   }
   try {

--- a/supabase/migrations/20260731110000_memory_consent_and_message_delete_policy.sql
+++ b/supabase/migrations/20260731110000_memory_consent_and_message_delete_policy.sql
@@ -1,0 +1,28 @@
+-- Data-controls P0: memory consent + fix the silent cat_messages delete no-op.
+--
+-- 1. memory_enabled — the "Remember details from our conversations" consent
+--    toggle. Read by the Cat chat orchestrator before extracting/storing
+--    memories; default true preserves current behavior for everyone.
+--    Lives on user_ai_preferences (the existing per-user AI settings row,
+--    own-row RLS already in place).
+--
+-- 2. cat_messages DELETE policy — cat_messages has RLS enabled but only
+--    INSERT/SELECT policies, so every `.delete()` through a user-scoped
+--    client silently removes 0 rows. Existing flows only worked because
+--    deleting the cat_conversations row cascades (FK ON DELETE CASCADE), and
+--    DELETE /api/cat/history's clearDefaultConversation is a silent no-op
+--    today. Add the missing own-row DELETE policy to end that failure class.
+--
+-- Idempotent — safe if a box already has either change.
+
+ALTER TABLE public.user_ai_preferences
+  ADD COLUMN IF NOT EXISTS memory_enabled BOOLEAN NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN public.user_ai_preferences.memory_enabled IS
+  'Consent: may Cat extract and store memories from conversations? Gates extractAndStoreMemories in src/services/cat/memory.ts';
+
+DROP POLICY IF EXISTS cat_messages_delete_own ON public.cat_messages;
+CREATE POLICY cat_messages_delete_own
+  ON public.cat_messages
+  FOR DELETE
+  USING (user_id = auth.uid());


### PR DESCRIPTION
## What

The **P0 trust layer** from the settings gap analysis — user control surface over data the platform already stores:

1. **Memory consent toggle** — "Remember details from our conversations" in the Cat memory section (`/settings/ai`). `user_ai_preferences.memory_enabled` (default `true`) gates `extractAndStoreMemories` via `memoryConsentGranted()`. Failure semantics deliberate: only an explicit `false` disables memory — a missing row or a failed read never does. Off stops NEW memories; existing ones stay until deleted (copy states this).
2. **Export my data** — `GET /api/account/export` (withAuth, rate-limited, RLS-scoped client) returns a downloadable JSON: profile, AI + notification preferences, Cat conversations/messages/memories (content only — embedding vectors are internal derivatives), economic profile, credit ledger, and messages the user *sent* (other participants' messages are theirs). Encrypted BYOK keys excluded. A manifest states scope + exclusions. Button in Settings → "Your data".
3. **Delete all Cat conversations** — `DELETE /api/cat/conversations?all=true` (explicit `?all=true` so a bare DELETE can't wipe by accident) → `deleteAllConversations()`; messages removed via the FK cascade. Two-step confirm in Settings.

## Bonus class-fix

`cat_messages` had RLS enabled with only INSERT/SELECT policies — **every user-scoped message delete silently removed 0 rows** (existing flows only worked via the conversation-row cascade; `DELETE /api/cat/history` was a complete no-op). The migration adds the missing own-row DELETE policy.

## Migration

`20260731110000_memory_consent_and_message_delete_policy.sql` — idempotent, additive (defaulted column + permissive-only policy). **Already applied to the prod self-host** and verified: `memory_enabled` default `true`, `cat_messages_delete_own` present.

## Verified

- `type-check` 0 · lint 0 errors · **1356 unit tests** (6 new: consent-gate failure semantics, delete-all scoping) · `audit:routes` clean
- Browser E2E on prod after deploy: toggle persists, export downloads, delete-all clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)