### PR TITLE
fix(payments): settle through the admin client — RLS silently voided recipient confirmation

### DIFF
--- a/__tests__/unit/domain/payments/buyerConfirmPayment.test.ts
+++ b/__tests__/unit/domain/payments/buyerConfirmPayment.test.ts
@@ -1,5 +1,6 @@
 /**
- * buyerConfirmPayment — state-transition correctness + trust-boundary guard.
+ * buyerConfirmPayment / sellerConfirmPayment — state-transition correctness +
+ * trust-boundary guard.
  *
  * A buyer acknowledging an unverifiable payment flips only the intent to
  * BUYER_CONFIRMED. It must not mark money or an order paid: the recipient
@@ -12,13 +13,17 @@
  * on-chain). Only a bare Lightning address with no LUD-21 verify URL may be
  * self-attested — the buyer's word must never flip an order to paid over a
  * trustworthy on-rail signal.
+ *
+ * And they pin the RLS lesson: ALL status transitions write through the admin
+ * client. RLS grants UPDATE on payment_intents to buyers only, so a
+ * seller-scoped client updates zero rows with no error — the recipient's
+ * confirmation silently changed nothing while the API reported paid.
  */
 
-import {
-  buyerConfirmPayment,
-  sellerConfirmPayment,
-} from '@/domain/payments/paymentFlowService';
+import { buyerConfirmPayment, sellerConfirmPayment } from '@/domain/payments/paymentFlowService';
+import { getAdminClient } from '@/lib/supabase/admin';
 import { STATUS } from '@/config/database-constants';
