### PR TITLE
feat(wallets): lock down wallet reads + notify recipients of payment claims

### DIFF
--- a/__tests__/unit/domain/payments/buyerConfirmPayment.test.ts
+++ b/__tests__/unit/domain/payments/buyerConfirmPayment.test.ts
@@ -145,6 +145,30 @@ describe('buyerConfirmPayment', () => {
     });
   });
 
+  it('notifies the recipient of the claim — once, on the actual transition', async () => {
+    const intent = { ...fixedPriceIntent, seller_id: 'seller-1', amount_btc: 0.0001 };
+    const { supabase } = makeCallerSupabase(intent);
+    await buyerConfirmPayment(supabase, PI_ID, BUYER);
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'seller-1',
+        type: 'payment',
+        data: expect.objectContaining({ kind: 'buyer_claim' }),
+      })
+    );
+
+    // Re-claim is idempotent: no state write, no second notification.
+    dispatchMock.mockClear();
+    const { supabase: again } = makeCallerSupabase({
+      ...intent,
+      status: STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
+    });
+    const res = await buyerConfirmPayment(again, PI_ID, BUYER);
+    expect(res.status).toBe(STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['NWC', { payment_method: 'nwc', payment_hash: 'h' }],
     ['on-chain', { payment_method: 'onchain', onchain_address: 'bc1qxyz' }],

--- a/__tests__/unit/utils/validation.test.ts
+++ b/__tests__/unit/utils/validation.test.ts
@@ -1,7 +1,5 @@
 import {
   isValidUUID,
-  isValidBitcoinAddress,
-  isValidLightningInvoice,
   isValidLightningAddress,
   isValidEmail,
   isValidUsername,
@@ -44,114 +42,6 @@ describe('isValidUUID', () => {
 
   it('rejects a random word', () => {
     expect(isValidUUID('not-a-uuid')).toBe(false);
-  });
-});
-
-describe('isValidBitcoinAddress', () => {
-  // Synthetic addresses that conform to the regex (Base58: uppercase A-H, J-N, P-Z, 0-9)
-  // The validation regex uses Base58 uppercase charset for the body of each address type.
-  const B58BODY = 'ABCDEFGHJKMNPQRSTUVWXYZ01234'; // 28 uppercase Base58 chars
-
-  // Mainnet P2PKH (legacy, starts with '1')
-  it('accepts a valid mainnet P2PKH address', () => {
-    expect(isValidBitcoinAddress('1' + B58BODY)).toBe(true);
-  });
-
-  // Mainnet P2SH (starts with '3')
-  it('accepts a valid mainnet P2SH address', () => {
-    expect(isValidBitcoinAddress('3' + B58BODY)).toBe(true);
-  });
-
-  // Mainnet bech32 (starts with 'bc1')
-  it('accepts a valid mainnet bech32 address', () => {
-    expect(isValidBitcoinAddress('bc1qar0srrr7xfkvy5l643lydnw9re59gt')).toBe(true);
-  });
-
-  // Testnet addresses rejected by default
-  it('rejects a testnet legacy address (m-prefix) when allowTestnet is false', () => {
-    expect(isValidBitcoinAddress('m' + B58BODY)).toBe(false);
-  });
-
-  it('rejects a testnet legacy address (n-prefix) when allowTestnet is false', () => {
-    expect(isValidBitcoinAddress('n' + B58BODY)).toBe(false);
-  });
-
-  it('rejects a testnet P2SH address (starts with 2) when allowTestnet is false', () => {
-    expect(isValidBitcoinAddress('2' + B58BODY)).toBe(false);
-  });
-
-  it('rejects a testnet bech32 address (tb1) when allowTestnet is false', () => {
-    expect(isValidBitcoinAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx')).toBe(false);
-  });
-
-  // Testnet addresses accepted when allowTestnet=true
-  it('accepts a testnet legacy (m-prefix) address when allowTestnet=true', () => {
-    expect(isValidBitcoinAddress('m' + B58BODY, true)).toBe(true);
-  });
-
-  it('accepts a testnet legacy (n-prefix) address when allowTestnet=true', () => {
-    expect(isValidBitcoinAddress('n' + B58BODY, true)).toBe(true);
-  });
-
-  it('accepts a testnet P2SH address (starts with 2) when allowTestnet=true', () => {
-    expect(isValidBitcoinAddress('2' + B58BODY, true)).toBe(true);
-  });
-
-  it('accepts a testnet bech32 address (tb1) when allowTestnet=true', () => {
-    expect(isValidBitcoinAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx', true)).toBe(true);
-  });
-
-  // Invalid cases
-  it('rejects an empty string', () => {
-    expect(isValidBitcoinAddress('')).toBe(false);
-  });
-
-  it('rejects a random string', () => {
-    expect(isValidBitcoinAddress('notabitcoinaddress')).toBe(false);
-  });
-
-  it('rejects an address that is too short', () => {
-    expect(isValidBitcoinAddress('1abc')).toBe(false);
-  });
-
-  it('rejects null (cast to any)', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(isValidBitcoinAddress(null as any)).toBe(false);
-  });
-});
-
-describe('isValidLightningInvoice', () => {
-  it('accepts a mainnet invoice starting with lnbc', () => {
-    expect(
-      isValidLightningInvoice(
-        'lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvusx7mje'
-      )
-    ).toBe(true);
-  });
-
-  it('accepts a testnet invoice starting with lntb', () => {
-    expect(isValidLightningInvoice('lntb100n1p3zj8r5pp5test')).toBe(true);
-  });
-
-  it('accepts an invoice with lnbcrt prefix (regtest)', () => {
-    expect(isValidLightningInvoice('lnbcrt1p3test123abc')).toBe(true);
-  });
-
-  it('is case-insensitive (LNBC uppercase)', () => {
-    expect(isValidLightningInvoice('LNBC1pvjluezpp5abc123')).toBe(true);
-  });
-
-  it('rejects a random string', () => {
-    expect(isValidLightningInvoice('notaninvoice')).toBe(false);
-  });
-
-  it('rejects an empty string', () => {
-    expect(isValidLightningInvoice('')).toBe(false);
-  });
-
-  it('rejects null (cast to any)', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(isValidLightningInvoice(null as any)).toBe(false);
   });
 });
 

--- a/src/app/api/payments/can-receive/route.ts
+++ b/src/app/api/payments/can-receive/route.ts
@@ -1,0 +1,41 @@
+/**
+ * GET /api/payments/can-receive?profile_id=X — public: can this user be paid?
+ *
+ * Answered by the SAME wallet resolution the payment flow runs — never by
+ * inspecting wallet rows from the client (wallet rows are owner-readable
+ * only). The answer is a single boolean; no wallet details leave the server.
+ * Anonymous access is allowed (payment buttons render on public pages),
+ * rate-limited per IP.
+ */
+
+import type { NextRequest } from 'next/server';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { rateLimit, createRateLimitResponse } from '@/lib/rate-limit';
+import { apiBadRequest, apiSuccess, apiInternalError } from '@/lib/api/standardResponse';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
+import { logger } from '@/utils/logger';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function GET(request: NextRequest) {
+  try {
+    const rl = await rateLimit(request);
+    if (!rl.success) {
+      return createRateLimitResponse(rl);
+    }
+
+    const profileId = request.nextUrl.searchParams.get('profile_id');
+    if (!profileId || !UUID_REGEX.test(profileId)) {
+      return apiBadRequest('profile_id must be a valid UUID');
+    }
+
+    const admin = getAdminClient() as unknown as SupabaseClient;
+    const wallet = await resolveUserWallet(admin, profileId).catch(() => null);
+
+    return apiSuccess({ canReceive: !!wallet }, { cache: 'SHORT' });
+  } catch (error) {
+    logger.error('can-receive check failed', { error }, 'Payments');
+    return apiInternalError('Could not check payment capability.');
+  }
+}

--- a/src/app/api/wallets/[id]/refresh/route.ts
+++ b/src/app/api/wallets/[id]/refresh/route.ts
@@ -15,7 +15,7 @@ import {
 } from '@/lib/api/standardResponse';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { validateUUID, getValidationError } from '@/lib/api/validation';
-import { DATABASE_TABLES } from '@/config/database-tables';
+import { DATABASE_TABLES, WALLET_CLIENT_COLUMNS } from '@/config/database-tables';
 import { refreshWalletBalance } from '@/domain/wallets/refreshBalance';
 
 interface RouteContext {
@@ -32,12 +32,12 @@ export const POST = withAuth(async (request: AuthenticatedRequest, context: Rout
   try {
     const { user, supabase } = request;
 
-    const { data: wallet, error: fetchError } = await supabase
+    const { data: wallet, error: fetchError } = (await supabase
       .from(DATABASE_TABLES.WALLETS)
-      .select('*')
+      .select(WALLET_CLIENT_COLUMNS)
       .eq('id', id)
       .eq('user_id', user.id)
-      .single();
+      .single()) as { data: Record<string, unknown> | null; error: unknown };
 
     if (fetchError || !wallet) {
       logger.error('Wallet not found for refresh', { walletId: id, userId: user.id });

--- a/src/app/api/wallets/[id]/route.ts
+++ b/src/app/api/wallets/[id]/route.ts
@@ -16,7 +16,7 @@ import {
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { validateUUID, getValidationError } from '@/lib/api/validation';
 import { auditSuccess, AUDIT_ACTIONS } from '@/lib/api/auditLog';
-import { DATABASE_TABLES } from '@/config/database-tables';
+import { DATABASE_TABLES, WALLET_CLIENT_COLUMNS } from '@/config/database-tables';
 import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { walletUpdateSchema } from '@/lib/validation/finance';
 import {
@@ -74,7 +74,7 @@ export const PATCH = withAuth(async (request: AuthenticatedRequest, context: Rou
       .from(DATABASE_TABLES.WALLETS)
       .update(updates)
       .eq('id', id)
-      .select()
+      .select(WALLET_CLIENT_COLUMNS)
       .single();
 
     if (updateError) {

--- a/src/app/api/wallets/route.ts
+++ b/src/app/api/wallets/route.ts
@@ -13,6 +13,8 @@ import { applyRateLimitHeaders, rateLimitWriteAsync, retryAfterSeconds } from '@
 import { apiSuccess, apiRateLimited } from '@/lib/api/standardResponse';
 import { validateOneOfIds, getValidationError } from '@/lib/api/validation';
 import { getTableName } from '@/config/entity-registry';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { WALLET_CLIENT_COLUMNS } from '@/config/database-tables';
 import { createWallet } from '@/domain/wallets/createWallet';
 
 // Public wallet fields (safe to return without auth)
@@ -37,9 +39,15 @@ export const GET = withOptionalAuth(async request => {
     }
 
     const isOwner = user ? isProfileOwner(user, profileId) : false;
-    const selectFields = isOwner ? '*' : PUBLIC_WALLET_FIELDS;
+    const selectFields = isOwner ? WALLET_CLIENT_COLUMNS : PUBLIC_WALLET_FIELDS;
 
-    let query = supabase
+    // Wallet rows are owner-readable only at the RLS level; the public wallet
+    // listing (profile wallets tab) is served through this route's CURATED
+    // field list via service role — the API is the one public surface, so raw
+    // PostgREST can no longer enumerate balances or other wallet internals.
+    const db = isOwner ? supabase : (getAdminClient() as unknown as typeof supabase);
+
+    let query = db
       .from(getTableName('wallet'))
       .select(selectFields)
       .eq('is_active', true)

--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -205,3 +205,18 @@ export const STORAGE_BUCKETS = {
   PROOFS: 'proofs',
   DOCUMENTS: 'documents',
 } as const;
+
+/**
+ * Every wallets column EXCEPT the write-only secret `nwc_connection_uri`.
+ *
+ * Client roles have a column-level SELECT grant for exactly this list
+ * (migration 20260802120000_wallets_select_lockdown) — `select('*')` on the
+ * wallets table therefore fails with permission-denied for anon/authenticated.
+ * Use this constant wherever a non-service-role client selects wallet rows.
+ */
+export const WALLET_CLIENT_COLUMNS =
+  'id, profile_id, project_id, user_id, label, description, address_or_xpub, ' +
+  'wallet_type, category, category_icon, behavior_type, budget_amount, ' +
+  'budget_period, goal_amount, goal_currency, goal_deadline, balance_btc, ' +
+  'balance_updated_at, is_active, display_order, is_primary, created_at, ' +
+  'updated_at, lightning_address, next_derivation_index';

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -485,11 +485,34 @@ export async function acknowledgePublicPayment(
   }
 
   await updatePaymentStatus(paymentIntentId, STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
+  notifyRecipientOfClaim(pi as PaymentIntent);
   return {
     status: STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
     paid_at: null,
     requires_recipient_confirmation: true,
   };
+}
+
+/**
+ * Tell the recipient a payer claims to have paid — fire-and-forget.
+ *
+ * A claim needs the recipient's action to settle (they confirm receipt in
+ * their wallet); a claim nobody sees rots in buyer_confirmed forever. Called
+ * only on the actual transition into BUYER_CONFIRMED, never on idempotent
+ * re-claims, so the recipient is notified at most once per intent.
+ */
+function notifyRecipientOfClaim(pi: PaymentIntent): void {
+  const entityTitle = pi.description?.split(': ')[1] || 'your listing';
+  void NotificationDispatcher.dispatch({
+    userId: pi.seller_id,
+    type: 'payment',
+    title: `Payment reported: ${pi.amount_btc} BTC`,
+    message: `A supporter says they've paid ${pi.amount_btc} BTC for ${entityTitle}. Check your wallet and confirm receipt.`,
+    data: { paymentIntentId: pi.id, amount_btc: pi.amount_btc, kind: 'buyer_claim' },
+    sourceEntityType: (pi.entity_type as EntityType) ?? undefined,
+    sourceEntityId: pi.entity_id ?? undefined,
+    actionUrl: '/dashboard',
+  });
 }
 
 async function refreshPaymentStatus(
@@ -609,6 +632,11 @@ export async function buyerConfirmPayment(
     return { status: STATUS.PAYMENT_INTENTS.PAID, paid_at: pi.paid_at };
   }
 
+  // Already claimed — idempotent, and no second notification to the recipient.
+  if (pi.status === STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED) {
+    return { status: STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED, paid_at: null };
+  }
+
   // Guard the trust boundary: only a bare Lightning address (no LUD-21 verify
   // URL) is genuinely undetectable. NWC (relay lookup), verify-capable Lightning
   // addresses, and on-chain (mempool confirmation) are all confirmed by
@@ -623,6 +651,7 @@ export async function buyerConfirmPayment(
 
   // Mark as buyer_confirmed — seller verifies in their wallet
   await updatePaymentStatus(paymentIntentId, STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
+  notifyRecipientOfClaim(pi as PaymentIntent);
 
   return { status: STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED, paid_at: null };
 }

--- a/src/domain/wallets/createWallet.ts
+++ b/src/domain/wallets/createWallet.ts
@@ -15,6 +15,7 @@ import {
   type Wallet,
 } from '@/types/wallet';
 import { logger } from '@/utils/logger';
+import { WALLET_CLIENT_COLUMNS } from '@/config/database-tables';
 import { MAX_WALLETS_PER_ENTITY } from '@/lib/wallets/constants';
 import {
   logWalletError,
@@ -134,7 +135,7 @@ export async function createWallet(
         is_primary: body.is_primary !== undefined ? body.is_primary : isFirstWallet,
         balance_btc: 0,
       })
-      .select()
+      .select(WALLET_CLIENT_COLUMNS)
       .single()) as { data: Wallet | null; error: { message: string; code?: string } | null };
 
     if (error) {

--- a/src/domain/wallets/refreshBalance.ts
+++ b/src/domain/wallets/refreshBalance.ts
@@ -6,7 +6,7 @@
  */
 
 import { fetchBitcoinBalance } from '@/services/blockchain';
-import { DATABASE_TABLES } from '@/config/database-tables';
+import { DATABASE_TABLES, WALLET_CLIENT_COLUMNS } from '@/config/database-tables';
 import { auditSuccess, AUDIT_ACTIONS } from '@/lib/api/auditLog';
 import { logger } from '@/utils/logger';
 import { BITCOIN_FETCH_TIMEOUT_MS } from '@/lib/wallets/constants';
@@ -123,7 +123,7 @@ export async function refreshWalletBalance(
     .update({ balance_btc: totalBalanceBtc, balance_updated_at: new Date().toISOString() })
     .eq('id', walletId)
     .eq('user_id', userId)
-    .select()
+    .select(WALLET_CLIENT_COLUMNS)
     .single();
 
   if (updateError || !updatedWallet) {

--- a/src/domain/wallets/transferService.ts
+++ b/src/domain/wallets/transferService.ts
@@ -7,7 +7,7 @@
 import { type Wallet } from '@/types/wallet';
 import { logger } from '@/utils/logger';
 import { auditSuccess, AUDIT_ACTIONS } from '@/lib/api/auditLog';
-import { DATABASE_TABLES } from '@/config/database-tables';
+import { DATABASE_TABLES, WALLET_CLIENT_COLUMNS } from '@/config/database-tables';
 import { STATUS } from '@/config/database-constants';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -173,7 +173,7 @@ export async function executeWalletTransfer(
 
   // Fetch updated wallet states
   const { data: updatedWalletsData } = await (supabase.from(DATABASE_TABLES.WALLETS) as AnyClient)
-    .select('*')
+    .select(WALLET_CLIENT_COLUMNS)
     .in('id', [fromWalletId, toWalletId]);
 
   await auditSuccess(AUDIT_ACTIONS.WALLET_BALANCE_REFRESHED, userId, 'wallet', fromWalletId, {

--- a/src/domain/wallets/updateWallet.ts
+++ b/src/domain/wallets/updateWallet.ts
@@ -10,7 +10,7 @@ import { isValidLightningAddress } from '@/lib/validation/base';
 import { encrypt } from '@/domain/payments/encryptionService';
 import { logger } from '@/utils/logger';
 import { apiBadRequest, apiForbidden, apiNotFound } from '@/lib/api/standardResponse';
-import { DATABASE_TABLES } from '@/config/database-tables';
+import { DATABASE_TABLES, WALLET_CLIENT_COLUMNS } from '@/config/database-tables';
 import type { z } from 'zod';
 import type { walletUpdateSchema } from '@/lib/validation/finance';
 import type { NextResponse } from 'next/server';
@@ -46,7 +46,9 @@ export async function fetchWalletAndVerifyOwner(
 ): Promise<FetchResult | FetchError> {
   const { data: walletData, error: fetchError } = await supabase
     .from(DATABASE_TABLES.WALLETS)
-    .select('*, profiles!wallets_profile_id_fkey(id), projects!wallets_project_id_fkey(user_id)')
+    .select(
+      `${WALLET_CLIENT_COLUMNS}, profiles!wallets_profile_id_fkey(id), projects!wallets_project_id_fkey(user_id)`
+    )
     .eq('id', walletId)
     .single();
 

--- a/src/hooks/useSellerPaymentMethods.ts
+++ b/src/hooks/useSellerPaymentMethods.ts
@@ -1,77 +1,50 @@
 /**
- * useSellerPaymentMethods — Checks what payment methods a seller supports
+ * useSellerPaymentMethods — can this seller be paid?
  *
- * Used to show/disable the PaymentButton on entity pages.
- * Returns whether the seller has any wallet connected.
+ * Used to show/disable the PaymentButton on entity pages. Asks the server
+ * (GET /api/payments/can-receive), which answers via the SAME wallet
+ * resolution the payment flow runs — the UI can never claim a capability the
+ * payment path doesn't have. Never reads wallet rows from the browser:
+ * wallet rows are owner-readable only, and another user's wallet details
+ * (xpub, addresses) must not reach the client.
  */
 
 'use client';
 
 import { useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabase/browser';
-import { DATABASE_TABLES } from '@/config/database-tables';
 
 interface SellerPaymentInfo {
   hasWallet: boolean;
-  hasNWC: boolean;
-  hasLightningAddress: boolean;
-  hasOnchain: boolean;
   loading: boolean;
 }
 
 export function useSellerPaymentMethods(sellerProfileId: string | null): SellerPaymentInfo {
-  const [info, setInfo] = useState<SellerPaymentInfo>({
-    hasWallet: false,
-    hasNWC: false,
-    hasLightningAddress: false,
-    hasOnchain: false,
-    loading: true,
-  });
+  const [info, setInfo] = useState<SellerPaymentInfo>({ hasWallet: false, loading: true });
 
   useEffect(() => {
     if (!sellerProfileId) {
-      setInfo(prev => ({ ...prev, loading: false }));
+      setInfo({ hasWallet: false, loading: false });
       return;
     }
 
     let cancelled = false;
-    const profileId = sellerProfileId;
 
     async function check() {
-      type WalletRow = {
-        id: string;
-        wallet_type: string | null;
-        lightning_address: string | null;
-        address_or_xpub: string | null;
-      };
-      const { data: rawWallets } = await supabase
-        .from(DATABASE_TABLES.WALLETS)
-        .select('id, wallet_type, lightning_address, address_or_xpub')
-        .eq('profile_id', profileId!)
-        .eq('is_active', true);
-      if (cancelled) {
-        return;
+      try {
+        const res = await fetch(
+          `/api/payments/can-receive?profile_id=${encodeURIComponent(sellerProfileId!)}`
+        );
+        const body = res.ok ? await res.json() : null;
+        if (!cancelled) {
+          setInfo({ hasWallet: !!body?.data?.canReceive, loading: false });
+        }
+      } catch {
+        // Conservative default: claiming a working payment rail we could not
+        // verify is the failure mode to avoid.
+        if (!cancelled) {
+          setInfo({ hasWallet: false, loading: false });
+        }
       }
-      const wallets = (rawWallets || []) as WalletRow[];
-
-      if (wallets.length === 0) {
-        setInfo({
-          hasWallet: false,
-          hasNWC: false,
-          hasLightningAddress: false,
-          hasOnchain: false,
-          loading: false,
-        });
-        return;
-      }
-
-      setInfo({
-        hasWallet: true,
-        hasNWC: wallets.some(w => w.wallet_type === 'nwc'),
-        hasLightningAddress: wallets.some(w => !!w.lightning_address),
-        hasOnchain: wallets.some(w => !!w.address_or_xpub),
-        loading: false,
-      });
     }
 
     check();

--- a/src/lib/validation/base.ts
+++ b/src/lib/validation/base.ts
@@ -46,16 +46,10 @@ export function isValidLightningAddress(address: string): boolean {
 // GENERAL VALIDATORS
 // =============================================================================
 
-const BITCOIN_ADDRESS_PATTERNS = {
-  legacy: /^1[A-HJ-NP-Z0-9]{25,34}$/,
-  segwit: /^3[A-HJ-NP-Z0-9]{25,34}$/,
-  bech32: /^bc1[a-z0-9]{8,87}$/,
-  testnetLegacy: /^[mn][A-HJ-NP-Z0-9]{25,34}$/,
-  testnetSegwit: /^2[A-HJ-NP-Z0-9]{25,34}$/,
-  testnetBech32: /^tb1[a-z0-9]{8,87}$/,
-};
-
-const LIGHTNING_INVOICE_PATTERN = /^ln(bc|tb|tbs|bcrt)[0-9]+[munp]?[a-z0-9]+$/i;
+// NOTE: there is deliberately NO Bitcoin address/xpub validator here. Address
+// validation is cryptographic (checksums, network bytes) and lives in ONE
+// place: src/types/wallet.ts. A regex approximation that accepts typo'd
+// addresses is worse than none.
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const USERNAME_PATTERN = /^[a-zA-Z0-9_-]{3,30}$/;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -65,35 +59,6 @@ export function isValidUUID(value: string): boolean {
     return false;
   }
   return UUID_PATTERN.test(value.trim());
-}
-
-export function isValidBitcoinAddress(address: string, allowTestnet: boolean = false): boolean {
-  if (!address || typeof address !== 'string') {
-    return false;
-  }
-  const trimmed = address.trim();
-  if (allowTestnet) {
-    return (
-      BITCOIN_ADDRESS_PATTERNS.legacy.test(trimmed) ||
-      BITCOIN_ADDRESS_PATTERNS.segwit.test(trimmed) ||
-      BITCOIN_ADDRESS_PATTERNS.bech32.test(trimmed) ||
-      BITCOIN_ADDRESS_PATTERNS.testnetLegacy.test(trimmed) ||
-      BITCOIN_ADDRESS_PATTERNS.testnetSegwit.test(trimmed) ||
-      BITCOIN_ADDRESS_PATTERNS.testnetBech32.test(trimmed)
-    );
-  }
-  return (
-    BITCOIN_ADDRESS_PATTERNS.legacy.test(trimmed) ||
-    BITCOIN_ADDRESS_PATTERNS.segwit.test(trimmed) ||
-    BITCOIN_ADDRESS_PATTERNS.bech32.test(trimmed)
-  );
-}
-
-export function isValidLightningInvoice(invoice: string): boolean {
-  if (!invoice || typeof invoice !== 'string') {
-    return false;
-  }
-  return LIGHTNING_INVOICE_PATTERN.test(invoice.trim());
 }
 
 export function isValidEmail(email: string): boolean {

--- a/src/services/ai/document-context.ts
+++ b/src/services/ai/document-context.ts
@@ -11,6 +11,8 @@
 
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { logger } from '@/utils/logger';
+import { getAdminClient } from '@/lib/supabase/admin';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { isCatHubPath } from '@/config/routes';
@@ -167,7 +169,10 @@ async function fetchWalletsForCat(
       return [];
     }
 
-    const { data: wallets, error } = await supabase
+    // No client-role SELECT grant on nwc_connection_uri (write-only secret);
+    // the Cat only needs presence, so read via service role and never let the
+    // encrypted value into the context assembly.
+    const { data: wallets, error } = await (getAdminClient() as unknown as SupabaseClient)
       .from(DATABASE_TABLES.WALLETS)
       .select(
         'label, description, category, behavior_type, goal_amount, goal_currency, goal_deadline, budget_amount, budget_period, is_primary, balance_btc, balance_updated_at, nwc_connection_uri, lightning_address'

--- a/src/services/cat/handlers/payments.ts
+++ b/src/services/cat/handlers/payments.ts
@@ -128,7 +128,10 @@ export const paymentHandlers: Record<string, ActionHandler> = {
     }
 
     // 1. Get sender's NWC wallet (user can only read their own wallets via RLS)
-    const { data: senderWallets } = await supabase
+    // Own-secret read: the NWC URI has no client-role column grant (write-only
+    // for anon/authenticated), so read it via service role — scoped to the
+    // authenticated user's own profile_id established by the caller.
+    const { data: senderWallets } = await (getAdminClient() as unknown as SupabaseClient)
       .from(DATABASE_TABLES.WALLETS)
       .select('nwc_connection_uri')
       .eq('profile_id', userId)
@@ -259,7 +262,10 @@ export const paymentHandlers: Record<string, ActionHandler> = {
     }
 
     // 1. Get sender's NWC wallet
-    const { data: senderWallets } = await supabase
+    // Own-secret read: the NWC URI has no client-role column grant (write-only
+    // for anon/authenticated), so read it via service role — scoped to the
+    // authenticated user's own profile_id established by the caller.
+    const { data: senderWallets } = await (getAdminClient() as unknown as SupabaseClient)
       .from(DATABASE_TABLES.WALLETS)
       .select('nwc_connection_uri')
       .eq('profile_id', userId)

--- a/supabase/migrations/20260802120000_wallets_select_lockdown.sql
+++ b/supabase/migrations/20260802120000_wallets_select_lockdown.sql
@@ -1,0 +1,44 @@
+-- Wallets read lockdown — two independent tightenings:
+--
+-- 1. ROWS: wallet rows are readable only by their owner. The old public arm
+--    ("any active wallet of an existing profile/active project") existed so
+--    browser code could answer "can this seller be paid?" by inspecting rows.
+--    That question is now answered server-side by the same wallet resolution
+--    the payment flow runs (GET /api/payments/can-receive), so no client ever
+--    needs to read another user's wallet rows — which also stops address_or_xpub
+--    (an xpub reveals the owner's ENTIRE address history) from being publicly
+--    selectable.
+--
+-- 2. COLUMNS: nwc_connection_uri is a write-only secret for client roles.
+--    It was encrypted but still selectable; app code promised "never echoed
+--    back" while `select('*')` quietly returned it. Column-level grants make
+--    the database enforce the contract: client roles can INSERT/UPDATE it but
+--    never SELECT it. Only service_role (payment detection, receive-status
+--    probing, Cat's own-wallet payments — all server-side, post-authorization)
+--    can read it.
+--
+-- Postgres cannot subtract one column from a table-level SELECT grant, so the
+-- grant is rebuilt as an explicit column list (every column except the secret).
+-- Client code therefore must not `select('*')` on wallets — all call sites use
+-- WALLET_CLIENT_COLUMNS (src/config/database-tables.ts), the code-side mirror
+-- of this list.
+
+DROP POLICY IF EXISTS wallets_select ON public.wallets;
+DROP POLICY IF EXISTS wallets_select_own ON public.wallets;
+-- profile_id IS the auth user id for profile wallets; user_id covers project
+-- wallets. Either identifies the owner (user_id is nullable with no default,
+-- so don't key on it alone).
+CREATE POLICY wallets_select_own ON public.wallets
+  FOR SELECT USING ((SELECT auth.uid()) IN (user_id, profile_id));
+
+REVOKE SELECT ON public.wallets FROM anon, authenticated;
+GRANT SELECT (
+  id, profile_id, project_id, user_id, label, description, address_or_xpub,
+  wallet_type, category, category_icon, behavior_type, budget_amount,
+  budget_period, goal_amount, goal_currency, goal_deadline, balance_btc,
+  balance_updated_at, is_active, display_order, is_primary, created_at,
+  updated_at, lightning_address, next_derivation_index
+) ON public.wallets TO anon, authenticated;
+
+COMMENT ON COLUMN public.wallets.nwc_connection_uri IS
+  'Encrypted NWC connection URI. WRITE-ONLY for client roles (no column SELECT grant) — read exclusively through service_role after authorization.';


### PR DESCRIPTION
Follow-ups from the live payment audit:

1. **Wallets read lockdown** — wallet rows owner-readable only (RLS) + `nwc_connection_uri` write-only for client roles (column grant). Public "can this seller be paid?" is now `GET /api/payments/can-receive`, answered by the same wallet resolution the payment flow runs; the profile wallets tab keeps its curated public listing via the API. Raw PostgREST can no longer enumerate balances/xpubs. Migration `20260802120000` (apply post-deploy).
2. **Claim notifications** — recipients get an in-app notification the moment a payer claims "I paid"; exactly once per intent.
3. **Dead code** — removed the regex-only Bitcoin validators; cryptographic validation in `src/types/wallet.ts` is the single source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)