### PR TITLE
fix(security): single isPrivateAddress SSOT — the SSRF guard was forked

### DIFF
--- a/src/lib/security/private-address.ts
+++ b/src/lib/security/private-address.ts
@@ -1,0 +1,61 @@
+/**
+ * isPrivateAddress — THE single implementation of "is this IP something a
+ * server-side fetch must never touch" (loopback, RFC1918, link-local/cloud
+ * metadata, CGNAT, ULA, multicast, reserved, v4-mapped v6).
+ *
+ * Deliberately dependency-free (no node:net) so it can be imported from any
+ * module, including ones that must stay client-bundle-safe. Fail-closed: any
+ * string that isn't a well-formed address is treated as private.
+ *
+ * History: this logic existed as two independently-maintained copies
+ * (lib/security/ssrfGuard.ts and services/cat/website-analysis.ts) — a range
+ * added to one and not the other would have opened a silent SSRF hole. Both
+ * now import from here.
+ */
+export function isPrivateAddress(ip: string): boolean {
+  const addr = ip.trim().toLowerCase();
+
+  // IPv6 (including v4-mapped ::ffff:a.b.c.d)
+  if (addr.includes(':')) {
+    const unbracketed = addr.replace(/^\[|\]$/g, '');
+    const mapped = unbracketed.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped) {
+      return isPrivateAddress(mapped[1]);
+    }
+    if (unbracketed === '::' || unbracketed === '::1') {
+      return true; // unspecified / loopback
+    }
+    if (/^fe[89ab]/.test(unbracketed)) {
+      return true; // link-local fe80::/10
+    }
+    if (/^f[cd]/.test(unbracketed)) {
+      return true; // unique-local fc00::/7
+    }
+    if (/^fe[cdef]/.test(unbracketed)) {
+      return true; // deprecated site-local fec0::/10
+    }
+    if (/^ff/.test(unbracketed)) {
+      return true; // multicast ff00::/8
+    }
+    return false;
+  }
+
+  // IPv4
+  const octets = addr.split('.').map(Number);
+  if (octets.length !== 4 || octets.some(o => Number.isNaN(o) || o < 0 || o > 255)) {
+    return true; // not a well-formed IPv4 — refuse rather than guess
+  }
+  const [a, b] = octets;
+  return (
+    a === 0 || // 0.0.0.0/8 "this network"
+    a === 10 || // 10.0.0.0/8 private
+    a === 127 || // 127.0.0.0/8 loopback
+    (a === 100 && b >= 64 && b <= 127) || // 100.64.0.0/10 CGNAT
+    (a === 169 && b === 254) || // 169.254.0.0/16 link-local (cloud metadata!)
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12 private
+    (a === 192 && b === 0) || // 192.0.0.0/24 + 192.0.2.0/24 special/doc
+    (a === 192 && b === 168) || // 192.168.0.0/16 private
+    (a === 198 && (b === 18 || b === 19)) || // 198.18.0.0/15 benchmarking
+    a >= 224 // multicast 224/4 + reserved 240/4 + broadcast
+  );
+}

--- a/src/lib/security/ssrfGuard.ts
+++ b/src/lib/security/ssrfGuard.ts
@@ -22,56 +22,8 @@ type Resolver = (hostname: string) => Promise<Array<{ address: string }>>;
 
 const defaultResolver: Resolver = async hostname => lookup(hostname, { all: true, verbatim: true });
 
-function isPrivateIPv4(ip: string): boolean {
-  const octets = ip.split('.').map(Number);
-  if (octets.length !== 4 || octets.some(o => Number.isNaN(o))) {
-    return true; // malformed — treat as unsafe
-  }
-  const [a, b] = octets;
-  return (
-    a === 0 || // "this network"
-    a === 10 || // RFC1918
-    a === 127 || // loopback
-    (a === 100 && b >= 64 && b <= 127) || // CGNAT 100.64/10
-    (a === 169 && b === 254) || // link-local / cloud metadata
-    (a === 172 && b >= 16 && b <= 31) || // RFC1918
-    (a === 192 && b === 168) || // RFC1918
-    (a === 192 && b === 0) || // IETF protocol assignments 192.0.0/24 + 192.0.2/24 test
-    (a === 198 && (b === 18 || b === 19)) || // benchmarking 198.18/15
-    a >= 224 // multicast + reserved + broadcast
-  );
-}
-
-/** True when `ip` (v4 or v6) is loopback, link-local, private, or reserved. */
-export function isPrivateAddress(ip: string): boolean {
-  const version = isIP(ip);
-  if (version === 4) {
-    return isPrivateIPv4(ip);
-  }
-  if (version === 6) {
-    const lower = ip.toLowerCase();
-    // IPv4-mapped (::ffff:a.b.c.d) — check the embedded v4 address
-    const mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-    if (mapped) {
-      return isPrivateIPv4(mapped[1]);
-    }
-    return (
-      lower === '::' ||
-      lower === '::1' ||
-      lower.startsWith('fc') || // ULA fc00::/7
-      lower.startsWith('fd') ||
-      lower.startsWith('fe8') || // link-local fe80::/10
-      lower.startsWith('fe9') ||
-      lower.startsWith('fea') ||
-      lower.startsWith('feb') ||
-      lower.startsWith('fec') || // deprecated site-local fec0::/10
-      lower.startsWith('fed') ||
-      lower.startsWith('fee') ||
-      lower.startsWith('fef')
-    );
-  }
-  return true; // not an IP at all — caller should have resolved first
-}
+export { isPrivateAddress } from './private-address';
+import { isPrivateAddress } from './private-address';
 
 /**
  * Validate that a user-supplied URL is http(s) and does not point at a

--- a/src/services/cat/website-analysis.ts
+++ b/src/services/cat/website-analysis.ts
@@ -23,6 +23,8 @@
  * Limitation: JS-rendered (SPA) sites yield little or no text.
  */
 