+import { NotificationDispatcher } from '@/services/notifications/dispatcher';
 
 jest.mock('@/utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
@@ -30,36 +35,57 @@ jest.mock('@/lib/email/send-seller-notification', () => ({
 jest.mock('@/services/notifications/dispatcher', () => ({
   NotificationDispatcher: { dispatch: jest.fn().mockResolvedValue(undefined) },
 }));
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
+jest.mock('@/services/webhooks/paymentSettledWebhook', () => ({
+  enqueuePaymentSettledWebhook: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/services/fleetcrown/entitlement-notify', () => ({
+  notifyFleetCrownEntitlement: jest.fn().mockResolvedValue(undefined),
+  notifyFleetCrownProjectFunding: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/services/supporter/grant', () => ({
+  grantSupporterPlan: jest.fn().mockResolvedValue(undefined),
+}));
+
+const getAdminClientMock = getAdminClient as jest.Mock;
+const dispatchMock = NotificationDispatcher.dispatch as jest.Mock;
 
 const PI_ID = 'pi-1';
 const BUYER = 'buyer-1';
 
 /**
- * Supabase stub for buyerConfirmPayment's two operations, in call order:
- *  1. from(PAYMENT_INTENTS).select().eq().eq().single()  -> the intent row
- *  2. from(PAYMENT_INTENTS).update().eq()                -> status flip (awaited)
+ * Caller-scoped client: READS only (the intent lookup). Its update builder is
+ * instrumented so tests can assert the caller client is never used to write.
  */
-function makeSupabase(opts: {
-  intent: Record<string, unknown> | null;
-  statusUpdateError?: unknown;
-}) {
-  // The status flip is now a claim: it returns the row when this caller won it.
-  const awaitQueue: Array<{ data?: unknown; error: unknown }> = [
-    opts.statusUpdateError
-      ? { data: null, error: opts.statusUpdateError }
-      : { data: [{ id: PI_ID }], error: null },
-  ];
-
+function makeCallerSupabase(intent: Record<string, unknown> | null) {
   const builder: Record<string, unknown> = {};
   for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
     builder[m] = jest.fn(() => builder);
   }
-  builder.single = jest.fn(() => Promise.resolve({ data: opts.intent, error: null }));
-  builder.maybeSingle = jest.fn(() => Promise.resolve({ data: opts.intent, error: null }));
+  builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
+  builder.maybeSingle = jest.fn(() => Promise.resolve({ data: intent, error: null }));
+  // An awaited caller-client write behaves like RLS silently filtering the row:
+  // zero rows, no error. If production code ever writes through this client
+  // again, the assertions on the admin client below will catch it.
   builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
-    Promise.resolve(awaitQueue.shift() ?? { error: null }).then(resolve, reject);
+    Promise.resolve({ data: [], error: null }).then(resolve, reject);
+  return { supabase: { from: jest.fn(() => builder) } as never, builder };
+}
 
-  return { from: jest.fn(() => builder) } as never;
+/** Admin client: serves all status-transition writes, in call order. */
+function makeAdmin(awaitQueue: Array<{ data?: unknown; error: unknown }>) {
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(awaitQueue.shift() ?? { data: [{ id: PI_ID }], error: null }).then(
+      resolve,
+      reject
+    );
+  const rpc = jest.fn(() => Promise.resolve({ error: null }));
+  const admin = { from: jest.fn(() => builder), rpc };
+  return { admin, builder };
 }
 
 const fixedPriceIntent = {
@@ -73,38 +99,45 @@ const fixedPriceIntent = {
   lnurl_verify_url: null,
 };
 
+beforeEach(() => {
+  jest.clearAllMocks();
+  getAdminClientMock.mockReturnValue(makeAdmin([]).admin);
+});
+
 describe('buyerConfirmPayment', () => {
   it('throws when the payment intent is not found', async () => {
-    const supabase = makeSupabase({ intent: null });
+    const { supabase } = makeCallerSupabase(null);
     await expect(buyerConfirmPayment(supabase, PI_ID, BUYER)).rejects.toThrow('Payment not found');
   });
 
   it('is idempotent when already paid', async () => {
-    const supabase = makeSupabase({
-      intent: { ...fixedPriceIntent, status: STATUS.PAYMENT_INTENTS.PAID, paid_at: 'ts' },
+    const { supabase } = makeCallerSupabase({
+      ...fixedPriceIntent,
+      status: STATUS.PAYMENT_INTENTS.PAID,
+      paid_at: 'ts',
     });
     const res = await buyerConfirmPayment(supabase, PI_ID, BUYER);
     expect(res.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
   });
 
   it('confirms and returns BUYER_CONFIRMED on success', async () => {
-    const supabase = makeSupabase({ intent: fixedPriceIntent });
+    const { supabase } = makeCallerSupabase(fixedPriceIntent);
     const res = await buyerConfirmPayment(supabase, PI_ID, BUYER);
     expect(res.status).toBe(STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
   });
 
   it('surfaces a failed intent status update instead of reporting success', async () => {
-    const supabase = makeSupabase({
-      intent: fixedPriceIntent,
-      statusUpdateError: { message: 'db down' },
-    });
+    const { supabase } = makeCallerSupabase(fixedPriceIntent);
+    getAdminClientMock.mockReturnValue(
+      makeAdmin([{ data: null, error: { message: 'db down' } }]).admin
+    );
     await expect(buyerConfirmPayment(supabase, PI_ID, BUYER)).rejects.toThrow(
       'Failed to update payment status'
     );
   });
 
   it('does not finalize an order before the recipient confirms receipt', async () => {
-    const supabase = makeSupabase({ intent: fixedPriceIntent });
+    const { supabase } = makeCallerSupabase(fixedPriceIntent);
     const res = await buyerConfirmPayment(supabase, PI_ID, BUYER);
     expect(res).toEqual({
       status: STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
@@ -121,7 +154,7 @@ describe('buyerConfirmPayment', () => {
     ],
   ])('refuses manual confirmation for an auto-detected rail: %s', async (_label, rail) => {
     // Detectable rail → the guard throws before any state change (no write reached).
-    const supabase = makeSupabase({ intent: { ...fixedPriceIntent, ...rail } });
+    const { supabase } = makeCallerSupabase({ ...fixedPriceIntent, ...rail });
     await expect(buyerConfirmPayment(supabase, PI_ID, BUYER)).rejects.toThrow(
       'This payment is confirmed automatically'
     );
@@ -142,20 +175,43 @@ describe('sellerConfirmPayment', () => {
   };
 
   it('marks an acknowledged bare-Lightning payment paid after recipient verification', async () => {
-    const supabase = makeSupabase({ intent: publicSupportIntent });
+    const { supabase } = makeCallerSupabase(publicSupportIntent);
     const res = await sellerConfirmPayment(supabase, PI_ID, 'seller-1');
     expect(res.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
   });
 
   it('refuses recipient confirmation unless the payment awaits it', async () => {
-    const supabase = makeSupabase({
-      intent: {
-        ...publicSupportIntent,
-        status: STATUS.PAYMENT_INTENTS.INVOICE_READY,
-      },
+    const { supabase } = makeCallerSupabase({
+      ...publicSupportIntent,
+      status: STATUS.PAYMENT_INTENTS.INVOICE_READY,
     });
     await expect(sellerConfirmPayment(supabase, PI_ID, 'seller-1')).rejects.toThrow(
       'Payment is not awaiting recipient confirmation'
+    );
+  });
+
+  it('settles through the ADMIN client — never the seller-scoped caller client', async () => {
+    // Regression (found live 2026-08-02): RLS grants UPDATE on payment_intents
+    // to buyers only. Writing the paid transition through the seller's client
+    // updated zero rows with no error, was misread as "another observer already
+    // settled it", skipped every side-effect — and still answered "paid". The
+    // recipient-confirmation flow had never actually worked in production.
+    const { supabase, builder: callerBuilder } = makeCallerSupabase(publicSupportIntent);
+    const { admin, builder: adminBuilder } = makeAdmin([]);
+    getAdminClientMock.mockReturnValue(admin);
+
+    const res = await sellerConfirmPayment(supabase, PI_ID, 'seller-1');
+
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
+    // The transition itself must run on the admin client…
+    expect(adminBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: STATUS.PAYMENT_INTENTS.PAID })
+    );
+    // …and the caller's RLS-scoped client must never be asked to write.
+    expect(callerBuilder.update).not.toHaveBeenCalled();
+    // Side-effects actually ran: the recipient got their notification.
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'seller-1', type: 'payment' })
     );
   });
 });

--- a/__tests__/unit/domain/payments/checkPaymentStatus.test.ts
+++ b/__tests__/unit/domain/payments/checkPaymentStatus.test.ts
@@ -10,6 +10,8 @@
 
 import { checkPaymentStatus } from '@/domain/payments/paymentFlowService';
 import { STATUS } from '@/config/database-constants';
+import { getAdminClient } from '@/lib/supabase/admin';
+const getAdminClientMock = getAdminClient as jest.Mock;
 
 jest.mock('@/utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
@@ -20,6 +22,7 @@ jest.mock('@/lib/email/send-seller-notification', () => ({
 jest.mock('@/services/notifications/dispatcher', () => ({
   NotificationDispatcher: { dispatch: jest.fn().mockResolvedValue(undefined) },
 }));
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
 
 const PI_ID = 'pi-1';
 const BUYER = 'buyer-1';
@@ -38,7 +41,9 @@ function makeSupabase(intent: Record<string, unknown> | null) {
   // Awaited update chains resolve cleanly.
   builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
     Promise.resolve({ error: null }).then(resolve, reject);
-  return { client: { from: jest.fn(() => builder) } as never, update };
+  const client = { from: jest.fn(() => builder) } as never;
+  getAdminClientMock.mockReturnValue(client);
+  return { client, update };
 }
 
 const baseIntent = {

--- a/__tests__/unit/domain/payments/exactlyOncePaid.test.ts
+++ b/__tests__/unit/domain/payments/exactlyOncePaid.test.ts
@@ -17,6 +17,8 @@ import { checkPaymentStatus } from '@/domain/payments/paymentFlowService';
 import { STATUS } from '@/config/database-constants';
 import { checkOnchainPaymentStatus } from '@/domain/payments/paymentStatusService';
 import { NotificationDispatcher } from '@/services/notifications/dispatcher';
+import { getAdminClient } from '@/lib/supabase/admin';
+const getAdminClientMock = getAdminClient as jest.Mock;
 
 jest.mock('@/utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
@@ -31,6 +33,7 @@ jest.mock('@/domain/payments/paymentStatusService', () => ({
   checkNWCPaymentStatus: jest.fn(),
   checkOnchainPaymentStatus: jest.fn(),
 }));
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
 
 const onchainMock = checkOnchainPaymentStatus as jest.Mock;
 const dispatchMock = NotificationDispatcher.dispatch as jest.Mock;
@@ -68,7 +71,9 @@ function makeSupabase(claimWon: boolean) {
   builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
   builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
     Promise.resolve({ data: claimWon ? [{ id: PI_ID }] : [], error: null }).then(resolve, reject);
-  return { from: jest.fn(() => builder), rpc } as never;
+  const client = { from: jest.fn(() => builder), rpc } as never;
+  getAdminClientMock.mockReturnValue(client);
+  return client;
 }
 
 beforeEach(() => {
@@ -115,6 +120,7 @@ describe('exactly-once settlement', () => {
       );
     };
     const supabase = { from: jest.fn(() => builder), rpc } as never;
+    getAdminClientMock.mockReturnValue(supabase);
 
     await Promise.all([
       checkPaymentStatus(supabase, PI_ID, SELLER),

--- a/__tests__/unit/domain/payments/handlePaymentConfirmed.test.ts
+++ b/__tests__/unit/domain/payments/handlePaymentConfirmed.test.ts
@@ -26,7 +26,21 @@ jest.mock('@/domain/payments/paymentStatusService', () => ({
   checkNWCPaymentStatus: jest.fn(),
   checkOnchainPaymentStatus: jest.fn(),
 }));
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
+jest.mock('@/services/webhooks/paymentSettledWebhook', () => ({
+  enqueuePaymentSettledWebhook: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/services/fleetcrown/entitlement-notify', () => ({
+  notifyFleetCrownEntitlement: jest.fn().mockResolvedValue(undefined),
+  notifyFleetCrownProjectFunding: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/services/supporter/grant', () => ({
+  grantSupporterPlan: jest.fn().mockResolvedValue(undefined),
+}));
 
+import { getAdminClient } from '@/lib/supabase/admin';
+
+const getAdminClientMock = getAdminClient as jest.Mock;
 const errorMock = logger.error as jest.Mock;
 const onchainMock = checkOnchainPaymentStatus as jest.Mock;
 const dispatchMock = NotificationDispatcher.dispatch as jest.Mock;
@@ -52,24 +66,34 @@ const onchainIntent = {
 };
 
 /**
- * single() -> the intent. Awaited builder chains resolve from a queue in order:
- *   [ intent status update, order update ].  rpc() resolves cleanly.
+ * Caller client serves the intent READ (single()); every status-transition
+ * write now goes through the admin client (RLS lesson — see
+ * buyerConfirmPayment.test.ts). makeSupabase wires both and installs the admin
+ * mock, whose awaited chains resolve from a queue in order:
+ *   [ paid-transition claim (returns the row = we won), order update ]
  */
-function makeSupabase(orderUpdateError: unknown) {
-  // [ paid-transition claim (returns the row = we won), order update ]
+function makeSupabase(orderUpdateError: unknown, intent: unknown = onchainIntent) {
   const awaitQueue: Array<{ data?: unknown; error: unknown }> = [
     { data: [{ id: PI_ID }], error: null },
     { error: orderUpdateError },
   ];
+  const adminBuilder: Record<string, unknown> = {};
+  for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
+    adminBuilder[m] = jest.fn(() => adminBuilder);
+  }
+  adminBuilder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(awaitQueue.shift() ?? { error: null }).then(resolve, reject);
+  const rpc = jest.fn(() => Promise.resolve({ error: null }));
+  getAdminClientMock.mockReturnValue({ from: jest.fn(() => adminBuilder), rpc });
+
   const builder: Record<string, unknown> = {};
   for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
     builder[m] = jest.fn(() => builder);
   }
-  builder.single = jest.fn(() => Promise.resolve({ data: onchainIntent, error: null }));
+  builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
   builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
-    Promise.resolve(awaitQueue.shift() ?? { error: null }).then(resolve, reject);
-  const rpc = jest.fn(() => Promise.resolve({ error: null }));
-  return { from: jest.fn(() => builder), rpc } as never;
+    Promise.resolve({ data: [], error: null }).then(resolve, reject);
+  return { from: jest.fn(() => builder), rpc: jest.fn() } as never;
 }
 
 /** A tip intent: entity-less, kind='tip'. Confirming it must NOT touch orders or
@@ -90,19 +114,9 @@ const tipIntent = {
   expires_at: null,
 };
 
-/** Builder returning `intent`; the tip path only awaits ONE update (mark paid). */
+/** Caller reads `intent`; the tip path only awaits ONE admin write (mark paid). */
 function makeSupabaseReturning(intent: unknown) {
-  const builder: Record<string, unknown> = {};
-  for (const m of ['select', 'update', 'eq', 'neq', 'in']) {
-    builder[m] = jest.fn(() => builder);
-  }
-  builder.single = jest.fn(() => Promise.resolve({ data: intent, error: null }));
-  // Awaited writes resolve as a won claim (the conditional paid-transition
-  // returns the row it updated).
-  builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
-    Promise.resolve({ data: [{ id: PI_ID }], error: null }).then(resolve, reject);
-  const rpc = jest.fn(() => Promise.resolve({ error: null }));
-  return { from: jest.fn(() => builder), rpc } as never;
+  return makeSupabase(null, intent);
 }
 
 beforeEach(() => {

--- a/__tests__/unit/domain/payments/lnurlVerify.test.ts
+++ b/__tests__/unit/domain/payments/lnurlVerify.test.ts
@@ -9,6 +9,8 @@
 import { checkLnurlVerifyPaymentStatus } from '@/domain/payments/paymentStatusService';
 import { checkPaymentStatus } from '@/domain/payments/paymentFlowService';
 import { STATUS } from '@/config/database-constants';
+import { getAdminClient } from '@/lib/supabase/admin';
+const getAdminClientMock = getAdminClient as jest.Mock;
 
 jest.mock('@/utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
@@ -19,6 +21,7 @@ jest.mock('@/lib/email/send-seller-notification', () => ({
 jest.mock('@/services/notifications/dispatcher', () => ({
   NotificationDispatcher: { dispatch: jest.fn().mockResolvedValue(undefined) },
 }));
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
 
 const VERIFY_URL = 'https://getalby.com/lnurlp/oc/verify/abc123';
 
@@ -104,7 +107,9 @@ describe('checkPaymentStatus — lightning_address + verify URL', () => {
     // a returned row means THIS caller won the claim and owns the side-effects.
     builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
       Promise.resolve({ data: [{ id: intent.id }], error: null }).then(resolve, reject);
-    return { client: { from: jest.fn(() => builder) } as never, update };
+    const client = { from: jest.fn(() => builder) } as never;
+    getAdminClientMock.mockReturnValue(client);
+    return { client, update };
   }
 
   it('flips to PAID when the verify endpoint reports settled', async () => {

--- a/__tests__/unit/domain/payments/undetectableIntentLifecycle.test.ts
+++ b/__tests__/unit/domain/payments/undetectableIntentLifecycle.test.ts
@@ -15,6 +15,8 @@ import { BUYER_CLAIM_GRACE_MS } from '@/domain/payments/intentExpiry';
 import { STATUS } from '@/config/database-constants';
 import type { PaymentIntent } from '@/domain/payments/types';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { getAdminClient } from '@/lib/supabase/admin';
+const getAdminClientMock = getAdminClient as jest.Mock;
 
 jest.mock('@/utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
@@ -30,6 +32,7 @@ jest.mock('@/domain/payments/paymentStatusService', () => ({
   checkOnchainPaymentStatus: jest.fn(),
   checkLnurlVerifyPaymentStatus: jest.fn(),
 }));
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
 
 const updates: Array<Record<string, unknown>> = [];
 
@@ -40,7 +43,9 @@ function makeSupabase(): SupabaseClient {
     return builder;
   });
   builder.eq = jest.fn(() => Promise.resolve({ error: null }));
-  return { from: jest.fn(() => builder) } as unknown as SupabaseClient;
+  const client = { from: jest.fn(() => builder) } as unknown as SupabaseClient;
+  getAdminClientMock.mockReturnValue(client);
+  return client;
 }
 
 function bareLightningIntent(expiresAt: string): PaymentIntent {

--- a/src/app/api/payments/[id]/route.ts
+++ b/src/app/api/payments/[id]/route.ts
@@ -89,6 +89,9 @@ export const POST = withAuth(
       if (message.includes('not found')) {
         return apiBadRequest('Payment not found');
       }
+      if (message.includes('not awaiting') || message.includes('automatically')) {
+        return apiBadRequest(message);
+      }
 
       return apiInternalError('Failed to confirm payment');
     }

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -458,7 +458,7 @@ export async function acknowledgePublicPayment(
       pi.status !== STATUS.PAYMENT_INTENTS.EXPIRED &&
       pi.status !== STATUS.PAYMENT_INTENTS.FAILED
     ) {
-      await updatePaymentStatus(admin, paymentIntentId, STATUS.PAYMENT_INTENTS.EXPIRED);
+      await updatePaymentStatus(paymentIntentId, STATUS.PAYMENT_INTENTS.EXPIRED);
     }
     throw new Error('This payment request has expired');
   }
@@ -470,7 +470,7 @@ export async function acknowledgePublicPayment(
     };
   }
 
-  await updatePaymentStatus(admin, paymentIntentId, STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
+  await updatePaymentStatus(paymentIntentId, STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
   return {
     status: STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
     paid_at: null,
@@ -501,9 +501,9 @@ async function refreshPaymentStatus(
   // afterwards. Ask first, expire only on a genuine no.
 
   if (pi.payment_method === 'nwc' && pi.payment_hash) {
-    const paid = await checkNWCPaymentStatus(supabase, pi);
+    const paid = await checkNWCPaymentStatus(pi);
     if (paid) {
-      await handlePaymentConfirmed(supabase, pi);
+      await handlePaymentConfirmed(pi);
       return { status: STATUS.PAYMENT_INTENTS.PAID, paid_at: new Date().toISOString() };
     }
   }
@@ -511,7 +511,7 @@ async function refreshPaymentStatus(
   if (pi.payment_method === 'lightning_address' && pi.lnurl_verify_url) {
     const paid = await checkLnurlVerifyPaymentStatus(pi);
     if (paid) {
-      await handlePaymentConfirmed(supabase, pi);
+      await handlePaymentConfirmed(pi);
       return { status: STATUS.PAYMENT_INTENTS.PAID, paid_at: new Date().toISOString() };
     }
   }
@@ -519,14 +519,14 @@ async function refreshPaymentStatus(
   if (pi.payment_method === 'onchain' && pi.onchain_address) {
     const onchainStatus = await checkOnchainPaymentStatus(pi);
     if (onchainStatus === 'confirmed') {
-      await handlePaymentConfirmed(supabase, pi);
+      await handlePaymentConfirmed(pi);
       return { status: STATUS.PAYMENT_INTENTS.PAID, paid_at: new Date().toISOString() };
     }
     if (
       onchainStatus === 'in_mempool' &&
       pi.status !== STATUS.PAYMENT_INTENTS.PENDING_CONFIRMATION
     ) {
-      await updatePaymentStatus(supabase, pi.id, STATUS.PAYMENT_INTENTS.PENDING_CONFIRMATION);
+      await updatePaymentStatus(pi.id, STATUS.PAYMENT_INTENTS.PENDING_CONFIRMATION);
       return { status: STATUS.PAYMENT_INTENTS.PENDING_CONFIRMATION, paid_at: null };
     }
   }
@@ -539,7 +539,7 @@ async function refreshPaymentStatus(
   const undetectable = pi.payment_method === 'lightning_address' && !pi.lnurl_verify_url;
   if (undetectable) {
     if (isBeyondClaimWindow(pi.expires_at)) {
-      await updatePaymentStatus(supabase, pi.id, STATUS.PAYMENT_INTENTS.EXPIRED);
+      await updatePaymentStatus(pi.id, STATUS.PAYMENT_INTENTS.EXPIRED);
       return { status: STATUS.PAYMENT_INTENTS.EXPIRED, paid_at: null };
     }
     return { status: pi.status, paid_at: pi.paid_at };
@@ -547,7 +547,7 @@ async function refreshPaymentStatus(
 
   // The rail says no payment arrived. Only now is expiry the truth.
   if (pi.expires_at && new Date(pi.expires_at) < new Date()) {
-    await updatePaymentStatus(supabase, pi.id, STATUS.PAYMENT_INTENTS.EXPIRED);
+    await updatePaymentStatus(pi.id, STATUS.PAYMENT_INTENTS.EXPIRED);
     return { status: STATUS.PAYMENT_INTENTS.EXPIRED, paid_at: null };
   }
 
@@ -608,7 +608,7 @@ export async function buyerConfirmPayment(
   }
 
   // Mark as buyer_confirmed — seller verifies in their wallet
-  await updatePaymentStatus(supabase, paymentIntentId, STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
+  await updatePaymentStatus(paymentIntentId, STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
 
   return { status: STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED, paid_at: null };
 }
@@ -637,7 +637,7 @@ export async function sellerConfirmPayment(
     throw new Error('Payment is not awaiting recipient confirmation');
   }
 
-  await handlePaymentConfirmed(supabase, pi as PaymentIntent);
+  await handlePaymentConfirmed(pi as PaymentIntent);
   return { status: STATUS.PAYMENT_INTENTS.PAID, paid_at: new Date().toISOString() };
 }
 
@@ -712,7 +712,6 @@ async function getEntityTitle(
 }
 
 async function updatePaymentStatus(
-  supabase: SupabaseClient,
   paymentIntentId: string,
   status: PaymentIntentStatus
 ): Promise<void> {
@@ -721,7 +720,13 @@ async function updatePaymentStatus(
     updates.paid_at = new Date().toISOString();
   }
 
-  const { error } = await supabase
+  // Always write through the admin client. A status transition is a system fact
+  // recorded AFTER the caller was authorized — but RLS only grants UPDATE on
+  // payment_intents to the buyer, so a seller- (or anon-) scoped client updates
+  // zero rows with NO error, and the intent silently stays in its old status
+  // while the caller reports success.
+  const admin = getAdminClient() as unknown as SupabaseClient;
+  const { error } = await admin
     .from(DATABASE_TABLES.PAYMENT_INTENTS)
     .update(updates)
     .eq('id', paymentIntentId);
@@ -753,11 +758,13 @@ async function updatePaymentStatus(
  * @returns true when THIS caller won the transition; false when someone else
  *          already settled it (a safe, silent no-op).
  */
-async function claimPaidTransition(
-  supabase: SupabaseClient,
-  paymentIntentId: string
-): Promise<boolean> {
-  const { data, error } = await supabase
+async function claimPaidTransition(paymentIntentId: string): Promise<boolean> {
+  // Admin client, always: under a caller-scoped client, RLS (UPDATE granted to
+  // buyers only) makes this conditional update match zero rows WITHOUT an error
+  // — indistinguishable from "another observer won the race" — so a recipient's
+  // confirmation skipped every side-effect while the API reported paid.
+  const admin = getAdminClient() as unknown as SupabaseClient;
+  const { data, error } = await admin
     .from(DATABASE_TABLES.PAYMENT_INTENTS)
     .update({ status: STATUS.PAYMENT_INTENTS.PAID, paid_at: new Date().toISOString() })
     .eq('id', paymentIntentId)
@@ -779,18 +786,21 @@ async function claimPaidTransition(
  *
  * Runs at most once per payment intent — see {@link claimPaidTransition}.
  */
-async function handlePaymentConfirmed(
-  supabase: SupabaseClient,
-  paymentIntent: PaymentIntent
-): Promise<void> {
+async function handlePaymentConfirmed(paymentIntent: PaymentIntent): Promise<void> {
   const piId = paymentIntent.id;
   const entityType = paymentIntent.entity_type as EntityType;
   const entityId = paymentIntent.entity_id;
 
+  // Settlement side-effects span multiple users' data (the buyer's order, the
+  // seller's notification, the entity's inventory) — no single user-scoped
+  // client can be entitled to all of it. Authorization already happened at the
+  // call sites; from here on, writes are system writes.
+  const admin = getAdminClient() as unknown as SupabaseClient;
+
   // Mark payment intent as paid — and only continue if we were the observer
   // that actually moved it there. Losing the race means another poller (or the
   // recipient's confirmation) already ran every side-effect below.
-  const claimed = await claimPaidTransition(supabase, piId);
+  const claimed = await claimPaidTransition(piId);
   if (!claimed) {
     logger.info(
       'Payment already settled by another observer — skipping duplicate side-effects',
@@ -827,7 +837,7 @@ async function handlePaymentConfirmed(
     // payment, and the terminal-status short-circuit means a retry wouldn't
     // re-run this anyway). But a silent failure left the order stuck in
     // pending_payment with no trace — log it loudly so it can be reconciled.
-    const { error: orderError } = await supabase
+    const { error: orderError } = await admin
       .from(DATABASE_TABLES.ORDERS)
       .update({ status: STATUS.ORDERS.PAID })
       .eq('payment_intent_id', piId);
@@ -841,7 +851,7 @@ async function handlePaymentConfirmed(
     }
 
     // Decrement inventory (atomic — prevents overselling)
-    await supabase
+    await admin
       .rpc('decrement_inventory', {
         p_entity_type: entityType,
         p_entity_id: entityId,
@@ -859,7 +869,7 @@ async function handlePaymentConfirmed(
   }
 
   // Notify seller — fire-and-forget, must not block payment confirmation
-  sendSellerPaymentNotification(paymentIntent, supabase).catch(err =>
+  sendSellerPaymentNotification(paymentIntent, admin).catch(err =>
     logger.warn('Seller payment notification failed', { err }, 'paymentFlowService')
   );
 

--- a/src/domain/payments/paymentStatusService.ts
+++ b/src/domain/payments/paymentStatusService.ts
@@ -10,6 +10,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { NWCClient } from '@/lib/nostr/nwc';
+import { getAdminClient } from '@/lib/supabase/admin';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { checkAddressPayment, type OnchainPaymentCheck } from '@/lib/bitcoin/mempool';
 import { decrypt } from './encryptionService';
@@ -22,18 +23,22 @@ import type { PaymentIntent } from './types';
  *
  * Returns true if paid, false otherwise.
  */
-export async function checkNWCPaymentStatus(
-  supabase: SupabaseClient,
-  paymentIntent: PaymentIntent
-): Promise<boolean> {
+export async function checkNWCPaymentStatus(paymentIntent: PaymentIntent): Promise<boolean> {
   if (!paymentIntent.payment_hash) {
     return false;
   }
 
+  // Read the seller's wallet through the admin client: detection is a system
+  // operation on the SELLER's secret, and the caller is usually the buyer (or
+  // anonymous). It only worked under caller clients because wallets_select is
+  // currently public-read — tightening that policy must not silently kill
+  // payment detection.
+  const admin = getAdminClient() as unknown as SupabaseClient;
+
   // Use the exact wallet selected when the invoice was created. The fallback
   // keeps pre-migration intents checkable, but new intents must never search an
   // arbitrary NWC wallet belonging to the same recipient.
-  let walletQuery = supabase
+  let walletQuery = admin
     .from(DATABASE_TABLES.WALLETS)
     .select('nwc_connection_uri')
     .not('nwc_connection_uri', 'is', null);


### PR DESCRIPTION
Found by a live end-to-end payment simulation (no real money): RLS grants UPDATE on `payment_intents` to buyers only, so a recipient confirming an acknowledged bare-Lightning payment updated zero rows with no error — misread as a lost settle race, every side-effect skipped, API still answered "paid". The recipient-confirmation flow had never worked in production.

Status transitions are system facts recorded after authorization; they now write through the admin client (`claimPaidTransition`, `updatePaymentStatus`, `handlePaymentConfirmed`, and the NWC wallet read in `checkNWCPaymentStatus`). `seller_confirm` on a non-awaiting intent returns 400 instead of 500. Regression test pins the transition to the admin client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)