### PR TITLE
refactor(settings): unified settings shell — one nav SSOT, zero per-page headers

### DIFF
--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -16,7 +16,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Bot, Check, Server, Terminal, AlertCircle } from 'lucide-react';
+import { Bot, Check, Server, Terminal, AlertCircle } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
 import { CAT_FRONTIER_MODELS_OR } from '@/config/cat-plans';
 import { useRequireAuth } from '@/hooks/useAuth';
@@ -54,19 +54,8 @@ export default function AISettingsPage() {
   const localProviders = getProvidersByCategory('local');
 
   return (
-    <div className="min-h-screen bg-surface-page">
-      <div className="border-b border-default bg-surface-base">
-        <div className="mx-auto flex h-16 max-w-4xl items-center gap-4 px-4 sm:px-6 lg:px-8">
-          <Link href={ROUTES.SETTINGS} className="text-fg-secondary hover:text-fg-primary">
-            <ArrowLeft className="h-5 w-5" />
-          </Link>
-          <Bot className="h-6 w-6 text-fg-secondary" />
-          <h1 className="text-xl font-semibold text-fg-primary">Cat AI</h1>
-        </div>
-      </div>
-
-      <div className="mx-auto max-w-4xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-        <p className="text-fg-primary">
+    <div className="space-y-6">
+      <p className="text-fg-primary">
           Cat works any of three ways. Pick whichever fits — they&apos;re all first-class. OrangeCat
           earns from platform activity, not from your AI bill.
         </p>
@@ -206,7 +195,6 @@ export default function AISettingsPage() {
             them anytime from the chat panel.
           </p>
         </div>
-      </div>
     </div>
   );
 }

--- a/src/app/(authenticated)/settings/integrations/page.tsx
+++ b/src/app/(authenticated)/settings/integrations/page.tsx
@@ -17,7 +17,7 @@
  */
 
 import Link from 'next/link';
-import { ArrowLeft, KeyRound, LogIn, Webhook } from 'lucide-react';
+import { KeyRound, LogIn, Webhook } from 'lucide-react';
 import { useRequireAuth } from '@/hooks/useAuth';
 import { useMessagingActors } from '@/features/messaging/hooks/useMessagingActors';
 import { ROUTES } from '@/config/routes';
@@ -68,17 +68,9 @@ export default function IntegrationsPage() {
   const defaultActorId = personalActor?.actor_id ?? actors[0]?.actor_id ?? null;
 
   return (
-    <div className="mx-auto max-w-3xl space-y-10 p-4 sm:p-6 lg:p-8">
+    <div className="space-y-10">
       <div>
-        <Link
-          href={ROUTES.SETTINGS}
-          className="inline-flex items-center gap-1.5 text-sm text-fg-secondary hover:text-fg-primary"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Settings
-        </Link>
-        <h1 className="mt-3 text-2xl font-semibold text-fg-primary">Integrations</h1>
-        <p className="mt-1 text-sm text-fg-secondary">
+        <p className="text-sm text-fg-secondary">
           Let external services authenticate to OrangeCat and receive signed events.
         </p>
         <p className="mt-2 text-xs text-fg-secondary">

--- a/src/app/(authenticated)/settings/layout.tsx
+++ b/src/app/(authenticated)/settings/layout.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from 'next';
+import SettingsShell from '@/components/settings/SettingsShell';
 
 export const metadata: Metadata = {
   title: { default: 'Settings', template: '%s | OrangeCat' },
 };
 
+/**
+ * Every /settings/* page renders inside the shared SettingsShell (header +
+ * section tabs from the settings-nav SSOT). Pages contribute content only —
+ * no per-page headers, back arrows, or hand-rolled nav.
+ */
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return <SettingsShell>{children}</SettingsShell>;
 }

--- a/src/app/(authenticated)/settings/notifications/page.tsx
+++ b/src/app/(authenticated)/settings/notifications/page.tsx
@@ -20,7 +20,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Bell, Check, Loader2, LogIn } from 'lucide-react';
+import { Bell, Check, Loader2, LogIn } from 'lucide-react';
 import { useRequireAuth } from '@/hooks/useAuth';
 import { API_ROUTES } from '@/config/api-routes';
 import { ROUTES } from '@/config/routes';
@@ -189,23 +189,10 @@ export default function NotificationSettingsPage() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 p-4 sm:p-6 lg:p-8">
-      <div>
-        <Link
-          href={ROUTES.SETTINGS}
-          className="inline-flex items-center gap-1.5 text-sm text-fg-secondary hover:text-fg-primary"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Settings
-        </Link>
-        <h1 className="mt-3 flex items-center gap-2 text-2xl font-semibold text-fg-primary">
-          <Bell className="h-5 w-5" />
-          Notifications
-        </h1>
-        <p className="mt-1 text-sm text-fg-secondary">
-          Transactional emails (auth, security) are always sent. Everything else is in your hands.
-        </p>
-      </div>
+    <div className="space-y-6">
+      <p className="text-sm text-fg-secondary">
+        Transactional emails (auth, security) are always sent. Everything else is in your hands.
+      </p>
 
       {error && (
         <div className="rounded-md border border-status-negative/30 bg-status-negative/5 px-3 py-2 text-sm text-status-negative">

--- a/src/app/(authenticated)/settings/page.tsx
+++ b/src/app/(authenticated)/settings/page.tsx
@@ -1,11 +1,8 @@
 'use client';
 
-import Link from 'next/link';
 import { useRequireAuth } from '@/hooks/useAuth';
 import Loading from '@/components/Loading';
-import { Bell, BrainCircuit, ChevronRight, KeyRound, Lock } from 'lucide-react';
-import EntityListShell from '@/components/entity/EntityListShell';
-import { ROUTES } from '@/config/routes';
+import { Lock } from 'lucide-react';
 import { useSettingsForm } from './useSettingsForm';
 import { SettingsEmailSection } from './SettingsEmailSection';
 import { SettingsPasswordSection } from './SettingsPasswordSection';
@@ -13,32 +10,6 @@ import { SettingsSecuritySection } from './SettingsSecuritySection';
 import { SettingsDangerSection } from './SettingsDangerSection';
 import { SettingsDataSection } from './SettingsDataSection';
 import { SettingsModals } from './SettingsModals';
-
-const SETTINGS_SUB_PAGES: Array<{
-  href: string;
-  icon: typeof Bell;
-  label: string;
-  description: string;
-}> = [
-  {
-    href: ROUTES.SETTINGS_NOTIFICATIONS,
-    icon: Bell,
-    label: 'Notifications',
-    description: 'Pick which emails you receive and how often you get the digest.',
-  },
-  {
-    href: ROUTES.SETTINGS_AI,
-    icon: BrainCircuit,
-    label: 'AI assistants',
-    description: 'Bring-your-own-key models, defaults, and routing.',
-  },
-  {
-    href: ROUTES.SETTINGS_INTEGRATIONS,
-    icon: KeyRound,
-    label: 'Integrations',
-    description: 'Integration keys + webhook endpoints for external services.',
-  },
-];
 
 export default function SettingsPage() {
   const { user, isLoading } = useRequireAuth();
@@ -74,11 +45,7 @@ export default function SettingsPage() {
 
   return (
     <>
-      <EntityListShell
-        title="Account Settings"
-        description="Manage your email, password, and security"
-      >
-        <div className="bg-surface-base rounded-lg border border-subtle overflow-hidden">
+      <div className="bg-surface-base rounded-lg border border-subtle overflow-hidden">
           <div className="flex items-center gap-4 border-b border-subtle px-4 py-5 sm:px-8 sm:py-6">
             <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-surface-raised text-fg-secondary">
               <Lock className="h-5 w-5" />
@@ -119,37 +86,7 @@ export default function SettingsPage() {
 
             <SettingsDangerSection isDeleting={isDeleting} onDelete={handleDeleteAccount} />
           </div>
-        </div>
-
-        <div className="mt-6 rounded-lg border border-subtle bg-surface-base">
-          <div className="border-b border-subtle px-4 py-3">
-            <h2 className="text-sm font-medium text-fg-primary">More settings</h2>
-            <p className="mt-0.5 text-xs text-fg-secondary">
-              Configuration that lives outside the account-and-security card above.
-            </p>
-          </div>
-          <ul className="divide-y divide-border-subtle">
-            {SETTINGS_SUB_PAGES.map(page => {
-              const Icon = page.icon;
-              return (
-                <li key={page.href}>
-                  <Link
-                    href={page.href}
-                    className="flex items-center gap-3 p-4 hover:bg-surface-raised/30"
-                  >
-                    <Icon className="h-5 w-5 text-fg-secondary" />
-                    <div className="min-w-0 flex-1">
-                      <div className="text-sm font-medium text-fg-primary">{page.label}</div>
-                      <p className="mt-0.5 text-xs text-fg-secondary">{page.description}</p>
-                    </div>
-                    <ChevronRight className="h-4 w-4 text-fg-secondary" />
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      </EntityListShell>
+      </div>
 
       <SettingsModals
         showMFASetup={showMFASetup}

--- a/src/components/settings/SettingsShell.tsx
+++ b/src/components/settings/SettingsShell.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+import EntityListShell from '@/components/entity/EntityListShell';
+import { SETTINGS_SECTIONS, isSettingsSectionActive } from '@/config/settings-nav';
+
+/**
+ * SettingsShell — the one header + tab rail every /settings/* page renders
+ * inside (mounted by the settings layout, so pages can't drift back to
+ * hand-rolled headers). Sections come from the SETTINGS_SECTIONS SSOT.
+ *
+ * Tabs are a horizontal, scrollable rail: identical on mobile and desktop,
+ * 44px touch targets, active tab underlined with the warm accent.
+ */
+export default function SettingsShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname() ?? '';
+  const active = SETTINGS_SECTIONS.find(s => isSettingsSectionActive(s.href, pathname));
+
+  return (
+    <EntityListShell title="Settings" description={active?.description}>
+      <nav aria-label="Settings sections" className="border-b border-subtle">
+        <ul className="-mb-px flex gap-1 overflow-x-auto">
+          {SETTINGS_SECTIONS.map(section => {
+            const Icon = section.icon;
+            const isActive = section === active;
+            return (
+              <li key={section.href} className="shrink-0">
+                <Link
+                  href={section.href}
+                  aria-current={isActive ? 'page' : undefined}
+                  className={cn(
+                    'flex min-h-11 items-center gap-2 border-b-2 px-3 py-2.5 text-sm font-medium transition-colors',
+                    isActive
+                      ? 'border-accent-warm text-fg-primary'
+                      : 'border-transparent text-fg-secondary hover:border-default hover:text-fg-primary'
+                  )}
+                >
+                  <Icon className="h-4 w-4" aria-hidden />
+                  {section.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+      <div className="pt-6">{children}</div>
+    </EntityListShell>
+  );
+}

--- a/src/config/settings-nav.ts
+++ b/src/config/settings-nav.ts
@@ -1,0 +1,56 @@
+import { Bell, BrainCircuit, KeyRound, UserRound, type LucideIcon } from 'lucide-react';
+import { ROUTES } from '@/config/routes';
+
+/**
+ * SSOT for the settings information architecture.
+ *
+ * Every surface under /settings/* is declared here once; the shared
+ * SettingsShell renders the nav from this list, so adding a settings page is
+ * one entry + one route file — never a hand-edited link list on some other
+ * page (that pattern left /settings/ai reachable only via a footnote card).
+ */
+export interface SettingsSection {
+  href: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+export const SETTINGS_SECTIONS: SettingsSection[] = [
+  {
+    href: ROUTES.SETTINGS,
+    label: 'Account',
+    description: 'Email, password, security, and your data.',
+    icon: UserRound,
+  },
+  {
+    href: ROUTES.SETTINGS_NOTIFICATIONS,
+    label: 'Notifications',
+    description: 'Pick which emails you receive and how often you get the digest.',
+    icon: Bell,
+  },
+  {
+    href: ROUTES.SETTINGS_AI,
+    label: 'AI',
+    description: 'How Cat runs: managed, credits, your own keys, or local.',
+    icon: BrainCircuit,
+  },
+  {
+    href: ROUTES.SETTINGS_INTEGRATIONS,
+    label: 'Integrations',
+    description: 'Integration keys + webhook endpoints for external services.',
+    icon: KeyRound,
+  },
+];
+
+/**
+ * Active-tab test: exact match for the root section, prefix match for
+ * sub-sections so nested flows (e.g. /settings/ai/onboarding) highlight
+ * their parent tab.
+ */
+export function isSettingsSectionActive(sectionHref: string, pathname: string): boolean {
+  if (sectionHref === ROUTES.SETTINGS) {
+    return pathname === ROUTES.SETTINGS;
+  }
+  return pathname === sectionHref || pathname.startsWith(`${sectionHref}/`);
+}


### PR DESCRIPTION
## Problem (reported by George)
- Settings navigation was one buried 'More settings' link list at the bottom of the account page — no way to move between sections.
- Every settings page invented its own header: /settings/ai had a floating back-arrow + robot-icon bar (the misaligned one), integrations and notifications each had different '← Settings' treatments, /settings used EntityListShell. Four pages, four patterns, zero SSOT.

## Fix
- **`src/config/settings-nav.ts`** — SSOT for the settings IA: sections (Account / Notifications / AI / Integrations) + the active-tab rule. Adding a settings page = one entry here + the route file.
- **`SettingsShell`** — shared header (EntityListShell) + horizontal tab rail, mounted by the settings **layout**, so every /settings/* page gets the same chrome structurally and can't drift.
- All four pages stripped to content only (−111 lines of duplicated chrome): ad-hoc headers, back arrows, per-page containers, and the 'More settings' card deleted.

## Verify
tsc clean · eslint clean · audit:routes clean · 1439 unit tests green · CI E2E matrix gates the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)