### PR TITLE
feat(articles): multi-draft autosave, auto-growing editor, faster article paint

### DIFF
--- a/__tests__/unit/services/articles/local-drafts.test.ts
+++ b/__tests__/unit/services/articles/local-drafts.test.ts
@@ -1,0 +1,111 @@
+import {
+  deleteLocalDraft,
+  listLocalDrafts,
+  MAX_LOCAL_DRAFTS,
+  newDraftId,
+  saveLocalDraft,
+  type LocalArticleDraft,
+} from '@/services/articles/local-drafts';
+
+const STORE_KEY = 'oc:drafts:articles';
+const LEGACY_KEY = 'oc:draft:article';
+
+function makeDraft(overrides: Partial<LocalArticleDraft> = {}): LocalArticleDraft {
+  return {
+    id: newDraftId(),
+    title: 'Title',
+    excerpt: '',
+    coverImage: '',
+    body: 'Body',
+    visibility: 'public',
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('local article drafts', () => {
+  it('round-trips a draft through save and list', () => {
+    const draft = makeDraft({ title: 'My draft' });
+    saveLocalDraft(draft);
+    expect(listLocalDrafts()).toEqual([draft]);
+  });
+
+  it('lists drafts most recently touched first', () => {
+    const old = makeDraft({ title: 'old', updatedAt: 1000 });
+    const fresh = makeDraft({ title: 'fresh', updatedAt: 2000 });
+    saveLocalDraft(old);
+    saveLocalDraft(fresh);
+    expect(listLocalDrafts().map(d => d.title)).toEqual(['fresh', 'old']);
+  });
+
+  it('upserts by id instead of duplicating', () => {
+    const draft = makeDraft({ title: 'v1' });
+    saveLocalDraft(draft);
+    saveLocalDraft({ ...draft, title: 'v2', updatedAt: draft.updatedAt + 1 });
+    const drafts = listLocalDrafts();
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].title).toBe('v2');
+  });
+
+  it('deletes only the targeted draft', () => {
+    const keep = makeDraft({ title: 'keep' });
+    const drop = makeDraft({ title: 'drop' });
+    saveLocalDraft(keep);
+    saveLocalDraft(drop);
+    deleteLocalDraft(drop.id);
+    expect(listLocalDrafts().map(d => d.title)).toEqual(['keep']);
+  });
+
+  it('trims the store to MAX_LOCAL_DRAFTS, dropping the oldest', () => {
+    for (let i = 0; i < MAX_LOCAL_DRAFTS + 3; i++) {
+      saveLocalDraft(makeDraft({ title: `d${i}`, updatedAt: i }));
+    }
+    const drafts = listLocalDrafts();
+    expect(drafts).toHaveLength(MAX_LOCAL_DRAFTS);
+    // The oldest three (d0..d2) were dropped; the newest survives.
+    expect(drafts[0].title).toBe(`d${MAX_LOCAL_DRAFTS + 2}`);
+    expect(drafts.some(d => d.title === 'd0')).toBe(false);
+  });
+
+  it('migrates the legacy single-slot draft and removes the old key', () => {
+    localStorage.setItem(
+      LEGACY_KEY,
+      JSON.stringify({ title: 'Legacy', excerpt: '', coverImage: '', body: 'old body', visibility: 'followers' })
+    );
+    const drafts = listLocalDrafts();
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]).toMatchObject({ title: 'Legacy', body: 'old body', visibility: 'followers' });
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it('ignores an empty legacy slot without creating a draft', () => {
+    localStorage.setItem(
+      LEGACY_KEY,
+      JSON.stringify({ title: '', excerpt: '', coverImage: '', body: '', visibility: 'public' })
+    );
+    expect(listLocalDrafts()).toEqual([]);
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it('survives a corrupt store by treating it as empty', () => {
+    localStorage.setItem(STORE_KEY, 'not-json{');
+    expect(listLocalDrafts()).toEqual([]);
+    const draft = makeDraft();
+    saveLocalDraft(draft);
+    expect(listLocalDrafts()).toEqual([draft]);
+  });
+
+  it('filters malformed entries out of the store', () => {
+    const good = makeDraft({ title: 'good' });
+    localStorage.setItem(STORE_KEY, JSON.stringify([good, { nonsense: true }, null]));
+    expect(listLocalDrafts()).toEqual([good]);
+  });
+
+  it('generates unique draft ids', () => {
+    expect(newDraftId()).not.toBe(newDraftId());
+  });
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -105,31 +105,11 @@ Object.defineProperty(process.env, 'SUPABASE_SERVICE_ROLE_KEY', {
 // Mock fetch globally
 global.fetch = jest.fn();
 
-// Mock localStorage
-const localStorageMock = {
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-  clear: jest.fn(),
-  length: 0,
-  key: jest.fn(),
-};
-Object.defineProperty(window, 'localStorage', {
-  value: localStorageMock,
-});
-
-// Mock sessionStorage
-const sessionStorageMock = {
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-  clear: jest.fn(),
-  length: 0,
-  key: jest.fn(),
-};
-Object.defineProperty(window, 'sessionStorage', {
-  value: sessionStorageMock,
-});
+// localStorage / sessionStorage are already replaced above with spy-able,
+// store-backed mocks (createStorageMock) — these are just handles to them.
+// One mock, one source of truth: don't define a second stub here.
+const localStorageMock = window.localStorage as unknown as ReturnType<typeof createStorageMock>;
+const sessionStorageMock = window.sessionStorage as unknown as ReturnType<typeof createStorageMock>;
 
 // Mock window.location
 delete (window as any).location;
@@ -351,7 +331,10 @@ beforeEach(() => {
   // Reset all mocks
   jest.clearAllMocks();
 
-  // Reset localStorage and sessionStorage
+  // Empty the storage backing stores, then reset call history, so every test
+  // starts with clean storage and clean spies.
+  localStorageMock.clear();
+  sessionStorageMock.clear();
   if (localStorageMock.getItem?.mockClear) {
     localStorageMock.getItem.mockClear();
     localStorageMock.setItem.mockClear();

--- a/src/app/(public)/articles/[slug]/loading.tsx
+++ b/src/app/(public)/articles/[slug]/loading.tsx
@@ -1,0 +1,34 @@
+/**
+ * Article route skeleton — immediate paint while the article streams in.
+ * Without this the post-publish navigation showed a blank page for the full
+ * fetch duration (observed ~4s on prod).
+ */
+export default function ArticleLoading() {
+  return (
+    <div className="min-h-screen bg-surface-page pt-20 pb-24">
+      <div className="mx-auto w-full max-w-[720px] animate-pulse px-5">
+        <div className="mb-8 h-4 w-28 rounded bg-surface-raised" />
+        <div className="space-y-3">
+          <div className="h-9 w-4/5 rounded bg-surface-raised" />
+          <div className="h-9 w-3/5 rounded bg-surface-raised" />
+        </div>
+        <div className="mt-6 flex items-center gap-3">
+          <div className="h-9 w-9 rounded-full bg-surface-raised" />
+          <div className="space-y-2">
+            <div className="h-3 w-32 rounded bg-surface-raised" />
+            <div className="h-3 w-24 rounded bg-surface-raised" />
+          </div>
+        </div>
+        <div className="mt-10 space-y-4">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="space-y-2">
+              <div className="h-4 w-full rounded bg-surface-raised" />
+              <div className="h-4 w-11/12 rounded bg-surface-raised" />
+              <div className="h-4 w-4/6 rounded bg-surface-raised" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/articles/new/ArticleComposer.tsx
+++ b/src/app/(public)/articles/new/ArticleComposer.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, Eye, PenLine } from 'lucide-react';
+import { ArrowLeft, Eye, PenLine, Trash2 } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
 import Textarea from '@/components/ui/Textarea';
@@ -15,6 +15,14 @@ import { publishArticle } from '@/services/articles/create';
 import { updateArticle } from '@/services/articles/update';
 import type { TimelineVisibility } from '@/types/timeline';
 import type { ArticleDraft } from '@/services/cat/writing-types';
+import {
+  deleteLocalDraft,
+  listLocalDrafts,
+  newDraftId,
+  saveLocalDraft,
+  type LocalArticleDraft,
+} from '@/services/articles/local-drafts';
+import { formatRelativeTime } from '@/utils/dates';
 import ArticleMarkdown from '../[slug]/ArticleMarkdown';
 import MarkdownToolbar from '@/components/articles/MarkdownToolbar';
 import { useMarkdownTextarea } from '@/components/articles/useMarkdownTextarea';
@@ -23,16 +31,6 @@ import ArticleAiControls from '@/components/articles/ArticleAiControls';
 import CoverImageUpload from '@/components/articles/CoverImageUpload';
 import ImageSuggestPicker from '@/components/articles/ImageSuggestPicker';
 import type { StockImage } from '@/services/images/types';
-
-const DRAFT_KEY = 'oc:draft:article';
-
-interface DraftShape {
-  title: string;
-  excerpt: string;
-  coverImage: string;
-  body: string;
-  visibility: TimelineVisibility;
-}
 
 /** Existing article passed when the composer is opened in edit mode. */
 export interface ArticleInitial {
@@ -65,35 +63,31 @@ export default function ArticleComposer({
   const [restored, setRestored] = useState(false);
   // Which target the AI image picker is open for (null = closed).
   const [imagePicker, setImagePicker] = useState<null | 'cover' | 'inline'>(null);
+  const [draftId, setDraftId] = useState(() => newDraftId());
+  const [otherDrafts, setOtherDrafts] = useState<LocalArticleDraft[]>([]);
 
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const md = useMarkdownTextarea(bodyRef, body, setBody);
 
-  // Restore an in-progress draft once on mount (new articles only — never clobber
-  // an article being edited with a stale local draft).
+  // Restore the most recent draft once on mount (new articles only — never
+  // clobber an article being edited with a stale local draft). Older drafts
+  // stay listed so starting a new article never destroys an in-progress one.
   useEffect(() => {
     if (isEditing) {
       return;
     }
-    try {
-      const raw = localStorage.getItem(DRAFT_KEY);
-      if (!raw) {
-        return;
-      }
-      const d = JSON.parse(raw) as Partial<DraftShape>;
-      if (d.title || d.body) {
-        setTitle(d.title ?? '');
-        setExcerpt(d.excerpt ?? '');
-        setCoverImage(d.coverImage ?? '');
-        setBody(d.body ?? '');
-        if (d.visibility) {
-          setVisibility(d.visibility);
-        }
-        setRestored(true);
-      }
-    } catch {
-      /* ignore corrupt draft */
+    const drafts = listLocalDrafts();
+    const [latest, ...rest] = drafts;
+    if (latest) {
+      setTitle(latest.title);
+      setExcerpt(latest.excerpt);
+      setCoverImage(latest.coverImage);
+      setBody(latest.body);
+      setVisibility(latest.visibility);
+      setDraftId(latest.id);
+      setRestored(true);
     }
+    setOtherDrafts(rest);
   }, [isEditing]);
 
   // Autosave (debounced) whenever content changes (new articles only).
@@ -105,17 +99,29 @@ export default function ArticleComposer({
       return;
     }
     const id = setTimeout(() => {
-      try {
-        localStorage.setItem(
-          DRAFT_KEY,
-          JSON.stringify({ title, excerpt, coverImage, body, visibility } satisfies DraftShape)
-        );
-      } catch {
-        /* storage full / disabled — non-fatal */
-      }
+      saveLocalDraft({
+        id: draftId,
+        title,
+        excerpt,
+        coverImage,
+        body,
+        visibility,
+        updatedAt: Date.now(),
+      });
     }, 600);
     return () => clearTimeout(id);
-  }, [isEditing, title, excerpt, coverImage, body, visibility]);
+  }, [isEditing, draftId, title, excerpt, coverImage, body, visibility]);
+
+  // Grow the body textarea with its content so the page scrolls, never an inner
+  // box — long-form writing shouldn't happen inside a fixed scroll trap.
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (!el) {
+      return;
+    }
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, [body, tab]);
 
   const wordCount = body.trim() ? body.trim().split(/\s+/).length : 0;
   const readingTime = wordCount ? estimateReadingTime(body) : 0;
@@ -141,6 +147,37 @@ export default function ArticleComposer({
     setImagePicker(null);
   }
 
+  /** Delete the current draft and reset to a blank one; other drafts survive. */
+  function discardCurrentDraft() {
+    deleteLocalDraft(draftId);
+    setTitle('');
+    setExcerpt('');
+    setCoverImage('');
+    setBody('');
+    setVisibility('public');
+    setDraftId(newDraftId());
+    setRestored(false);
+    setOtherDrafts(listLocalDrafts());
+  }
+
+  /** Switch to another saved draft; the current one is already autosaved. */
+  function loadDraft(draft: LocalArticleDraft) {
+    setTitle(draft.title);
+    setExcerpt(draft.excerpt);
+    setCoverImage(draft.coverImage);
+    setBody(draft.body);
+    setVisibility(draft.visibility);
+    setDraftId(draft.id);
+    setRestored(true);
+    setTab('write');
+    setOtherDrafts(listLocalDrafts().filter(d => d.id !== draft.id));
+  }
+
+  function deleteOtherDraft(id: string) {
+    deleteLocalDraft(id);
+    setOtherDrafts(prev => prev.filter(d => d.id !== id));
+  }
+
   function handleBodyKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (!(e.metaKey || e.ctrlKey)) {
       return;
@@ -155,6 +192,20 @@ export default function ArticleComposer({
     } else if (k === 'k') {
       e.preventDefault();
       md.insertLink();
+    } else if (k === 's') {
+      // Flush the draft now instead of letting the browser offer to save the page.
+      e.preventDefault();
+      if (!isEditing && (title || body || excerpt || coverImage)) {
+        saveLocalDraft({
+          id: draftId,
+          title,
+          excerpt,
+          coverImage,
+          body,
+          visibility,
+          updatedAt: Date.now(),
+        });
+      }
     }
   }
 
@@ -190,11 +241,7 @@ export default function ArticleComposer({
       setPublishing(false);
       return;
     }
-    try {
-      localStorage.removeItem(DRAFT_KEY);
-    } catch {
-      /* ignore */
-    }
+    deleteLocalDraft(draftId);
     router.push(ROUTES.ARTICLE(result.slug));
   }
 
@@ -225,9 +272,49 @@ export default function ArticleComposer({
         )}
 
         {restored && (
-          <p className="mb-4 rounded-md border border-subtle bg-surface-raised/30 px-3 py-2 text-xs text-fg-secondary">
-            Restored your saved draft.
-          </p>
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-subtle bg-surface-raised/30 px-3 py-2 text-xs text-fg-secondary">
+            <span>Restored your saved draft.</span>
+            <button
+              type="button"
+              onClick={discardCurrentDraft}
+              className="shrink-0 font-medium text-fg-secondary underline-offset-2 transition-colors hover:text-status-negative hover:underline"
+            >
+              Discard draft
+            </button>
+          </div>
+        )}
+
+        {otherDrafts.length > 0 && (
+          <div className="mb-4 rounded-md border border-subtle bg-surface-raised/30 px-3 py-2">
+            <p className="mb-1.5 text-xs font-medium text-fg-secondary">
+              {otherDrafts.length === 1 ? 'Another draft' : `${otherDrafts.length} more drafts`}
+            </p>
+            <ul className="space-y-1">
+              {otherDrafts.map(draft => (
+                <li key={draft.id} className="flex items-center gap-2 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => loadDraft(draft)}
+                    className="min-w-0 flex-1 truncate text-left text-fg-primary underline-offset-2 hover:underline"
+                    title="Open this draft"
+                  >
+                    {draft.title.trim() || 'Untitled draft'}
+                  </button>
+                  <span className="shrink-0 text-fg-tertiary">
+                    {formatRelativeTime(new Date(draft.updatedAt))}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => deleteOtherDraft(draft.id)}
+                    className="shrink-0 text-fg-tertiary transition-colors hover:text-status-negative"
+                    aria-label="Delete draft"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
 
         {/* Write / Preview tabs */}
@@ -320,7 +407,7 @@ export default function ArticleComposer({
                 rows={18}
                 maxLength={ARTICLE_LIMITS.body}
                 aria-label="Article body"
-                className="rounded-t-none font-mono text-sm leading-6"
+                className="resize-none overflow-hidden rounded-t-none font-mono text-sm leading-6"
               />
             </div>
           </div>

--- a/src/services/articles/get-article.ts
+++ b/src/services/articles/get-article.ts
@@ -4,6 +4,7 @@
  * view (joins actor data for the byline).
  */
 
+import { cache } from 'react';
 import { createServerClient } from '@/lib/supabase/server';
 import { getUserActorId } from '@/domain/actors';
 import { logger } from '@/utils/logger';
@@ -65,8 +66,12 @@ function rowToArticle(row: EnrichedArticleRow): Article | null {
 /**
  * Fetch a single article by slug. Non-public articles are returned only to their
  * author (the server client carries the viewer's session cookies), otherwise null.
+ *
+ * React cache(): generateMetadata and the page body both call this with the
+ * same slug in one request — without dedupe the DB round-trip (plus two auth
+ * lookups for non-public articles) ran twice before first paint.
  */
-export async function getArticleBySlug(slug: string): Promise<Article | null> {
+export const getArticleBySlug = cache(async (slug: string): Promise<Article | null> => {
   try {
     const supabase = await createServerClient();
     const { data, error } = await supabase
@@ -106,7 +111,7 @@ export async function getArticleBySlug(slug: string): Promise<Article | null> {
     logger.error('Failed to fetch article by slug', { err, slug }, 'Articles');
     return null;
   }
-}
+});
 
 /**
  * Whether the current (session) viewer is the article's author. Compares actor

--- a/src/services/articles/local-drafts.ts
+++ b/src/services/articles/local-drafts.ts
@@ -1,0 +1,116 @@
+/**
+ * Client-side article draft store (localStorage). Multiple drafts live under one
+ * key so starting a new article never clobbers an in-progress one. The legacy
+ * single-slot key (`oc:draft:article`) is migrated into the store on first read.
+ */
+
+import type { TimelineVisibility } from '@/types/timeline';
+
+export interface LocalArticleDraft {
+  id: string;
+  title: string;
+  excerpt: string;
+  coverImage: string;
+  body: string;
+  visibility: TimelineVisibility;
+  /** Epoch ms of the last autosave — drives "most recent first" ordering. */
+  updatedAt: number;
+}
+
+const STORE_KEY = 'oc:drafts:articles';
+const LEGACY_KEY = 'oc:draft:article';
+
+/** Oldest drafts are dropped beyond this — localStorage is a ~5MB budget. */
+export const MAX_LOCAL_DRAFTS = 20;
+
+function hasStorage(): boolean {
+  return typeof window !== 'undefined' && !!window.localStorage;
+}
+
+function readStore(): LocalArticleDraft[] {
+  if (!hasStorage()) {
+    return [];
+  }
+  try {
+    const raw = localStorage.getItem(STORE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(
+      (d): d is LocalArticleDraft =>
+        !!d &&
+        typeof d === 'object' &&
+        typeof (d as LocalArticleDraft).id === 'string' &&
+        typeof (d as LocalArticleDraft).body === 'string'
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeStore(drafts: LocalArticleDraft[]): void {
+  if (!hasStorage()) {
+    return;
+  }
+  try {
+    localStorage.setItem(STORE_KEY, JSON.stringify(drafts));
+  } catch {
+    /* storage full / disabled — autosave is best-effort */
+  }
+}
+
+/** Import the pre-multi-draft single slot, then remove it. */
+function migrateLegacyDraft(): void {
+  if (!hasStorage()) {
+    return;
+  }
+  try {
+    const raw = localStorage.getItem(LEGACY_KEY);
+    if (!raw) {
+      return;
+    }
+    const d = JSON.parse(raw) as Partial<LocalArticleDraft>;
+    if (d.title || d.body) {
+      saveLocalDraft({
+        id: newDraftId(),
+        title: d.title ?? '',
+        excerpt: d.excerpt ?? '',
+        coverImage: d.coverImage ?? '',
+        body: d.body ?? '',
+        visibility: d.visibility ?? 'public',
+        updatedAt: Date.now(),
+      });
+    }
+    localStorage.removeItem(LEGACY_KEY);
+  } catch {
+    /* corrupt legacy draft — leave it untouched rather than destroy it */
+  }
+}
+
+export function newDraftId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `draft-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** All drafts, most recently touched first. Runs the legacy migration. */
+export function listLocalDrafts(): LocalArticleDraft[] {
+  migrateLegacyDraft();
+  return readStore().sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/** Upsert by id; trims the store to MAX_LOCAL_DRAFTS (oldest dropped). */
+export function saveLocalDraft(draft: LocalArticleDraft): void {
+  const rest = readStore().filter(d => d.id !== draft.id);
+  const next = [draft, ...rest].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, MAX_LOCAL_DRAFTS);
+  writeStore(next);
+}
+
+export function deleteLocalDraft(id: string): void {
+  writeStore(readStore().filter(d => d.id !== id));
+}


### PR DESCRIPTION
Rebase + completion of #495 (which predated the #496 composer rewrite; conflicts resolved keeping both feature sets), plus the remaining composer-friction fix found in live testing:

- **Multi-draft local autosave**: debounced localStorage drafts with restore banner, draft list, per-draft delete, Cmd+S flush; draft cleared on successful publish (`src/services/articles/local-drafts.ts` + tests)
- **Auto-growing body editor**: the page scrolls, not an inner box — no fixed scroll trap for long-form writing
- **Jest storage-mock consolidation** (duplicate localStorage/sessionStorage mocks → one)
- **perf(articles)**: `getArticleBySlug` ran twice per request (generateMetadata + page) with no route loading state — post-publish navigation painted blank ~4s on prod. React `cache()` dedupes the fetch; new `loading.tsx` paints an article skeleton immediately.

Supersedes #495.

Verified: `npm run verify` green (1344 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)