### PR TITLE
fix(ci): bake NEXT_PUBLIC_CAT_CREDITS_LIVE into the CI standalone build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
           SELF_HOST: '1'
           NEXT_PUBLIC_LIGHTNING_ADDRESS: ${{ vars.NEXT_PUBLIC_LIGHTNING_ADDRESS }}
           NEXT_PUBLIC_BITCOIN_ADDRESS: ${{ vars.NEXT_PUBLIC_BITCOIN_ADDRESS }}
+          # Cat Credits go-live flag. This build step is the one that bakes the
+          # client bundle CD ships (artifact download, no rebuild) — a client
+          # var set only in cd.yml never reaches production.
+          NEXT_PUBLIC_CAT_CREDITS_LIVE: ${{ vars.NEXT_PUBLIC_CAT_CREDITS_LIVE }}
         run: npm run build
 
       - name: Assemble standalone (static + public)


### PR DESCRIPTION
## Bug
#525 added the flag to **cd.yml**, but CD deploys the **CI-built** standalone artifact and skips its own build — so the flag never reached the shipped client bundle. Live symptom: /pricing credits card still badged "Activating" after #525 + #527 deployed.

## Fix
Add `NEXT_PUBLIC_CAT_CREDITS_LIVE` to CI's build-step env, right next to `NEXT_PUBLIC_LIGHTNING_ADDRESS` / `NEXT_PUBLIC_BITCOIN_ADDRESS` which already follow this pattern (and which did reach prod — that's how /support got the working address). Comment documents why cd.yml-only client vars are a trap.

## Verify after deploy
/pricing Cat Credits card shows badge **Live** + CTA **Top up credits**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)