### PR TITLE
refactor(ai): key-chain ordering SSOT + composer god-file slimming

### DIFF
--- a/__tests__/unit/ai/key-chain.test.ts
+++ b/__tests__/unit/ai/key-chain.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The fallback-chain ordering rule (src/services/ai/key-chain) — previously
+ * implemented three times (manager component, settings hook, service) and
+ * able to drift. These tests pin the single shared implementation.
+ */
+import {
+  PLATFORM_CHAIN_ID,
+  applyOrderToKeys,
+  buildChain,
+  chainItemId,
+  moveChainItem,
+  platformPositionFromOrder,
+} from '@/services/ai/key-chain';
+
+const keys = [
+  { id: 'a', sort_order: 0 },
+  { id: 'b', sort_order: 2 },
+];
+
+describe('key-chain', () => {
+  it('buildChain interleaves keys and the platform default by shared index — gaps included', () => {
+    const chain = buildChain(keys, 1);
+    expect(chain.map(chainItemId)).toEqual(['a', PLATFORM_CHAIN_ID, 'b']);
+  });
+
+  it('moveChainItem returns the new persisted order', () => {
+    const chain = buildChain(keys, 1);
+    expect(moveChainItem(chain, 2, 0)).toEqual(['b', 'a', PLATFORM_CHAIN_ID]);
+  });
+
+  it('moveChainItem rejects no-ops and out-of-range moves', () => {
+    const chain = buildChain(keys, 1);
+    expect(moveChainItem(chain, 1, 1)).toBeNull();
+    expect(moveChainItem(chain, 0, 3)).toBeNull();
+    expect(moveChainItem(chain, -1, 0)).toBeNull();
+  });
+
+  it('applyOrderToKeys stamps sort_order from array index, skipping the platform slot', () => {
+    const reordered = applyOrderToKeys(keys, ['b', PLATFORM_CHAIN_ID, 'a']);
+    expect(reordered).toEqual([
+      { id: 'b', sort_order: 0 },
+      { id: 'a', sort_order: 2 },
+    ]);
+  });
+
+  it('platformPositionFromOrder finds the platform slot (or -1)', () => {
+    expect(platformPositionFromOrder(['b', PLATFORM_CHAIN_ID, 'a'])).toBe(1);
+    expect(platformPositionFromOrder(['b', 'a'])).toBe(-1);
+  });
+});

--- a/src/app/(public)/articles/new/ArticleComposer.tsx
+++ b/src/app/(public)/articles/new/ArticleComposer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, Eye, PenLine } from 'lucide-react';
@@ -21,18 +21,9 @@ import { useMarkdownTextarea } from '@/components/articles/useMarkdownTextarea';
 import AiWriterPanel from '@/components/articles/AiWriterPanel';
 import ArticleAiControls from '@/components/articles/ArticleAiControls';
 import CoverImageUpload from '@/components/articles/CoverImageUpload';
+import { useArticleLocalDraft } from '@/hooks/useArticleLocalDraft';
 import ImageSuggestPicker from '@/components/images/ImageSuggestPicker';
 import type { StockImage } from '@/services/images/types';
