### PR TITLE
fix(feedback): bake widget token into the CI/CD build for prerendered pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,10 @@ jobs:
       # server can actually receive. Server-side receive is gated independently
       # on PLATFORM_NWC_URI (runtime), so this flag is display-only.
       NEXT_PUBLIC_CAT_CREDITS_LIVE: ${{ vars.NEXT_PUBLIC_CAT_CREDITS_LIVE }}
+      # FleetCrown feedback widget token — must match ci.yml's build env so a
+      # cd-side rebuild bakes the same embed into prerendered pages. Public by
+      # design (ships in page source): repo variable, not a secret.
+      FLEETCROWN_FEEDBACK_TOKEN: ${{ vars.FLEETCROWN_FEEDBACK_TOKEN }}
       OC_BOX: ${{ vars.OC_BOX || 'root@167.233.22.31' }}
     steps:
       - name: Guard — is the deploy key configured?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
           # client bundle CD ships (artifact download, no rebuild) — a client
           # var set only in cd.yml never reaches production.
           NEXT_PUBLIC_CAT_CREDITS_LIVE: ${{ vars.NEXT_PUBLIC_CAT_CREDITS_LIVE }}
+          # FleetCrown feedback widget token. Statically prerendered routes
+          # (e.g. /dashboard/*) evaluate the root layout's env gate at BUILD
+          # time — without this the widget bakes out of every static page and
+          # only runtime-rendered routes get it. Public by design (it ships in
+          # page source), hence a repo variable, not a secret.
+          FLEETCROWN_FEEDBACK_TOKEN: ${{ vars.FLEETCROWN_FEEDBACK_TOKEN }}
         run: npm run build
 
       - name: Assemble standalone (static + public)


### PR DESCRIPTION
## Problem

The FleetCrown feedback widget was missing on every statically prerendered route — which is all of `/dashboard/*`, the pages signed-in users actually live on. The root layout gates the embed on `process.env.FLEETCROWN_FEEDBACK_TOKEN`; static pages evaluate that at **build** time, and the CI build env didn't have it. Runtime-rendered routes (e.g. `/`) got the widget from the box `.env`, which made the gap invisible in spot checks.

Confirmed live: authed fetch of `/dashboard/cat` HTML → 0 widget references (GA is missing there too, for the same reason — left as-is, whether GA belongs on authed pages is a separate call).

## Fix

Same class + same pattern as #529 (`NEXT_PUBLIC_CAT_CREDITS_LIVE`): inject `${{ vars.FLEETCROWN_FEEDBACK_TOKEN }}` into the build env in `ci.yml` (the standalone artifact CD ships) and `cd.yml` (parity for cd-side rebuilds). Repo variable is set — the token is public by design (it ships in page source on every embedding site).

## Verification plan

After merge + deploy: authed fetch of `/dashboard/cat` must contain the `widget.js` embed; FAB must mount within seconds (afterInteractive, from #530).

🤖 Generated with [Claude Code](https://claude.com/claude-code)