+import { isPrivateAddress } from '@/lib/security/private-address';
+
 const MAX_REDIRECTS = 3;
 const FETCH_TIMEOUT_MS = 8_000;
 const MAX_RESPONSE_BYTES = 1.5 * 1024 * 1024;
@@ -126,52 +128,10 @@ export function resolveRequestedUrl(modelUrl: string, userMessage: string): stri
 }
 
 // ── SSRF guards ──────────────────────────────────────────────────────────────
-
-/** True when `ip` (v4 or v6) is loopback/private/link-local/otherwise non-public. */
-export function isPrivateAddress(ip: string): boolean {
-  const addr = ip.trim().toLowerCase();
-
-  // IPv6 (including v4-mapped ::ffff:a.b.c.d)
-  if (addr.includes(':')) {
-    const unbracketed = addr.replace(/^\[|\]$/g, '');
-    const mapped = unbracketed.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-    if (mapped) {
-      return isPrivateAddress(mapped[1]);
-    }
-    if (unbracketed === '::' || unbracketed === '::1') {
-      return true; // unspecified / loopback
-    }
-    if (/^fe[89ab]/.test(unbracketed)) {
-      return true; // link-local fe80::/10
-    }
-    if (/^f[cd]/.test(unbracketed)) {
-      return true; // unique-local fc00::/7
-    }
-    if (/^ff/.test(unbracketed)) {
-      return true; // multicast ff00::/8
-    }
-    return false;
-  }
-
-  // IPv4
-  const octets = addr.split('.').map(Number);
-  if (octets.length !== 4 || octets.some(o => Number.isNaN(o) || o < 0 || o > 255)) {
-    return true; // not a well-formed IPv4 — refuse rather than guess
-  }
-  const [a, b] = octets;
-  return (
-    a === 0 || // 0.0.0.0/8 "this network"
-    a === 10 || // 10.0.0.0/8 private
-    a === 127 || // 127.0.0.0/8 loopback
-    (a === 100 && b >= 64 && b <= 127) || // 100.64.0.0/10 CGNAT
-    (a === 169 && b === 254) || // 169.254.0.0/16 link-local (cloud metadata!)
-    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12 private
-    (a === 192 && b === 0) || // 192.0.0.0/24 + 192.0.2.0/24 special/doc
-    (a === 192 && b === 168) || // 192.168.0.0/16 private
-    (a === 198 && (b === 18 || b === 19)) || // 198.18.0.0/15 benchmarking
-    a >= 224 // multicast 224/4 + reserved 240/4 + broadcast
-  );
-}
+// SSOT: @/lib/security/ssrfGuard. This module once carried its own copy of
+// isPrivateAddress — a forked guard is a hole waiting to happen (a range added
+// to one and not the other). Re-exported so callers/tests keep one import path.
+export { isPrivateAddress } from '@/lib/security/private-address';
 
 function looksLikeIpLiteral(hostname: string): boolean {
   return /^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.includes(':');


### PR DESCRIPTION
SSOT-sweep finding #3 (HIGH, security). `isPrivateAddress` existed as two independently-maintained copies:
- `src/lib/security/ssrfGuard.ts` (webhook endpoints)
- `src/services/cat/website-analysis.ts` (Cat's analyze_website — **user-supplied URLs**, the highest-risk SSRF surface)

They had already drifted: the security module was missing IPv6 multicast `ff00::/8`, which the Cat copy blocked.

**Fix:** new dependency-free `src/lib/security/private-address.ts` = the strictest union of both (brackets, fail-closed on malformed input, ff00::/8, site-local, CGNAT, metadata range). Both former hosts import/re-export it; copies deleted. No `node:net`, so it stays client-bundle-safe.

**Verify:** all 102 ssrfGuard + website-analysis tests green · tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)