### PR TITLE
fix(features): static NEXT_PUBLIC_* reads so flags reach the client bundle

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -5,18 +5,24 @@
  * checks across components.
  */
 
-function envFlag(name: string): boolean {
-  return process.env[name] === 'true';
+/**
+ * Next.js only inlines NEXT_PUBLIC_* vars into the client bundle when they are
+ * read as static literals (`process.env.NEXT_PUBLIC_X`). Dynamic access like
+ * `process.env[name]` compiles to `undefined` in the browser, silently forcing
+ * every flag off client-side regardless of the build env. Keep each read static.
+ */
+function envFlag(value: string | undefined): boolean {
+  return value === 'true';
 }
 
 export const FEATURES = {
   /** Voice input on create forms and onboarding (requires browser speech APIs). */
-  voiceInput: envFlag('NEXT_PUBLIC_FEATURE_VOICE_INPUT'),
+  voiceInput: envFlag(process.env.NEXT_PUBLIC_FEATURE_VOICE_INPUT),
   /**
    * Cat Credits Lightning top-up is live. Set alongside the server-side
    * PLATFORM_NWC_URI (the receiving wallet) once one live top-up is verified —
    * this flag only flips the UI from "Activating" to a live top-up CTA; the
    * server still independently refuses top-up when PLATFORM_NWC_URI is unset.
    */
-  catCreditsLive: envFlag('NEXT_PUBLIC_CAT_CREDITS_LIVE'),
+  catCreditsLive: envFlag(process.env.NEXT_PUBLIC_CAT_CREDITS_LIVE),
 } as const;


### PR DESCRIPTION
## Bug
`envFlag(name)` read `process.env[name]` **dynamically**. Next.js can only inline `NEXT_PUBLIC_*` env vars into the client bundle when accessed as static literals (`process.env.NEXT_PUBLIC_X`) — dynamic access compiles to `undefined` in the browser. Result: every flag routed through `envFlag` (including `NEXT_PUBLIC_CAT_CREDITS_LIVE` and `NEXT_PUBLIC_FEATURE_VOICE_INPUT`) was permanently **off** client-side, regardless of build env. Observed live: #525 deployed with the repo variable set to `true`, yet /pricing still rendered "Activating".

## Fix
Read each var as a static literal and pass the value into `envFlag`. Comment documents the constraint so the class of bug doesn't recur.

## Verification
- `npm run type-check` clean
- 35 tests green (`cat-plans|features|credit`)
- After deploy: /pricing credits card must show **Live**

🤖 Generated with [Claude Code](https://claude.com/claude-code)