### PR TITLE
refactor(settings/ai): two-group IA + progressive disclosure for memory surfaces

### DIFF
--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -54,11 +54,22 @@ export default function AISettingsPage() {
   const localProviders = getProvidersByCategory('local');
 
   return (
-    <div className="space-y-6">
-      <p className="text-fg-primary">
-          Cat works any of three ways. Pick whichever fits — they&apos;re all first-class. OrangeCat
-          earns from platform activity, not from your AI bill.
-        </p>
+    <div className="space-y-12">
+      {/* ════ Group 1 · How Cat runs ═══════════════════════════════════════ */}
+      <section aria-labelledby="how-cat-runs" className="space-y-4">
+        <div>
+          <h2
+            id="how-cat-runs"
+            className="text-xs font-semibold uppercase tracking-caps text-fg-tertiary"
+          >
+            How Cat runs
+          </h2>
+          <p className="mt-1 text-sm text-fg-secondary">
+            Cat already works — free, no setup needed. Everything below is optional power: prepaid
+            credits, your own keys, or your own machine. OrangeCat earns from platform activity, not
+            from your AI bill.
+          </p>
+        </div>
 
         {/* ── Managed ───────────────────────────────────────────────────── */}
         <section className="rounded-lg border border-default bg-surface-base p-6">
@@ -129,18 +140,6 @@ export default function AISettingsPage() {
           />
         </section>
 
-        {/* ── Memory ────────────────────────────────────────────────────── */}
-        <CatMemoryManager
-          reloadKey={memoryReloadKey}
-          memoryEnabled={preferences?.memory_enabled !== false}
-          onToggleMemory={async enabled => {
-            await updatePreferences({ memory_enabled: enabled });
-          }}
-        />
-
-        {/* ── Import memory from another AI ──────────────────────────────── */}
-        <CatMemoryImport onImported={() => setMemoryReloadKey(k => k + 1)} />
-
         {/* ── Local ─────────────────────────────────────────────────────── */}
         <section className="rounded-lg border border-default bg-surface-base p-6">
           <div className="mb-4 flex items-start gap-3">
@@ -186,15 +185,42 @@ export default function AISettingsPage() {
             </p>
           </div>
         </section>
+      </section>
 
-        {/* Privacy footnote */}
-        <div className="rounded-md border border-subtle bg-surface-raised/30 p-4 text-sm text-fg-secondary">
-          <p>
-            <strong className="text-fg-primary">Privacy:</strong> keys are encrypted at rest, never
-            logged, and stripped of whitespace before use. Cat chats save to your history; clear
-            them anytime from the chat panel.
+      {/* ════ Group 2 · What Cat knows ═════════════════════════════════════ */}
+      <section aria-labelledby="what-cat-knows" className="space-y-4">
+        <div>
+          <h2
+            id="what-cat-knows"
+            className="text-xs font-semibold uppercase tracking-caps text-fg-tertiary"
+          >
+            What Cat knows
+          </h2>
+          <p className="mt-1 text-sm text-fg-secondary">
+            Cat&apos;s memory is yours: review it, delete any of it, export it, or bring context
+            over from another AI.
           </p>
         </div>
+
+        <CatMemoryManager
+          reloadKey={memoryReloadKey}
+          memoryEnabled={preferences?.memory_enabled !== false}
+          onToggleMemory={async enabled => {
+            await updatePreferences({ memory_enabled: enabled });
+          }}
+        />
+
+        <CatMemoryImport onImported={() => setMemoryReloadKey(k => k + 1)} />
+      </section>
+
+      {/* Privacy footnote */}
+      <div className="rounded-md border border-subtle bg-surface-raised/30 p-4 text-sm text-fg-secondary">
+        <p>
+          <strong className="text-fg-primary">Privacy:</strong> keys are encrypted at rest, never
+          logged, and stripped of whitespace before use. Cat chats save to your history; clear them
+          anytime from the chat panel.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/ai/CatMemoryImport.tsx
+++ b/src/components/ai/CatMemoryImport.tsx
@@ -27,6 +27,9 @@ export function CatMemoryImport({ onImported }: CatMemoryImportProps) {
   const [isImporting, setIsImporting] = useState(false);
   const [copied, setCopied] = useState(false);
   const [showPrompt, setShowPrompt] = useState(false);
+  // Collapsed by default: importing is a one-time task, so the two-step wizard
+  // should not occupy the page for everyone who never needs it.
+  const [open, setOpen] = useState(false);
 
   const copyPrompt = useCallback(async () => {
     try {
@@ -93,83 +96,107 @@ export function CatMemoryImport({ onImported }: CatMemoryImportProps) {
 
   return (
     <section className="rounded-lg border border-default bg-surface-base p-6">
-      <div className="mb-4 flex items-start gap-3">
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        className="flex w-full items-start gap-3 text-left"
+      >
         <div className="rounded-md bg-surface-raised p-2">
           <ArrowDownToLine className="h-5 w-5 text-fg-primary" />
         </div>
         <div className="flex-1">
-          <h2 className="text-lg font-semibold text-fg-primary">Import from another AI</h2>
+          <span className="flex items-center justify-between gap-2">
+            <h2 className="text-lg font-semibold text-fg-primary">Import from another AI</h2>
+            {open ? (
+              <ChevronUp className="h-4 w-4 shrink-0 text-fg-secondary" />
+            ) : (
+              <ChevronDown className="h-4 w-4 shrink-0 text-fg-secondary" />
+            )}
+          </span>
           <p className="mt-1 text-sm text-fg-secondary">
-            Already have context in ChatGPT, Grok, Gemini or Claude? Bring it over so Cat starts warm
-            instead of cold. Copy the prompt, run it in your other assistant, and paste the result
-            back — Cat keeps what&apos;s new and skips anything it already knows.
+            Already have context in ChatGPT, Grok, Gemini or Claude? Bring it over so Cat starts
+            warm instead of cold.
           </p>
         </div>
-      </div>
+      </button>
 
-      {/* Step 1 — copy the prompt */}
-      <div className="mb-4 rounded-md border border-subtle bg-surface-raised/30 p-3">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <span className="text-sm font-medium text-fg-primary">
-            1 · Copy this prompt into your other AI
-          </span>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setShowPrompt(v => !v)}
-              className="inline-flex items-center gap-1 text-sm text-fg-secondary hover:text-fg-primary"
-            >
-              {showPrompt ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-              {showPrompt ? 'Hide' : 'Show'} prompt
-            </button>
-            <Button
-              variant="outline"
-              onClick={copyPrompt}
-              className="h-11 gap-2 px-3 text-sm"
-              aria-label="Copy the import prompt"
-            >
-              {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-              {copied ? 'Copied' : 'Copy prompt'}
-            </Button>
+      {!open ? null : (
+        <div className="mt-4">
+          <p className="mb-4 text-sm text-fg-secondary">
+            Copy the prompt, run it in your other assistant, and paste the result back — Cat keeps
+            what&apos;s new and skips anything it already knows.
+          </p>
+
+          {/* Step 1 — copy the prompt */}
+          <div className="mb-4 rounded-md border border-subtle bg-surface-raised/30 p-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-sm font-medium text-fg-primary">
+                1 · Copy this prompt into your other AI
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowPrompt(v => !v)}
+                  className="inline-flex items-center gap-1 text-sm text-fg-secondary hover:text-fg-primary"
+                >
+                  {showPrompt ? (
+                    <ChevronUp className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                  {showPrompt ? 'Hide' : 'Show'} prompt
+                </button>
+                <Button
+                  variant="outline"
+                  onClick={copyPrompt}
+                  className="h-11 gap-2 px-3 text-sm"
+                  aria-label="Copy the import prompt"
+                >
+                  {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                  {copied ? 'Copied' : 'Copy prompt'}
+                </Button>
+              </div>
+            </div>
+            {showPrompt && (
+              <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap rounded-md border border-subtle bg-surface-page p-3 text-xs text-fg-secondary">
+                {MEMORY_IMPORT_PROMPT}
+              </pre>
+            )}
+          </div>
+
+          {/* Step 2 — paste the result */}
+          <div className="rounded-md border border-subtle bg-surface-raised/30 p-3">
+            <label htmlFor="memory-import" className="text-sm font-medium text-fg-primary">
+              2 · Paste the result here
+            </label>
+            <textarea
+              id="memory-import"
+              value={text}
+              onChange={e => setText(e.target.value)}
+              disabled={isImporting}
+              rows={6}
+              placeholder="Paste everything your other AI exported…"
+              className="mt-2 w-full resize-y rounded-md border border-subtle bg-surface-page p-3 text-sm text-fg-primary placeholder:text-fg-tertiary focus:outline-none focus:ring-2 focus:ring-accent-warm disabled:opacity-60"
+            />
+            <div className="mt-3 flex items-center justify-end">
+              <Button
+                variant="accent"
+                onClick={handleImport}
+                disabled={isImporting || !text.trim()}
+                className="h-11 gap-2 px-4 text-sm"
+              >
+                {isImporting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ArrowDownToLine className="h-4 w-4" />
+                )}
+                Import into Cat
+              </Button>
+            </div>
           </div>
         </div>
-        {showPrompt && (
-          <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap rounded-md border border-subtle bg-surface-page p-3 text-xs text-fg-secondary">
-            {MEMORY_IMPORT_PROMPT}
-          </pre>
-        )}
-      </div>
-
-      {/* Step 2 — paste the result */}
-      <div className="rounded-md border border-subtle bg-surface-raised/30 p-3">
-        <label htmlFor="memory-import" className="text-sm font-medium text-fg-primary">
-          2 · Paste the result here
-        </label>
-        <textarea
-          id="memory-import"
-          value={text}
-          onChange={e => setText(e.target.value)}
-          disabled={isImporting}
-          rows={6}
-          placeholder="Paste everything your other AI exported…"
-          className="mt-2 w-full resize-y rounded-md border border-subtle bg-surface-page p-3 text-sm text-fg-primary placeholder:text-fg-tertiary focus:outline-none focus:ring-2 focus:ring-accent-warm disabled:opacity-60"
-        />
-        <div className="mt-3 flex items-center justify-end">
-          <Button
-            variant="accent"
-            onClick={handleImport}
-            disabled={isImporting || !text.trim()}
-            className="h-11 gap-2 px-4 text-sm"
-          >
-            {isImporting ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <ArrowDownToLine className="h-4 w-4" />
-            )}
-            Import into Cat
-          </Button>
-        </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/src/components/ai/CatMemoryManager.tsx
+++ b/src/components/ai/CatMemoryManager.tsx
@@ -9,7 +9,15 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Brain, Trash2, Loader2, AlertCircle, Download } from 'lucide-react';
+import {
+  Brain,
+  Trash2,
+  Loader2,
+  AlertCircle,
+  Download,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import Button from '@/components/ui/Button';
 import { logger } from '@/utils/logger';
@@ -21,6 +29,9 @@ interface Memory {
   content: string;
   created_at: string;
 }
+
+/** How many memories show before "Show all" — enough to prove the feature, few enough to scan. */
+const MEMORY_PREVIEW_COUNT = 3;
 
 interface CatMemoryManagerProps {
   /** Bump to force a reload — e.g. after an import adds new memories. */
@@ -42,6 +53,7 @@ export function CatMemoryManager({
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmClear, setConfirmClear] = useState(false);
   const [isClearing, setIsClearing] = useState(false);
+  const [showAll, setShowAll] = useState(false);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -226,29 +238,51 @@ export function CatMemoryManager({
           </p>
         </div>
       ) : (
-        <ul className="space-y-2">
-          {memories.map(m => (
-            <li
-              key={m.id}
-              className="flex items-start justify-between gap-3 rounded-md border border-subtle bg-surface-raised/30 p-3"
-            >
-              <span className="text-sm text-fg-primary">{m.content}</span>
-              <button
-                type="button"
-                onClick={() => handleDelete(m.id)}
-                disabled={deletingId === m.id}
-                aria-label="Forget this memory"
-                className="shrink-0 rounded-md p-1 text-fg-tertiary hover:bg-surface-raised hover:text-status-negative disabled:opacity-40"
+        <>
+          {/* Preview a few, disclose the rest — a long memory list must not
+              dominate the settings page (it once dumped 20+ items inline). */}
+          <ul className="space-y-2">
+            {(showAll ? memories : memories.slice(0, MEMORY_PREVIEW_COUNT)).map(m => (
+              <li
+                key={m.id}
+                className="flex items-start justify-between gap-3 rounded-md border border-subtle bg-surface-raised/30 p-3"
               >
-                {deletingId === m.id ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Trash2 className="h-4 w-4" />
-                )}
-              </button>
-            </li>
-          ))}
-        </ul>
+                <span className="text-sm text-fg-primary">{m.content}</span>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(m.id)}
+                  disabled={deletingId === m.id}
+                  aria-label="Forget this memory"
+                  className="shrink-0 rounded-md p-1 text-fg-tertiary hover:bg-surface-raised hover:text-status-negative disabled:opacity-40"
+                >
+                  {deletingId === m.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+          {memories.length > MEMORY_PREVIEW_COUNT && (
+            <button
+              type="button"
+              onClick={() => setShowAll(v => !v)}
+              aria-expanded={showAll}
+              className="mt-3 inline-flex min-h-11 items-center gap-1 text-sm text-fg-secondary hover:text-fg-primary"
+            >
+              {showAll ? (
+                <>
+                  <ChevronUp className="h-4 w-4" /> Show fewer
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-4 w-4" /> Show all {memories.length} memories
+                </>
+              )}
+            </button>
+          )}
+        </>
       )}
     </section>
   );


### PR DESCRIPTION
## Problem (George)
/settings/ai is a wall of seven equal-weight blocks — mode cards, the FULL memory list (20+ items inline), and an always-open two-step import wizard. No hierarchy, no flow.

## Fix
- The page now tells a two-part story with labeled groups:
  **HOW CAT RUNS** — Use OrangeCat (active) → Cat Credits → Bring your own key → Run locally
  **WHAT CAT KNOWS** — What Cat remembers → Import from another AI
  Each group opens with one orientation sentence.
- **CatMemoryManager**: previews 3 memories + 'Show all N memories' toggle (SSOT'd `MEMORY_PREVIEW_COUNT`).
- **CatMemoryImport**: collapsed to its header by default (aria-expanded button) — it's a one-time task.

No API/logic changes; Export / Forget everything / consent toggle untouched.

## Verify
tsc clean · eslint clean · 14 related unit tests green · CI E2E gates deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)