### PR TITLE
fix(payments): publication gate on authenticated payment initiation

### DIFF
--- a/__tests__/unit/domain/payments/initiatePayment.guards.test.ts
+++ b/__tests__/unit/domain/payments/initiatePayment.guards.test.ts
@@ -2,7 +2,8 @@
  * Guard-rail coverage for initiatePayment — the entry point to every money flow.
  *
  * These guards are security-relevant: they stop a payment before any intent is
- * created when the seller can't be resolved, when a buyer tries to purchase
+ * created when the entity isn't published (the buyer's own RLS read is the
+ * gate), when the seller can't be resolved, when a buyer tries to purchase
  * their own entity, or when the seller has no wallet to receive funds.
  */
 
@@ -27,8 +28,21 @@ jest.mock('@/services/notifications/dispatcher', () => ({
 const getSellerUserIdMock = getSellerUserId as jest.Mock;
 const resolveSellerWalletMock = resolveSellerWallet as jest.Mock;
 
-// Guards short-circuit before any DB access, so an empty client is sufficient.
-const supabase = {} as never;
+/**
+ * Caller-scoped client serving only the publication-gate read. `visible`
+ * models what the buyer's RLS lets them see: null = draft/hidden entity.
+ */
+function makeSupabase(visible: boolean) {
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'eq']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  builder.maybeSingle = jest.fn(() =>
+    Promise.resolve({ data: visible ? { id: 'prod-1' } : null, error: null })
+  );
+  return { from: jest.fn(() => builder) } as never;
+}
+
 const BUYER = 'buyer-1';
 const input = { entity_type: 'product' as const, entity_id: 'prod-1' };
 
@@ -37,15 +51,28 @@ beforeEach(() => {
 });
 
 describe('initiatePayment — guards', () => {
+  it('refuses an entity the buyer cannot see (draft/unpublished)', async () => {
+    // Regression (found live 2026-08-02): seller + wallet resolution run on the
+    // admin client, so without this gate an authenticated user could mint an
+    // invoice + order against a DRAFT entity the owner never published.
+    await expect(initiatePayment(makeSupabase(false), BUYER, input)).rejects.toThrow(
+      'Entity is not publicly available'
+    );
+    expect(getSellerUserIdMock).not.toHaveBeenCalled();
+    expect(resolveSellerWalletMock).not.toHaveBeenCalled();
+  });
+
   it('throws when the entity owner cannot be resolved', async () => {
     getSellerUserIdMock.mockResolvedValue(null);
-    await expect(initiatePayment(supabase, BUYER, input)).rejects.toThrow('Entity owner not found');
+    await expect(initiatePayment(makeSupabase(true), BUYER, input)).rejects.toThrow(
+      'Entity owner not found'
+    );
     expect(resolveSellerWalletMock).not.toHaveBeenCalled();
   });
 
   it('refuses a buyer purchasing their own entity', async () => {
     getSellerUserIdMock.mockResolvedValue(BUYER);
-    await expect(initiatePayment(supabase, BUYER, input)).rejects.toThrow(
+    await expect(initiatePayment(makeSupabase(true), BUYER, input)).rejects.toThrow(
       'Cannot purchase your own entity'
     );
     expect(resolveSellerWalletMock).not.toHaveBeenCalled();
@@ -54,7 +81,7 @@ describe('initiatePayment — guards', () => {
   it('throws when the seller has no wallet connected', async () => {
     getSellerUserIdMock.mockResolvedValue('seller-1');
     resolveSellerWalletMock.mockResolvedValue(null);
-    await expect(initiatePayment(supabase, BUYER, input)).rejects.toThrow(
+    await expect(initiatePayment(makeSupabase(true), BUYER, input)).rejects.toThrow(
       'Seller has no wallet connected. Payment not available.'
     );
   });

--- a/src/domain/payments/knownPaymentErrors.ts
+++ b/src/domain/payments/knownPaymentErrors.ts
@@ -11,6 +11,7 @@ const KNOWN_PAYMENT_ERRORS: Record<string, string> = {
   'no price': 'This entity has no price set',
   'Amount is required': 'Payment amount is required for contributions',
   'owner not found': 'This listing is no longer available.',
+  'not publicly available': 'This listing is not available.',
   'LNURL-pay endpoint': 'Seller Lightning Address is unreachable. Try again later.',
   'outside allowed range': 'Payment amount is outside the allowed range for this seller.',
   'LNURL callback': 'Lightning Address invoice request failed. Try again later.',

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -68,6 +68,20 @@ export async function initiatePayment(
   const { entity_type, entity_id } = input;
   const meta = getEntityMetadata(entity_type);
 
+  // 0. Publication gate — the buyer's own RLS read is the check, exactly like
+  // the public-support flow. Everything after this resolves through the admin
+  // client (seller lookup, wallet secrets), so without this gate an
+  // authenticated user could mint an invoice + order against a DRAFT entity
+  // the owner never published (found by live simulation, 2026-08-02).
+  const { data: visibleEntity } = await supabase
+    .from(meta.tableName)
+    .select('id')
+    .eq('id', entity_id)
+    .maybeSingle();
+  if (!visibleEntity) {
+    throw new Error('Entity is not publicly available');
+  }
+
   // 1. Resolve seller
   const sellerId = await getSellerUserId(supabase, entity_type, entity_id);
   if (!sellerId) {


### PR DESCRIPTION
Found by live simulation: `initiatePayment` resolves seller + wallet through the admin client, so an authenticated user could mint a real invoice + order against a DRAFT entity. The authed flow now applies the same publication gate the public-support flow already has — the buyer's own RLS read decides visibility. Regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)