### PR TITLE
refactor(settings): connect Usage/AI/Integrations into one flow, all driven by cat-plans

### DIFF
--- a/__tests__/unit/cat/plan-limit-drift.test.ts
+++ b/__tests__/unit/cat/plan-limit-drift.test.ts
@@ -19,7 +19,12 @@
 
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { CAT_FREE_DAILY_LIMIT, CAT_SUPPORTER_DAILY_LIMIT, CAT_PLANS } from '@/config/cat-plans';
+import {
+  CAT_FREE_DAILY_LIMIT,
+  CAT_SUPPORTER_DAILY_LIMIT,
+  CAT_PLANS,
+  SETTINGS_AI_ANCHORS,
+} from '@/config/cat-plans';
 
 const MIGRATIONS_DIR = join(process.cwd(), 'supabase', 'migrations');
 
@@ -78,6 +83,20 @@ describe('plan limit SSOT (TS ↔ SQL drift guard)', () => {
     expect(free.bullets[0]).toContain(String(CAT_FREE_DAILY_LIMIT));
     const supporter = CAT_PLANS.find(p => p.id === 'supporter')!;
     expect(supporter.bullets[0]).toContain(String(CAT_SUPPORTER_DAILY_LIMIT));
+  });
+
+  it('settings anchors point at sections that exist', () => {
+    // SETTINGS_AI_ANCHORS deep-links (#credits/#byok/#local) are config facts;
+    // the ids live in settings/ai/page.tsx. If a section is renamed or removed
+    // the pricing CTAs would silently land on the page top — fail instead.
+    const aiPage = readFileSync(
+      join(process.cwd(), 'src', 'app', '(authenticated)', 'settings', 'ai', 'page.tsx'),
+      'utf8'
+    );
+    for (const anchor of Object.values(SETTINGS_AI_ANCHORS)) {
+      const id = anchor.split('#')[1];
+      expect(aiPage).toContain(`id="${id}"`);
+    }
   });
 
   it('supporter grants never hardcode the limit', () => {

--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -28,6 +28,7 @@ import { CatCustomInstructions } from '@/components/ai/CatCustomInstructions';
 import { CatMemoryManager } from '@/components/ai/CatMemoryManager';
 import { CatMemoryImport } from '@/components/ai/CatMemoryImport';
 import { LocalRuntimePanel } from '@/components/ai/LocalRuntimePanel';
+import { AiUsageStrip } from '@/components/ai/AiUsageStrip';
 
 export default function AISettingsPage() {
   const { user, hydrated, isLoading: authLoading } = useRequireAuth();
@@ -54,6 +55,10 @@ export default function AISettingsPage() {
 
   return (
     <div className="space-y-12">
+      {/* Live status strip — the numbers live on /settings/usage; this one
+          line connects config to consumption so neither tab is a dead end. */}
+      <AiUsageStrip />
+
       {/* ════ Group 1 · How Cat runs ═══════════════════════════════════════ */}
       <section aria-labelledby="how-cat-runs" className="space-y-4">
         <div>
@@ -105,10 +110,12 @@ export default function AISettingsPage() {
         </section>
 
         {/* ── Cat Credits (pay with Bitcoin) ────────────────────────────── */}
-        <CatCreditsPanel />
+        <div id="credits" className="scroll-mt-24">
+          <CatCreditsPanel />
+        </div>
 
         {/* ── BYOK ──────────────────────────────────────────────────────── */}
-        <section className="rounded-lg border border-default bg-surface-base p-6">
+        <section id="byok" className="scroll-mt-24 rounded-lg border border-default bg-surface-base p-6">
           <div className="mb-4 flex items-start gap-3">
             <div className="rounded-md bg-surface-raised p-2">
               <Server className="h-5 w-5 text-fg-primary" />
@@ -147,7 +154,7 @@ export default function AISettingsPage() {
         </section>
 
         {/* ── Local ─────────────────────────────────────────────────────── */}
-        <section className="rounded-lg border border-default bg-surface-base p-6">
+        <section id="local" className="scroll-mt-24 rounded-lg border border-default bg-surface-base p-6">
           <div className="mb-4 flex items-start gap-3">
             <div className="rounded-md bg-surface-raised p-2">
               <Terminal className="h-5 w-5 text-fg-primary" />

--- a/src/app/(authenticated)/settings/integrations/page.tsx
+++ b/src/app/(authenticated)/settings/integrations/page.tsx
@@ -73,6 +73,13 @@ export default function IntegrationsPage() {
         <p className="text-sm text-fg-secondary">
           Let external services authenticate to OrangeCat and receive signed events.
         </p>
+        <p className="mt-1 text-xs text-fg-tertiary">
+          Looking for AI provider keys (Groq, OpenRouter, OpenAI…)? Those live in{' '}
+          <Link href={ROUTES.SETTINGS_AI} className="underline hover:text-fg-primary">
+            Settings → AI
+          </Link>
+          — this page is for OrangeCat platform access from outside.
+        </p>
         <p className="mt-2 text-xs text-fg-secondary">
           API contract:{' '}
           <a

--- a/src/app/(authenticated)/settings/usage/page.tsx
+++ b/src/app/(authenticated)/settings/usage/page.tsx
@@ -251,6 +251,14 @@ export default function UsageSettingsPage() {
                 <span className="w-full text-sm text-fg-tertiary sm:w-auto sm:flex-1">
                   {plan.bullets[0]} · {plan.priceCopy}
                 </span>
+                {!isActive && plan.status === 'available' && (
+                  <Link
+                    href={plan.cta.href}
+                    className="text-sm text-fg-secondary underline underline-offset-2 hover:text-fg-primary"
+                  >
+                    {plan.cta.label} →
+                  </Link>
+                )}
               </li>
             );
           })}

--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -5,6 +5,7 @@ import Button from '@/components/ui/Button';
 import { PageHeading } from '@/components/layout/PageHeading';
 import {
   CAT_PLANS,
+  CAT_WIRED_PROVIDERS,
   CAT_FREE_DAILY_LIMIT,
   CAT_SUPPORTER_DAILY_LIMIT,
   CAT_FRONTIER_MODELS_LIST,
@@ -39,9 +40,9 @@ export default function PricingPage() {
           </div>
           <PageHeading className="mb-4">Your AI, your bill, your choice</PageHeading>
           <p className="mx-auto max-w-2xl text-xl text-fg-secondary">
-            Cat works any way you want. Free out of the box, or bring your own key from six wired
-            providers — OpenAI, OpenRouter, Together, Groq, DeepSeek, xAI. OrangeCat doesn&apos;t
-            mark up inference; we earn from the platform, not your AI bill.
+            Cat works any way you want. Free out of the box, or bring your own key from{' '}
+            {CAT_WIRED_PROVIDERS.length} wired providers — {CAT_WIRED_PROVIDERS.join(', ')}.
+            OrangeCat doesn&apos;t mark up inference; we earn from the platform, not your AI bill.
           </p>
         </div>
 

--- a/src/components/ai/AiUsageStrip.tsx
+++ b/src/components/ai/AiUsageStrip.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+/**
+ * AiUsageStrip — one line of live numbers at the top of /settings/ai,
+ * linking to /settings/usage. The Usage tab owns the full story (meter,
+ * reset time, what counts); this strip only CONNECTS the config surface to
+ * the consumption surface so neither tab is a dead end. Renders nothing
+ * while loading or on fetch failure — a missing strip is honest, a stale
+ * one is not.
+ */
+
+import Link from 'next/link';
+import { Gauge, ChevronRight } from 'lucide-react';
+import { useCatQuota } from '@/components/ai-chat/ModernChatPanel/hooks/useCatQuota';
+import { ROUTES } from '@/config/routes';
+
+export function AiUsageStrip() {
+  const { quota } = useCatQuota();
+  if (!quota) {
+    return null;
+  }
+
+  const label =
+    quota.tier === 'byok'
+      ? `On your own key${quota.activeByokProviderName ? ` (${quota.activeByokProviderName})` : ''} — no daily cap`
+      : `${quota.requestsRemaining} of ${quota.dailyLimit} messages left today`;
+
+  return (
+    <Link
+      href={ROUTES.SETTINGS_USAGE}
+      className="flex min-h-11 items-center justify-between rounded-md border border-subtle bg-surface-raised/50 px-4 py-2 transition-colors hover:bg-surface-raised"
+    >
+      <span className="flex items-center gap-2 text-sm text-fg-secondary">
+        <Gauge className="h-4 w-4" aria-hidden="true" />
+        {label}
+      </span>
+      <span className="flex items-center gap-1 text-sm text-fg-tertiary">
+        Full usage
+        <ChevronRight className="h-4 w-4" aria-hidden="true" />
+      </span>
+    </Link>
+  );
+}

--- a/src/config/cat-plans.ts
+++ b/src/config/cat-plans.ts
@@ -126,6 +126,20 @@ export const CAT_FRONTIER_MODELS_LIST = CAT_FRONTIER_MODELS.join(', ');
 /** "Claude, GPT, or Grok" */
 export const CAT_FRONTIER_MODELS_OR = `${CAT_FRONTIER_MODELS.slice(0, -1).join(', ')}, or ${CAT_FRONTIER_MODELS[CAT_FRONTIER_MODELS.length - 1]}`;
 
+
+/**
+ * Deep links into /settings/ai — the EXACT section where each plan is acted
+ * on. Config-level so every surface (pricing cards, /settings/usage, chat
+ * upsells) lands the user on the form, not a page top they must scan.
+ * The ids are stamped on the sections in settings/ai/page.tsx; the drift
+ * pair is guarded by __tests__/unit/cat/plan-limit-drift.test.ts.
+ */
+export const SETTINGS_AI_ANCHORS = {
+  credits: `${ROUTES.SETTINGS_AI}#credits`,
+  byok: `${ROUTES.SETTINGS_AI}#byok`,
+  local: `${ROUTES.SETTINGS_AI}#local`,
+} as const;
+
 export const CAT_PLANS: CatPlan[] = [
   {
     id: 'free',
@@ -171,7 +185,7 @@ export const CAT_PLANS: CatPlan[] = [
       'Cat routes through your key — OrangeCat never sees your bill, never marks it up',
       'Keys encrypted at rest, scrubbed from logs, never echoed back to the client',
     ],
-    cta: { label: 'Add your key', href: ROUTES.SETTINGS_AI, variant: 'accent' },
+    cta: { label: 'Add your key', href: SETTINGS_AI_ANCHORS.byok, variant: 'accent' },
     status: 'available',
     badge: 'Available now',
   },
@@ -187,7 +201,7 @@ export const CAT_PLANS: CatPlan[] = [
       'Full agentic Cat: discovery, matchmaking, multi-step tasks',
     ],
     cta: CAT_CREDITS_LIVE
-      ? { label: 'Top up credits', href: ROUTES.SETTINGS_AI, variant: 'accent' }
+      ? { label: 'Top up credits', href: SETTINGS_AI_ANCHORS.credits, variant: 'accent' }
       : { label: 'Back us as a founding supporter', href: ROUTES.SUPPORT, variant: 'outline' },
     status: CAT_CREDITS_LIVE ? 'available' : 'coming-soon',
     badge: CAT_CREDITS_LIVE ? 'Live' : 'Activating',


### PR DESCRIPTION
## Problem

The Usage, AI, and Integrations tabs each worked but didn't work *together*:
- Usage showed "2 of 10 left" with no path to act on it
- `/settings/ai` had no section anchors — nothing anywhere could land a user on the key form or the top-up, only on the page top to scan
- Integrations ("integration keys") collides with "AI keys" in users' heads, with no disambiguation
- `/pricing`'s hero hand-typed the provider list (`OpenAI, OpenRouter, Together, Groq, DeepSeek, xAI`) that `CAT_WIRED_PROVIDERS` already owns — the exact drift class we just built guards against

## Fix — every fact once, every surface lands where you act

- **`SETTINGS_AI_ANCHORS`** in `cat-plans.ts`: the deep links (`#credits` / `#byok` / `#local`) become config facts. The BYOK and Credits plan CTAs use them — so pricing cards, usage-page rows, and any future upsell all land on the exact form.
- **`/settings/ai`**: sections carry the anchor ids (`scroll-mt-24`), and a new one-line **`AiUsageStrip`** at the top shows live remaining-today linking to Usage. Config surface ↔ consumption surface, connected both ways. Strip renders nothing on fetch failure (honest absence, never stale numbers).
- **`/settings/usage`**: each non-active available plan row now carries its config-defined CTA — "Add your key →" opens the key form section, "Top up credits" opens the credits panel.
- **`/settings/integrations`**: one scope line up top — AI provider keys live in Settings → AI; this page is OrangeCat platform access from outside.
- **`/pricing` hero**: provider count + names derived from `CAT_WIRED_PROVIDERS`.
- **Drift guard extended**: new test asserts every `SETTINGS_AI_ANCHORS` id exists in the AI page — a renamed section fails CI instead of CTAs silently degrading.

## The business knob

Changing a package = editing one object in `cat-plans.ts` (limits, price, status, copy, CTA target). Cards, rows, deep links, upsell copy update everywhere; drift tests hold the SQL boundary and the anchors. No other file needs touching.

## Verification

`npm run verify` green: type-check, docs, route audit, lint 0 errors, **1460 unit tests** (6 drift guards incl. the new anchor check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)