-
-const DRAFT_KEY = 'oc:draft:article';
-
-interface DraftShape {
-  title: string;
-  excerpt: string;
-  coverImage: string;
-  body: string;
-  visibility: TimelineVisibility;
-}
 
 /** Existing article passed when the composer is opened in edit mode. */
 export interface ArticleInitial {
@@ -62,60 +53,25 @@ export default function ArticleComposer({
   const [tab, setTab] = useState<'write' | 'preview'>('write');
   const [publishing, setPublishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [restored, setRestored] = useState(false);
   // Which target the AI image picker is open for (null = closed).
   const [imagePicker, setImagePicker] = useState<null | 'cover' | 'inline'>(null);
 
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const md = useMarkdownTextarea(bodyRef, body, setBody);
 
-  // Restore an in-progress draft once on mount (new articles only — never clobber
-  // an article being edited with a stale local draft).
-  useEffect(() => {
-    if (isEditing) {
-      return;
-    }
-    try {
-      const raw = localStorage.getItem(DRAFT_KEY);
-      if (!raw) {
-        return;
+  const localDraft = useArticleLocalDraft({
+    enabled: !isEditing,
+    draft: { title, excerpt, coverImage, body, visibility },
+    onRestore: d => {
+      setTitle(d.title ?? '');
+      setExcerpt(d.excerpt ?? '');
+      setCoverImage(d.coverImage ?? '');
+      setBody(d.body ?? '');
+      if (d.visibility) {
+        setVisibility(d.visibility);
       }
-      const d = JSON.parse(raw) as Partial<DraftShape>;
-      if (d.title || d.body) {
-        setTitle(d.title ?? '');
-        setExcerpt(d.excerpt ?? '');
-        setCoverImage(d.coverImage ?? '');
-        setBody(d.body ?? '');
-        if (d.visibility) {
-          setVisibility(d.visibility);
-        }
-        setRestored(true);
-      }
-    } catch {
-      /* ignore corrupt draft */
-    }
-  }, [isEditing]);
-
-  // Autosave (debounced) whenever content changes (new articles only).
-  useEffect(() => {
-    if (isEditing) {
-      return;
-    }
-    if (!title && !body && !excerpt && !coverImage) {
-      return;
-    }
-    const id = setTimeout(() => {
-      try {
-        localStorage.setItem(
-          DRAFT_KEY,
-          JSON.stringify({ title, excerpt, coverImage, body, visibility } satisfies DraftShape)
-        );
-      } catch {
-        /* storage full / disabled — non-fatal */
-      }
-    }, 600);
-    return () => clearTimeout(id);
-  }, [isEditing, title, excerpt, coverImage, body, visibility]);
+    },
+  });
 
   const wordCount = body.trim() ? body.trim().split(/\s+/).length : 0;
   const readingTime = wordCount ? estimateReadingTime(body) : 0;
@@ -128,7 +84,7 @@ export default function ArticleComposer({
     }
     setBody(draft.body);
     setTab('write');
-    setRestored(false);
+    localDraft.dismissRestored();
   }
 
   function handlePickImage(img: StockImage) {
@@ -191,7 +147,7 @@ export default function ArticleComposer({
       return;
     }
     try {
-      localStorage.removeItem(DRAFT_KEY);
+      localDraft.clearDraft();
     } catch {
       /* ignore */
     }
@@ -224,7 +180,7 @@ export default function ArticleComposer({
           </div>
         )}
 
-        {restored && (
+        {localDraft.restored && (
           <p className="mb-4 rounded-md border border-subtle bg-surface-raised/30 px-3 py-2 text-xs text-fg-secondary">
             Restored your saved draft.
           </p>

--- a/src/app/api/user/api-keys/route.ts
+++ b/src/app/api/user/api-keys/route.ts
@@ -12,6 +12,7 @@ import { createApiKeyService, hasActiveByok } from '@/services/ai/api-key-servic
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { z } from 'zod';
 import { WIRED_PROVIDER_IDS } from '@/data/aiProviders';
+import { PLATFORM_CHAIN_ID } from '@/services/ai/key-chain';
 import { logger } from '@/utils/logger';
 import {
   apiSuccess,
@@ -36,7 +37,7 @@ const reorderSchema = z.object({
   // Each entry is a key id (uuid) or the literal 'platform' sentinel for the
   // free OrangeCat default's position in the chain.
   order: z
-    .array(z.union([z.string().uuid(), z.literal('platform')]))
+    .array(z.union([z.string().uuid(), z.literal(PLATFORM_CHAIN_ID)]))
     .min(1)
     .max(50),
 });

--- a/src/components/ai/AIKeyManager.tsx
+++ b/src/components/ai/AIKeyManager.tsx
@@ -22,10 +22,7 @@ export type { UserApiKey } from '@/services/ai/api-key-service';
 import type { UserApiKey } from '@/services/ai/api-key-service';
 
 /** The free OrangeCat default's position in the chain (sentinel id). */
-const PLATFORM_ID = 'platform';
-
-/** A row in the merged fallback chain: a user key or the platform default. */
-type ChainItem = { kind: 'key'; key: UserApiKey } | { kind: 'platform' };
+import { buildChain, chainItemId, moveChainItem } from '@/services/ai/key-chain';
 
 interface AIKeyManagerProps {
   keys: UserApiKey[];
@@ -75,28 +72,17 @@ export function AIKeyManager({
     // via "Add another key" or navigates away via "Start chatting."
   };
 
-  // Reconstruct the merged chain from stored positions. Keys carry their
-  // sort_order; the platform default sits at platformPosition. Both share one
-  // 0-based index space, so sorting by it interleaves them correctly even
-  // after reordering leaves gaps in the key sort_orders.
-  const chain: ChainItem[] = [
-    ...keys.map(key => ({ order: key.sort_order, item: { kind: 'key', key } as ChainItem })),
-    { order: platformPosition, item: { kind: 'platform' } as ChainItem },
-  ]
-    .sort((a, b) => a.order - b.order)
-    .map(entry => entry.item);
-
-  const itemId = (it: ChainItem) => (it.kind === 'platform' ? PLATFORM_ID : it.key.id);
+  const chain = buildChain(keys, platformPosition);
 
   // Move the chain item at `from` to slot `to`, then persist the new order.
   const reorderTo = async (from: number, to: number) => {
-    if (!onReorder || from === to || to < 0 || to >= chain.length) {
+    if (!onReorder) {
       return;
     }
-    const next = [...chain];
-    const [moved] = next.splice(from, 1);
-    next.splice(to, 0, moved);
-    await onReorder(next.map(itemId));
+    const order = moveChainItem(chain, from, to);
+    if (order) {
+      await onReorder(order);
+    }
   };
 
   const canReorder = !!onReorder && chain.length > 1;
@@ -113,7 +99,7 @@ export function AIKeyManager({
             </p>
           )}
           {chain.map((it, index) => {
-            const id = itemId(it);
+            const id = chainItemId(it);
             const rowProps = canReorder
               ? {
                   draggable: !isLoading,

--- a/src/components/ai/TopUpDialog.tsx
+++ b/src/components/ai/TopUpDialog.tsx
@@ -18,7 +18,7 @@ import { logger } from '@/utils/logger';
 import { API_ROUTES } from '@/config/api-routes';
 
 /** Preset top-up amounts in BTC. */
-const PRESETS_BTC = [0.0001, 0.0005, 0.001];
+import { TOPUP_PRESETS_BTC as PRESETS_BTC } from '@/config/cat-plans';
 const POLL_MS = 3000;
 
 interface Invoice {

--- a/src/components/timeline/ComposerImageAttachment.tsx
+++ b/src/components/timeline/ComposerImageAttachment.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { ImagePlus, Loader2, X } from 'lucide-react';
+import ImageSuggestPicker from '@/components/images/ImageSuggestPicker';
+import { uploadUserImage } from '@/services/images/upload';
+import { toPostImageMeta, type PostImageMeta } from '@/types/timeline';
+import type { StockImage } from '@/services/images/types';
+import { TIMELINE_SURFACE } from '@/config/timeline';
+import { cn } from '@/lib/utils';
+
+/**
+ * Everything image-attachment for the post composer: picker toggle state,
+ * paste-upload flow, chip, preview, and picker panel. Extracted so
+ * TimelineComposer stays a layout component.
+ */
+export function useComposerImage({
+  userId,
+  setImage,
+}: {
+  userId: string | undefined;
+  setImage: (image: PostImageMeta | null) => void;
+}) {
+  const [showPicker, setShowPicker] = useState(false);
+  const [isPasting, setIsPasting] = useState(false);
+
+  const handlePick = useCallback(
+    (img: StockImage) => {
+      setImage(toPostImageMeta(img));
+      setShowPicker(false);
+    },
+    [setImage]
+  );
+
+  // Pasting a screenshot/photo into the editor attaches it directly —
+  // zero clicks, same upload path as the picker's Upload tab.
+  const handlePasteFiles = useCallback(
+    async (files: File[]) => {
+      const file = files[0];
+      if (!file || !userId || isPasting) {
+        return;
+      }
+      setIsPasting(true);
+      const result = await uploadUserImage(userId, file, 'post-image');
+      setIsPasting(false);
+      if (result.success && result.url) {
+        setImage(
+          toPostImageMeta({
+            fullUrl: result.url,
+            title: file.name.replace(/\.[^.]+$/, ''),
+            creator: null,
+            license: '',
+            sourceUrl: null,
+          })
+        );
+      }
+    },
+    [userId, setImage, isPasting]
+  );
+
+  return {
+    showPicker,
+    isPasting,
+    togglePicker: () => setShowPicker(v => !v),
+    closePicker: () => setShowPicker(false),
+    handlePick,
+    handlePasteFiles,
+  };
+}
+
+export function ComposerImageChip({
+  active,
+  disabled,
+  onToggle,
+}: {
+  active: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      className={cn(TIMELINE_SURFACE.chip, active && TIMELINE_SURFACE.chipActive, 'gap-1.5')}
+      title="Add an image — search free photos, generate, or upload"
+      aria-expanded={active}
+    >
+      <ImagePlus className="h-4 w-4" />
+      Image
+    </button>
+  );
+}
+
+export function ComposerImageAttachment({
+  image,
+  isPasting,
+  showPicker,
+  content,
+  disabled,
+  onPick,
+  onRemove,
+  onClosePicker,
+}: {
+  image: PostImageMeta | null;
+  isPasting: boolean;
+  showPicker: boolean;
+  content: string;
+  disabled: boolean;
+  onPick: (img: StockImage) => void;
+  onRemove: () => void;
+  onClosePicker: () => void;
+}) {
+  return (
+    <>
+      {isPasting && (
+        <div className="mt-3 inline-flex items-center gap-1.5 text-xs text-fg-tertiary">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Adding photo…
+        </div>
+      )}
+
+      {image && (
+        <div className="relative mt-3 inline-block max-w-full">
+          {/* eslint-disable-next-line @next/next/no-img-element -- may be an external (Openverse) host, not in next/image remotePatterns */}
+          <img
+            src={image.url}
+            alt={image.alt}
+            className="max-h-56 max-w-full rounded-lg border border-subtle object-cover"
+          />
+          <button
+            type="button"
+            onClick={onRemove}
+            disabled={disabled}
+            aria-label="Remove image"
+            className="absolute right-2 top-2 rounded-full border border-subtle bg-surface-base/90 p-1 text-fg-primary transition-colors hover:bg-surface-base"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {showPicker && !image && (
+        <div className="mt-3">
+          <ImageSuggestPicker
+            title=""
+            body={content}
+            heading="Add an image"
+            onPick={onPick}
+            onClose={onClosePicker}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/timeline/TimelineComposer.tsx
+++ b/src/components/timeline/TimelineComposer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { Globe, ImagePlus, Loader2, Lock, X } from 'lucide-react';
+import { Globe, Lock } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import { usePostComposer } from '@/hooks/usePostComposerNew';
 import { useContentEditableEditor } from '@/hooks/useContentEditableEditor';
@@ -26,10 +26,11 @@ import {
 import PostAiButton from './PostAiButton';
 import ReplyAiButton from './ReplyAiButton';
 import PostAiEditMenu from './PostAiEditMenu';
-import ImageSuggestPicker from '@/components/images/ImageSuggestPicker';
-import { uploadUserImage } from '@/services/images/upload';
-import { toPostImageMeta } from '@/types/timeline';
-import type { StockImage } from '@/services/images/types';
+import {
+  ComposerImageAttachment,
+  ComposerImageChip,
+  useComposerImage,
+} from './ComposerImageAttachment';
 
 export interface TimelineComposerProps {
   targetOwnerId?: string;
@@ -67,8 +68,6 @@ const TimelineComposer = React.memo(function TimelineComposer({
 }: TimelineComposerProps) {
   const { user, profile } = useAuth();
   const [showProjects, setShowProjects] = useState(false);
-  const [showImagePicker, setShowImagePicker] = useState(false);
-  const [pastingImage, setPastingImage] = useState(false);
   const [isOnline, setIsOnline] = useState(true);
 
   useEffect(() => {
@@ -111,37 +110,13 @@ const TimelineComposer = React.memo(function TimelineComposer({
     ? TIMELINE_COPY.composePlaceholder
     : `Write on ${targetName}...`;
 
-  // Pasting a screenshot/photo into the editor attaches it directly —
-  // zero clicks, same upload path as the picker's Upload tab.
-  const handlePasteFiles = useCallback(
-    async (files: File[]) => {
-      const file = files[0];
-      if (!file || !user?.id || pastingImage) {
-        return;
-      }
-      setPastingImage(true);
-      const result = await uploadUserImage(user.id, file, 'post-image');
-      setPastingImage(false);
-      if (result.success && result.url) {
-        postComposer.setImage(
-          toPostImageMeta({
-            fullUrl: result.url,
-            title: file.name.replace(/\.[^.]+$/, ''),
-            creator: null,
-            license: '',
-            sourceUrl: null,
-          })
-        );
-      }
-    },
-    [user?.id, postComposer, pastingImage]
-  );
+  const composerImage = useComposerImage({ userId: user?.id, setImage: postComposer.setImage });
 
   const { editorRef, handleInput, handlePaste, handleKeyDown, handleFormat } =
     useContentEditableEditor({
       content: postComposer.content,
       onContentChange: postComposer.setContent,
-      onPasteFiles: handlePasteFiles,
+      onPasteFiles: composerImage.handlePasteFiles,
       onSubmit: () => {
         if (!postComposer.isPosting && postComposer.content.trim()) {
           postComposer.handlePost();
@@ -166,14 +141,6 @@ const TimelineComposer = React.memo(function TimelineComposer({
   const handleOpenProjects = useCallback(() => {
     setShowProjects(true);
   }, []);
-
-  const handlePickImage = useCallback(
-    (img: StockImage) => {
-      postComposer.setImage(toPostImageMeta(img));
-      setShowImagePicker(false);
-    },
-    [postComposer]
-  );
 
   const isButtonDisabled = useMemo(
     () =>
@@ -235,44 +202,16 @@ const TimelineComposer = React.memo(function TimelineComposer({
             />
           )}
 
-          {pastingImage && (
-            <div className="mt-3 inline-flex items-center gap-1.5 text-xs text-fg-tertiary">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Adding photo…
-            </div>
-          )}
-
-          {postComposer.image && (
-            <div className="relative mt-3 inline-block max-w-full">
-              {/* eslint-disable-next-line @next/next/no-img-element -- may be an external (Openverse) host, not in next/image remotePatterns */}
-              <img
-                src={postComposer.image.url}
-                alt={postComposer.image.alt}
-                className="max-h-56 max-w-full rounded-lg border border-subtle object-cover"
-              />
-              <button
-                type="button"
-                onClick={() => postComposer.setImage(null)}
-                disabled={postComposer.isPosting}
-                aria-label="Remove image"
-                className="absolute right-2 top-2 rounded-full border border-subtle bg-surface-base/90 p-1 text-fg-primary transition-colors hover:bg-surface-base"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-          )}
-
-          {showImagePicker && !postComposer.image && (
-            <div className="mt-3">
-              <ImageSuggestPicker
-                title=""
-                body={postComposer.content}
-                heading="Add an image"
-                onPick={handlePickImage}
-                onClose={() => setShowImagePicker(false)}
-              />
-            </div>
-          )}
+          <ComposerImageAttachment
+            image={postComposer.image}
+            isPasting={composerImage.isPasting}
+            showPicker={composerImage.showPicker}
+            content={postComposer.content}
+            disabled={postComposer.isPosting}
+            onPick={composerImage.handlePick}
+            onRemove={() => postComposer.setImage(null)}
+            onClosePicker={composerImage.closePicker}
+          />
 
           <ComposerMessages error={postComposer.error} success={postComposer.postSuccess} />
 
@@ -296,21 +235,11 @@ const TimelineComposer = React.memo(function TimelineComposer({
                   disabled={postComposer.isPosting}
                 />
               )}
-              <button
-                type="button"
-                onClick={() => setShowImagePicker(v => !v)}
+              <ComposerImageChip
+                active={composerImage.showPicker || Boolean(postComposer.image)}
                 disabled={postComposer.isPosting}
-                className={cn(
-                  TIMELINE_SURFACE.chip,
-                  (showImagePicker || postComposer.image) && TIMELINE_SURFACE.chipActive,
-                  'gap-1.5'
-                )}
-                title="Add a free image (AI-suggested from your post)"
-                aria-expanded={showImagePicker}
-              >
-                <ImagePlus className="h-4 w-4" />
-                Image
-              </button>
+                onToggle={composerImage.togglePicker}
+              />
               {!simpleMode && <TextFormatToolbar onFormat={handleFormat} />}
 
               {!simpleMode && allowProjectSelection && postComposer.userProjects.length > 0 && (

--- a/src/config/cat-plans.ts
+++ b/src/config/cat-plans.ts
@@ -61,6 +61,16 @@ export interface CatPlan {
  * default in src/services/ai/api-key-service.ts:checkPlatformUsage so the
  * page never advertises a different number than the runtime enforces.
  */
+// ---------------------------------------------------------------------------
+// Cat Credits top-up bounds + UI presets — one place, so a preset can never
+// drift outside what the API accepts.
+// ---------------------------------------------------------------------------
+export const MIN_TOPUP_BTC = 0.00001;
+export const MAX_TOPUP_BTC = 0.01;
+export const TOPUP_PRESETS_BTC = ([0.0001, 0.0005, 0.001] as const).filter(
+  v => v >= MIN_TOPUP_BTC && v <= MAX_TOPUP_BTC
+);
+
 export const CAT_FREE_DAILY_LIMIT = 10;
 
 /**

--- a/src/hooks/useAISettings.ts
+++ b/src/hooks/useAISettings.ts
@@ -5,6 +5,7 @@ import { supabase } from '@/lib/supabase/browser';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import type { ModelTier } from '@/config/ai-models';
 import { hasActiveByok, type UserApiKey } from '@/services/ai/api-key-service';
+import { applyOrderToKeys, platformPositionFromOrder } from '@/services/ai/key-chain';
 import { API_ROUTES } from '@/config/api-routes';
 import { useAISettingsMutations } from './useAISettingsMutations';
 
@@ -131,26 +132,14 @@ export function useAISettings() {
   const reorderKeys = useCallback(
     async (orderedIds: string[]) => {
       setState(prev => {
-        // Optimistically stamp each item's new chain index (shared by keys via
-        // sort_order and the platform default via platform_chain_position) so
+        // Optimistic: stamp new chain indexes via the shared ordering rule so
         // the merged-chain UI reflects the move before the server round-trip.
-        const byId = new Map(prev.keys.map(k => [k.id, k]));
-        const reordered: UserApiKey[] = [];
-        orderedIds.forEach((id, idx) => {
-          if (id === 'platform') {
-            return;
-          }
-          const k = byId.get(id);
-          if (k) {
-            reordered.push({ ...k, sort_order: idx });
-          }
-        });
-        const platformIdx = orderedIds.indexOf('platform');
+        const platformIdx = platformPositionFromOrder(orderedIds);
         const preferences =
           prev.preferences && platformIdx >= 0
             ? { ...prev.preferences, platform_chain_position: platformIdx }
             : prev.preferences;
-        return { ...prev, keys: reordered, preferences };
+        return { ...prev, keys: applyOrderToKeys(prev.keys, orderedIds), preferences };
       });
       const res = await fetch(API_ROUTES.USER.API_KEYS, {
         method: 'PATCH',

--- a/src/hooks/useArticleLocalDraft.ts
+++ b/src/hooks/useArticleLocalDraft.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import type { TimelineVisibility } from '@/types/timeline';
+
+const DRAFT_KEY = 'oc:draft:article';
+const AUTOSAVE_DEBOUNCE_MS = 600;
+
+export interface ArticleLocalDraft {
+  title: string;
+  excerpt: string;
+  coverImage: string;
+  body: string;
+  visibility: TimelineVisibility;
+}
+
+/**
+ * Local (browser) draft persistence for the article composer: restores an
+ * in-progress draft once on mount and autosaves (debounced) on every change.
+ * Disabled while editing an existing article — a stale local draft must never
+ * clobber server content.
+ */
+export function useArticleLocalDraft({
+  enabled,
+  draft,
+  onRestore,
+}: {
+  enabled: boolean;
+  draft: ArticleLocalDraft;
+  onRestore: (draft: Partial<ArticleLocalDraft>) => void;
+}) {
+  const [restored, setRestored] = useState(false);
+
+  // Restore once on mount.
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY);
+      if (!raw) {
+        return;
+      }
+      const saved = JSON.parse(raw) as Partial<ArticleLocalDraft>;
+      if (saved.title || saved.body) {
+        onRestore(saved);
+        setRestored(true);
+      }
+    } catch {
+      /* ignore corrupt draft */
+    }
+    // Mount-only by design — onRestore is a plain state applier.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+
+  // Autosave (debounced) whenever content changes.
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const { title, excerpt, coverImage, body } = draft;
+    if (!title && !body && !excerpt && !coverImage) {
+      return;
+    }
+    const id = setTimeout(() => {
+      try {
+        localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+      } catch {
+        /* storage full / disabled — non-fatal */
+      }
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(id);
+    // Value-level deps: a fresh `draft` object every render must not reset
+    // the debounce unless a field actually changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, draft.title, draft.excerpt, draft.coverImage, draft.body, draft.visibility]);
+
+  return {
+    restored,
+    dismissRestored: () => setRestored(false),
+    clearDraft: () => {
+      try {
+        localStorage.removeItem(DRAFT_KEY);
+      } catch {
+        /* non-fatal */
+      }
+    },
+  };
+}

--- a/src/services/ai/api-key-service.ts
+++ b/src/services/ai/api-key-service.ts
@@ -18,6 +18,7 @@ import { DATABASE_TABLES } from '@/config/database-tables';
 import { logger } from '@/utils/logger';
 import { PROVIDER_BASE_URLS } from '@/config/ai-provider-runtime';
 import { WIRED_PROVIDER_IDS } from '@/data/aiProviders';
+import { PLATFORM_CHAIN_ID } from '@/services/ai/key-chain';
 
 // ==================== TYPES ====================
 
@@ -315,7 +316,7 @@ export class ApiKeyService {
   async reorderKeys(userId: string, orderedIds: string[]): Promise<boolean> {
     for (let i = 0; i < orderedIds.length; i++) {
       const id = orderedIds[i];
-      if (id === 'platform') {
+      if (id === PLATFORM_CHAIN_ID) {
         // The free OrangeCat default — store its position in prefs.
         const { error } = await this.supabase
           .from(DATABASE_TABLES.USER_AI_PREFERENCES)

--- a/src/services/ai/key-chain.ts
+++ b/src/services/ai/key-chain.ts
@@ -1,0 +1,85 @@
+/**
+ * The fallback-chain ordering rule, defined once.
+ *
+ * A user's chain interleaves their API keys (each carrying `sort_order`) with
+ * the free platform default (carrying `platform_chain_position` in prefs) in
+ * ONE 0-based index space. A persisted order is an array of ids — key ids
+ * plus the 'platform' sentinel — where array index = chain position.
+ *
+ * Previously this rule lived in three places (the manager component, the
+ * settings hook's optimistic update, and the service's persistence loop) and
+ * could drift; every consumer now goes through these helpers.
+ */
+
+/** Sentinel id for the free OrangeCat default's slot in the chain. */
+export const PLATFORM_CHAIN_ID = 'platform';
+
+export interface ChainKey {
+  id: string;
+  sort_order: number;
+}
+
+export type ChainItem<K extends ChainKey = ChainKey> =
+  | { kind: 'key'; key: K }
+  | { kind: 'platform' };
+
+/**
+ * Reconstruct the merged chain from stored positions. Sorting by the shared
+ * index interleaves keys and the platform default correctly even after
+ * reordering leaves gaps in the key sort_orders.
+ */
+export function buildChain<K extends ChainKey>(
+  keys: K[],
+  platformPosition: number
+): ChainItem<K>[] {
+  return [
+    ...keys.map(key => ({ order: key.sort_order, item: { kind: 'key', key } as ChainItem<K> })),
+    { order: platformPosition, item: { kind: 'platform' } as ChainItem<K> },
+  ]
+    .sort((a, b) => a.order - b.order)
+    .map(entry => entry.item);
+}
+
+export function chainItemId(item: ChainItem): string {
+  return item.kind === 'platform' ? PLATFORM_CHAIN_ID : item.key.id;
+}
+
+/**
+ * Move the item at `from` to slot `to` and return the resulting persisted
+ * order (ids, first = tried earliest) — or null when the move is a no-op or
+ * out of range.
+ */
+export function moveChainItem<K extends ChainKey>(
+  chain: ChainItem<K>[],
+  from: number,
+  to: number
+): string[] | null {
+  if (from === to || from < 0 || to < 0 || from >= chain.length || to >= chain.length) {
+    return null;
+  }
+  const next = [...chain];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next.map(chainItemId);
+}
+
+/** Stamp each key's new sort_order from its index in a persisted order. */
+export function applyOrderToKeys<K extends ChainKey>(keys: K[], orderedIds: string[]): K[] {
+  const byId = new Map(keys.map(k => [k.id, k]));
+  const reordered: K[] = [];
+  orderedIds.forEach((id, idx) => {
+    if (id === PLATFORM_CHAIN_ID) {
+      return;
+    }
+    const key = byId.get(id);
+    if (key) {
+      reordered.push({ ...key, sort_order: idx });
+    }
+  });
+  return reordered;
+}
+
+/** The platform default's position in a persisted order (absent → unchanged marker -1). */
+export function platformPositionFromOrder(orderedIds: string[]): number {
+  return orderedIds.indexOf(PLATFORM_CHAIN_ID);
+}

--- a/src/services/cat/credit-topup.ts
+++ b/src/services/cat/credit-topup.ts
@@ -22,8 +22,8 @@ import { appendCreditEntry, getCreditBalance } from '@/services/cat/credits';
 import { logger } from '@/utils/logger';
 
 /** Top-up bounds in BTC (1-sat precision). 0.00001 BTC = 1k sats … 0.01 BTC = 1M sats. */
-export const MIN_TOPUP_BTC = 0.00001;
-export const MAX_TOPUP_BTC = 0.01;
+export { MIN_TOPUP_BTC, MAX_TOPUP_BTC } from '@/config/cat-plans';
+import { MIN_TOPUP_BTC, MAX_TOPUP_BTC } from '@/config/cat-plans';
 /** Invoice validity. */
 const INVOICE_EXPIRY_SECONDS = 3600;
 const SATS_PER_BTC = 100_000_000;


### PR DESCRIPTION
Closes the three items deferred from #522's audit.

## Chain-reorder triplication → one SSOT

The fallback-chain ordering rule (keys via `sort_order` + the platform default via `platform_chain_position`, sharing one 0-based index space) was implemented **three times** — `AIKeyManager`'s chain reconstruction + drag splice, `useAISettings`' optimistic re-stamp, and `ApiKeyService.reorderKeys`' persistence loop — and could silently drift. It now lives once in `src/services/ai/key-chain.ts` (`buildChain` / `moveChainItem` / `applyOrderToKeys` / `platformPositionFromOrder` + the `PLATFORM_CHAIN_ID` sentinel). All three consumers and the route's zod schema derive from it, and **unit tests pin the rule** (interleaving with sort-order gaps, no-op/out-of-range moves, index stamping).

## Top-up presets clamped

`TopUpDialog`'s hardcoded presets moved to `cat-plans.ts` next to `MIN/MAX_TOPUP_BTC` (which also moved there — config owns bounds, the service re-exports for its callers) and are filtered against those bounds **by construction** — a preset can no longer drift outside what the API accepts.

## God-file slimming (cohesive extractions only)

- `TimelineComposer` 402 → **331** lines: the whole image-attachment concern (picker toggle state, paste-upload flow, chip, preview, panel) → `ComposerImageAttachment.tsx` (`useComposerImage` + two small components).
- `ArticleComposer` 396 → **353** lines: localStorage draft restore/autosave → `useArticleLocalDraft` hook.
- Both remain above the 300 guideline; the remaining weight is their genuine page/form responsibility — further splitting would be indirection for its own sake, so stopping here deliberately.

## Verification

tsc 0 errors · eslint clean on changed files · audit:routes clean · **1415/1415 tests** (5 new key-chain tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)