### PR TITLE
refactor(pricing): one SSOT, machine-guarded — tier map, upsell copy, SQL drift test

### DIFF
--- a/__tests__/unit/cat/plan-limit-drift.test.ts
+++ b/__tests__/unit/cat/plan-limit-drift.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Plan-limit drift guard — machine-enforces the SSOT across the one boundary
+ * config/cat-plans.ts cannot reach: SQL.
+ *
+ * The free daily limit is ENFORCED in Postgres (check_platform_limit,
+ * increment_platform_usage, the user_plans default and the signup trigger),
+ * where literals can't import CAT_FREE_DAILY_LIMIT. Historically the TS
+ * constant and the SQL literals were maintained by hand in parallel — the
+ * classic two-sources-of-truth setup that WILL diverge. This test reads the
+ * migrations and fails the moment either side changes alone, with the fix
+ * spelled out.
+ *
+ * If this test fails you have exactly two valid moves:
+ *   1. You changed CAT_FREE_DAILY_LIMIT → write a NEW forward migration that
+ *      updates the SQL functions/default to the same number (never edit the
+ *      baseline), then extend MIGRATION_FILES below with it.
+ *   2. You changed the SQL → update CAT_FREE_DAILY_LIMIT to match.
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { CAT_FREE_DAILY_LIMIT, CAT_SUPPORTER_DAILY_LIMIT, CAT_PLANS } from '@/config/cat-plans';
+
+const MIGRATIONS_DIR = join(process.cwd(), 'supabase', 'migrations');
+
+/** Every migration that states the free daily limit as a literal. */
+const MIGRATION_FILES = ['20240101000001_baseline_public_schema.sql'];
+
+function readMigration(name: string): string {
+  return readFileSync(join(MIGRATIONS_DIR, name), 'utf8');
+}
+
+describe('plan limit SSOT (TS ↔ SQL drift guard)', () => {
+  const baseline = readMigration(MIGRATION_FILES[0]);
+
+  it('check_platform_limit / increment_platform_usage literals match CAT_FREE_DAILY_LIMIT', () => {
+    // All the shapes the baseline uses to state the free limit inside the
+    // two quota functions: `v_daily_limit INTEGER := N;`,
+    // `COALESCE(up.daily_limit, N)`, `v_daily_limit := N;`.
+    const literalSites = [
+      ...baseline.matchAll(/v_daily_limit\s+INTEGER\s*:=\s*(\d+)/gi),
+      ...baseline.matchAll(/COALESCE\(\s*up\.daily_limit\s*,\s*(\d+)\s*\)/gi),
+      ...baseline.matchAll(/v_daily_limit\s*:=\s*(\d+)\s*;/gi),
+    ].map(m => Number(m[1]));
+
+    expect(literalSites.length).toBeGreaterThanOrEqual(4);
+    for (const value of literalSites) {
+      expect(value).toBe(CAT_FREE_DAILY_LIMIT);
+    }
+  });
+
+  it('user_plans default and the signup trigger match CAT_FREE_DAILY_LIMIT', () => {
+    const columnDefault = baseline.match(/daily_limit\s+integer\s+DEFAULT\s+(\d+)/i);
+    expect(columnDefault).not.toBeNull();
+    expect(Number(columnDefault![1])).toBe(CAT_FREE_DAILY_LIMIT);
+
+    const signupInsert = baseline.match(
+      /INSERT INTO public\.user_plans\s*\(user_id,\s*tier,\s*daily_limit\)\s*VALUES\s*\(NEW\.id,\s*'free',\s*(\d+)\)/i
+    );
+    expect(signupInsert).not.toBeNull();
+    expect(Number(signupInsert![1])).toBe(CAT_FREE_DAILY_LIMIT);
+  });
+
+  it('no LATER migration restates a daily limit without being registered here', () => {
+    // A future migration that touches daily_limit with a literal is a new
+    // drift site — it must be added to MIGRATION_FILES with assertions, not
+    // slipped in silently.
+    const later = readdirSync(MIGRATIONS_DIR)
+      .filter(f => f.endsWith('.sql') && !MIGRATION_FILES.includes(f))
+      .filter(f => /daily_limit/i.test(readMigration(f)));
+    expect(later).toEqual([]);
+  });
+
+  it('marketing copy advertises the enforced numbers', () => {
+    // The plan cards derive bullets from the constants via template strings;
+    // this pins the derivation so a hand-edited bullet can't drift.
+    const free = CAT_PLANS.find(p => p.id === 'free')!;
+    expect(free.bullets[0]).toContain(String(CAT_FREE_DAILY_LIMIT));
+    const supporter = CAT_PLANS.find(p => p.id === 'supporter')!;
+    expect(supporter.bullets[0]).toContain(String(CAT_SUPPORTER_DAILY_LIMIT));
+  });
+
+  it('supporter grants never hardcode the limit', () => {
+    // grant.ts must import CAT_SUPPORTER_DAILY_LIMIT — a literal there would
+    // bypass the SSOT the moment the cap changes.
+    const grant = readFileSync(
+      join(process.cwd(), 'src', 'services', 'supporter', 'grant.ts'),
+      'utf8'
+    );
+    expect(grant).toContain('CAT_SUPPORTER_DAILY_LIMIT');
+    expect(grant).not.toMatch(/daily_limit:\s*\d+/);
+  });
+});

