### PR TITLE
feat(usage): Settings → Usage — daily budget, reset time, credits, and plan at a glance

### DIFF
--- a/src/app/(authenticated)/settings/usage/page.tsx
+++ b/src/app/(authenticated)/settings/usage/page.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+/**
+ * Settings → Usage — the one page that answers "how much AI do I have left,
+ * what counts against it, and when does it reset?" in a single glance.
+ *
+ * Everything here was ALREADY computed server-side and returned by
+ * GET /api/cat/quota (resetInSeconds, dailyRequests, expiresAt) and
+ * GET /api/cat/credits (balanceBtc) — it just was never rendered anywhere,
+ * leaving the tiny chat-toolbar chip as the only quota surface. This page
+ * composes those two existing endpoints; no new backend.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Gauge, KeyRound, Sparkles, Wallet } from 'lucide-react';
+import { useCatQuota } from '@/components/ai-chat/ModernChatPanel/hooks/useCatQuota';
+import { API_ROUTES } from '@/config/api-routes';
+import { ROUTES } from '@/config/routes';
+import { CAT_PLANS, type CatPlanId } from '@/config/cat-plans';
+import { logger } from '@/utils/logger';
+
+/** "3h 24m" / "45m" from seconds — for the daily-reset countdown. */
+function formatCountdown(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.max(1, Math.floor((totalSeconds % 3600) / 60));
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function useCreditBalance(): { balanceBtc: number | null; isLoading: boolean } {
+  const [balanceBtc, setBalanceBtc] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(API_ROUTES.CAT.CREDITS, { credentials: 'include' });
+        if (!res.ok) {
+          return;
+        }
+        const body = (await res.json()) as { success: boolean; data?: { balanceBtc: number } };
+        if (!cancelled && body.success && body.data) {
+          setBalanceBtc(body.data.balanceBtc);
+        }
+      } catch (error) {
+        logger.warn('Usage page: credit balance fetch failed', { error }, 'Usage');
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return { balanceBtc, isLoading };
+}
+
+export default function UsageSettingsPage() {
+  const { quota, isLoading: quotaLoading } = useCatQuota();
+  const { balanceBtc } = useCreditBalance();
+
+  /** Which CAT_PLANS card is the user's current reality. */
+  const activePlanId: CatPlanId | null = quota
+    ? quota.tier === 'byok'
+      ? 'byok'
+      : quota.tier === 'pro'
+        ? 'supporter'
+        : 'free'
+    : null;
+
+  const used = quota ? quota.dailyRequests : 0;
+  const limit = quota ? quota.dailyLimit : 0;
+  const pct = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* ── Today's budget ─────────────────────────────────────────────── */}
+      <section className="rounded-lg border border-default bg-surface-base p-6">
+        <div className="flex items-start gap-3">
+          <div className="rounded-md bg-surface-raised p-2">
+            <Gauge className="h-5 w-5 text-fg-secondary" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="font-heading text-base font-semibold text-fg-primary">
+              Today&apos;s Cat budget
+            </h2>
+            {quotaLoading ? (
+              <p className="mt-2 text-sm text-fg-tertiary">Loading your usage…</p>
+            ) : !quota ? (
+              <p className="mt-2 text-sm text-fg-tertiary">
+                Couldn&apos;t load your usage right now — the chat itself still works. Refresh to
+                try again.
+              </p>
+            ) : quota.tier === 'byok' ? (
+              <div className="mt-2 space-y-2">
+                <p className="text-sm text-fg-secondary">
+                  <KeyRound className="mr-1 inline h-4 w-4 align-text-bottom" aria-hidden="true" />
+                  You&apos;re on your own key
+                  {quota.activeByokProviderName ? ` (${quota.activeByokProviderName})` : ''} —{' '}
+                  <span className="font-medium text-fg-primary">no daily cap</span>. You pay your
+                  provider directly; OrangeCat never marks it up.
+                </p>
+                <p className="text-sm text-fg-tertiary">
+                  Remove your key in{' '}
+                  <Link href={ROUTES.SETTINGS_AI} className="underline underline-offset-2">
+                    AI settings
+                  </Link>{' '}
+                  and you fall back to the free daily budget below.
+                </p>
+              </div>
+            ) : (
+              <div className="mt-3 space-y-3">
+                <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                  <span className="text-2xl font-semibold text-fg-primary">
+                    {quota.requestsRemaining}
+                  </span>
+                  <span className="text-sm text-fg-secondary">
+                    of {limit} messages left today
+                    {quota.tier === 'pro' && (
+                      <>
+                        {' '}
+                        <Sparkles
+                          className="inline h-3.5 w-3.5 text-accent-warm"
+                          aria-hidden="true"
+                        />{' '}
+                        Supporter
+                      </>
+                    )}
+                  </span>
+                </div>
+                <div
+                  className="h-2 w-full overflow-hidden rounded-full bg-surface-raised"
+                  role="progressbar"
+                  aria-valuenow={used}
+                  aria-valuemin={0}
+                  aria-valuemax={limit}
+                  aria-label={`${used} of ${limit} daily messages used`}
+                >
+                  <div
+                    className={
+                      quota.requestsRemaining <= 0
+                        ? 'h-full rounded-full bg-status-negative'
+                        : quota.requestsRemaining <= 2
+                          ? 'h-full rounded-full bg-status-warning'
+                          : 'h-full rounded-full bg-accent-warm'
+                    }
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <p className="text-sm text-fg-tertiary">
+                  Used {used} today · resets in{' '}
+                  <span className="font-medium text-fg-secondary">
+                    {formatCountdown(quota.resetInSeconds)}
+                  </span>{' '}
+                  (midnight UTC)
+                  {quota.tier === 'pro' && quota.expiresAt && (
+                    <>
+                      {' '}
+                      · Supporter until{' '}
+                      {new Date(quota.expiresAt).toLocaleDateString(undefined, {
+                        day: 'numeric',
+                        month: 'short',
+                        year: 'numeric',
+                      })}
+                    </>
+                  )}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* ── What counts ────────────────────────────────────────────────── */}
+      <section className="rounded-lg border border-default bg-surface-base p-6">
+        <h2 className="font-heading text-base font-semibold text-fg-primary">What counts</h2>
+        <ul className="mt-3 space-y-2 text-sm text-fg-secondary">
+          <li>• Every message you send to Cat on the free or Supporter plan counts as 1.</li>
+          <li>
+            • Messages sent through your own API key don&apos;t touch this budget — your provider
+            bills you directly.
+          </li>
+          <li>
+            • Frontier-model messages paid with Cat Credits are metered per message from your credit
+            balance, not from the daily budget.
+          </li>
+          <li>• Image generation is free and doesn&apos;t count.</li>
+          <li>
+            • The counter resets every day at midnight UTC. Unused messages don&apos;t roll over.
+          </li>
+        </ul>
+      </section>
+
+      {/* ── Cat Credits ────────────────────────────────────────────────── */}
+      <section className="rounded-lg border border-default bg-surface-base p-6">
+        <div className="flex items-start gap-3">
+          <div className="rounded-md bg-surface-raised p-2">
+            <Wallet className="h-5 w-5 text-fg-secondary" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="font-heading text-base font-semibold text-fg-primary">Cat Credits</h2>
+            <p className="mt-2 text-sm text-fg-secondary">
+              {balanceBtc !== null ? (
+                <>
+                  Balance:{' '}
+                  <span className="font-medium text-fg-primary">{balanceBtc.toFixed(8)} BTC</span>
+                </>
+              ) : (
+                'Prepaid balance for managed frontier models, billed per message.'
+              )}
+            </p>
+            <p className="mt-1 text-sm text-fg-tertiary">
+              Top up and see the per-message ledger in{' '}
+              <Link href={ROUTES.SETTINGS_AI} className="underline underline-offset-2">
+                AI settings
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Plans at a glance ──────────────────────────────────────────── */}
+      <section className="rounded-lg border border-default bg-surface-base p-6">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <h2 className="font-heading text-base font-semibold text-fg-primary">
+            Your plan options
+          </h2>
+          <Link
+            href={ROUTES.PRICING}
+            className="text-sm text-fg-secondary underline underline-offset-2 hover:text-fg-primary"
+          >
+            Full comparison →
+          </Link>
+        </div>
+        <ul className="mt-3 divide-y divide-border-subtle">
+          {CAT_PLANS.map(plan => {
+            const isActive = plan.id === activePlanId;
+            return (
+              <li
+                key={plan.id}
+                className="flex min-h-11 flex-wrap items-center gap-x-3 gap-y-1 py-3"
+              >
+                <span className="font-medium text-fg-primary">{plan.name}</span>
+                {isActive && (
+                  <span className="rounded-full bg-accent-warm/15 px-2 py-0.5 text-xs font-medium text-accent-warm">
+                    Your plan
+                  </span>
+                )}
+                {plan.status === 'coming-soon' && (
+                  <span className="rounded-full bg-surface-raised px-2 py-0.5 text-xs text-fg-tertiary">
+                    Activating
+                  </span>
+                )}
+                <span className="w-full text-sm text-fg-tertiary sm:w-auto sm:flex-1">
+                  {plan.bullets[0]} · {plan.priceCopy}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/components/ai-chat/ModernChatPanel/components/QuotaMeter.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/QuotaMeter.tsx
@@ -43,16 +43,17 @@ export function QuotaMeter({ quota, className }: QuotaMeterProps) {
     // "Together" in their toolbar instead of a generic "Your key".
     const label = quota.activeByokProviderName ?? 'Your key';
     return (
-      <span
+      <Link
+        href={ROUTES.SETTINGS_USAGE}
         className={cn(
-          'inline-flex items-center gap-1 rounded-md border border-subtle bg-surface-raised px-2 py-1 text-xs text-fg-secondary',
+          'inline-flex items-center gap-1 rounded-md border border-subtle bg-surface-raised px-2 py-1 text-xs text-fg-secondary hover:text-fg-primary',
           className
         )}
-        title={`Cat is routing through your ${label} key — you pay them directly.`}
+        title={`Cat is routing through your ${label} key — you pay them directly. Click for full usage.`}
       >
         <KeyRound className="h-3 w-3" aria-hidden="true" />
         {label}
-      </span>
+      </Link>
     );
   }
 
@@ -86,7 +87,12 @@ export function QuotaMeter({ quota, className }: QuotaMeterProps) {
       {isPro && !isCapped && !isNearCap && (
         <Sparkles className="h-3 w-3 text-accent-warm" aria-hidden="true" />
       )}
-      <span className="whitespace-nowrap" aria-live="polite">
+      <Link
+        href={ROUTES.SETTINGS_USAGE}
+        className="whitespace-nowrap hover:underline"
+        aria-live="polite"
+        title="See your full usage — what counts, when it resets, and your plan"
+      >
         {isCapped ? (
           'Daily limit reached'
         ) : (
@@ -98,7 +104,7 @@ export function QuotaMeter({ quota, className }: QuotaMeterProps) {
           </>
         )}
         <span className="sr-only"> {explanation}</span>
-      </span>
+      </Link>
       {(isCapped || isNearCap) && (
         <Link
           href={ROUTES.SETTINGS_AI}

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -91,10 +91,22 @@ const headerNavigationConfig = {
       name: 'Product',
       children: [
         { name: 'About & mission', href: ROUTES.ABOUT, description: 'Why OrangeCat exists' },
-        { name: 'Roadmap', href: ROUTES.ROADMAP, description: 'What works now and what comes next' },
+        {
+          name: 'Roadmap',
+          href: ROUTES.ROADMAP,
+          description: 'What works now and what comes next',
+        },
         { name: 'Changelog', href: ROUTES.CHANGELOG, description: 'Every shipped improvement' },
-        { name: 'Docs', href: ROUTES.DOCS, description: 'Entities, Bitcoin payments, and security' },
-        { name: 'Whitepaper', href: ROUTES.WHITEPAPER, description: 'The economic coordination thesis' },
+        {
+          name: 'Docs',
+          href: ROUTES.DOCS,
+          description: 'Entities, Bitcoin payments, and security',
+        },
+        {
+          name: 'Whitepaper',
+          href: ROUTES.WHITEPAPER,
+          description: 'The economic coordination thesis',
+        },
       ],
     },
     { name: 'Blog', href: ROUTES.BLOG },
@@ -314,6 +326,7 @@ export const footerNavigation = {
     { name: 'How it works', href: ROUTES.HOW_IT_WORKS },
     { name: 'Roadmap', href: ROUTES.ROADMAP },
     { name: 'Changelog', href: ROUTES.CHANGELOG },
+    { name: 'Cat plans', href: ROUTES.PRICING },
   ],
   learn: [
     { name: 'Documentation', href: ROUTES.DOCS },

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -424,4 +424,5 @@ export const ROUTES = {
   SETTINGS_AI_ONBOARDING: '/settings/ai/onboarding',
   SETTINGS_INTEGRATIONS: '/settings/integrations',
   SETTINGS_NOTIFICATIONS: '/settings/notifications',
+  SETTINGS_USAGE: '/settings/usage',
 } as const;

--- a/src/config/settings-nav.ts
+++ b/src/config/settings-nav.ts
@@ -1,4 +1,4 @@
-import { Bell, BrainCircuit, KeyRound, UserRound, type LucideIcon } from 'lucide-react';
+import { Bell, BrainCircuit, Gauge, KeyRound, UserRound, type LucideIcon } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
 
 /**
@@ -34,6 +34,12 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     label: 'AI',
     description: 'How Cat runs: managed, credits, your own keys, or local.',
     icon: BrainCircuit,
+  },
+  {
+    href: ROUTES.SETTINGS_USAGE,
+    label: 'Usage',
+    description: 'How much Cat you have left today, what counts, and when it resets.',
+    icon: Gauge,
   },
   {
     href: ROUTES.SETTINGS_INTEGRATIONS,


### PR DESCRIPTION
## Problem

"How much AI do I have left?" was answerable only by a tiny chip inside the chat toolbar. The quota API already computed `resetInSeconds`, `dailyRequests`, and the Supporter `expiresAt` — rendered nowhere. `/pricing` existed but wasn't linked from any nav. Nothing explained what counts against the cap, that image generation is exempt, that BYOK bypasses it, or that it resets at midnight UTC.

## Fix

**New `/settings/usage`** (one entry in the `SETTINGS_SECTIONS` SSOT + one page file, per the #532 architecture):
- Today's budget: N of M left, progress bar (warning/negative near/at cap), used-today, **resets in Xh Ym (midnight UTC)** — first render of `resetInSeconds`
- Supporter: shows the 200/day tier and **expiry date** — first render of `expiresAt`
- BYOK: explains no-cap + active provider, and how to fall back to free
- "What counts" explainer (messages count 1; BYOK and credit-metered don't; images free; no rollover)
- Cat Credits balance + link to the ledger/top-up in AI settings
- Compact plan list from `CAT_PLANS` with a "Your plan" marker — the config's first in-app consumer, links to /pricing

**Discoverability:** both chat quota chips (free/pro counter and the BYOK provider chip) link to the page; `/pricing` added to footer product nav.

Composes existing `GET /api/cat/quota` + `GET /api/cat/credits` — zero new backend.

## Verification

`npm run verify` green (type-check, docs, route audit, lint 0 errors, 1444 unit tests). Live check after deploy: /settings/usage renders real numbers for a signed-in user; chip click-through works.

## Noted, out of scope

Copy drift on /pricing prose + CatSettingsTab still says "Pro is a waitlist / when it ships" while the plan cards say Supporter/activating — separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)