### PR TITLE
feat(cat): custom instructions + sign-out-everywhere + Cat activity log

### DIFF
--- a/__tests__/unit/cat/custom-instructions.test.ts
+++ b/__tests__/unit/cat/custom-instructions.test.ts
@@ -1,0 +1,96 @@
+import {
+  getCustomInstructions,
+  MAX_CUSTOM_INSTRUCTIONS_LENGTH,
+} from '@/services/cat/custom-instructions';
+import { buildCatSystemPrompt } from '@/services/cat/system-prompt';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+
+/**
+ * Cat custom instructions — the user's standing instructions.
+ *
+ * Two contracts matter:
+ * 1. getCustomInstructions is best-effort: missing row, empty/whitespace value,
+ *    or a failed read must all yield undefined — a preference can never break a
+ *    chat turn. Values are trimmed and hard-capped at the SSOT length.
+ * 2. buildCatSystemPrompt injects them as a delimited section that names them
+ *    preferences-not-overrides, placed BEFORE the user context, and omits the
+ *    section entirely when there are none.
+ */
+
+function supabaseReturning(row: unknown, error: unknown = null): AnySupabaseClient {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: row, error }),
+        }),
+      }),
+    }),
+  } as unknown as AnySupabaseClient;
+}
+
+describe('getCustomInstructions', () => {
+  it('returns the trimmed instructions when set', async () => {
+    const supabase = supabaseReturning({ custom_instructions: '  Answer in German.  ' });
+    expect(await getCustomInstructions(supabase, 'u1')).toBe('Answer in German.');
+  });
+
+  it('returns undefined when no preferences row exists', async () => {
+    expect(await getCustomInstructions(supabaseReturning(null), 'u1')).toBeUndefined();
+  });
+
+  it('returns undefined for empty or whitespace-only instructions', async () => {
+    expect(
+      await getCustomInstructions(supabaseReturning({ custom_instructions: '   ' }), 'u1')
+    ).toBeUndefined();
+    expect(
+      await getCustomInstructions(supabaseReturning({ custom_instructions: null }), 'u1')
+    ).toBeUndefined();
+  });
+
+  it('caps runaway values at the SSOT length', async () => {
+    const long = 'x'.repeat(MAX_CUSTOM_INSTRUCTIONS_LENGTH + 500);
+    const result = await getCustomInstructions(
+      supabaseReturning({ custom_instructions: long }),
+      'u1'
+    );
+    expect(result).toHaveLength(MAX_CUSTOM_INSTRUCTIONS_LENGTH);
+  });
+
+  it('returns undefined when the read throws (never break a chat turn)', async () => {
+    const throwing = {
+      from: () => {
+        throw new Error('db down');
+      },
+    } as unknown as AnySupabaseClient;
+    expect(await getCustomInstructions(throwing, 'u1')).toBeUndefined();
+  });
+});
+
+describe('buildCatSystemPrompt with custom instructions', () => {
+  it('omits the standing-instructions section when none are set', () => {
+    expect(buildCatSystemPrompt({})).not.toContain('Standing Instructions From This User');
+    expect(buildCatSystemPrompt({ userContext: 'ctx' })).not.toContain(
+      'Standing Instructions From This User'
+    );
+  });
+
+  it('injects instructions in a delimited section that names them preferences, not overrides', () => {
+    const prompt = buildCatSystemPrompt({ customInstructions: 'Prefer Lightning.' });
+    expect(prompt).toContain('## Standing Instructions From This User');
+    expect(prompt).toContain('Prefer Lightning.');
+    // The guardrail wording must survive edits: instructions never trump the rules.
+    expect(prompt).toMatch(/preferences, not overrides/i);
+  });
+
+  it('places instructions after the base prompt and before the user context', () => {
+    const prompt = buildCatSystemPrompt({
+      customInstructions: 'INSTRUCTIONS_MARKER',
+      userContext: 'CONTEXT_MARKER',
+    });
+    const instructionsAt = prompt.indexOf('INSTRUCTIONS_MARKER');
+    const contextAt = prompt.indexOf('CONTEXT_MARKER');
+    expect(instructionsAt).toBeGreaterThan(0);
+    expect(contextAt).toBeGreaterThan(instructionsAt);
+  });
+});