--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -91,7 +91,7 @@ export default function AISettingsPage() {
                 <Link href={ROUTES.PRICING} className="underline hover:no-underline">
                   pricing
                 </Link>{' '}
-                for the Pro option (coming soon — it&apos;s a waitlist for now).
+                for every plan — Supporter, your own key, and Cat Credits.
               </p>
               <p className="mt-2 text-xs text-fg-tertiary">
                 Capability: <span className="font-medium text-fg-secondary">Capable</span> — great

--- a/src/app/(authenticated)/settings/usage/page.tsx
+++ b/src/app/(authenticated)/settings/usage/page.tsx
@@ -17,7 +17,7 @@ import { Gauge, KeyRound, Sparkles, Wallet } from 'lucide-react';
 import { useCatQuota } from '@/components/ai-chat/ModernChatPanel/hooks/useCatQuota';
 import { API_ROUTES } from '@/config/api-routes';
 import { ROUTES } from '@/config/routes';
-import { CAT_PLANS, type CatPlanId } from '@/config/cat-plans';
+import { CAT_PLANS, PLAN_ID_BY_QUOTA_TIER, type CatPlanId } from '@/config/cat-plans';
 import { logger } from '@/utils/logger';
 
 /** "3h 24m" / "45m" from seconds — for the daily-reset countdown. */
@@ -61,14 +61,8 @@ export default function UsageSettingsPage() {
   const { quota, isLoading: quotaLoading } = useCatQuota();
   const { balanceBtc } = useCreditBalance();
 
-  /** Which CAT_PLANS card is the user's current reality. */
-  const activePlanId: CatPlanId | null = quota
-    ? quota.tier === 'byok'
-      ? 'byok'
-      : quota.tier === 'pro'
-        ? 'supporter'
-        : 'free'
-    : null;
+  /** Which CAT_PLANS card is the user's current reality — via the SSOT map. */
+  const activePlanId: CatPlanId | null = quota ? PLAN_ID_BY_QUOTA_TIER[quota.tier] : null;
 
   const used = quota ? quota.dailyRequests : 0;
   const limit = quota ? quota.dailyLimit : 0;

--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -5,6 +5,8 @@ import Button from '@/components/ui/Button';
 import { PageHeading } from '@/components/layout/PageHeading';
 import {
   CAT_PLANS,
+  CAT_FREE_DAILY_LIMIT,
+  CAT_SUPPORTER_DAILY_LIMIT,
   CAT_FRONTIER_MODELS_LIST,
   CAT_FRONTIER_MODELS_OR,
   type CatPlan,
@@ -15,15 +17,16 @@ import { cn } from '@/lib/utils';
 export const metadata = {
   title: 'Cat plans',
   description:
-    'OrangeCat Cat is free for everyone. Bring your own key, or join the Pro waitlist to help fund the platform AI budget.',
+    'OrangeCat Cat is free for everyone — 10 messages a day, no card. Go further with your own API key, Cat Credits, or a Supporter pass in Bitcoin.',
 };
 
 /**
- * /pricing — honest tier card layout. Free + BYOK are real and shipped;
- * Pro is a waitlist with no declared price (intentional: we want signal
- * before we price). One warm-accent CTA on the recommended (BYOK) tier;
- * everything else is monochrome surfaces per the FleetCrown-aligned
- * design tier.
+ * /pricing — honest tier card layout, rendered 1:1 from the CAT_PLANS SSOT
+ * (config/cat-plans.ts): every number, status, and CTA comes from there;
+ * this file owns layout only. "Pro" in the prose below refers to the FUTURE
+ * managed-frontier tier — distinct from the Supporter pass, which is a plan
+ * card. One warm-accent CTA on the recommended (BYOK) tier; everything else
+ * is monochrome surfaces per the FleetCrown-aligned design tier.
  */
 export default function PricingPage() {
   return (
@@ -73,9 +76,13 @@ export default function PricingPage() {
                 {CAT_FRONTIER_MODELS_OR} for you right now.
               </li>
               <li>
-                <strong className="text-fg-primary">Back us in Bitcoin</strong> — believe in where
-                this is heading? Become a founding supporter. It&apos;s a donation, not a
-                subscription — and supporters get first access the day Pro ships.
+                <strong className="text-fg-primary">Cat Credits</strong> — prepaid Bitcoin balance,
+                metered per message: managed frontier AI without a subscription.
+              </li>
+              <li>
+                <strong className="text-fg-primary">Become a Supporter</strong> — a flat monthly in
+                Bitcoin for a {Math.round(CAT_SUPPORTER_DAILY_LIMIT / CAT_FREE_DAILY_LIMIT)}× daily
+                cap, funding the platform AI budget — and first access the day Pro ships.
               </li>
             </ul>
           </div>

--- a/src/components/ai-chat/CatSettingsTab.tsx
+++ b/src/components/ai-chat/CatSettingsTab.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import { ROUTES } from '@/config/routes';
+import { CAT_UPSELL } from '@/config/cat-plans';
 
 export function CatSettingsTab() {
   const { hasByok } = useAISettings();
@@ -70,7 +71,7 @@ export function CatSettingsTab() {
                     : 'platform key, daily cap'}
                 </p>
                 <p className="text-xs text-fg-secondary">
-                  Add a free Groq key for unlimited use, or upgrade to Pro when it ships.
+                  {CAT_UPSELL.byokShort} — or see the plans for more ways to run Cat.
                 </p>
               </div>
             </div>
@@ -89,7 +90,7 @@ export function CatSettingsTab() {
               href={ROUTES.PRICING}
               className="flex min-h-11 items-center justify-between rounded-md border border-accent-warm/30 bg-accent-warm/10 px-3 py-2 transition-colors hover:bg-accent-warm/20"
             >
-              <span className="text-sm font-medium text-fg-primary">See Pro pricing</span>
+              <span className="text-sm font-medium text-fg-primary">See Cat plans</span>
               <ArrowUpRight className="h-4 w-4 text-accent-warm" />
             </Link>
           )}

--- a/src/components/ai-chat/ModernChatPanel/components/QuotaMeter.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/QuotaMeter.tsx
@@ -22,6 +22,7 @@
 import Link from 'next/link';
 import { KeyRound, Sparkles } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
+import { CAT_UPSELL } from '@/config/cat-plans';
 import { cn } from '@/lib/utils';
 import type { CatQuota } from '../hooks/useCatQuota';
 
@@ -66,8 +67,8 @@ export function QuotaMeter({ quota, className }: QuotaMeterProps) {
   // stays compact on small screens and spells itself out on ≥sm.
   const noun = isPro ? 'Cat messages' : 'free messages';
   const explanation = isCapped
-    ? `You've used all ${dailyLimit} ${noun} for today · Add your own API key for unlimited`
-    : `${requestsRemaining} of ${dailyLimit} ${noun} left today · Add your own API key for unlimited`;
+    ? `You've used all ${dailyLimit} ${noun} for today · ${CAT_UPSELL.byokShort}`
+    : `${requestsRemaining} of ${dailyLimit} ${noun} left today · ${CAT_UPSELL.byokShort}`;
 
   return (
     <span
@@ -111,7 +112,7 @@ export function QuotaMeter({ quota, className }: QuotaMeterProps) {
           className="whitespace-nowrap font-medium underline decoration-dotted underline-offset-2 hover:no-underline"
           title="Bring your own API key — unlimited messages, you pay your provider directly"
         >
-          Add your key →
+          {CAT_UPSELL.byokAction} →
         </Link>
       )}
     </span>


### PR DESCRIPTION
## Problem

`cat-plans.ts` claimed to be the pricing SSOT, but its facts leaked into four parallel sources that already disagreed:
- The free daily limit is enforced in Postgres with **6 hand-mirrored literals** in the baseline migration (`check_platform_limit`, `increment_platform_usage`, `user_plans` default, signup trigger) — SQL can't import TS, so nothing kept them honest
- The DB-tier `'pro'` ↔ plan `'supporter'` naming seam was re-derived as an inline ternary in every consumer
- The "add your own key" upsell promise existed in ~10 hand-written variants
- `/pricing` metadata + prose, `settings/ai`, and `CatSettingsTab` still sold a "Pro waitlist" that doesn't exist (the plan cards ship Supporter/Credits)

## Fix

**Config (facts, stated once):** `cat-plans.ts` header now documents the layer contract — config=facts, SQL=enforcement, services=rules, UI=render-only — and gains `PLAN_ID_BY_QUOTA_TIER` (the naming seam as data), `getCatPlan()`, and `CAT_UPSELL` (canonical upsell copy).

**Enforcement (the smart part):** new `plan-limit-drift.test.ts` machine-guards the one boundary config can't reach. It parses the migrations and fails if any SQL literal, the column default, the signup trigger, the plan-card bullets, or `grant.ts` disagree with the TS constants — **and** fails if any future migration mentions `daily_limit` without being registered in the test. Changing a limit on one side alone is now a red build with the fix spelled out, forever. No runtime SQL was touched — the working quota RPCs stay exactly as they are.

**Consumers (render-only):** QuotaMeter, CatSettingsTab, `/settings/usage`, `settings/ai`, `/pricing` all derive mapping + copy from the config. Stale waitlist copy replaced; the pricing prose now names all four real paths with the Supporter cap multiple computed (`200/10 → 20×`), not typed.

(Recovered via reflog cherry-pick after a concurrent-session branch clobber; re-verified on latest main in an isolated worktree.)

## Verification

Worktree on latest main: type-check green, cat unit suites 379/379 (5 new drift-guard tests proving today's TS↔SQL agreement), eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)