### PR TITLE
feat(cat): never-a-dead-end — circuit breaker + recovery-action error cards

### DIFF
--- a/__tests__/unit/ai/link-health.test.ts
+++ b/__tests__/unit/ai/link-health.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Circuit breaker for the Cat provider chain — dead links are skipped for a
+ * TTL, but pruning may NEVER empty a chain (retrying dead links beats
+ * refusing to try, which is the "Cat is never unavailable" invariant).
+ */
+import {
+  isLinkDown,
+  markLinkDown,
+  pruneDownLinks,
+  resetLinkHealth,
+} from '@/services/ai/link-health';
+
+const CHAIN = [
+  { provider: 'groq', model: 'llama-3.3-70b-versatile' },
+  { provider: 'openrouter', model: 'a:free' },
+  { provider: 'openrouter', model: 'b:free' },
+];
+
+describe('link-health', () => {
+  beforeEach(() => {
+    resetLinkHealth();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('marks a link down and prunes it from the chain', () => {
+    markLinkDown('groq', 'llama-3.3-70b-versatile');
+    expect(isLinkDown('groq', 'llama-3.3-70b-versatile')).toBe(true);
+    const pruned = pruneDownLinks(CHAIN, l => l);
+    expect(pruned.map(l => l.provider)).toEqual(['openrouter', 'openrouter']);
+  });
+
+  it('expires the down-mark after the TTL', () => {
+    markLinkDown('groq', 'llama-3.3-70b-versatile', 1000);
+    jest.advanceTimersByTime(1001);
+    expect(isLinkDown('groq', 'llama-3.3-70b-versatile')).toBe(false);
+    expect(pruneDownLinks(CHAIN, l => l)).toHaveLength(3);
+  });
+
+  it('never prunes to an empty chain — all-down returns the original', () => {
+    for (const l of CHAIN) {
+      markLinkDown(l.provider, l.model);
+    }
+    expect(pruneDownLinks(CHAIN, l => l)).toEqual(CHAIN);
+  });
+
+  it('same model id under different providers is tracked separately', () => {
+    markLinkDown('openrouter', 'a:free');
+    expect(isLinkDown('together', 'a:free')).toBe(false);
+  });
+});

--- a/src/components/ai-chat/ModernChatPanel/components/ErrorDisplay.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/ErrorDisplay.tsx
@@ -1,24 +1,44 @@
 /**
  * ERROR DISPLAY COMPONENT
- * Shows error messages with optional API key link
+ *
+ * The invariant this card serves: Cat being unavailable must never be a dead
+ * end. Every failure code maps to the concrete actions that FIX it (free key,
+ * credits, retry) — deep-linked, not narrated. Falls back to text-sniffing
+ * only for legacy errors that carry no code.
  */
 
 import { useRouter } from 'next/navigation';
-import { AlertCircle, Key, X } from 'lucide-react';
+import { AlertCircle, Coins, Key, X } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
 import { CatStatusButton } from '@/components/ai-chat/CatStatusNote';
 
 interface ErrorDisplayProps {
   error: string;
+  /** Machine-readable failure code from the chat API (drives recovery CTAs). */
+  code?: string | null;
   onRetry?: () => void;
   onDismiss?: () => void;
 }
 
-export function ErrorDisplay({ error, onRetry, onDismiss }: ErrorDisplayProps) {
+/** Codes where adding a key / topping up credits genuinely fixes the problem. */
+const FIXABLE_CODES = new Set([
+  'DAILY_LIMIT',
+  'AI_RATE_LIMITED',
+  'ALL_PROVIDERS_DOWN',
+  'NO_API_KEY',
+  'STREAM_ERROR',
+  'INSUFFICIENT_CREDITS',
+]);
+
+export function ErrorDisplay({ error, code, onRetry, onDismiss }: ErrorDisplayProps) {
   const router = useRouter();
 
-  const showApiKeyLink =
+  const legacyKeyHint =
     error.includes('API key') || error.includes('openrouter') || error.includes('not configured');
+  const showFixActions = (code ? FIXABLE_CODES.has(code) : false) || legacyKeyHint;
+  // Retrying a hard daily cap or an empty credit balance just fails again —
+  // don't offer a button that lies.
+  const showRetry = Boolean(onRetry) && code !== 'DAILY_LIMIT' && code !== 'INSUFFICIENT_CREDITS';
 
   return (
     <div className="mx-4 mb-2 rounded-md border border-status-negative/20 bg-status-negative/10 p-3">
@@ -27,16 +47,25 @@ export function ErrorDisplay({ error, onRetry, onDismiss }: ErrorDisplayProps) {
         <div className="flex-1 min-w-0">
           <p className="text-base text-status-negative">{error}</p>
           <div className="flex flex-wrap items-center gap-2 mt-2">
-            {showApiKeyLink && (
-              <button
-                onClick={() => router.push(ROUTES.SETTINGS_AI)}
-                className="inline-flex items-center gap-1.5 rounded-md bg-accent-warm px-3 py-1.5 text-xs font-semibold text-white hover:bg-accent-warm/90 transition-colors"
-              >
-                <Key className="h-3.5 w-3.5" />
-                Add your API key
-              </button>
+            {showFixActions && (
+              <>
+                <button
+                  onClick={() => router.push(ROUTES.SETTINGS_AI)}
+                  className="inline-flex items-center gap-1.5 rounded-md bg-accent-warm px-3 py-1.5 text-xs font-semibold text-white hover:bg-accent-warm/90 transition-colors"
+                >
+                  <Key className="h-3.5 w-3.5" />
+                  Add a free key
+                </button>
+                <button
+                  onClick={() => router.push(ROUTES.SETTINGS_AI)}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-default px-3 py-1.5 text-xs font-semibold text-fg-primary hover:bg-surface-raised transition-colors"
+                >
+                  <Coins className="h-3.5 w-3.5" />
+                  Top up Cat Credits
+                </button>
+              </>
             )}
-            {onRetry && (
+            {showRetry && (
               <button
                 onClick={onRetry}
                 className="text-xs font-medium text-fg-secondary hover:text-fg-primary underline-offset-4 hover:underline"

--- a/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
+++ b/src/components/ai-chat/ModernChatPanel/hooks/useChatMessages.ts
@@ -15,6 +15,15 @@ import type {
 } from '../types';
 import { useChatHistory } from './useChatHistory';
 
+/** Chat error that carries the server's machine-readable code (drives recovery CTAs). */
+class CatChatError extends Error {
+  code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
 const STREAM_TIMEOUT_MS = 60_000;
 
 /**
@@ -116,6 +125,7 @@ export function useChatMessages({
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const onPendingResultRef = useRef(onPendingResult);
@@ -165,6 +175,7 @@ export function useChatMessages({
       }
 
       setError(null);
+      setErrorCode(null);
 
       const userMessage: Message = {
         id: `user-${Date.now()}`,
@@ -222,18 +233,21 @@ export function useChatMessages({
 
         if (!res.ok || !res.body) {
           let msg = 'Failed to get response';
+          let code: string | undefined;
           try {
             const data = await res.json();
             // standardResponse envelope: { success:false, error:{code,message,details} }.
             // Prefer error.message; fall back through legacy shapes so anything
             // truthy beats the generic default.
             msg =
+              data?.message ||
               data?.error?.message ||
               data?.details?.message ||
               (typeof data?.error === 'string' ? data.error : undefined) ||
               msg;
+            code = data?.code || data?.error?.code;
           } catch {}
-          throw new Error(msg);
+          throw new CatChatError(msg, code);
         }
 
         let modelUsed = selectedModel;
@@ -258,9 +272,10 @@ export function useChatMessages({
             fallback?: { from: string; to: string; model: string; reason: string };
             suggestUpgrade?: boolean;
             error?: string;
+            code?: string;
           };
           if (event?.error) {
-            throw new Error(event.error);
+            throw new CatChatError(event.error, event.code);
           }
           if (event?.content) {
             setMessages(prev =>
@@ -362,9 +377,11 @@ export function useChatMessages({
           // intentional no-op: keep partial streamed content
         } else if (isAbort) {
           setError('Response timed out. Try again or rephrase your question.');
+          setErrorCode(null);
           setMessages(prev => prev.filter(m => m.id !== assistantId));
         } else {
           setError(e instanceof Error ? e.message : 'Something went wrong');
+          setErrorCode(e instanceof CatChatError ? (e.code ?? null) : null);
           setMessages(prev => prev.filter(m => m.id !== assistantId));
         }
       } finally {
@@ -382,6 +399,7 @@ export function useChatMessages({
   const clearChat = useCallback(() => {
     setMessages([]);
     setError(null);
+    setErrorCode(null);
     // A fresh draft has no server-side thread yet — nothing to clear there.
     const targetId = conversationId ?? pendingConversationIdRef.current;
     if (!targetId) {
@@ -395,6 +413,7 @@ export function useChatMessages({
 
   const setErrorState = useCallback((err: string | null) => {
     setError(err);
+    setErrorCode(null);
   }, []);
 
   const addSystemMessage = useCallback((content: string) => {
@@ -414,6 +433,7 @@ export function useChatMessages({
     stopGeneration,
     clearChat,
     setError: setErrorState,
+    errorCode,
     addSystemMessage,
   };
 }

--- a/src/components/ai-chat/ModernChatPanel/index.tsx
+++ b/src/components/ai-chat/ModernChatPanel/index.tsx
@@ -100,6 +100,7 @@ export function ModernChatPanel({
     isLoading,
     isLoadingHistory,
     error,
+    errorCode,
     messagesEndRef,
     sendMessage,
     stopGeneration,
@@ -276,7 +277,12 @@ export function ModernChatPanel({
         </div>
 
         {error && (
-          <ErrorDisplay error={error} onRetry={handleRetry} onDismiss={handleDismissError} />
+          <ErrorDisplay
+            error={error}
+            code={errorCode}
+            onRetry={handleRetry}
+            onDismiss={handleDismissError}
+          />
         )}
 
         <ChatInput

--- a/src/services/ai/link-health.ts
+++ b/src/services/ai/link-health.ts
@@ -1,0 +1,66 @@
+/**
+ * Provider-link health memory — a tiny circuit breaker for the Cat chain.
+ *
+ * When a platform link (provider+model) fails, the chat walk moves on — but
+ * without memory, the NEXT message pays the same dead link's round-trip
+ * again (a rate-limited Groq adds ~1-2s to every message for the whole
+ * rate-limit window). Marking a link down for a short TTL lets the chain
+ * builder skip it while it's known-dead, then automatically retry after.
+ *
+ * Deliberately simple: an in-process Map. The self-hosted app is one
+ * long-lived Node process, so this covers all requests; if we ever go
+ * multi-process, the worst case is each process re-learning independently —
+ * safe, just less effective. Never applied to BYOK keys (the user's own
+ * capacity is theirs to burn), and pruning NEVER empties a chain: with
+ * every link down, retrying them all beats refusing to try.
+ */
+
+const DEFAULT_TTL_MS = 60_000;
+
+const downUntil = new Map<string, number>();
+
+const linkKey = (provider: string, model: string): string => `${provider}:${model}`;
+
+/** Record a failed link so chain builders can skip it for a while. */
+export function markLinkDown(
+  provider: string,
+  model: string,
+  ttlMs: number = DEFAULT_TTL_MS
+): void {
+  downUntil.set(linkKey(provider, model), Date.now() + ttlMs);
+}
+
+/** Is this link inside its down-window? Expired entries are cleaned up lazily. */
+export function isLinkDown(provider: string, model: string): boolean {
+  const key = linkKey(provider, model);
+  const until = downUntil.get(key);
+  if (until === undefined) {
+    return false;
+  }
+  if (Date.now() >= until) {
+    downUntil.delete(key);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Drop known-down links from a chain — unless that would drop ALL of them,
+ * in which case the original chain is returned untouched (retrying dead
+ * links is strictly better than having nothing to try).
+ */
+export function pruneDownLinks<T>(
+  links: T[],
+  keyOf: (link: T) => { provider: string; model: string }
+): T[] {
+  const alive = links.filter(l => {
+    const k = keyOf(l);
+    return !isLinkDown(k.provider, k.model);
+  });
+  return alive.length > 0 ? alive : links;
+}
+
+/** Test hook: forget everything. */
+export function resetLinkHealth(): void {
+  downUntil.clear();
+}

--- a/src/services/ai/platform-providers.ts
+++ b/src/services/ai/platform-providers.ts
@@ -29,6 +29,7 @@ import {
 import { getFreeModels, getModelMetadata, DEFAULT_FREE_MODEL_ID } from '@/config/ai-models';
 import { PROVIDER_BASE_URLS } from '@/config/ai-provider-runtime';
 import { createAutoRouter } from '@/services/ai/auto-router';
+import { pruneDownLinks } from '@/services/ai/link-health';
 
 import type { AiService } from './types';
 
@@ -109,7 +110,9 @@ export function buildPlatformProviders(message: string): PlatformProvider[] {
     });
   }
 
-  return out;
+  // Skip links that failed in the last minute (circuit breaker) — but never
+  // prune to an empty chain; retrying dead links beats refusing to try.
+  return pruneDownLinks(out, p => ({ provider: p.providerId, model: p.defaultModel }));
 }
 
 /**

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -44,6 +44,7 @@ import { getUserActorId } from '@/domain/actors';
 import type { ExecAction, CatAction, ExecActionResult } from '@/types/cat';
 import { AI_MESSAGE_MAX_CHARS } from '@/lib/validation/ai';
 import { PAGE_EXCERPT_MAX_CHARS } from '@/config/cat-page-context';
+import { markLinkDown } from '@/services/ai/link-health';
 
 export const catChatBodySchema = z.object({
   message: z.string().min(1).max(AI_MESSAGE_MAX_CHARS),
@@ -308,6 +309,7 @@ export async function orchestrateCatChat(
         let activeProvider = provider;
         let activeModel = modelToUse;
         let activeService = aiService;
+        let activeIsPlatform = !hasByok;
         try {
           let usage:
             | {
@@ -420,7 +422,15 @@ export async function orchestrateCatChat(
           while (lastErr && !streamStarted && fallbackIndex < fallbacks.length) {
             attemptedFallback = true;
             const reason = isAiRateLimitError(lastErr) ? 'rate_limit' : 'provider_error';
+            // Remember the dead PLATFORM link so the next message's chain
+            // skips it for a minute instead of paying the failed round-trip
+            // again. BYOK links are never marked — the user's own key failing
+            // must not sideline the platform's identical provider+model.
+            if (activeIsPlatform) {
+              markLinkDown(activeProvider, activeModel);
+            }
             const next = fallbacks[fallbackIndex++];
+            activeIsPlatform = !next.hasByok;
             logger.warn(
               'Cat chat: provider failed, trying next fallback',
               {
@@ -453,6 +463,9 @@ export async function orchestrateCatChat(
             }
           }
           if (lastErr) {
+            if (activeIsPlatform) {
+              markLinkDown(activeProvider, activeModel);
+            }
             throw lastErr;
           }
 
@@ -602,8 +615,13 @@ export async function orchestrateCatChat(
     lastErr = err;
   }
   let fallbackIndex = 0;
+  let lastTried = { provider: provider as string, model: modelToUse, platform: !hasByok };
   while (!result && lastErr && fallbackIndex < fallbacks.length) {
+    if (lastTried.platform) {
+      markLinkDown(lastTried.provider, lastTried.model);
+    }
     const next = fallbacks[fallbackIndex++];
+    lastTried = { provider: next.provider, model: next.modelToUse, platform: !next.hasByok };
     logger.warn(
       'Cat chat (non-streaming): provider failed, trying next fallback',
       {
@@ -630,6 +648,9 @@ export async function orchestrateCatChat(
     }
   }
   if (!result) {
+    if (lastTried.platform) {
+      markLinkDown(lastTried.provider, lastTried.model);
+    }
     throw lastErr ?? new Error('Cat chat: no AI provider produced a response');
   }
 

--- a/src/services/cat/provider-resolver.ts
+++ b/src/services/cat/provider-resolver.ts
@@ -44,6 +44,8 @@ export interface FallbackProvider {
   modelToUse: string;
   aiService: AiService;
   reason: 'rate_limit';
+  /** Platform-served link (false = the user's own key). Drives circuit-breaker marking. */
+  hasByok: boolean;
 }
 
 interface ResolvedProvider {
@@ -327,7 +329,15 @@ export async function resolveProvider(
     const usage = await keyService.checkPlatformUsage(userId);
     if (!usage.can_use_platform) {
       return Response.json(
-        { success: false, error: 'Daily limit reached', retryAfter: 86400 },
+        {
+          success: false,
+          error: 'Daily limit reached',
+          code: 'DAILY_LIMIT',
+          message:
+            "You've used today's free Cat messages. Top up Cat Credits or add your own key — both remove the daily cap.",
+          retryAfter: 86400,
+          helpUrl: ROUTES.SETTINGS_AI,
+        },
         { status: 429 }
       );
     }
@@ -356,6 +366,7 @@ export async function resolveProvider(
     modelToUse: s.modelToUse,
     aiService: s.aiService,
     reason: 'rate_limit' as const,
+    hasByok: s.hasByok,
   }));
 
   return {


### PR DESCRIPTION
Toward the invariant 'Cat is never unavailable — and when it truly is, fixing it is one click':

- **Circuit breaker**: failed platform links are skipped for 60s (never BYOK links, never prunes to empty). Cuts dead-provider latency from every message during rate-limit windows.
- **Recovery cards**: error `code` now flows server→client; fixable codes render deep-linked actions (Add a free key / Top up Cat Credits → Settings → AI). Daily-cap 429 gains `DAILY_LIMIT` + honest copy; Try again hidden where retrying just fails.

1449 tests green (4 new for link-health).

🤖 Generated with [Claude Code](https://claude.com/claude-code)