### PR TITLE
feat(images): Upload tab — own photos on posts and articles

### DIFF
--- a/src/components/articles/ImageSuggestPicker.tsx
+++ b/src/components/articles/ImageSuggestPicker.tsx
@@ -1,18 +1,48 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Search, Loader2, X, ImageOff, Sparkles } from 'lucide-react';
+import { Search, Loader2, X, ImageOff, Sparkles, Upload } from 'lucide-react';
 import { suggestArticleImages } from '@/services/articles/image-client';
 import ImageGeneratePanel from '@/components/images/ImageGeneratePanel';
+import ImageUploadPanel from '@/components/images/ImageUploadPanel';
 import type { StockImage } from '@/services/images/types';
 import { cn } from '@/lib/utils';
 
+type PickerMode = 'search' | 'generate' | 'upload';
+
+function ModeTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors',
+        active
+          ? 'border-default bg-surface-raised font-medium text-fg-primary'
+          : 'border-subtle text-fg-secondary hover:border-default hover:text-fg-primary'
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
 /**
- * AI image picker with two modes: Search (Openverse CC0/public-domain, AI
- * turns the given text into search terms) and Generate (the user's OWN
- * OpenAI/xAI key — see ImageGeneratePanel). Picking either way hands back a
- * full-res URL. Used for article covers, inline article images, and the
- * timeline post composer.
+ * Image picker with three modes: Search (Openverse CC0/public-domain, AI
+ * turns the given text into search terms), Generate (the user's OWN
+ * OpenRouter/OpenAI/xAI key — see ImageGeneratePanel), and Upload (own
+ * photo). Picking any way hands back a full-res URL. Used for article
+ * covers, inline article images, and the timeline post composer.
  */
 export default function ImageSuggestPicker({
   title,
@@ -27,7 +57,7 @@ export default function ImageSuggestPicker({
   onPick: (image: StockImage) => void;
   onClose: () => void;
 }) {
-  const [mode, setMode] = useState<'search' | 'generate'>('search');
+  const [mode, setMode] = useState<PickerMode>('search');
   const [images, setImages] = useState<StockImage[]>([]);
   const [queries, setQueries] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -70,40 +100,24 @@ export default function ImageSuggestPicker({
         </button>
       </div>
 
-      <div className="mb-2 flex gap-1.5" role="tablist" aria-label="Image source">
-        <button
-          type="button"
-          role="tab"
-          aria-selected={mode === 'search'}
-          onClick={() => setMode('search')}
-          className={cn(
-            'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors',
-            mode === 'search'
-              ? 'border-default bg-surface-raised font-medium text-fg-primary'
-              : 'border-subtle text-fg-secondary hover:border-default hover:text-fg-primary'
-          )}
-        >
+      <div className="mb-2 flex flex-wrap gap-1.5" role="tablist" aria-label="Image source">
+        <ModeTab active={mode === 'search'} onClick={() => setMode('search')}>
           <Search className="h-3.5 w-3.5" />
           Search free photos
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={mode === 'generate'}
-          onClick={() => setMode('generate')}
-          className={cn(
-            'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors',
-            mode === 'generate'
-              ? 'border-default bg-surface-raised font-medium text-fg-primary'
-              : 'border-subtle text-fg-secondary hover:border-default hover:text-fg-primary'
-          )}
-        >
+        </ModeTab>
+        <ModeTab active={mode === 'generate'} onClick={() => setMode('generate')}>
           <Sparkles className="h-3.5 w-3.5" />
           Generate
-        </button>
+        </ModeTab>
+        <ModeTab active={mode === 'upload'} onClick={() => setMode('upload')}>
+          <Upload className="h-3.5 w-3.5" />
+          Upload
+        </ModeTab>
       </div>
 
-      {mode === 'generate' ? (
+      {mode === 'upload' ? (
+        <ImageUploadPanel onPick={onPick} />
+      ) : mode === 'generate' ? (
         <ImageGeneratePanel initialPrompt={title || body} onPick={onPick} />
       ) : (
         <>

--- a/src/components/images/ImageUploadPanel.tsx
+++ b/src/components/images/ImageUploadPanel.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { ImagePlus, Loader2 } from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
+import {
+  IMAGE_UPLOAD_ACCEPT,
+  IMAGE_UPLOAD_MAX_MB,
+  uploadUserImage,
+} from '@/services/images/upload';
+import type { StockImage } from '@/services/images/types';
+
+/**
+ * Own-photo upload for the shared image picker. Validates client-side,
+ * uploads to the user's storage folder, and hands the picked image back in
+ * the same StockImage shape the search/generate tabs use.
+ */
+export default function ImageUploadPanel({ onPick }: { onPick: (image: StockImage) => void }) {
+  const { user } = useAuth();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFile(file: File | undefined) {
+    if (!file || busy || !user?.id) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    const result = await uploadUserImage(user.id, file, 'post-image');
+    setBusy(false);
+    if (!result.success || !result.url) {
+      setError(result.error || 'Upload failed. Please try again.');
+      return;
+    }
+    onPick({
+      id: `upload-${Date.now()}`,
+      thumbUrl: result.url,
+      fullUrl: result.url,
+      title: file.name.replace(/\.[^.]+$/, ''),
+      creator: null,
+      license: '',
+      sourceUrl: null,
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3 py-6 text-center">
+      <input
+        ref={inputRef}
+        type="file"
+        accept={IMAGE_UPLOAD_ACCEPT}
+        className="hidden"
+        aria-label="Choose an image file"
+        onChange={e => {
+          void handleFile(e.target.files?.[0]);
+          e.target.value = '';
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={busy || !user?.id}
+        className="inline-flex items-center gap-1.5 rounded-md bg-accent-warm px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-accent-warm/90 disabled:opacity-50"
+      >
+        {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImagePlus className="h-4 w-4" />}
+        {busy ? 'Uploading…' : 'Choose a photo'}
+      </button>
+      {error && <p className="text-xs text-status-negative">{error}</p>}
+      <p className="text-2xs text-fg-tertiary">
+        JPEG, PNG, WebP, or GIF — up to {IMAGE_UPLOAD_MAX_MB}MB.
+      </p>
+    </div>
+  );
+}

--- a/src/services/articles/cover-storage.ts
+++ b/src/services/articles/cover-storage.ts
@@ -1,62 +1,18 @@
 /**
- * Upload an article cover image. Reuses the public BANNERS bucket with a
- * `${userId}/…` path — a cover is a banner-class hero image, matching the same
- * upload path avatars/banners already use (no new bucket needed). Returns a
- * public URL to store in `metadata.article.cover_image`.
+ * Article cover upload — thin wrapper over the shared user-image upload
+ * (src/services/images/upload.ts), kept for its existing import surface.
+ * Returns a public URL to store in `metadata.article.cover_image`.
  */
 
-import supabase from '@/lib/supabase/browser';
-import { logger } from '@/utils/logger';
-import { STORAGE_BUCKETS } from '@/config/database-tables';
+import { uploadUserImage } from '@/services/images/upload';
 import type { FileUploadResult } from '@/types/storage';
 
-const BUCKET = STORAGE_BUCKETS.BANNERS;
-// Must not exceed the banners bucket's server-side file_size_limit (5MB) — a
-// larger file passes this check then fails at the bucket with a cryptic error.
-const MAX_SIZE = 5 * 1024 * 1024;
-const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif'];
+export {
+  IMAGE_UPLOAD_ACCEPT as COVER_ACCEPT,
+  IMAGE_UPLOAD_MAX_MB as COVER_MAX_MB,
+  validateImageFile as validateCoverFile,
+} from '@/services/images/upload';
 
-export const COVER_ACCEPT = ALLOWED_TYPES.join(',');
-export const COVER_MAX_MB = MAX_SIZE / 1024 / 1024;
-
-export function validateCoverFile(file: File): { valid: boolean; error?: string } {
-  if (!ALLOWED_TYPES.includes(file.type)) {
-    return { valid: false, error: 'Please choose a JPEG, PNG, WebP, or GIF image.' };
-  }
-  if (file.size > MAX_SIZE) {
-    return { valid: false, error: `Image must be under ${COVER_MAX_MB}MB.` };
-  }
-  return { valid: true };
-}
-
-export async function uploadArticleCover(userId: string, file: File): Promise<FileUploadResult> {
-  const validation = validateCoverFile(file);
-  if (!validation.valid) {
-    return { success: false, error: validation.error };
-  }
-
-  try {
-    const ext = file.name.split('.').pop() || 'jpg';
-    // userId first segment namespaces each author's uploads (same convention as
-    // avatars/banners). Timestamp keeps successive covers from colliding.
-    const fileName = `${userId}/article-cover_${Date.now()}.${ext}`;
-
-    const { error } = await supabase.storage.from(BUCKET).upload(fileName, file, {
-      cacheControl: '31536000',
-      upsert: true,
-    });
-    if (error) {
-      logger.error('Failed to upload article cover', { error: error.message }, 'Articles');
-      return { success: false, error: error.message || 'Upload failed. Please try again.' };
-    }
-
-    const {
-      data: { publicUrl },
-    } = supabase.storage.from(BUCKET).getPublicUrl(fileName);
-    return { success: true, url: publicUrl };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Upload failed. Please try again.';
-    logger.error('Error uploading article cover', { message }, 'Articles');
-    return { success: false, error: message };
-  }
+export function uploadArticleCover(userId: string, file: File): Promise<FileUploadResult> {
+  return uploadUserImage(userId, file, 'article-cover');
 }

--- a/src/services/images/upload.ts
+++ b/src/services/images/upload.ts
@@ -1,0 +1,65 @@
+/**
+ * Generic user-image upload to the public BANNERS bucket under `${userId}/…`
+ * — the same convention avatars/banners/article covers already use, so no new
+ * bucket or policy. Shared by article covers and the post-image Upload tab.
+ */
+
+import supabase from '@/lib/supabase/browser';
+import { logger } from '@/utils/logger';
+import { STORAGE_BUCKETS } from '@/config/database-tables';
+import type { FileUploadResult } from '@/types/storage';
+
+const BUCKET = STORAGE_BUCKETS.BANNERS;
+// Must not exceed the banners bucket's server-side file_size_limit (5MB) — a
+// larger file passes this check then fails at the bucket with a cryptic error.
+const MAX_SIZE = 5 * 1024 * 1024;
+const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif'];
+
+export const IMAGE_UPLOAD_ACCEPT = ALLOWED_TYPES.join(',');
+export const IMAGE_UPLOAD_MAX_MB = MAX_SIZE / 1024 / 1024;
+
+export function validateImageFile(file: File): { valid: boolean; error?: string } {
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return { valid: false, error: 'Please choose a JPEG, PNG, WebP, or GIF image.' };
+  }
+  if (file.size > MAX_SIZE) {
+    return { valid: false, error: `Image must be under ${IMAGE_UPLOAD_MAX_MB}MB.` };
+  }
+  return { valid: true };
+}
+
+export async function uploadUserImage(
+  userId: string,
+  file: File,
+  prefix: string
+): Promise<FileUploadResult> {
+  const validation = validateImageFile(file);
+  if (!validation.valid) {
+    return { success: false, error: validation.error };
+  }
+
+  try {
+    const ext = file.name.split('.').pop() || 'jpg';
+    // userId first segment namespaces each user's uploads (same convention as
+    // avatars/banners). Timestamp keeps successive uploads from colliding.
+    const fileName = `${userId}/${prefix}_${Date.now()}.${ext}`;
+
+    const { error } = await supabase.storage.from(BUCKET).upload(fileName, file, {
+      cacheControl: '31536000',
+      upsert: true,
+    });
+    if (error) {
+      logger.error('Failed to upload image', { error: error.message, prefix }, 'Images');
+      return { success: false, error: error.message || 'Upload failed. Please try again.' };
+    }
+
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from(BUCKET).getPublicUrl(fileName);
+    return { success: true, url: publicUrl };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Upload failed. Please try again.';
+    logger.error('Error uploading image', { message, prefix }, 'Images');
+    return { success: false, error: message };
+  }
+}


### PR DESCRIPTION
## What

Completes the post-image story from #509/#513/#516: the shared image picker now has all three sources — **Search free photos | Generate | Upload**. Users can put their *own* photo in a post (or article cover / inline image) without leaving the composer.

## How

- New `ImageUploadPanel`: file input → client-side validation (JPEG/PNG/WebP/GIF, 5MB bucket limit) → upload to `${userId}/post-image_*` in the banners bucket → picked back in the same `StockImage` shape the other tabs use. Own photos carry **no license caption** in the feed (they're the user's).
- **Shared upload SSOT**: third use of the browser-upload pattern justified the extraction — new `src/services/images/upload.ts` (`uploadUserImage`, validation, accept/max constants); `articles/cover-storage.ts` is now a thin wrapper re-exporting from it, so its existing import surface (`CoverImageUpload`) is untouched.
- Picker tab buttons deduplicated into a `ModeTab` component (three instances).

## Verification

tsc 0 errors · eslint clean · audit:routes clean · **1358/1358 tests** · storage path + bucket + RLS convention identical to the already-working article-cover upload, so no new policies needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)