### PR TITLE
feat(cat): ground page help in what the user actually sees

### DIFF
--- a/__tests__/unit/cat/runtime-context.test.ts
+++ b/__tests__/unit/cat/runtime-context.test.ts
@@ -67,4 +67,43 @@ describe('Cat Tier 1: runtime context block', () => {
     // dates should format without throwing
     expect(s).toContain('## Current Date & Time');
   });
+
+  describe('page excerpt (visible-page grounding)', () => {
+    const onPage = (excerpt?: string): FullUserContext => ({
+      ...ctx,
+      runtime: {
+        ...ctx.runtime,
+        currentPath: '/settings/ai',
+        pageExcerpt: excerpt,
+      },
+    });
+
+    it('renders the excerpt verbatim with a describe-only-whats-here rule', () => {
+      const s = buildFullContextString(
+        onPage('Cat AI\nUse OrangeCat\nCat Credits\nBring your own key')
+      );
+      expect(s).toContain('Visible on this page right now');
+      expect(s).toContain('Bring your own key');
+      expect(s).toContain('never invent');
+    });
+
+    it('without an excerpt on a non-entity page, tells Cat it cannot see the page', () => {
+      const s = buildFullContextString(onPage(undefined));
+      expect(s).toContain('can NOT see this page');
+      expect(s).not.toContain('Visible on this page right now');
+    });
+
+    it('entity pages keep the lookup-tools instruction instead of the blind-page warning', () => {
+      const s = buildFullContextString({
+        ...ctx,
+        runtime: {
+          ...ctx.runtime,
+          currentPath: '/projects/abc123',
+          currentEntity: { type: 'project', ref: 'abc123' },
+        },
+      });
+      expect(s).toContain('lookup/search tools');
+      expect(s).not.toContain('can NOT see this page');
+    });
+  });
 });

--- a/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
@@ -5,7 +5,7 @@ import { API_ROUTES } from '@/config/api-routes';
 import { isCatHubPath } from '@/config/routes';
 import { useUserCurrency } from '@/hooks/useUserCurrency';
 import { STORAGE_KEYS } from '@/config/storage-keys';
-import type { CatPageDescriptor } from '@/config/cat-page-context';
+import { readPageExcerptForCat, type CatPageDescriptor } from '@/config/cat-page-context';
 import type {
   Message,
   CatAction,
@@ -212,6 +212,9 @@ export function useChatMessages({
             lastVisitedPath: readLastVisitedPath(),
             currentPath: pageContextRef.current?.path,
             currentEntity: pageContextRef.current?.entity,
+            // What the user actually sees, captured fresh each send — without
+            // it Cat knows the path but invents the page's contents.
+            pageExcerpt: pageContextRef.current?.path ? readPageExcerptForCat() : undefined,
             conversationId: activeConversationId ?? undefined,
           }),
           signal: abortController.signal,

--- a/src/config/cat-page-context.ts
+++ b/src/config/cat-page-context.ts
@@ -58,6 +58,45 @@ const AREA_LABELS: Array<{ re: RegExp; label: string }> = [
 ];
 
 /**
+ * Character cap for the visible-page excerpt sent alongside currentPath.
+ * ~450 tokens: enough for a settings page's headings and copy, small enough
+ * to never crowd out the rest of the context budget. Client trims to this;
+ * the server schema enforces it again.
+ */
+export const PAGE_EXCERPT_MAX_CHARS = 1800;
+
+/**
+ * Capture what the user can actually SEE on the current page, so Cat helps
+ * with the real page instead of hallucinating a plausible one. Path labels
+ * alone ("your settings") tell Cat WHERE the user is but not WHAT is there —
+ * and app surfaces (unlike entities) have no lookup tool, so without this
+ * excerpt the model invents sections that don't exist.
+ *
+ * Reads `<main>` only — the Cat overlay and navigation mount outside it, so
+ * the excerpt never captures the chat conversation itself. Client-only;
+ * returns undefined during SSR or when there's nothing readable.
+ */
+export function readPageExcerptForCat(): string | undefined {
+  if (typeof document === 'undefined') {
+    return undefined;
+  }
+  const root = document.querySelector<HTMLElement>('main');
+  if (!root) {
+    return undefined;
+  }
+  const clean = (root.innerText ?? '')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\s*\n\s*/g, '\n')
+    .trim();
+  if (!clean) {
+    return undefined;
+  }
+  return clean.length > PAGE_EXCERPT_MAX_CHARS
+    ? `${clean.slice(0, PAGE_EXCERPT_MAX_CHARS)}…`
+    : clean;
+}
+
+/**
  * Describe the current page for Cat. Returns undefined for anything that isn't a
  * safe same-origin path (so callers can simply skip sending page context).
  */

