### PR TITLE
feat(cat): loss side of the track record — failures, denials, unconfirmed proposals

### DIFF
--- a/__tests__/unit/cat/spend-caps.test.ts
+++ b/__tests__/unit/cat/spend-caps.test.ts
@@ -222,7 +222,7 @@ describe('CatActionExecutor spend-cap enforcement', () => {
     mockSendPaymentHandler.mockResolvedValue({ success: true, data: { status: 'paid' } });
   });
 
-  it('denies an over-cap payment before creating a pending action or log row', async () => {
+  it('denies an over-cap payment before creating a pending action, leaving a denied audit row', async () => {
     mockPermissionService.checkSpendCaps.mockResolvedValue({
       allowed: false,
       reason: 'Amount 0.5 BTC exceeds your per-action cap of 0.001 BTC.',
@@ -238,7 +238,14 @@ describe('CatActionExecutor spend-cap enforcement', () => {
     expect(result.status).toBe('denied');
     expect(result.error).toContain('per-action cap');
     expect(supabase._insertsByTable[DATABASE_TABLES.CAT_PENDING_ACTIONS]).toBeUndefined();
-    expect(supabase._insertsByTable[DATABASE_TABLES.CAT_ACTION_LOG]).toBeUndefined();
+    // Denials ARE audit rows now (loss side of the track record): one terminal
+    // 'denied' insert with the reason, instead of no trace at all.
+    const deniedRows = supabase._insertsByTable[DATABASE_TABLES.CAT_ACTION_LOG] as
+      | { status: string; error_message: string | null }[]
+      | undefined;
+    expect(deniedRows).toHaveLength(1);
+    expect(deniedRows?.[0]?.status).toBe('denied');
+    expect(deniedRows?.[0]?.error_message).toContain('per-action cap');
     expect(mockSendPaymentHandler).not.toHaveBeenCalled();
   });
 
@@ -264,12 +271,12 @@ describe('CatActionExecutor spend-cap enforcement', () => {
       0.005,
       { excludeLogId: 'log-1' }
     );
-    // Audit trail: the log row is marked failed with the denial reason
+    // Audit trail: the log row is marked denied with the reason
     const logUpdates = supabase._updatesByTable[DATABASE_TABLES.CAT_ACTION_LOG] as {
       status: string;
       error_message: string | null;
     }[];
-    expect(logUpdates?.at(-1)?.status).toBe('failed');
+    expect(logUpdates?.at(-1)?.status).toBe('denied');
     expect(logUpdates?.at(-1)?.error_message).toBe('daily budget exceeded');
   });
 

--- a/__tests__/unit/cat/track-record-setbacks.test.ts
+++ b/__tests__/unit/cat/track-record-setbacks.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Track record — loss side (setbacks).
+ *
+ * The funnel (proposed → published → funded) only ever counted wins:
+ * failures/denials never reached context, so the Cat could re-propose its
+ * losses forever (survivorship bias in an agent's memory). These tests pin
+ * the setback derivation, the renderer, and the executor's denial audit rows.
+ */
+
+import { getCatTrackRecord } from '@/services/cat/track-record';
+import { renderTrackRecord } from '@/services/ai/context-sections';
+import { CatActionExecutor } from '@/services/cat/action-executor';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockPermissionService = {
+  checkPermission: jest.fn(),
+  checkSpendCaps: jest.fn(),
+};
+jest.mock('@/services/cat/permission-service', () => {
+  const actual = jest.requireActual('@/services/cat/permission-service');
+  return {
+    ...actual,
+    CatPermissionService: jest.fn().mockImplementation(() => mockPermissionService),
+  };
+});
+jest.mock('@/services/cat/handlers', () => ({ ACTION_HANDLERS: {} }));
+
+const USER_ID = 'user-1';
+
+/**
+ * Minimal thenable query-builder fake: routes a query to canned rows based on
+ * table + how it was filtered (the funnel query filters status='completed' via
+ * .eq; the setback query filters status via .in).
+ */
+function fakeSupabase(routes: {
+  funnelLog?: unknown[];
+  setbackLog?: unknown[] | { error: string };
+  pending?: unknown[] | { error: string };
+  inserts?: Array<{ table: string; row: Record<string, unknown> }>;
+}): AnySupabaseClient {
+  const resolve = (table: string, filters: Record<string, unknown>) => {
+    if (table === DATABASE_TABLES.CAT_ACTION_LOG) {
+      const target = filters['in:status'] ? (routes.setbackLog ?? []) : (routes.funnelLog ?? []);
+      return Array.isArray(target)
+        ? { data: target, error: null }
+        : { data: null, error: { message: target.error } };
+    }
+    if (table === DATABASE_TABLES.CAT_PENDING_ACTIONS) {
+      const target = routes.pending ?? [];
+      return Array.isArray(target)
+        ? { data: target, error: null }
+        : { data: null, error: { message: target.error } };
+    }
+    return { data: [], error: null };
+  };
+  return {
+    from(table: string) {
+      const filters: Record<string, unknown> = {};
+      const builder: Record<string, unknown> = {
+        select: () => builder,
+        eq: (col: string, v: unknown) => ((filters[`eq:${col}`] = v), builder),
+        in: (col: string, v: unknown) => ((filters[`in:${col}`] = v), builder),
+        gte: () => builder,
+        order: () => builder,
+        limit: () => builder,
+        insert: (row: Record<string, unknown>) => {
+          routes.inserts?.push({ table, row });
+          return Promise.resolve({ data: null, error: null });
+        },
+        then: (onFulfilled: (v: unknown) => unknown) =>
+          Promise.resolve(resolve(table, filters)).then(onFulfilled),
+      };
+      return builder;
+    },
+  } as unknown as AnySupabaseClient;
+}
+
+const NOW = new Date().toISOString();
+
+describe('getCatTrackRecord setbacks', () => {
+  it('derives failed/denied/unconfirmed counts and a merged recent list', async () => {
+    const record = await getCatTrackRecord(
+      fakeSupabase({
+        funnelLog: [],
+        setbackLog: [
+          {
+            action_id: 'send_payment',
+            status: 'denied',
+            error_message: 'Spend cap exceeded',
+            created_at: '2026-08-02T10:00:00Z',
+          },
+          {
+            action_id: 'create_product',
+            status: 'failed',
+            error_message: 'boom',
+            created_at: '2026-08-01T10:00:00Z',
+          },
+        ],
+        pending: [
+          {
+            action_id: 'send_payment',
+            status: 'expired',
+            rejection_reason: null,
+            created_at: '2026-08-02T09:00:00Z',
+          },
+          {
+            action_id: 'create_event',
+            status: 'rejected',
+            rejection_reason: 'not now',
+            created_at: '2026-07-30T10:00:00Z',
+          },
+        ],
+      }),
+      USER_ID
+    );
+
+    expect(record).not.toBeNull();
+    expect(record!.setbacks.failed).toBe(1);
+    expect(record!.setbacks.denied).toBe(1);
+    expect(record!.setbacks.unconfirmed).toBe(2);
+    // Merged newest-first across both sources.
+    expect(record!.setbacks.recent.map(s => s.kind)).toEqual([
+      'denied',
+      'expired',
+      'failed',
+      'rejected',
+    ]);
+    expect(record!.setbacks.recent[0].reason).toBe('Spend cap exceeded');
+  });
+
+  it('degrades to zero setbacks on query errors (e.g. un-migrated enum) without killing the funnel', async () => {
+    const record = await getCatTrackRecord(
+      fakeSupabase({
+        funnelLog: [],
+        setbackLog: { error: 'invalid input value for enum cat_action_status: "denied"' },
+        pending: { error: 'nope' },
+      }),
+      USER_ID
+    );
+    expect(record).not.toBeNull();
+    expect(record!.setbacks).toEqual({ failed: 0, denied: 0, unconfirmed: 0, recent: [] });
+  });
+});
+
+describe('renderTrackRecord setbacks', () => {
+  const base = {
+    proposed: 0,
+    published: 0,
+    funded: 0,
+    totalFundedBtc: 0,
+    entries: [],
+    windowDays: 90,
+  };
+
+  it('renders a record with ONLY setbacks (all-denials is still a record)', () => {
+    const out = renderTrackRecord({
+      ...base,
+      setbacks: {
+        failed: 0,
+        denied: 2,
+        unconfirmed: 1,
+        recent: [{ actionId: 'send_payment', kind: 'denied', reason: 'cap', at: NOW }],
+      },
+    });
+    expect(out).toContain('Setbacks: 0 failed · 2 denied · 1 unconfirmed');
+    expect(out).toContain('send_payment — denied: cap');
+    expect(out).toContain("don't re-propose an action that was denied");
+  });
+
+  it('stays null when there is nothing either way (cold start unchanged)', () => {
+    expect(
+      renderTrackRecord({
+        ...base,
+        setbacks: { failed: 0, denied: 0, unconfirmed: 0, recent: [] },
+      })
+    ).toBeNull();
+  });
+});
+
+describe('executor denial audit rows', () => {
+  it('logs a denied row when permission is refused (previously: no trace at all)', async () => {
+    const inserts: Array<{ table: string; row: Record<string, unknown> }> = [];
+    const executor = new CatActionExecutor(fakeSupabase({ inserts }));
+    mockPermissionService.checkPermission.mockResolvedValue({
+      allowed: false,
+      reason: 'Category disabled',
+    });
+
+    const result = await executor.executeAction(USER_ID, 'actor-1', {
+      actionId: 'send_message',
+      parameters: {},
+    });
+
+    expect(result.status).toBe('denied');
+    const logged = inserts.find(i => i.table === DATABASE_TABLES.CAT_ACTION_LOG);
+    expect(logged).toBeDefined();
+    expect(logged!.row.status).toBe('denied');
+    expect(logged!.row.error_message).toBe('Category disabled');
+  });
+
+  it('logs a denied row when the early spend cap refuses', async () => {
+    const inserts: Array<{ table: string; row: Record<string, unknown> }> = [];
+    const executor = new CatActionExecutor(fakeSupabase({ inserts }));
+    mockPermissionService.checkPermission.mockResolvedValue({
+      allowed: true,
+      requiresConfirmation: false,
+    });
+    mockPermissionService.checkSpendCaps.mockResolvedValue({
+      allowed: false,
+      reason: 'Spend cap exceeded: 0.01 > 0.001',
+    });
+
+    const result = await executor.executeAction(USER_ID, 'actor-1', {
+      actionId: 'send_payment',
+      parameters: { amount_btc: 0.01 },
+    });
+
+    expect(result.status).toBe('denied');
+    const logged = inserts.find(i => i.table === DATABASE_TABLES.CAT_ACTION_LOG);
+    expect(logged?.row.status).toBe('denied');
+    expect(logged?.row.amount_btc).toBe(0.01);
+  });
+});

--- a/__tests__/unit/services/cat/track-record.test.ts
+++ b/__tests__/unit/services/cat/track-record.test.ts
@@ -68,6 +68,7 @@ describe('getCatTrackRecord', () => {
       funded: 0,
       totalFundedBtc: 0,
       entries: [],
+      setbacks: { failed: 0, denied: 0, unconfirmed: 0, recent: [] },
       windowDays: 90,
     });
   });

--- a/src/components/ai-chat/CatTrackRecordCard.tsx
+++ b/src/components/ai-chat/CatTrackRecordCard.tsx
@@ -113,6 +113,26 @@ export function CatTrackRecordCard() {
           </ul>
         </>
       )}
+
+      {/* Loss side — the same setbacks Cat sees in its context. Rendered even
+          when the funnel is empty: an all-denials record is still a record. */}
+      {record.setbacks &&
+        record.setbacks.failed + record.setbacks.denied + record.setbacks.unconfirmed > 0 && (
+          <div className="mt-4 border-t border-subtle pt-3">
+            <p className="text-xs text-fg-tertiary">
+              Setbacks: {record.setbacks.failed} failed · {record.setbacks.denied} denied ·{' '}
+              {record.setbacks.unconfirmed} unconfirmed
+            </p>
+            <ul className="mt-2 space-y-1">
+              {record.setbacks.recent.map((s, i) => (
+                <li key={`${s.actionId}-${s.at}-${i}`} className="text-xs text-fg-secondary">
+                  <span className="font-medium text-fg-primary">{s.actionId}</span> — {s.kind}
+                  {s.reason ? `: ${s.reason}` : ''}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
     </div>
   );
 }

--- a/src/services/ai/context-sections.ts
+++ b/src/services/ai/context-sections.ts
@@ -678,12 +678,15 @@ export function renderActivitySummary(stats: FullUserContext['stats']): string |
 /**
  * Outcome feedback loop — what actually happened to what Cat created with this
  * user (published? funded?), derived from real platform state (see
- * cat/track-record.ts). Renders only when there's at least one proposal in the
- * window: cold-start users get the interview flow instead, and snapshot
- * contexts (field undefined) stay byte-identical.
+ * cat/track-record.ts). Renders when there's at least one proposal OR one
+ * setback in the window — an all-denials record is precisely the one the Cat
+ * most needs to see. Cold-start users (nothing either way) get the interview
+ * flow instead, and snapshot contexts (field undefined) stay byte-identical.
  */
 export function renderTrackRecord(tr: FullUserContext['trackRecord']): string | null {
-  if (!tr || tr.proposed === 0) {
+  const setbacks = tr?.setbacks;
+  const setbackCount = setbacks ? setbacks.failed + setbacks.denied + setbacks.unconfirmed : 0;
+  if (!tr || (tr.proposed === 0 && setbackCount === 0)) {
     return null;
   }
 
@@ -703,8 +706,17 @@ export function renderTrackRecord(tr: FullUserContext['trackRecord']): string | 
     lines.push(`- ${e.entityType} "${e.title}" — ${outcome}`);
   }
 
+  if (setbacks && setbackCount > 0) {
+    lines.push(
+      `Setbacks: ${setbacks.failed} failed · ${setbacks.denied} denied · ${setbacks.unconfirmed} unconfirmed`
+    );
+    for (const s of setbacks.recent) {
+      lines.push(`- ${s.actionId} — ${s.kind}${s.reason ? `: ${s.reason}` : ''}`);
+    }
+  }
+
   lines.push(
-    `_Ground your advice in these outcomes: lean into what published and got funded; nudge stalled drafts toward publishing or retiring. Never claim an outcome not listed here._`
+    `_Ground your advice in these outcomes: lean into what published and got funded; nudge stalled drafts toward publishing or retiring. Learn from the setbacks — don't re-propose an action that was denied or repeatedly left unconfirmed unless something changed (caps raised, permission granted, user asked). Never claim an outcome not listed here._`
   );
   return lines.join('\n');
 }

--- a/src/services/cat/action-executor.ts
+++ b/src/services/cat/action-executor.ts
@@ -92,11 +92,15 @@ export class CatActionExecutor {
     const permission = await this.permissionService.checkPermission(userId, actionId);
 
     if (!permission.allowed) {
+      const reason = permission.reason || 'Permission denied';
+      // Denials are audit rows too — without them the track record only ever
+      // sees wins, and the Cat re-proposes its losses forever.
+      await this.logDeniedAction(userId, action, parameters, reason, conversationId, messageId);
       return {
         success: false,
         actionId,
         status: 'denied',
-        error: permission.reason || 'Permission denied',
+        error: reason,
       };
     }
 
@@ -109,11 +113,13 @@ export class CatActionExecutor {
       this.extractBtcAmount(action, parameters)
     );
     if (!spendCheck.allowed) {
+      const reason = spendCheck.reason || 'Spend cap exceeded';
+      await this.logDeniedAction(userId, action, parameters, reason, conversationId, messageId);
       return {
         success: false,
         actionId,
         status: 'denied',
-        error: spendCheck.reason || 'Spend cap exceeded',
+        error: reason,
       };
     }
 
@@ -319,7 +325,7 @@ export class CatActionExecutor {
     if (!spendCheck.allowed) {
       const reason = spendCheck.reason || 'Spend cap exceeded';
       if (logEntry) {
-        await this.updateActionLog(logEntry.id, 'failed', null, reason);
+        await this.updateActionLog(logEntry.id, 'denied', null, reason);
       }
       return {
         success: false,
@@ -428,9 +434,39 @@ export class CatActionExecutor {
     };
   }
 
+  /**
+   * Audit a denial that happens BEFORE performAction opens a log row (early
+   * permission / spend-cap checks). One terminal insert, fire-and-safe: a
+   * failed write only warns — denying the action never depends on logging it.
+   */
+  private async logDeniedAction(
+    userId: string,
+    action: CatAction,
+    parameters: Record<string, unknown>,
+    reason: string,
+    conversationId?: string,
+    messageId?: string
+  ): Promise<void> {
+    const { error } = await this.supabase.from(DATABASE_TABLES.CAT_ACTION_LOG).insert({
+      user_id: userId,
+      action_id: action.id,
+      category: action.category,
+      parameters,
+      status: 'denied',
+      error_message: reason,
+      conversation_id: conversationId || null,
+      message_id: messageId || null,
+      completed_at: new Date().toISOString(),
+      amount_btc: this.extractBtcAmount(action, parameters),
+    });
+    if (error) {
+      logger.warn('Failed to log denied action', { error: error.message }, 'CatActionExecutor');
+    }
+  }
+
   private async updateActionLog(
     logId: string,
-    status: 'completed' | 'failed',
+    status: 'completed' | 'failed' | 'denied',
     result: unknown,
     errorMessage?: string
   ): Promise<void> {

--- a/src/services/cat/track-record.ts
+++ b/src/services/cat/track-record.ts
@@ -37,6 +37,17 @@ export interface TrackRecordEntry {
   payments: number;
 }
 
+/** A concrete thing that went wrong — the loss side of the feedback loop. */
+export interface TrackRecordSetback {
+  actionId: string;
+  /** failed = handler errored · denied = permission/spend-cap refusal ·
+   *  expired/rejected = a confirmation the user never gave / turned down. */
+  kind: 'failed' | 'denied' | 'expired' | 'rejected';
+  /** Recorded reason, when one exists. */
+  reason: string | null;
+  at: string;
+}
+
 export interface CatTrackRecord {
   /** Completed create_* actions found in the window. */
   proposed: number;
@@ -47,6 +58,16 @@ export interface CatTrackRecord {
   totalFundedBtc: number;
   /** Most recent first; capped at MAX_ENTRIES. */
   entries: TrackRecordEntry[];
+  /** Failed + denied actions and expired/rejected confirmations in the window.
+   *  Without these the record is survivorship-biased: an agent that only
+   *  remembers wins re-proposes its losses forever. */
+  setbacks: {
+    failed: number;
+    denied: number;
+    unconfirmed: number;
+    /** Most recent first; capped at MAX_SETBACKS. */
+    recent: TrackRecordSetback[];
+  };
   windowDays: number;
 }
 
@@ -60,6 +81,14 @@ const MAX_ENTRIES = 12;
 const SETTLED_INTENT_STATUSES = ['paid', 'buyer_confirmed'];
 /** Entity status that counts as published. */
 const PUBLISHED_STATUS = 'active';
+/** Cap the setback list injected into context / returned to the UI. */
+const MAX_SETBACKS = 6;
+/** Log statuses that count as setbacks ('denied' exists from migration
+ *  20260802140000; on an un-migrated DB the .in() filter simply errors and the
+ *  whole setback block degrades to empty — the funnel is unaffected). */
+const SETBACK_LOG_STATUSES = ['failed', 'denied'];
+/** Pending-confirmation outcomes where the human said no (or nothing). */
+const UNCONFIRMED_STATUSES = ['expired', 'rejected'];
 
 /**
  * SSOT mapping: the Cat's entity-creating action ids are `create_<type>` for
@@ -105,6 +134,12 @@ export async function getCatTrackRecord(
     return null;
   }
 
+  // Loss side — failed/denied actions and unconfirmed proposals. Fetched
+  // before the empty-proposals early return: a Cat whose every action was
+  // denied has an EMPTY funnel and a full setback list, and that record is
+  // exactly the one it most needs to see.
+  const setbacks = await getSetbacks(supabase, userId, since);
+
   // Proposal side: completed create_* actions whose result carries the entity id.
   const proposals: Array<{ entityType: EntityType; entityId: string; createdAt: string }> = [];
   for (const row of (logRows || []) as LogRow[]) {
@@ -122,6 +157,7 @@ export async function getCatTrackRecord(
       funded: 0,
       totalFundedBtc: 0,
       entries: [],
+      setbacks,
       windowDays: WINDOW_DAYS,
     };
   }
@@ -200,6 +236,70 @@ export async function getCatTrackRecord(
     funded: entries.filter(e => e.fundedBtc > 0).length,
     totalFundedBtc: entries.reduce((sum, e) => sum + e.fundedBtc, 0),
     entries,
+    setbacks,
     windowDays: WINDOW_DAYS,
+  };
+}
+
+/**
+ * Derive the loss side: failed + denied log rows and expired/rejected pending
+ * confirmations. Both sources degrade to zero on any error (e.g. a DB that
+ * predates the 'denied' enum value) — the funnel never depends on them.
+ */
+async function getSetbacks(
+  supabase: AnySupabaseClient,
+  userId: string,
+  since: string
+): Promise<CatTrackRecord['setbacks']> {
+  const [logRes, pendingRes] = await Promise.all([
+    supabase
+      .from(DATABASE_TABLES.CAT_ACTION_LOG)
+      .select('action_id, status, error_message, created_at')
+      .eq('user_id', userId)
+      .in('status', SETBACK_LOG_STATUSES)
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
+      .limit(50),
+    supabase
+      .from(DATABASE_TABLES.CAT_PENDING_ACTIONS)
+      .select('action_id, status, rejection_reason, created_at')
+      .eq('user_id', userId)
+      .in('status', UNCONFIRMED_STATUSES)
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
+      .limit(50),
+  ]);
+
+  if (logRes.error) {
+    logger.warn('Setback log lookup failed', { error: logRes.error.message }, 'CatTrackRecord');
+  }
+  if (pendingRes.error) {
+    logger.warn(
+      'Setback pending lookup failed',
+      { error: pendingRes.error.message },
+      'CatTrackRecord'
+    );
+  }
+
+  const fromLog: TrackRecordSetback[] = (logRes.data || []).map(row => ({
+    actionId: row.action_id,
+    kind: row.status === 'denied' ? 'denied' : 'failed',
+    reason: row.error_message ?? null,
+    at: row.created_at,
+  }));
+  const fromPending: TrackRecordSetback[] = (pendingRes.data || []).map(row => ({
+    actionId: row.action_id,
+    kind: row.status === 'rejected' ? 'rejected' : 'expired',
+    reason: row.rejection_reason ?? null,
+    at: row.created_at,
+  }));
+
+  return {
+    failed: fromLog.filter(s => s.kind === 'failed').length,
+    denied: fromLog.filter(s => s.kind === 'denied').length,
+    unconfirmed: fromPending.length,
+    recent: [...fromLog, ...fromPending]
+      .sort((a, b) => b.at.localeCompare(a.at))
+      .slice(0, MAX_SETBACKS),
   };
 }

--- a/supabase/migrations/20260802140000_cat_action_log_denied_status.sql
+++ b/supabase/migrations/20260802140000_cat_action_log_denied_status.sql
@@ -1,0 +1,12 @@
+-- Add 'denied' to cat_action_status so denials are first-class audit rows.
+--
+-- Before this, a permission- or spend-cap-denied action either never reached
+-- cat_action_log at all (the early checks in executeAction return before any
+-- write) or was logged as generic 'failed' (the performAction backstop). The
+-- Cat's track record could therefore only ever see wins — survivorship bias
+-- installed at the schema level. Denials become their own status so the
+-- outcome loop can feed "what the Cat was refused, and why" back into context.
+--
+-- ADD VALUE is append-only and safe on live enums; IF NOT EXISTS makes the
+-- migration replay-idempotent.
+ALTER TYPE public.cat_action_status ADD VALUE IF NOT EXISTS 'denied';


### PR DESCRIPTION
## Item 3 of the ledger-and-loop build sequence — let the agent see its own failures

The Cat's track record was success-only: denials left **no audit trace at all** (early permission/spend-cap checks returned before any log write), handler failures were logged but never read back, and expired/rejected confirmations never reached context. Survivorship bias, installed on purpose. An agent that remembers only wins re-proposes its losses forever.

### Changes
- **Migration** `20260802140000`: `ALTER TYPE cat_action_status ADD VALUE IF NOT EXISTS 'denied'` — append-only, replay-idempotent.
- **Executor**: early permission + spend-cap denials write a terminal `denied` audit row with the reason; the performAction backstop logs `denied` instead of generic `failed`. Denying never depends on logging (insert failure only warns).
- **Track record**: new `setbacks` block — failed/denied counts from `cat_action_log`, expired/rejected from `cat_pending_actions`, merged newest-first recent list (cap 6). Computed even when the funnel is empty: an all-denials record is exactly the one the Cat most needs to see. Degrades to zeros on any query error (incl. an un-migrated enum) — the funnel is never affected.
- **Context**: `renderTrackRecord` shows the setbacks + a directive: don't re-propose an action that was denied or repeatedly left unconfirmed unless something changed (caps raised, permission granted, user asked). Renders on setbacks-only records; cold-start behavior unchanged (snapshot test still byte-identical).
- **UI**: the Context-tab Track Record card shows the same loss side — the human sees what the Cat sees.

### Verified
- `npm run verify` green — 1470 tests incl. new `track-record-setbacks` suite (derivation, renderer, executor audit rows) and updated spend-caps/track-record assertions pinning the new contract.

### Deploy note
Migration must be applied to the self-hosted DB (`supabase db push`) — the code is order-independent either way (setbacks degrade to zero until the enum value exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)