### PR TITLE
fix(cat): survive free-model rot — registry refresh, any-failure fallback, drift probe

### DIFF
--- a/__tests__/unit/cat/model-display-name.test.ts
+++ b/__tests__/unit/cat/model-display-name.test.ts
@@ -9,21 +9,21 @@ import { getModelDisplayName, AI_MODEL_REGISTRY } from '@/config/ai-models';
 
 describe('getModelDisplayName', () => {
   it('returns the registry name for an exact id', () => {
-    expect(getModelDisplayName('openai/gpt-oss-120b:free')).toBe(
-      AI_MODEL_REGISTRY['openai/gpt-oss-120b:free'].name
+    expect(getModelDisplayName('nvidia/nemotron-3-super-120b-a12b:free')).toBe(
+      AI_MODEL_REGISTRY['nvidia/nemotron-3-super-120b-a12b:free'].name
     );
   });
 
   it('resolves dated snapshot ids to the registered model name', () => {
     // Providers can append snapshot suffixes to current free-model ids too.
-    expect(getModelDisplayName('meta-llama/llama-4-scout-20260402:free')).toBe(
-      AI_MODEL_REGISTRY['meta-llama/llama-4-scout:free'].name
+    expect(getModelDisplayName('google/gemma-4-31b-it-20260402:free')).toBe(
+      AI_MODEL_REGISTRY['google/gemma-4-31b-it:free'].name
     );
   });
 
   it('matches only at segment boundaries (20b must not swallow 120b)', () => {
-    expect(getModelDisplayName('openai/gpt-oss-120b-0525:free')).toBe(
-      AI_MODEL_REGISTRY['openai/gpt-oss-120b:free'].name
+    expect(getModelDisplayName('openai/gpt-oss-120b-0525')).toBe(
+      AI_MODEL_REGISTRY['openai/gpt-oss-120b'].name
     );
     expect(getModelDisplayName('openai/gpt-oss-20b-0525:free')).toBe(
       AI_MODEL_REGISTRY['openai/gpt-oss-20b:free'].name
@@ -32,8 +32,8 @@ describe('getModelDisplayName', () => {
 
   it('resolves a shorter reported id to the registered variant', () => {
     // Server may strip a suffix relative to the registry key.
-    expect(getModelDisplayName('meta-llama/llama-3.3-70b-instruct')).toBe(
-      AI_MODEL_REGISTRY['meta-llama/llama-3.3-70b-instruct:free'].name
+    expect(getModelDisplayName('nvidia/nemotron-3-super-120b-a12b')).toBe(
+      AI_MODEL_REGISTRY['nvidia/nemotron-3-super-120b-a12b:free'].name
     );
   });
 

--- a/__tests__/unit/cat/provider-ssot.test.ts
+++ b/__tests__/unit/cat/provider-ssot.test.ts
@@ -7,6 +7,7 @@
  * routing chain).
  */
 
+import { AI_MODEL_REGISTRY, DEFAULT_MODEL_ID, DEFAULT_FREE_MODEL_ID } from '@/config/ai-models';
 import { WIRED_PROVIDER_IDS, aiProviders, wiredProviders } from '@/data/aiProviders';
 import {
   IMAGE_PROVIDER_RUNTIME,
@@ -37,6 +38,17 @@ describe('provider SSOT invariants', () => {
   it('PROVIDER_RUNTIME entries use base URLs from the URL SSOT', () => {
     for (const [id, runtime] of Object.entries(PROVIDER_RUNTIME)) {
       expect(runtime.baseUrl).toBe(PROVIDER_BASE_URLS[id as keyof typeof PROVIDER_BASE_URLS]);
+    }
+  });
+
+  it('model defaults point at registered, available free models', () => {
+    // A default pointing at a removed registry entry breaks every non-BYOK
+    // consumer (chat fallback, platform-llm, offer-engine, form prefill).
+    for (const id of [DEFAULT_MODEL_ID, DEFAULT_FREE_MODEL_ID]) {
+      const model = AI_MODEL_REGISTRY[id];
+      expect(model).toBeDefined();
+      expect(model.isFree).toBe(true);
+      expect(model.isAvailable).toBe(true);
     }
   });
 });

--- a/__tests__/unit/services/ai/openrouter.test.ts
+++ b/__tests__/unit/services/ai/openrouter.test.ts
@@ -11,7 +11,7 @@ import { calculateCostBtc } from '@/config/ai-models';
 global.TextDecoder = NodeTextDecoder;
 
 const PAID_MODEL = 'deepseek/deepseek-v4-flash';
-const FREE_MODEL = 'openai/gpt-oss-120b:free';
+const FREE_MODEL = 'openai/gpt-oss-20b:free';
 const BTC_PRICE_USD = 100_000;
 
 function mockJsonResponse(body: unknown): Response {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -160,11 +160,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* FleetCrown feedback widget — OrangeCat is customer #2 of the sibling
             product's embeddable feedback loop (visitor points at the broken
             element → FleetCrown per-project inbox → one-click agent dispatch).
-            Env-gated like GA; data-fc-bottom clears the mobile bottom nav. */}
+            Env-gated like GA; data-fc-bottom clears the mobile bottom nav.
+            afterInteractive, not lazyOnload: busy pages (Cat chat streams and
+            polls) can keep the browser from going idle, so lazyOnload left the
+            FAB unmounted for minutes — a feedback button that isn't there when
+            something breaks is the one time it's needed. */}
         {process.env.FLEETCROWN_FEEDBACK_TOKEN && (
           <Script
             src="https://fleetcrown.orangecat.ch/widget.js"
-            strategy="lazyOnload"
+            strategy="afterInteractive"
             data-fc-project={process.env.FLEETCROWN_FEEDBACK_TOKEN}
             data-fc-bottom="80"
           />

--- a/src/config/ai-models.ts
+++ b/src/config/ai-models.ts
@@ -61,20 +61,24 @@ export interface AIModelMetadata {
 export const AI_MODEL_REGISTRY: Record<string, AIModelMetadata> = {
   // ==================== FREE TIER ====================
   // No API cost - rate limited (50/day on free accounts, 1000/day with $10+ credits)
-  // Refreshed 2026-07-08 against live OpenRouter model pages/docs.
+  // Refreshed 2026-08-02 against the live OpenRouter catalog (/api/v1/models).
+  // ⚠️ Free model ids ROT — OpenRouter retires them without notice and requests
+  // 404. Every entry here is checked by the free-model catalog health probe
+  // (services/cat/health-probes.ts); if the probe reports one missing, replace
+  // it here and nowhere else — every consumer derives from this registry.
 
-  'openai/gpt-oss-120b:free': {
-    id: 'openai/gpt-oss-120b:free',
-    name: 'GPT-OSS 120B (Free)',
-    provider: 'OpenAI',
-    description: 'Best free general model for coding, reasoning, and tool-friendly chat',
-    contextWindow: 131072,
+  'nvidia/nemotron-3-super-120b-a12b:free': {
+    id: 'nvidia/nemotron-3-super-120b-a12b:free',
+    name: 'Nemotron 3 Super 120B (Free)',
+    provider: 'NVIDIA',
+    description: 'Best free general model for reasoning, coding, and everyday chat',
+    contextWindow: 262144,
     maxOutputTokens: 8192,
     inputCostPer1M: 0,
     outputCostPer1M: 0,
-    capabilities: ['text', 'function_calling', 'json_mode', 'streaming'],
+    capabilities: ['text', 'streaming'],
     tier: 'free',
-    recommendedFor: ['coding', 'complex reasoning', 'general chat'],
+    recommendedFor: ['complex reasoning', 'coding', 'general chat'],
     isAvailable: true,
     isFree: true,
     rateLimit: '50-1000/day',
@@ -97,35 +101,35 @@ export const AI_MODEL_REGISTRY: Record<string, AIModelMetadata> = {
     rateLimit: '50-1000/day',
   },
 
-  'meta-llama/llama-3.3-70b-instruct:free': {
-    id: 'meta-llama/llama-3.3-70b-instruct:free',
-    name: 'Llama 3.3 70B (Free)',
-    provider: 'Meta',
-    description: 'Strong multilingual free model for analysis and everyday coding',
-    contextWindow: 65536,
+  'nvidia/nemotron-nano-9b-v2:free': {
+    id: 'nvidia/nemotron-nano-9b-v2:free',
+    name: 'Nemotron Nano 9B (Free)',
+    provider: 'NVIDIA',
+    description: 'Fast free model for quick answers and high-volume simple tasks',
+    contextWindow: 128000,
     maxOutputTokens: 8192,
     inputCostPer1M: 0,
     outputCostPer1M: 0,
     capabilities: ['text', 'streaming'],
     tier: 'free',
-    recommendedFor: ['general purpose', 'multilingual chat', 'analysis'],
+    recommendedFor: ['fast responses', 'simple tasks', 'high volume'],
     isAvailable: true,
     isFree: true,
     rateLimit: '50-1000/day',
   },
 
-  'meta-llama/llama-4-scout:free': {
-    id: 'meta-llama/llama-4-scout:free',
-    name: 'Llama 4 Scout (Free)',
-    provider: 'Meta',
+  'google/gemma-4-31b-it:free': {
+    id: 'google/gemma-4-31b-it:free',
+    name: 'Gemma 4 31B (Free)',
+    provider: 'Google',
     description: 'Free multimodal long-context model for image-aware and document-heavy prompts',
-    contextWindow: 10000000,
+    contextWindow: 262144,
     maxOutputTokens: 8192,
     inputCostPer1M: 0,
     outputCostPer1M: 0,
     capabilities: ['text', 'vision', 'streaming'],
     tier: 'free',
-    recommendedFor: ['vision tasks', 'huge context', 'multimodal chat'],
+    recommendedFor: ['vision tasks', 'long context', 'multimodal chat'],
     isAvailable: true,
     isFree: true,
     rateLimit: '50-1000/day',
@@ -393,10 +397,10 @@ export function calculateCostBtc(
 // ==================== CONSTANTS ====================
 
 /** Default model for Auto mode fallback (free model) */
-export const DEFAULT_MODEL_ID = 'meta-llama/llama-3.3-70b-instruct:free';
+export const DEFAULT_MODEL_ID = 'nvidia/nemotron-3-super-120b-a12b:free';
 
 /** Default free model for platform usage */
-export const DEFAULT_FREE_MODEL_ID = 'openai/gpt-oss-120b:free';
+export const DEFAULT_FREE_MODEL_ID = 'nvidia/nemotron-3-super-120b-a12b:free';
 
 /** Default BTC price for cost calculations (updated periodically) */
 export const DEFAULT_BTC_PRICE_USD = 100000;

--- a/src/lib/ai/form-prefill-service.ts
+++ b/src/lib/ai/form-prefill-service.ts
@@ -7,6 +7,7 @@
 
 import type { AIPrefillResponse } from '@/components/create/types';
 import { PROVIDER_BASE_URLS } from '@/config/ai-provider-runtime';
+import { DEFAULT_FREE_MODEL_ID } from '@/config/ai-models';
 import {
   AI_ASSIST_MIN_INPUT_LENGTH,
   USER_OVERRIDABLE_FIELDS,
@@ -20,7 +21,7 @@ import type { AiAssistTarget } from './assist-target';
 
 // Default models for form prefill (fast, good at JSON generation)
 const DEFAULT_GROQ_MODEL = 'llama-3.3-70b-versatile';
-const DEFAULT_OPENROUTER_MODEL = 'meta-llama/llama-4-maverick:free';
+const DEFAULT_OPENROUTER_MODEL = DEFAULT_FREE_MODEL_ID;
 
 /**
  * Configuration for the form prefill service

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -289,9 +289,13 @@ export async function orchestrateCatChat(
     const readable = new ReadableStream({
       async start(controller) {
         // Lifted outside the try block so the catch at the bottom can
-        // tell whether the failover attempt was reached. Block-scoped
+        // tell whether the failover attempt was reached (and which
+        // provider/model was active when the chain died). Block-scoped
         // `let` inside the try is invisible to the outer catch.
         let attemptedFallback = false;
+        let activeProvider = provider;
+        let activeModel = modelToUse;
+        let activeService = aiService;
         try {
           let usage:
             | {
@@ -332,14 +336,9 @@ export async function orchestrateCatChat(
             }
           );
 
-          // Track the *active* provider/model/service so we can swap to
-          // fallback (typically OpenRouter free) if primary rate-limits
-          // before emitting any content. After any content has streamed
-          // it's too late to swap cleanly without corrupting the response,
-          // so we only failover when nothing has been sent to the user yet.
-          let activeProvider = provider;
-          let activeModel = modelToUse;
-          let activeService = aiService;
+          // After any content has streamed it's too late to swap providers
+          // cleanly without corrupting the response, so we only failover
+          // when nothing has been sent to the user yet.
           let streamStarted = false;
 
           const emitDone = async () => {
@@ -393,9 +392,12 @@ export async function orchestrateCatChat(
             }
           };
 
-          // Walk the fallback chain on rate-limit. Each provider gets one
-          // attempt. We can only swap providers BEFORE any content streams
-          // — otherwise the client sees half a response and then a switch.
+          // Walk the fallback chain on ANY pre-stream failure — rate-limit,
+          // retired model id (404), upstream 5xx. A single dead link must
+          // never end the chat while a later link could serve it. Each
+          // provider gets one attempt. We can only swap providers BEFORE any
+          // content streams — otherwise the client sees half a response and
+          // then a switch.
           let lastErr: unknown = null;
           try {
             await consumeStream();
@@ -403,25 +405,27 @@ export async function orchestrateCatChat(
             lastErr = err;
           }
           let fallbackIndex = 0;
-          while (
-            lastErr &&
-            isAiRateLimitError(lastErr) &&
-            !streamStarted &&
-            fallbackIndex < fallbacks.length
-          ) {
+          while (lastErr && !streamStarted && fallbackIndex < fallbacks.length) {
             attemptedFallback = true;
+            const reason = isAiRateLimitError(lastErr) ? 'rate_limit' : 'provider_error';
             const next = fallbacks[fallbackIndex++];
+            logger.warn(
+              'Cat chat: provider failed, trying next fallback',
+              {
+                from: { provider: activeProvider, model: activeModel },
+                to: { provider: next.provider, model: next.modelToUse },
+                reason,
+                err: lastErr,
+                attempt: fallbackIndex,
+              },
+              'cat/chat'
+            );
             activeProvider = next.provider;
             activeModel = next.modelToUse;
             activeService = next.aiService;
-            logger.info(
-              'Cat chat: rate-limited, trying next fallback',
-              { from: provider, to: activeProvider, model: activeModel, attempt: fallbackIndex },
-              'cat/chat'
-            );
             controller.enqueue(
               encoder.encode(
-                `data: ${JSON.stringify({ fallback: { from: provider, to: activeProvider, model: activeModel, reason: 'rate_limit' } })}\n\n`
+                `data: ${JSON.stringify({ fallback: { from: provider, to: activeProvider, model: activeModel, reason } })}\n\n`
               )
             );
             controller.enqueue(
@@ -491,27 +495,33 @@ export async function orchestrateCatChat(
             await keyService.incrementPlatformUsage(user.id, 1, usage.totalTokens);
           }
         } catch (err) {
-          logger.error('Cat chat stream error', { err, attemptedFallback, hasByok }, 'cat/chat');
+          logger.error(
+            'Cat chat stream error',
+            { err, attemptedFallback, hasByok, provider: activeProvider, model: activeModel },
+            'cat/chat'
+          );
           // Honest error copy. Never echo raw err.message — it can contain
           // API keys (e.g. a malformed Authorization header leaks the
           // credential in the Headers.append error). Log server-side;
-          // return a structured, actionable error to the client.
+          // return a structured, actionable error to the client. Only claim
+          // what we actually know — "providers are down" when the real cause
+          // was a config bug erodes trust and sends users chasing outages.
           let errPayload: { error: string; code: string };
           if (isAiRateLimitError(err)) {
             errPayload = {
               error: hasByok
                 ? 'Your provider returned a rate-limit. Try again in a moment.'
-                : 'Cat is temporarily busy. Add your own Groq key in Settings to skip the cap.',
+                : 'Free AI capacity is maxed out right now. Try again in a minute — or add your own free Groq key in Settings → API Keys for capacity that’s all yours.',
               code: 'AI_RATE_LIMITED',
             };
           } else if (attemptedFallback) {
-            // Both primary AND failover threw. This is the "all providers
-            // down" path — common when the platform OpenRouter key is
-            // revoked or both quotas are exhausted at the same time.
+            // The whole chain threw — quota exhaustion, retired model ids,
+            // or a revoked platform key. From the user's side the action is
+            // the same; the details are in the server log either way.
             errPayload = {
               error: hasByok
-                ? 'Both providers are unreachable right now. Check your keys in Settings → API Keys.'
-                : 'Both Cat providers are temporarily down. Add your own free Groq key in Settings → API Keys to keep chatting.',
+                ? 'None of your providers could answer just now. Check your keys in Settings → API Keys, then try again.'
+                : 'Cat couldn’t reach an AI model just now — this is usually momentary. Try again; if it keeps happening, add your own free Groq key in Settings → API Keys.',
               code: 'ALL_PROVIDERS_DOWN',
             };
           } else {
@@ -562,9 +572,10 @@ export async function orchestrateCatChat(
       collectedPrefillProposals.push(proposal);
     }
   );
-  // Try primary; on rate-limit, walk the fallback chain. Non-streaming
-  // is even safer than streaming because each attempt is atomic — no
-  // partial-content corruption risk to worry about.
+  // Try primary; on ANY failure (rate-limit, retired model id, upstream
+  // 5xx), walk the fallback chain. Non-streaming is even safer than
+  // streaming because each attempt is atomic — no partial-content
+  // corruption risk to worry about.
   let activeProvider = provider;
   let result;
   let fellBackTo: FallbackProvider | null = null;
@@ -579,11 +590,18 @@ export async function orchestrateCatChat(
     lastErr = err;
   }
   let fallbackIndex = 0;
-  while (!result && lastErr && isAiRateLimitError(lastErr) && fallbackIndex < fallbacks.length) {
+  while (!result && lastErr && fallbackIndex < fallbacks.length) {
     const next = fallbacks[fallbackIndex++];
-    logger.info(
-      'Cat chat (non-streaming): rate-limited, trying next fallback',
-      { from: provider, to: next.provider, model: next.modelToUse, attempt: fallbackIndex },
+    logger.warn(
+      'Cat chat (non-streaming): provider failed, trying next fallback',
+      {
+        from: provider,
+        to: next.provider,
+        model: next.modelToUse,
+        reason: isAiRateLimitError(lastErr) ? 'rate_limit' : 'provider_error',
+        err: lastErr,
+        attempt: fallbackIndex,
+      },
       'cat/chat'
     );
     try {

--- a/src/services/cat/health-probes.ts
+++ b/src/services/cat/health-probes.ts
@@ -12,6 +12,7 @@
  */
 
 import { PROVIDER_BASE_URLS } from '@/config/ai-provider-runtime';
+import { DEFAULT_FREE_MODEL_ID, getFreeModels } from '@/config/ai-models';
 
 export type ProbeClass =
   | 'ok'
@@ -35,6 +36,11 @@ export interface ProbeResult {
 
 export interface CatHealthReport {
   probes: { groq: ProbeResult; openrouter: ProbeResult };
+  /**
+   * Registry free-model ids missing from the live OpenRouter catalog
+   * (model rot). Empty = no drift; null = catalog check unavailable.
+   */
+  missingFreeModels: string[] | null;
   catCanAnswer: boolean;
   summary: string;
 }
@@ -127,25 +133,67 @@ export function probeGroq(): Promise<ProbeResult> {
 }
 
 export function probeOpenRouter(): Promise<ProbeResult> {
+  // Probe with the registry's platform default — a hardcoded id here once
+  // drifted from the registry and kept "passing" while chat 404'd (and later
+  // kept "failing" after the registry was fixed).
   return probeProvider(
     'openrouter',
     'OPENROUTER_API_KEY',
     `${PROVIDER_BASE_URLS.openrouter}/chat/completions`,
-    'meta-llama/llama-3.3-70b-instruct:free'
+    DEFAULT_FREE_MODEL_ID
   );
+}
+
+/**
+ * Registry-vs-catalog drift check. OpenRouter retires free models without
+ * notice; a registry entry pointing at a retired id makes chat 404 mid-chain.
+ * This has bitten prod three times (gpt-oss-120b:free, llama-4-maverick:free,
+ * then llama-3.3-70b-instruct:free + llama-4-scout:free on 2026-08-02) —
+ * hence a standing probe instead of a fourth manual fix. Uses the public
+ * /models endpoint (no key needed). Returns the registry free-model ids that
+ * no longer exist upstream; empty array = no drift; null = catalog fetch
+ * failed (unknown, not necessarily broken).
+ */
+export async function probeFreeModelCatalog(): Promise<string[] | null> {
+  try {
+    const res = await fetch(`${PROVIDER_BASE_URLS.openrouter}/models`);
+    if (!res.ok) {
+      return null;
+    }
+    const body = (await res.json()) as { data?: Array<{ id?: string }> };
+    const live = new Set((body.data ?? []).map(m => m.id));
+    if (live.size === 0) {
+      return null;
+    }
+    return getFreeModels()
+      .map(m => m.id)
+      .filter(id => !live.has(id));
+  } catch {
+    return null;
+  }
 }
 
 /** Probe both providers and summarize. */
 export async function runCatHealthProbes(): Promise<CatHealthReport> {
-  const [groq, openrouter] = await Promise.all([probeGroq(), probeOpenRouter()]);
+  const [groq, openrouter, missingFreeModels] = await Promise.all([
+    probeGroq(),
+    probeOpenRouter(),
+    probeFreeModelCatalog(),
+  ]);
+  const drift =
+    missingFreeModels && missingFreeModels.length > 0
+      ? ` ⚠️ Registry free models no longer on OpenRouter: ${missingFreeModels.join(', ')} — update src/config/ai-models.ts.`
+      : '';
   return {
     probes: { groq, openrouter },
+    missingFreeModels,
     catCanAnswer: groq.class === 'ok' || openrouter.class === 'ok',
     summary:
-      groq.class === 'ok'
+      (groq.class === 'ok'
         ? `Cat is healthy: ${groq.provider} probe returned OK.`
         : openrouter.class === 'ok'
           ? `Primary (${groq.provider}) is degraded (${groq.class}); fallback (${openrouter.provider}) is healthy.`
-          : `Both providers are degraded: groq=${groq.class}, openrouter=${openrouter.class}.`,
+          : `Both providers are degraded: groq=${groq.class}, openrouter=${openrouter.class}.`) +
+      drift,
   };
 }

--- a/src/services/cat/offer-engine.ts
+++ b/src/services/cat/offer-engine.ts
@@ -21,10 +21,13 @@ import { buildFullContextString } from '@/services/ai/context-string-builder';
 import { listMemories } from './memory';
 import { getDemandSignals } from './demand-signals';
 import { logger } from '@/utils/logger';
+import { DEFAULT_FREE_MODEL_ID } from '@/config/ai-models';
 
 // Capable, JSON-reliable defaults (mirrors form-prefill-service's provider choice).
 const GROQ_MODEL = 'llama-3.3-70b-versatile';
-const OPENROUTER_MODEL = 'meta-llama/llama-4-maverick:free';
+// Free OpenRouter ids rot (404 without notice) — always take the registry
+// default, which the free-model catalog probe keeps honest.
+const OPENROUTER_MODEL = DEFAULT_FREE_MODEL_ID;
 const MAX_OFFERS = 5;
 
 export interface ProposedOffer {

--- a/src/services/cat/platform-llm.ts
+++ b/src/services/cat/platform-llm.ts
@@ -10,14 +10,16 @@
 
 import { logger } from '@/utils/logger';
 import { PROVIDER_BASE_URLS } from '@/config/ai-provider-runtime';
+import { DEFAULT_FREE_MODEL_ID } from '@/config/ai-models';
 
 // Capable, JSON-reliable defaults. Groq is fast + cheap for short work; the
-// OpenRouter free Maverick handles long-form with a large output budget. We use
-// the SAME OpenRouter model the offer-engine proves works on the box — free
-// model IDs rot (a bare gpt-oss-120b:free returned 404 in prod), so we pin the
-// one that's verified live rather than trusting DEFAULT_FREE_MODEL_ID.
+// registry's free OpenRouter default is the fallback. Free model ids rot —
+// the pinned llama-4-maverick:free this file once carried 404'd too. The
+// registry is now the one place ids live, guarded by the free-model catalog
+// probe (health-probes.ts), so drift is detected there instead of re-pinned
+// here.
 const GROQ_MODEL = 'llama-3.3-70b-versatile';
-const OPENROUTER_MODEL = 'meta-llama/llama-4-maverick:free';
+const OPENROUTER_MODEL = DEFAULT_FREE_MODEL_ID;
 
 export interface PlatformJsonOpts {
   temperature?: number;


### PR DESCRIPTION
## Problem

Cat chat has been failing for every free-tier user with "Both Cat providers are temporarily down":
- OpenRouter retired `openai/gpt-oss-120b:free`, `meta-llama/llama-3.3-70b-instruct:free`, and `meta-llama/llama-4-scout:free` → every request to the primary 404'd (`OpenRouterAPIError statusCode:404` in prod logs since early 2026-08-02)
- The fallback chain only engaged on **rate-limit** errors, so a 404 ended the chat even when a later provider could have served it
- The Groq fallback was itself 429ing (shared 12k TPM key), so both paths died

## Fix

- **Registry refresh** against the live OpenRouter catalog (`/api/v1/models`): `nvidia/nemotron-3-super-120b-a12b:free` (new default), `nvidia/nemotron-nano-9b-v2:free`, `google/gemma-4-31b-it:free` — all three verified present upstream today
- **Fallback on ANY pre-stream failure** (404 / 5xx / rate-limit) in both streaming and non-streaming orchestrator paths, with reason-tagged warn logs
- **SSOT**: platform-llm, offer-engine, form-prefill and the OpenRouter probe all derive from `DEFAULT_FREE_MODEL_ID` — no more per-file pinned ids to rot independently
- **Standing drift probe** `probeFreeModelCatalog()`: reports registry ids missing from the live catalog in the health report (this class of outage has hit prod three times — never-twice rule)
- **Honest error copy**: distinguishes rate-limit from provider failure; no more claiming an outage when the cause is a retired model id

## Verification

- `npm run verify` green: type-check, docs, route audit, lint (0 errors), 1440 unit tests
- All new model ids checked against the live OpenRouter catalog before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)