### PR TITLE
fix(routing): redirect guessable /cat /chat /ai aliases to /dashboard/cat

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -140,6 +140,24 @@ const nextConfig = {
         destination: '/dashboard/cat',
         permanent: true,
       },
+      // Guessable aliases for the flagship Cat surface. "The Cat is the
+      // interface" — someone typing orangecat.ch/cat must land on the Cat,
+      // never on a 404. Same alias policy as the /login → /auth block above.
+      {
+        source: '/cat',
+        destination: '/dashboard/cat',
+        permanent: true,
+      },
+      {
+        source: '/chat',
+        destination: '/dashboard/cat',
+        permanent: true,
+      },
+      {
+        source: '/ai',
+        destination: '/dashboard/cat',
+        permanent: true,
+      },
     ];
   },
 


### PR DESCRIPTION
## Problem
https://orangecat.ch/cat returns a 404 — the single most natural URL guess for the flagship Cat feature (reported by George, who hit it live).

## Fix
Extend the existing alias-redirect block in `next.config.js` (same policy that already maps `/login` → `/auth` and `/ai-chat/*` → `/dashboard/cat`):

- `/cat` → `/dashboard/cat` (permanent)
- `/chat` → `/dashboard/cat` (permanent)
- `/ai` → `/dashboard/cat` (permanent)

All three paths verified free (no route file, no collision in `src/app`). Config-only; no client code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)