### PR TITLE
feat(credits): wire NEXT_PUBLIC_CAT_CREDITS_LIVE into CD build env

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,6 +54,12 @@ jobs:
       # HERE at build time; the box's runtime .env can't reach the client bundle.)
       NEXT_PUBLIC_LIGHTNING_ADDRESS: ${{ vars.NEXT_PUBLIC_LIGHTNING_ADDRESS }}
       NEXT_PUBLIC_BITCOIN_ADDRESS: ${{ vars.NEXT_PUBLIC_BITCOIN_ADDRESS }}
+      # Flips the Cat Credits UI from "Activating" to "Live" (build-time, client
+      # bundle). Set the repo variable to true only once PLATFORM_NWC_URI exists
+      # in the box's runtime .env — the UI must never claim Live before the
+      # server can actually receive. Server-side receive is gated independently
+      # on PLATFORM_NWC_URI (runtime), so this flag is display-only.
+      NEXT_PUBLIC_CAT_CREDITS_LIVE: ${{ vars.NEXT_PUBLIC_CAT_CREDITS_LIVE }}
       OC_BOX: ${{ vars.OC_BOX || 'root@167.233.22.31' }}
     steps:
       - name: Guard — is the deploy key configured?


### PR DESCRIPTION
## What
Adds `NEXT_PUBLIC_CAT_CREDITS_LIVE` to the CD build env (repo variable, same pattern as the donation-address vars). The flag existed in `src/config/features.ts` but was never passed to the production build, so the Cat Credits UI could never leave its "Activating" state.

## Context — revenue go-live
- `PLATFORM_NWC_URI` is now set in the box's runtime env (Coinos treasury wallet `orangecat@coinos.io`) → server-side receive is live.
- Repo variable `NEXT_PUBLIC_CAT_CREDITS_LIVE=true` is set → this deploy flips the UI to Live.
- Repo variable `NEXT_PUBLIC_LIGHTNING_ADDRESS=orangecat@coinos.io` is set → /support Lightning donations activate (replaces the dead `orangecat@getalby.com`).

Display-only change: server receive stays independently gated on `PLATFORM_NWC_URI` at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)