--- a/src/services/ai/context-sections.ts
+++ b/src/services/ai/context-sections.ts
@@ -95,8 +95,17 @@ export function renderCurrentSession(r: FullUserContext['runtime']): string | nu
       ? ` — a ${r.currentEntity.type} (ref \`${r.currentEntity.ref}\`)`
       : '';
     lines.push(
-      `**Currently viewing**: \`${r.currentPath}\`${entity}. The user opened you WHILE on this page — if their question is about it ("this", "here", "them"), ground your answer in it. Use your lookup/search tools to pull the specifics of that ${r.currentEntity ? r.currentEntity.type : 'page'} rather than guessing.`
+      `**Currently viewing**: \`${r.currentPath}\`${entity}. The user opened you WHILE on this page — if their question is about it ("this", "here", "them"), ground your answer in it.${r.currentEntity ? ` Use your lookup/search tools to pull the specifics of that ${r.currentEntity.type} rather than guessing.` : ''}`
     );
+    if (r.pageExcerpt) {
+      lines.push(
+        `**Visible on this page right now** (verbatim excerpt of what the user sees):\n"""\n${r.pageExcerpt}\n"""\nWhen explaining or helping with this page, describe ONLY sections and controls that appear in this excerpt — never invent ones that don't. If something the user asks about isn't in the excerpt, say you don't see it on this page.`
+      );
+    } else if (!r.currentEntity) {
+      lines.push(
+        `You can NOT see this page's contents. If the user asks about "this page", say what you can't see and ask them to describe or paste the part they mean — do not guess at sections or controls.`
+      );
+    }
   } else if (r.lastVisitedPath) {
     lines.push(
       `**Just came from**: \`${r.lastVisitedPath}\` — if relevant to their question, reference what's on that page.`

--- a/src/services/ai/document-context-types.ts
+++ b/src/services/ai/document-context-types.ts
@@ -218,6 +218,12 @@ export interface RuntimeContext {
   /** The entity the current page is about, if recognised (type + id/slug). */
   currentEntity?: { type: string; ref: string };
   /**
+   * Verbatim excerpt of what's visible on the current page. App surfaces
+   * (settings, wallet, pricing) have no lookup tool — this is the only way
+   * Cat can describe the actual page instead of a hallucinated one.
+   */
+  pageExcerpt?: string;
+  /**
    * Live BTC exchange-rate snapshot so Cat quotes real numbers for BTC⇄fiat
    * conversions instead of recalling a stale rate from training data.
    */

--- a/src/services/ai/document-context.ts
+++ b/src/services/ai/document-context.ts
@@ -14,6 +14,7 @@ import { logger } from '@/utils/logger';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { isCatHubPath } from '@/config/routes';
+import { PAGE_EXCERPT_MAX_CHARS } from '@/config/cat-page-context';
 
 import type {
   DocumentContext,
@@ -248,6 +249,8 @@ export interface RuntimeContextHints {
   currentPath?: string;
   /** Entity the current page is about, if the client recognised one. */
   currentEntity?: { type: string; ref: string };
+  /** Visible-page excerpt captured by the client. Only kept when currentPath is valid. */
+  pageExcerpt?: string;
 }
 
 /**
@@ -314,6 +317,14 @@ async function fetchRuntimeContextForCat(
   const lastVisitedPath = sanitizeLastVisitedPath(hints?.lastVisitedPath);
   const currentPath = sanitizeLastVisitedPath(hints?.currentPath);
   const currentEntity = currentPath ? sanitizeCurrentEntity(hints?.currentEntity) : undefined;
+  // Excerpt only makes sense anchored to a valid current page; strip control
+  // chars (keep newlines) and re-cap server-side — the client is untrusted.
+  const rawExcerpt = currentPath && typeof hints?.pageExcerpt === 'string' ? hints.pageExcerpt : '';
+  const cleanedExcerpt = rawExcerpt
+    .replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '')
+    .trim()
+    .slice(0, PAGE_EXCERPT_MAX_CHARS + 1);
+  const pageExcerpt = cleanedExcerpt || undefined;
 
   // Current actor: for Tier 1 we always use the individual actor. Group-context
   // switching plumbs through later (Tier 5), with its own server-side validation
@@ -362,6 +373,7 @@ async function fetchRuntimeContextForCat(
     lastVisitedPath,
     currentPath,
     currentEntity,
+    pageExcerpt,
     btcRate,
   };
 }

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -43,6 +43,7 @@ import { createActionExecutor } from '@/services/cat';
 import { getUserActorId } from '@/domain/actors';
 import type { ExecAction, CatAction, ExecActionResult } from '@/types/cat';
 import { AI_MESSAGE_MAX_CHARS } from '@/lib/validation/ai';
+import { PAGE_EXCERPT_MAX_CHARS } from '@/config/cat-page-context';
 
 export const catChatBodySchema = z.object({
   message: z.string().min(1).max(AI_MESSAGE_MAX_CHARS),
@@ -61,6 +62,15 @@ export const catChatBodySchema = z.object({
   /** The page the user is on right now (global Cat overlay), + its entity if any. */
   currentPath: z.string().max(200).optional(),
   currentEntity: z.object({ type: z.string().max(32), ref: z.string().max(120) }).optional(),
+  /**
+   * Verbatim excerpt of what's visible on the current page (client-captured,
+   * capped at PAGE_EXCERPT_MAX_CHARS + ellipsis). Grounds "help me with this
+   * page" in the real page instead of a guessed one.
+   */
+  pageExcerpt: z
+    .string()
+    .max(PAGE_EXCERPT_MAX_CHARS + 1)
+    .optional(),
 });
 
 export type CatChatBody = z.infer<typeof catChatBodySchema>;
@@ -199,6 +209,7 @@ export async function orchestrateCatChat(
     lastVisitedPath,
     currentPath,
     currentEntity,
+    pageExcerpt,
     conversationId: requestedConversationId,
   } = body;
 
@@ -244,6 +255,7 @@ export async function orchestrateCatChat(
       lastVisitedPath,
       currentPath,
       currentEntity,
+      pageExcerpt,
     }),
     recallMemories(supabase, user.id, message),
   ]);


### PR DESCRIPTION
**Problem** (reported live): on /settings/ai the user asked Cat "help me with this page" — Cat, seeing only the path, hallucinated a plausible settings page (Display currency, Connected wallets…) that doesn't exist. The prompt told it to "pull the specifics rather than guessing", but app surfaces have no lookup tool.

**Fix**: send Cat a capped (1800-char) excerpt of what's actually visible in `<main>`, captured fresh at each send from the global overlay. New prompt block renders it verbatim with a describe-only-what's-here rule. Without an excerpt on a non-entity page, Cat is told it cannot see the page and must say so. Entity pages keep the lookup-tool path.

Works on any app page with zero per-page maintenance. 3 new tests pin the modes; 1443 total green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)