--- a/src/app/(authenticated)/dashboard/cat/permissions/CatActivityCard.tsx
+++ b/src/app/(authenticated)/dashboard/cat/permissions/CatActivityCard.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+/**
+ * CatActivityCard — read-only audit trail of what Cat actually did.
+ *
+ * Renders the user's recent cat_action_log rows (the table the action
+ * executor already writes; RLS limits reads to own rows). Pure view — no
+ * new bookkeeping, no mutations. Lives on the permissions page so "what
+ * can Cat do" and "what did Cat do" sit together.
+ */
+
+import { useEffect, useState } from 'react';
+import { History } from 'lucide-react';
+import { supabase } from '@/lib/supabase/browser';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { CAT_ACTIONS } from '@/config/cat-actions';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { logger } from '@/utils/logger';
+
+const ACTIVITY_LIMIT = 20;
+
+type ActionStatus = 'pending' | 'executing' | 'completed' | 'failed' | 'cancelled';
+
+interface ActivityRow {
+  id: string;
+  action_id: string;
+  status: ActionStatus;
+  amount_btc: number | null;
+  error_message: string | null;
+  requested_at: string;
+}
+
+const STATUS_STYLES: Record<ActionStatus, { label: string; className: string }> = {
+  completed: {
+    label: 'Done',
+    className: 'border-status-positive/30 bg-status-positive-subtle text-status-positive',
+  },
+  failed: {
+    label: 'Failed',
+    className: 'border-status-negative/30 bg-status-negative/10 text-status-negative',
+  },
+  cancelled: {
+    label: 'Cancelled',
+    className: 'border-subtle bg-surface-raised text-fg-secondary',
+  },
+  pending: {
+    label: 'Pending',
+    className: 'border-status-warning/30 bg-status-warning-subtle text-status-warning',
+  },
+  executing: {
+    label: 'Running',
+    className: 'border-status-warning/30 bg-status-warning-subtle text-status-warning',
+  },
+};
+
+export function CatActivityCard({ userId }: { userId: string }) {
+  const [rows, setRows] = useState<ActivityRow[] | null>(null);
+  const { formatAmountBtc } = useDisplayCurrency();
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data, error } = await supabase
+        .from(DATABASE_TABLES.CAT_ACTION_LOG)
+        .select('id, action_id, status, amount_btc, error_message, requested_at')
+        .eq('user_id', userId)
+        .order('requested_at', { ascending: false })
+        .limit(ACTIVITY_LIMIT);
+      if (cancelled) {
+        return;
+      }
+      if (error) {
+        logger.error('Failed to load Cat activity', error, 'CatPermissions');
+        setRows([]);
+        return;
+      }
+      setRows((data as ActivityRow[]) ?? []);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  return (
+    <div className="mt-6 rounded-lg border border-default bg-surface-base p-6">
+      <div className="mb-1 flex items-center gap-2">
+        <History className="h-5 w-5 text-fg-secondary" />
+        <h2 className="text-lg font-semibold text-fg-primary">Recent Cat activity</h2>
+      </div>
+      <p className="mb-4 text-sm text-fg-secondary">
+        Everything Cat has done on your behalf — the audit trail behind the permissions above.
+      </p>
+
+      {rows === null ? (
+        <p className="text-sm text-fg-tertiary">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-fg-tertiary">
+          No actions yet. When Cat creates something, sends a payment, or posts for you, it shows
+          up here.
+        </p>
+      ) : (
+        <ul className="divide-y divide-subtle">
+          {rows.map(row => {
+            const status = STATUS_STYLES[row.status] ?? STATUS_STYLES.pending;
+            return (
+              <li key={row.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2.5">
+                <span className="min-w-0 flex-1 truncate text-sm font-medium text-fg-primary">
+                  {CAT_ACTIONS[row.action_id]?.name ?? row.action_id}
+                </span>
+                {row.amount_btc !== null && row.amount_btc > 0 && (
+                  <span className="text-sm tabular-nums text-fg-secondary">
+                    {formatAmountBtc(row.amount_btc)}
+                  </span>
+                )}
+                <span
+                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${status.className}`}
+                >
+                  {status.label}
+                </span>
+                <span className="text-xs tabular-nums text-fg-tertiary">
+                  {new Date(row.requested_at).toLocaleDateString(undefined, {
+                    day: 'numeric',
+                    month: 'short',
+                  })}
+                </span>
+                {row.status === 'failed' && row.error_message && (
+                  <span className="w-full truncate text-xs text-status-negative">
+                    {row.error_message}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(authenticated)/dashboard/cat/permissions/page.tsx
+++ b/src/app/(authenticated)/dashboard/cat/permissions/page.tsx
@@ -15,6 +15,7 @@ import { CategoryRow } from './CategoryRow';
 import { SpendCapsCard } from './SpendCapsCard';
 import { PermissionPresets } from './PermissionPresets';
 import { PermissionInfo } from './PermissionInfo';
+import { CatActivityCard } from './CatActivityCard';
 
 export default function CatPermissionsPage() {
   const { user, isLoading: authLoading } = useRequireAuth();
@@ -220,6 +221,8 @@ export default function CatPermissionsPage() {
             saving={saving}
             onToggleCategory={toggleCategory}
           />
+
+          <CatActivityCard userId={user.id} />
 
           <PermissionInfo />
         </div>

--- a/src/app/(authenticated)/settings/SettingsDataSection.tsx
+++ b/src/app/(authenticated)/settings/SettingsDataSection.tsx
@@ -69,6 +69,12 @@ export function SettingsDataSection() {
         <DatabaseBackup className="mr-2 h-6 w-6" />
         Your data
       </h3>
+      <p className="mb-6 text-fg-secondary">
+        OrangeCat never uses your data to train AI models. When Cat calls an AI provider, that
+        provider&apos;s own data policy applies — with your own key it&apos;s your provider
+        agreement; on the free pool, prompts may be logged by the model host. Your data here exists
+        to serve you, and you can take it or delete it anytime.
+      </p>
 
       <div className="space-y-4">
         <div className="rounded-md border border-default bg-surface-raised/30 p-6">

--- a/src/app/(authenticated)/settings/SettingsSecuritySection.tsx
+++ b/src/app/(authenticated)/settings/SettingsSecuritySection.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { Shield, Link2 } from 'lucide-react';
+import { useState } from 'react';
+import { Shield, Link2, Loader2, MonitorSmartphone } from 'lucide-react';
 import { toast } from 'sonner';
 import { MFAStatus } from '@/components/auth/MFASetup';
 import { NostrConnectionCard } from '@/components/nostr/NostrConnectionCard';
+import Button from '@/components/ui/Button';
+import { supabase } from '@/lib/supabase/browser';
+import { ROUTES } from '@/config/routes';
+import { logger } from '@/utils/logger';
 
 interface Props {
   mfaStatusKey: number;
@@ -18,6 +23,26 @@ export function SettingsSecuritySection({
   onViewRecoveryCodes,
   onMFADisableComplete,
 }: Props) {
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  // Revokes every refresh token for the account (scope: 'global'), then sends
+  // this browser to the sign-in page. Other devices are signed out as their
+  // access tokens expire (~1h max).
+  const handleSignOutEverywhere = async () => {
+    setIsSigningOut(true);
+    try {
+      const { error } = await supabase.auth.signOut({ scope: 'global' });
+      if (error) {
+        throw error;
+      }
+      window.location.assign(ROUTES.AUTH);
+    } catch (err) {
+      logger.error('Global sign-out failed', err, 'Settings');
+      toast.error('Could not sign out everywhere. Try again.');
+      setIsSigningOut(false);
+    }
+  };
+
   return (
     <>
       <div className="border-t border-subtle pt-10">
@@ -51,6 +76,32 @@ export function SettingsSecuritySection({
             </p>
           </div>
         </div>
+      </div>
+
+      <div className="border-t border-subtle pt-10">
+        <h3 className="text-lg font-semibold text-fg-primary mb-4 flex items-center">
+          <MonitorSmartphone className="w-6 h-6 mr-2 text-fg-secondary" />
+          Active Sessions
+        </h3>
+        <p className="text-fg-secondary mb-6">
+          Lost a device, or signed in somewhere you don&apos;t trust? Sign out of your account on
+          every device, including this one. You&apos;ll need to sign in again.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleSignOutEverywhere}
+          disabled={isSigningOut}
+          className="px-6 py-2"
+        >
+          {isSigningOut ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Signing out…
+            </>
+          ) : (
+            'Sign out all devices'
+          )}
+        </Button>
       </div>
 
       <div className="border-t border-subtle pt-10">

--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -24,6 +24,7 @@ import { useAISettings } from '@/hooks/useAISettings';
 import Loading from '@/components/Loading';
 import { AIKeyManager } from '@/components/ai/AIKeyManager';
 import { CatCreditsPanel } from '@/components/ai/CatCreditsPanel';
+import { CatCustomInstructions } from '@/components/ai/CatCustomInstructions';
 import { CatMemoryManager } from '@/components/ai/CatMemoryManager';
 import { CatMemoryImport } from '@/components/ai/CatMemoryImport';
 import { getProvidersByCategory } from '@/data/aiProviders';
@@ -198,9 +199,17 @@ export default function AISettingsPage() {
           </h2>
           <p className="mt-1 text-sm text-fg-secondary">
             Cat&apos;s memory is yours: review it, delete any of it, export it, or bring context
-            over from another AI.
+            over from another AI. Standing instructions steer how Cat behaves in every chat.
           </p>
         </div>
+
+        <CatCustomInstructions
+          value={preferences?.custom_instructions ?? null}
+          isLoading={settingsLoading}
+          onSave={async instructions => {
+            await updatePreferences({ custom_instructions: instructions });
+          }}
+        />
 
         <CatMemoryManager
           reloadKey={memoryReloadKey}

--- a/src/components/ai/CatCustomInstructions.tsx
+++ b/src/components/ai/CatCustomInstructions.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+/**
+ * CatCustomInstructions — the user's standing instructions for their Cat.
+ *
+ * One textarea persisted to user_ai_preferences.custom_instructions and
+ * injected into every Cat system prompt (src/services/cat/system-prompt.ts).
+ * Instructions steer tone, language, and economic behavior; they never
+ * override confirmation requirements or spend permissions.
+ */
+
+import { useEffect, useState } from 'react';
+import { Loader2, SlidersHorizontal } from 'lucide-react';
+import { toast } from 'sonner';
+import Button from '@/components/ui/Button';
+import { MAX_CUSTOM_INSTRUCTIONS_LENGTH } from '@/services/cat/custom-instructions';
+
+interface Props {
+  value: string | null;
+  onSave: (value: string | null) => Promise<void>;
+  isLoading?: boolean;
+}
+
+export function CatCustomInstructions({ value, onSave, isLoading }: Props) {
+  const [draft, setDraft] = useState(value ?? '');
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Adopt the server value once it arrives (or after an external refetch),
+  // but never clobber an edit in progress.
+  useEffect(() => {
+    setDraft(prev => (prev === '' ? (value ?? '') : prev));
+  }, [value]);
+
+  const trimmed = draft.trim();
+  const dirty = trimmed !== (value ?? '').trim();
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await onSave(trimmed === '' ? null : trimmed);
+      toast.success(trimmed === '' ? 'Instructions cleared' : 'Instructions saved');
+    } catch {
+      toast.error('Could not save instructions. Try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-default bg-surface-base p-6">
+      <div className="mb-4 flex items-start gap-3">
+        <div className="rounded-md bg-surface-raised p-2">
+          <SlidersHorizontal className="h-5 w-5 text-fg-primary" />
+        </div>
+        <div className="flex-1">
+          <h2 className="text-lg font-semibold text-fg-primary">Custom instructions</h2>
+          <p className="mt-1 text-sm text-fg-secondary">
+            Standing instructions Cat follows in every conversation — tone, language, and how to
+            handle your economic activity (e.g. &ldquo;prefer Lightning&rdquo;, &ldquo;never suggest
+            loans&rdquo;, &ldquo;keep replies short&rdquo;). Cat still asks before anything spends
+            money — instructions can&apos;t change that.
+          </p>
+        </div>
+      </div>
+      <textarea
+        value={draft}
+        onChange={e => setDraft(e.target.value.slice(0, MAX_CUSTOM_INSTRUCTIONS_LENGTH))}
+        disabled={isLoading || isSaving}
+        rows={4}
+        placeholder="e.g. Answer in German. Prices in CHF. I only offer services, never physical products."
+        className="w-full rounded-md border border-default bg-surface-page p-3 text-sm text-fg-primary placeholder:text-fg-tertiary focus:border-interactive focus:outline-none disabled:opacity-60"
+      />
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <span className="text-xs text-fg-tertiary">
+          {draft.length}/{MAX_CUSTOM_INSTRUCTIONS_LENGTH}
+        </span>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleSave}
+          disabled={!dirty || isSaving || isLoading}
+          className="px-5 py-2"
+        >
+          {isSaving ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving…
+            </>
+          ) : (
+            'Save instructions'
+          )}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useAISettings.ts
+++ b/src/hooks/useAISettings.ts
@@ -25,6 +25,8 @@ export interface UserAIPreferences {
   onboarding_step: number;
   /** Consent: may Cat extract + store memories from conversations? Gates extractAndStoreMemories. */
   memory_enabled: boolean;
+  /** Standing instructions injected into the Cat system prompt (null = none). */
+  custom_instructions: string | null;
   /** The free platform default's position in the Cat fallback chain (0 = first). */
   platform_chain_position: number;
   cached_total_requests: number;

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -17,6 +17,7 @@ import { apiSuccess } from '@/lib/api/standardResponse';
 import type { AuthenticatedRequest } from '@/lib/api/withAuth';
 import { applyRateLimitHeaders, type RateLimitResult } from '@/lib/rate-limit';
 import { buildCatSystemPrompt } from '@/services/cat/system-prompt';
+import { getCustomInstructions } from '@/services/cat/custom-instructions';
 import { buildReplyLanguageDirective } from '@/services/cat/reply-language';
 import { getCatFewShotExamplesText } from '@/services/cat/few-shot-examples';
 import { parseActionsFromResponse } from '@/services/cat/response-parser';
@@ -248,7 +249,7 @@ export async function orchestrateCatChat(
   // every turn, it just has to beat the (already parallel) context fetchers. Recall
   // is best-effort: [] if memory is unavailable. Folded in near the top of the
   // context so the budget always keeps the durable facts.
-  const [userContext, memories] = await Promise.all([
+  const [userContext, memories, customInstructions] = await Promise.all([
     fetchFullContextForCat(supabase, user.id, {
       preferredCurrency,
       locale,
@@ -258,6 +259,7 @@ export async function orchestrateCatChat(
       pageExcerpt,
     }),
     recallMemories(supabase, user.id, message),
+    getCustomInstructions(supabase, user.id),
   ]);
   userContext.memories = memories;
   const contextString = buildFullContextString(userContext);
@@ -272,7 +274,7 @@ export async function orchestrateCatChat(
   // The per-turn reply-language directive goes DEAD LAST: weak free models
   // weight the prompt tail most, and burying the language rule mid-prompt let
   // them default to the browser locale's language (English in → German out).
-  const systemPrompt = `${buildCatSystemPrompt({ userContext: contextString || undefined })}\n\n${getCatFewShotExamplesText()}${buildReplyLanguageDirective(message)}`;
+  const systemPrompt = `${buildCatSystemPrompt({ userContext: contextString || undefined, customInstructions })}\n\n${getCatFewShotExamplesText()}${buildReplyLanguageDirective(message)}`;
 
   let conversationId: string | null = null;
   let historyMessages: Array<{ role: 'user' | 'assistant'; content: string }> = [];

--- a/src/services/cat/custom-instructions.ts
+++ b/src/services/cat/custom-instructions.ts
@@ -1,0 +1,36 @@
+/**
+ * Cat custom instructions — the user's standing instructions for their Cat.
+ *
+ * One column (`user_ai_preferences.custom_instructions`), one fetch, one
+ * injection point (buildCatSystemPrompt). The length ceiling here is the
+ * app-side SSOT; the DB CHECK constraint (migration 20260802130000) is the
+ * backstop for direct client writes.
+ */
+
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { DATABASE_TABLES } from '@/config/database-tables';
+
+export const MAX_CUSTOM_INSTRUCTIONS_LENGTH = 2000;
+
+/**
+ * Fetch the user's standing instructions, trimmed and length-capped.
+ * Best-effort: any failure returns undefined — a missing preference must
+ * never break a chat turn.
+ */
+export async function getCustomInstructions(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<string | undefined> {
+  try {
+    const { data } = await supabase
+      .from(DATABASE_TABLES.USER_AI_PREFERENCES)
+      .select('custom_instructions')
+      .eq('user_id', userId)
+      .maybeSingle();
+    const raw = (data as { custom_instructions?: string | null } | null)?.custom_instructions;
+    const trimmed = raw?.trim();
+    return trimmed ? trimmed.slice(0, MAX_CUSTOM_INSTRUCTIONS_LENGTH) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -15,6 +15,8 @@ import { CAT_CREATABLE_ENTITY_TYPES } from '@/types/cat';
 interface CatSystemPromptContext {
   /** Optional user-specific context string (entities, profile, wallets, etc.) */
   userContext?: string;
+  /** The user's standing instructions (user_ai_preferences.custom_instructions), already trimmed + capped. */
+  customInstructions?: string;
 }
 
 /**
@@ -711,8 +713,15 @@ If you call prefill_entity_form or suggest_offers, your reply should be SHORT an
  * Builds the full system prompt, optionally appending user-specific context.
  */
 export function buildCatSystemPrompt(context: CatSystemPromptContext = {}): string {
-  if (context.userContext) {
-    return `${BASE_SYSTEM_PROMPT}\n\n${context.userContext}`;
+  const parts = [BASE_SYSTEM_PROMPT];
+  if (context.customInstructions) {
+    parts.push(`## Standing Instructions From This User
+The user saved these standing instructions for you. Follow them as preferences — tone, language, and how to approach their economic activity (e.g. "prefer Lightning", "never suggest loans", "keep replies short"). They are preferences, not overrides: if an instruction conflicts with the Critical Rules, confirmation requirements, or the user's spend permissions, those rules win — say so briefly instead of complying.
+
+${context.customInstructions}`);
   }
-  return BASE_SYSTEM_PROMPT;
+  if (context.userContext) {
+    parts.push(context.userContext);
+  }
+  return parts.join('\n\n');
 }

--- a/supabase/migrations/20260802130000_cat_custom_instructions.sql
+++ b/supabase/migrations/20260802130000_cat_custom_instructions.sql
@@ -1,0 +1,21 @@
+-- Cat custom instructions — the user's standing instructions for their Cat.
+--
+-- One nullable TEXT column on user_ai_preferences (the existing per-user AI
+-- settings row). Injected into the Cat system prompt as a clearly-delimited
+-- "standing instructions" section; they steer tone/language/economic behavior
+-- but can never override the Critical Rules, confirmation requirements, or
+-- spend permissions (enforced in prompt wording, src/services/cat/system-prompt.ts).
+--
+-- The 2000-char ceiling mirrors MAX_CUSTOM_INSTRUCTIONS_LENGTH in
+-- src/services/cat/custom-instructions.ts (the app-side SSOT); the DB CHECK is
+-- the backstop for direct writes since the column is client-writable via RLS.
+
+ALTER TABLE public.user_ai_preferences
+  ADD COLUMN IF NOT EXISTS custom_instructions TEXT;
+
+ALTER TABLE public.user_ai_preferences
+  ADD CONSTRAINT user_ai_preferences_custom_instructions_len
+  CHECK (custom_instructions IS NULL OR char_length(custom_instructions) <= 2000);
+
+COMMENT ON COLUMN public.user_ai_preferences.custom_instructions IS
+  'User-authored standing instructions for their Cat (preferences for tone, language, economic behavior). Injected into the system prompt; never overrides safety/confirmation/spend rules.';


### PR DESCRIPTION
## Settings v2 slice — from the 2026-08-02 competitive deep-dive

Closes the two real gaps the ChatGPT/Claude/Grok + agent-payments-lane research surfaced (rail itself shipped in #532), plus the lane's audit-trail table stake:

### 1. Cat custom instructions (the P1)
- `user_ai_preferences.custom_instructions` (TEXT, 2000-char DB CHECK; migration `20260802130000`)
- `src/services/cat/custom-instructions.ts` — SSOT for the length cap + best-effort fetch (missing row / empty / error → undefined; a preference can never break a chat turn)
- Injected by `buildCatSystemPrompt` as a delimited **"Standing Instructions From This User"** section — explicitly preferences-not-overrides: Critical Rules, confirmation requirements, and spend permissions always win
- Fetched in the orchestrator's existing parallel `Promise.all` (no added latency path)
- Card on `/settings/ai` (textarea, counter, save via existing `updatePreferences` RLS path)

### 2. Sign out all devices
- `/settings` → Security: `supabase.auth.signOut({ scope: 'global' })` revokes every refresh token, then redirects to sign-in. ChatGPT/Claude both have this; a money platform needs it more.

### 3. Honest "never train" statement
- "Your data" now states OrangeCat never trains on user data — worded honestly: provider policy applies when Cat calls a provider (free-pool prompts may be logged by the model host).

### 4. Recent Cat activity (audit trail)
- Read-only card on `/dashboard/cat/permissions` over the existing `cat_action_log` table (whose own comment says "full history for transparency" — it had RLS SELECT policies but zero UI). Action names from `CAT_ACTIONS`, amounts via `useDisplayCurrency`, status chips, failure reasons. No new bookkeeping.

## Verification
- `npm run verify` green (type-check, lint, route audit, docs scan, 1448 unit tests incl. 8 new for fetch semantics + prompt injection/ordering/guardrail)
- Rebased onto #532's unified settings shell; cat suite (360 tests) green post-rebase
- Migration must be applied on the box before/with deploy: `scripts/apply-migrations.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)