### PR TITLE
feat(payments): HTTP 402 inline payment — speak the standard (L402-style)

### DIFF
--- a/__tests__/unit/api/v1-pay-l402.test.ts
+++ b/__tests__/unit/api/v1-pay-l402.test.ts
@@ -1,0 +1,221 @@
+/**
+ * HTTP 402 inline payment (L402-style) — pure helpers + route behavior.
+ *
+ * The route wraps the account-less support rails in the 402 convention:
+ * challenge without auth, cryptographic preimage verification on retry.
+ */
+
+import { createHash, randomBytes } from 'crypto';
+import {
+  parseL402Authorization,
+  preimageMatchesHash,
+  buildL402ChallengeHeader,
+} from '@/domain/payments/l402-codec';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+// Route tests: mock the response layer (NextResponse unavailable in jest) and
+// the domain flows; exercise branch selection + status codes.
+jest.mock('@/lib/api/standardResponse', () => ({
+  apiSuccess: (data: unknown, _opts?: unknown) => ({
+    status: 200,
+    json: async () => ({ success: true, data }),
+    headers: new Map(),
+  }),
+  apiBadRequest: (message: string, details?: unknown) => ({
+    status: 400,
+    json: async () => ({ success: false, error: { message, details } }),
+    headers: new Map(),
+  }),
+  apiNotFound: (message: string) => ({
+    status: 404,
+    json: async () => ({ success: false, error: { message } }),
+    headers: new Map(),
+  }),
+  apiRateLimited: (message: string) => ({
+    status: 429,
+    json: async () => ({ success: false, error: { message } }),
+    headers: new Map(),
+  }),
+  apiInternalError: (message: string) => ({
+    status: 500,
+    json: async () => ({ success: false, error: { message } }),
+    headers: new Map(),
+  }),
+  apiPaymentRequired: (message: string, details?: unknown, wwwAuthenticate?: string) => {
+    const headers = new Map<string, string>();
+    if (wwwAuthenticate) headers.set('WWW-Authenticate', wwwAuthenticate);
+    return {
+      status: 402,
+      json: async () => ({ success: false, error: { code: 'PAYMENT_REQUIRED', message, details } }),
+      headers,
+    };
+  },
+}));
+
+const mockCreateChallenge = jest.fn();
+const mockVerify = jest.fn();
+jest.mock('@/domain/payments/l402', () => ({
+  createL402Challenge: (...args: unknown[]) => mockCreateChallenge(...args),
+  verifyL402Payment: (...args: unknown[]) => mockVerify(...args),
+}));
+jest.mock('@/lib/supabase/public', () => ({ createPublicClient: () => ({ _kind: 'public' }) }));
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimitWriteAsync: jest.fn().mockResolvedValue({ success: true }),
+  retryAfterSeconds: () => 1,
+}));
+
+import { GET } from '@/app/api/v1/pay/[entity_type]/[entity_id]/route';
+
+const ENTITY_ID = '11111111-2222-3333-4444-555555555555';
+const params = Promise.resolve({ entity_type: 'product', entity_id: ENTITY_ID });
+
+/** Minimal Request stand-in — the route only touches headers + url. */
+function makeRequest(url: string, headers: Record<string, string> = {}): Request {
+  return { url, headers: new Headers(headers) } as unknown as Request;
+}
+
+// ── pure helpers ─────────────────────────────────────────────────────────────
+
+describe('preimageMatchesHash', () => {
+  it('accepts the real sha256 relationship and rejects everything else', () => {
+    const preimage = randomBytes(32).toString('hex');
+    const hash = createHash('sha256').update(Buffer.from(preimage, 'hex')).digest('hex');
+    expect(preimageMatchesHash(preimage, hash)).toBe(true);
+    expect(preimageMatchesHash(preimage, hash.toUpperCase())).toBe(true);
+    expect(preimageMatchesHash(randomBytes(32).toString('hex'), hash)).toBe(false);
+    // Wrong length / non-hex never match (and never throw).
+    expect(preimageMatchesHash('abcd', hash)).toBe(false);
+    expect(preimageMatchesHash('z'.repeat(64), hash)).toBe(false);
+  });
+});
+
+describe('parseL402Authorization', () => {
+  const preimage = 'a'.repeat(64);
+  it('parses L402 and legacy LSAT schemes', () => {
+    for (const scheme of ['L402', 'LSAT']) {
+      const creds = parseL402Authorization(`${scheme} ${ENTITY_ID}.tok_abc:${preimage}`);
+      expect(creds).toEqual({
+        paymentIntentId: ENTITY_ID,
+        statusToken: 'tok_abc',
+        preimage,
+      });
+    }
+  });
+  it('rejects malformed headers', () => {
+    expect(parseL402Authorization(null)).toBeNull();
+    expect(parseL402Authorization('Bearer xyz')).toBeNull();
+    expect(parseL402Authorization('L402 no-dot-token:' + preimage)).toBeNull();
+    expect(parseL402Authorization(`L402 ${ENTITY_ID}.tok:`)).toBeNull();
+    expect(parseL402Authorization(`L402 ${ENTITY_ID}.tok:nothex!`)).toBeNull();
+  });
+});
+
+describe('buildL402ChallengeHeader', () => {
+  it('formats token + invoice, omitting invoice when absent', () => {
+    expect(
+      buildL402ChallengeHeader({ paymentIntentId: 'id1', statusToken: 't1', bolt11: 'lnbc1x' })
+    ).toBe('L402 token="id1.t1", invoice="lnbc1x"');
+    expect(
+      buildL402ChallengeHeader({ paymentIntentId: 'id1', statusToken: 't1', bolt11: null })
+    ).toBe('L402 token="id1.t1"');
+  });
+});
+
+// ── route ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/v1/pay/{type}/{id}', () => {
+  beforeEach(() => {
+    mockCreateChallenge.mockReset();
+    mockVerify.mockReset();
+  });
+
+  it('answers 402 with a WWW-Authenticate challenge when unauthenticated', async () => {
+    mockCreateChallenge.mockResolvedValue({
+      header: 'L402 token="i.t", invoice="lnbc1"',
+      payment_intent_id: 'i',
+      status_token: 't',
+      bolt11: 'lnbc1',
+      onchain_address: null,
+      amount_btc: 0.0001,
+      expires_in_seconds: 600,
+      method_label: 'Lightning (NWC)',
+    });
+    const res = await GET(
+      makeRequest(`https://orangecat.ch/api/v1/pay/product/${ENTITY_ID}?amount_btc=0.0001`),
+      { params }
+    );
+    expect(res.status).toBe(402);
+    expect(res.headers.get('WWW-Authenticate')).toBe('L402 token="i.t", invoice="lnbc1"');
+    const body = await res.json();
+    expect(body.error.code).toBe('PAYMENT_REQUIRED');
+    expect(body.error.details.bolt11).toBe('lnbc1');
+    expect(body.error.details.token).toBe('i.t');
+  });
+
+  it('rejects a challenge request without a valid amount', async () => {
+    const res = await GET(makeRequest(`https://orangecat.ch/api/v1/pay/product/${ENTITY_ID}`), {
+      params,
+    });
+    expect(res.status).toBe(400);
+    expect(mockCreateChallenge).not.toHaveBeenCalled();
+  });
+
+  it('returns the receipt when the L402 proof verifies', async () => {
+    mockVerify.mockResolvedValue({
+      ok: true,
+      verified_by: 'preimage',
+      status: 'paid',
+      paid_at: '2026-08-02T12:00:00Z',
+    });
+    const res = await GET(
+      makeRequest(`https://orangecat.ch/api/v1/pay/product/${ENTITY_ID}`, {
+        authorization: `L402 ${ENTITY_ID}.tok:${'a'.repeat(64)}`,
+      }),
+      { params }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.verified_by).toBe('preimage');
+    expect(body.data.status).toBe('paid');
+    expect(mockCreateChallenge).not.toHaveBeenCalled();
+  });
+
+  it('answers 402 again (no new intent) when the invoice is still unpaid', async () => {
+    mockVerify.mockResolvedValue({ ok: false, status: 'invoice_ready', paid_at: null });
+    const res = await GET(
+      makeRequest(`https://orangecat.ch/api/v1/pay/product/${ENTITY_ID}`, {
+        authorization: `L402 ${ENTITY_ID}.tok:${'b'.repeat(64)}`,
+      }),
+      { params }
+    );
+    expect(res.status).toBe(402);
+    expect(mockCreateChallenge).not.toHaveBeenCalled();
+  });
+
+  it('maps an unknown token to 404', async () => {
+    mockVerify.mockRejectedValue(new Error('Payment not found'));
+    const res = await GET(
+      makeRequest(`https://orangecat.ch/api/v1/pay/product/${ENTITY_ID}`, {
+        authorization: `L402 ${ENTITY_ID}.tok:${'c'.repeat(64)}`,
+      }),
+      { params }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('maps domain safe-errors to 400 without leaking internals', async () => {
+    mockCreateChallenge.mockRejectedValue(
+      new Error('Seller has no wallet connected. Payment not available.')
+    );
+    const res = await GET(
+      makeRequest(`https://orangecat.ch/api/v1/pay/product/${ENTITY_ID}?amount_btc=0.0001`),
+      { params }
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toContain('has not connected a Bitcoin wallet');
+  });
+});

--- a/docs/api/AGENTS.md
+++ b/docs/api/AGENTS.md
@@ -85,6 +85,32 @@ not payable forever.
 Sellers can also subscribe to the `payment.settled` webhook instead of
 polling (Settings → Integrations → Webhooks).
 
+## Paying inline (HTTP 402)
+
+If your agent already speaks the 402 convention (L402-style), you can skip
+accounts, keys, and our JSON dialect entirely — one URL does the whole loop:
+
+```bash
+# 1. Ask for the thing. No auth. You get 402 + a Lightning challenge.
+curl -i "https://orangecat.ch/api/v1/pay/product/<entity-id>?amount_btc=0.0001"
+# → HTTP/2 402
+# → WWW-Authenticate: L402 token="<intent-id>.<status-token>", invoice="lnbc…"
+# → { "error": { "code": "PAYMENT_REQUIRED", "details": { "token": "…", "bolt11": "lnbc…", … } } }
+
+# 2. Pay the bolt11 with any Lightning wallet. Keep the preimage.
+
+# 3. Repeat the GET with proof. The preimage is verified cryptographically
+#    against the invoice's payment_hash — no polling needed.
+curl "https://orangecat.ch/api/v1/pay/product/<entity-id>" \
+  -H 'Authorization: L402 <token>:<preimage>'
+# → { "success": true, "data": { "status": "paid", "verified_by": "preimage", … } }
+```
+
+`verified_by` is `preimage` when the cryptographic proof checked out, or
+`settlement` when we fell back to observed settlement (on-chain has no
+preimage). Not paid yet → 402 again (your original invoice still stands —
+respect its expiry). Challenge creation is rate limited per IP.
+
 ## Rules of the road
 
 - **Idempotency**: entity-create endpoints accept an `Idempotency-Key`

--- a/src/app/api/v1/pay/[entity_type]/[entity_id]/route.ts
+++ b/src/app/api/v1/pay/[entity_type]/[entity_id]/route.ts
@@ -1,0 +1,133 @@
+import {
+  apiBadRequest,
+  apiInternalError,
+  apiNotFound,
+  apiPaymentRequired,
+  apiRateLimited,
+  apiSuccess,
+} from '@/lib/api/standardResponse';
+import { createL402Challenge, verifyL402Payment } from '@/domain/payments/l402';
+import { parseL402Authorization } from '@/domain/payments/l402-codec';
+import { publicSupportCreateSchema } from '@/lib/validation/finance';
+import { createPublicClient } from '@/lib/supabase/public';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { logger } from '@/utils/logger';
+
+/**
+ * GET /api/v1/pay/{entity_type}/{entity_id}?amount_btc=X — HTTP 402 inline payment.
+ *
+ * The standards-shaped face of the machine-payable flow (L402-style, see
+ * domain/payments/l402.ts): no account, no API key —
+ *   1. GET without Authorization → 402 Payment Required, WWW-Authenticate
+ *      carries `token` + Lightning `invoice`; body mirrors the challenge.
+ *   2. Pay the invoice with any Lightning wallet.
+ *   3. GET again with `Authorization: L402 <token>:<preimage>` → 200 receipt
+ *      (preimage verified against the invoice's payment_hash; settlement
+ *      status is the fallback for on-chain).
+ *
+ * The JSON-contract flow (POST /api/v1/payments + polling) remains the
+ * account-based sibling; this one exists so foreign agents that only speak
+ * 402 can pay without learning our dialect.
+ */
+
+function requestKey(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  return `l402:${forwarded || request.headers.get('x-real-ip') || 'anonymous'}`;
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ entity_type: string; entity_id: string }> }
+) {
+  const { entity_type, entity_id } = await params;
+
+  // Retry-with-proof branch first: verification is cheap and shouldn't share
+  // the challenge-creation rate budget.
+  const creds = parseL402Authorization(request.headers.get('authorization'));
+  if (creds) {
+    try {
+      const result = await verifyL402Payment(creds);
+      if (result.ok) {
+        return apiSuccess(
+          {
+            status: result.status,
+            paid_at: result.paid_at,
+            verified_by: result.verified_by,
+            entity_type,
+            entity_id,
+          },
+          { cache: 'NONE' }
+        );
+      }
+      // Not paid yet — 402 again. The client already holds the invoice from
+      // the original challenge, so no new intent is created here.
+      return apiPaymentRequired('Invoice not paid yet — pay it, then retry with the preimage.', {
+        status: result.status,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '';
+      if (message.includes('not found')) {
+        return apiNotFound('Payment not found');
+      }
+      logger.error('L402 verification failed', { error });
+      return apiInternalError('Could not verify the payment.');
+    }
+  }
+
+  // Challenge branch: create an account-less intent and answer 402.
+  const limit = await rateLimitWriteAsync(requestKey(request));
+  if (!limit.success) {
+    return apiRateLimited(
+      'Too many payment requests. Try again shortly.',
+      retryAfterSeconds(limit)
+    );
+  }
+
+  const url = new URL(request.url);
+  const parsed = publicSupportCreateSchema.safeParse({
+    entity_type,
+    entity_id,
+    amount_btc: Number(url.searchParams.get('amount_btc')),
+  });
+  if (!parsed.success) {
+    return apiBadRequest(
+      'Invalid payment request — pass ?amount_btc= between 0.000001 and 1.',
+      parsed.error.errors
+    );
+  }
+
+  try {
+    const challenge = await createL402Challenge(createPublicClient(), parsed.data);
+    return apiPaymentRequired(
+      'Pay the invoice, then retry with Authorization: L402 <token>:<preimage>.',
+      {
+        payment_intent_id: challenge.payment_intent_id,
+        token: `${challenge.payment_intent_id}.${challenge.status_token}`,
+        bolt11: challenge.bolt11,
+        onchain_address: challenge.onchain_address,
+        amount_btc: challenge.amount_btc,
+        method_label: challenge.method_label,
+        expires_in_seconds: challenge.expires_in_seconds,
+      },
+      challenge.header
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Payment initiation failed';
+    logger.error('L402 challenge creation failed', { error, entity_type, entity_id });
+    // Same safe-error surface as the public support route — never leak internals.
+    const safeErrors: Array<[string, string]> = [
+      ['not publicly available', 'This entity is not available for public payment.'],
+      ['cannot receive', 'This kind of entity cannot receive payments.'],
+      ['owner not found', 'This entity no longer has a receiving owner.'],
+      ['no wallet', 'The owner has not connected a Bitcoin wallet yet.'],
+      ['outside allowed range', 'That amount is outside the wallet provider’s allowed range.'],
+      ['LNURL', 'The Lightning Address could not create an invoice. Try again later.'],
+    ];
+    for (const [pattern, safe] of safeErrors) {
+      if (message.toLowerCase().includes(pattern.toLowerCase())) {
+        return apiBadRequest(safe);
+      }
+    }
+    return apiInternalError('Could not create the payment challenge.');
+  }
+}

--- a/src/config/public-api.ts
+++ b/src/config/public-api.ts
@@ -69,6 +69,11 @@ export const PUBLIC_API_INTEGRATION_ENDPOINTS = [
     endpoint: `${PUBLIC_API_BASE}/payments/public`,
   },
   {
+    name: 'payments.l402',
+    methods: ['GET'] as const,
+    endpoint: `${PUBLIC_API_BASE}/pay/{entity_type}/{entity_id}`,
+  },
+  {
     name: 'timeline.publish',
     methods: ['POST'] as const,
     endpoint: `${PUBLIC_API_BASE}/timeline/publish`,

--- a/src/domain/payments/l402-codec.ts
+++ b/src/domain/payments/l402-codec.ts
@@ -1,0 +1,60 @@
+/**
+ * L402 wire codec — pure header parsing/building + preimage proof. No db, no
+ * service imports, so the unit suite exercises it without the payment stack
+ * (which transitively pulls Resend/NWC). Flows live in l402.ts.
+ */
+
+import { createHash } from 'crypto';
+
+export interface L402Credentials {
+  paymentIntentId: string;
+  statusToken: string;
+  preimage: string;
+}
+
+/**
+ * Parse `Authorization: L402 <intentId>.<statusToken>:<preimage>`.
+ * Also accepts the legacy `LSAT` scheme name. Returns null for anything else.
+ */
+export function parseL402Authorization(header: string | null): L402Credentials | null {
+  if (!header) {
+    return null;
+  }
+  const match = /^(?:L402|LSAT)\s+([^:\s]+):([0-9a-fA-F]+)$/.exec(header.trim());
+  if (!match) {
+    return null;
+  }
+  const [token, preimage] = [match[1], match[2]];
+  const dot = token.indexOf('.');
+  if (dot <= 0 || dot === token.length - 1) {
+    return null;
+  }
+  return {
+    paymentIntentId: token.slice(0, dot),
+    statusToken: token.slice(dot + 1),
+    preimage: preimage.toLowerCase(),
+  };
+}
+
+/** The proof: a Lightning preimage hashes (sha256) to the invoice's payment_hash. */
+export function preimageMatchesHash(preimage: string, paymentHash: string): boolean {
+  if (!/^[0-9a-f]{64}$/.test(preimage) || !/^[0-9a-f]{64}$/i.test(paymentHash)) {
+    return false;
+  }
+  const digest = createHash('sha256').update(Buffer.from(preimage, 'hex')).digest('hex');
+  return digest === paymentHash.toLowerCase();
+}
+
+/** Value for the `WWW-Authenticate` response header of a 402 challenge. */
+export function buildL402ChallengeHeader(input: {
+  paymentIntentId: string;
+  statusToken: string;
+  bolt11: string | null;
+}): string {
+  const token = `${input.paymentIntentId}.${input.statusToken}`;
+  const parts = [`token="${token}"`];
+  if (input.bolt11) {
+    parts.push(`invoice="${input.bolt11}"`);
+  }
+  return `L402 ${parts.join(', ')}`;
+}

--- a/src/domain/payments/l402.ts
+++ b/src/domain/payments/l402.ts
@@ -1,0 +1,140 @@
+/**
+ * HTTP 402 (L402-style) inline payment — speak the standard, not just our dialect.
+ *
+ * The machine-payments world converged on the status code built for this
+ * moment: 402 Payment Required with a Lightning challenge, retried with proof
+ * of payment. This module maps that convention onto OrangeCat's existing
+ * account-less rails (initiatePublicSupport / public status tokens) — no new
+ * state, no accounts, no API keys:
+ *
+ *   GET /api/v1/pay/{type}/{id}?amount_btc=X
+ *     → 402 + `WWW-Authenticate: L402 token="<intentId>.<statusToken>", invoice="<bolt11>"`
+ *   …pay the invoice…
+ *   GET (same URL) + `Authorization: L402 <intentId>.<statusToken>:<preimage>`
+ *     → 200 receipt
+ *
+ * Proof is cryptographic first: sha256(preimage) must equal the invoice's
+ * payment_hash — a valid preimage can only exist if the invoice was paid, so
+ * this needs no trust in our own polling. Settlement-status verification is
+ * the fallback for rails without a hash (on-chain).
+ *
+ * Deliberately L402-"lite": the token is our existing public status token,
+ * not a macaroon — no caveats, no delegation, same privacy properties as the
+ * account-less support flow it wraps.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { STATUS } from '@/config/database-constants';
+import { getAdminClient } from '@/lib/supabase/admin';
+import {
+  initiatePublicSupport,
+  checkPublicPaymentStatus,
+  hashPublicStatusToken,
+} from './paymentFlowService';
+import type { InitiatePublicSupportInput } from './types';
+
+export {
+  parseL402Authorization,
+  preimageMatchesHash,
+  buildL402ChallengeHeader,
+  type L402Credentials,
+} from './l402-codec';
+import { buildL402ChallengeHeader, preimageMatchesHash, type L402Credentials } from './l402-codec';
+
+// ==================== FLOWS ====================
+
+export interface L402Challenge {
+  header: string;
+  payment_intent_id: string;
+  status_token: string;
+  bolt11: string | null;
+  onchain_address: string | null;
+  amount_btc: number;
+  expires_in_seconds: number | null;
+  method_label: string;
+}
+
+/**
+ * Open a 402 challenge: create an account-less support intent on the entity
+ * (all visibility/wallet rules enforced by initiatePublicSupport) and return
+ * the header + body for the 402 response.
+ */
+export async function createL402Challenge(
+  publicSupabase: SupabaseClient,
+  input: InitiatePublicSupportInput
+): Promise<L402Challenge> {
+  const result = await initiatePublicSupport(publicSupabase, input);
+  // The public result deliberately omits invoice internals — fetch the
+  // challenge fields with the admin client, scoped by the intent we just made.
+  const admin = getAdminClient() as unknown as SupabaseClient;
+  const { data: intent } = await admin
+    .from(DATABASE_TABLES.PAYMENT_INTENTS)
+    .select('bolt11, onchain_address')
+    .eq('id', result.payment_intent.id)
+    .maybeSingle();
+
+  return {
+    header: buildL402ChallengeHeader({
+      paymentIntentId: result.payment_intent.id,
+      statusToken: result.status_token,
+      bolt11: intent?.bolt11 ?? null,
+    }),
+    payment_intent_id: result.payment_intent.id,
+    status_token: result.status_token,
+    bolt11: intent?.bolt11 ?? null,
+    onchain_address: intent?.onchain_address ?? null,
+    amount_btc: Number(result.payment_intent.amount_btc),
+    expires_in_seconds: result.expires_in_seconds,
+    method_label: result.method_label,
+  };
+}
+
+export interface L402VerifyResult {
+  ok: boolean;
+  /** 'preimage' = cryptographic proof; 'settlement' = observed settled status. */
+  verified_by?: 'preimage' | 'settlement';
+  status: string;
+  paid_at: string | null;
+}
+
+/**
+ * Verify an L402 retry. Preimage proof wins (works even before our poller
+ * notices settlement); settled status is the fallback for hashless rails.
+ * Throws 'Payment not found' when the token doesn't match — same opacity as
+ * the public status endpoint.
+ */
+export async function verifyL402Payment(creds: L402Credentials): Promise<L402VerifyResult> {
+  const admin = getAdminClient() as unknown as SupabaseClient;
+  const { data: intent } = await admin
+    .from(DATABASE_TABLES.PAYMENT_INTENTS)
+    .select('id, payment_hash, status, paid_at')
+    .eq('id', creds.paymentIntentId)
+    .eq('public_status_token_hash', hashPublicStatusToken(creds.statusToken))
+    .maybeSingle();
+  if (!intent) {
+    throw new Error('Payment not found');
+  }
+
+  if (intent.payment_hash && preimageMatchesHash(creds.preimage, intent.payment_hash)) {
+    return {
+      ok: true,
+      verified_by: 'preimage',
+      status: intent.status,
+      paid_at: intent.paid_at ?? null,
+    };
+  }
+
+  // No (or wrong) preimage proof — fall back to live settlement status, which
+  // also runs the rail checks (LUD-21 / NWC / chain) and updates the row.
+  const refreshed = await checkPublicPaymentStatus(creds.paymentIntentId, creds.statusToken);
+  const settled =
+    refreshed.status === STATUS.PAYMENT_INTENTS.PAID ||
+    refreshed.status === STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED;
+  return {
+    ok: settled,
+    verified_by: settled ? 'settlement' : undefined,
+    status: refreshed.status,
+    paid_at: refreshed.paid_at ?? null,
+  };
+}

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -53,7 +53,8 @@ const METHOD_LABELS: Record<string, string> = {
   onchain: 'On-chain Bitcoin',
 };
 
-function hashPublicStatusToken(token: string): string {
+/** SSOT for public status-token hashing — also consumed by the L402 surface. */
+export function hashPublicStatusToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
 }
 
@@ -321,9 +322,7 @@ export async function initiatePublicSupport(
  * intent. Returns the same public shape as support: a bearer status token the
  * anonymous tipper polls with.
  */
-export async function initiateTip(
-  input: InitiateTipInput
-): Promise<InitiatePublicSupportResult> {
+export async function initiateTip(input: InitiateTipInput): Promise<InitiatePublicSupportResult> {
   const { recipientUserId, recipientName, wallet, amountBtc } = input;
   const description = `Tip for ${recipientName}`;
   const invoice = await generateInvoice(wallet, amountBtc, description);

--- a/src/lib/api/standardResponse.ts
+++ b/src/lib/api/standardResponse.ts
@@ -177,6 +177,31 @@ export function apiError(
 }
 
 /**
+ * 402 Payment Required — the HTTP-402/L402 machine-payment convention.
+ * `details` carries the challenge (token, bolt11, amount…); `wwwAuthenticate`
+ * sets the header wallets/agents parse. Not logged as an error: a 402 is the
+ * protocol working, not a failure.
+ */
+export function apiPaymentRequired(
+  message: string,
+  details?: unknown,
+  wwwAuthenticate?: string
+): NextResponse<ApiErrorResponse> {
+  const response = NextResponse.json<ApiErrorResponse>(
+    {
+      success: false,
+      error: { code: 'PAYMENT_REQUIRED', message, details },
+      metadata: { timestamp: new Date().toISOString() },
+    },
+    { status: 402 }
+  );
+  if (wwwAuthenticate) {
+    response.headers.set('WWW-Authenticate', wwwAuthenticate);
+  }
+  return response;
+}
+
+/**
  * 400 Bad Request
  */
 export function apiBadRequest(

--- a/src/lib/openapi/registerV1Routes.ts
+++ b/src/lib/openapi/registerV1Routes.ts
@@ -395,6 +395,90 @@ export function registerV1Routes(): void {
     },
   });
 
+  // HTTP 402 inline payment (L402-style) — the standards-shaped face of the
+  // machine-payable flow. One GET does both halves: challenge (no auth → 402
+  // with WWW-Authenticate: L402 token + invoice) and verify (Authorization:
+  // L402 <token>:<preimage> → 200 receipt, preimage checked against the
+  // invoice's payment_hash).
+  openApiRegistry.registerPath({
+    method: 'get',
+    path: `${PUBLIC_API_BASE}/pay/{entity_type}/{entity_id}`,
+    summary: 'Pay inline via HTTP 402 (L402-style)',
+    description:
+      'No account, no API key. GET with `?amount_btc=` returns **402 Payment Required** with a `WWW-Authenticate: L402 token="…", invoice="…"` challenge (Lightning bolt11). Pay it, then repeat the GET with `Authorization: L402 <token>:<preimage>` for a 200 receipt — the preimage is verified cryptographically against the invoice payment_hash (settlement status is the fallback for on-chain). Challenge creation is rate limited per IP.',
+    tags: ['Payments'],
+    request: {
+      params: z.object({
+        entity_type: z
+          .string()
+          .openapi({ description: 'Entity type (product, project, cause, …).' }),
+        entity_id: z.string().uuid(),
+      }),
+      query: z.object({
+        amount_btc: z.coerce.number().openapi({
+          description: 'Amount in BTC (0.000001–1). Required on the challenge request.',
+        }),
+      }),
+    },
+    responses: {
+      200: {
+        description: 'Payment verified — the receipt.',
+        content: {
+          'application/json': {
+            schema: apiSuccessSchema(
+              z
+                .object({
+                  status: z.string(),
+                  paid_at: z.string().datetime().nullable(),
+                  verified_by: z.enum(['preimage', 'settlement']),
+                  entity_type: z.string(),
+                  entity_id: z.string().uuid(),
+                })
+                .openapi('L402Receipt'),
+              'L402ReceiptSuccess'
+            ),
+          },
+        },
+      },
+      402: {
+        description:
+          'Payment required. `WWW-Authenticate` carries the L402 challenge; the body repeats the token, bolt11 invoice, amount, and expiry.',
+        content: {
+          'application/json': {
+            schema: z
+              .object({
+                success: z.literal(false),
+                error: z.object({
+                  code: z.literal('PAYMENT_REQUIRED'),
+                  message: z.string(),
+                  details: z
+                    .object({
+                      payment_intent_id: z.string().uuid(),
+                      token: z.string(),
+                      bolt11: z.string().nullable(),
+                      onchain_address: z.string().nullable(),
+                      amount_btc: z.number(),
+                      method_label: z.string(),
+                      expires_in_seconds: z.number().nullable(),
+                    })
+                    .partial()
+                    .openapi({
+                      description:
+                        'The challenge. On a not-paid-yet retry only `status` is present (the original challenge still stands).',
+                    }),
+                }),
+              })
+              .openapi('L402Challenge'),
+          },
+        },
+      },
+      400: COMMON_ERROR_RESPONSES[400],
+      404: COMMON_ERROR_RESPONSES[404],
+      429: COMMON_ERROR_RESPONSES[429],
+      500: COMMON_ERROR_RESPONSES[500],
+    },
+  });
+
   // Publish bus — not an entity create, so registered explicitly. External
   // clients (FleetCrown) land a build event on a project's wall; idempotent +
   // reconcilable by (source, external_id).


### PR DESCRIPTION
## Item 6 of the ledger-and-loop build sequence — let the machines pay in their own language

Our machine-payable API works, but it speaks a private JSON dialect. The machine-payments world standardized on **HTTP 402** this year. This PR adds that face over the *existing* account-less rails — zero new state, zero migrations:

```
GET /api/v1/pay/{type}/{id}?amount_btc=X
  → 402 Payment Required
  → WWW-Authenticate: L402 token="<intent>.<statusToken>", invoice="lnbc…"
…pay with any Lightning wallet…
GET + Authorization: L402 <token>:<preimage>
  → 200 receipt
```

### Design
- **Proof is cryptographic first**: `sha256(preimage) == payment_hash` — a valid preimage can only exist if the invoice was paid, so verification needs no trust in our own polling (and works before the poller notices). Settlement status is the fallback for hashless rails (on-chain). `verified_by: 'preimage' | 'settlement'` is honest about which path fired.
- **L402-lite**: the token is the existing public status token, not a macaroon — same privacy properties as the account-less support flow it wraps; documented as such.
- **Reuses everything**: `initiatePublicSupport` enforces visibility + wallet rules; challenge creation is per-IP rate limited; a not-paid retry answers 402 again without minting a new intent; safe-error surface mirrored from the public route.
- **SSOT**: pure wire codec in `l402-codec.ts` (dependency-free, unit-tested); `apiPaymentRequired` joins the response SSOT (a 402 is the protocol working, not an error to log); `hashPublicStatusToken` exported instead of duplicated; OpenAPI + `public-api.ts` registration; AGENTS.md walkthrough section.

### Verified
- `npm run verify` green — full suite incl. new 10-case L402 suite (real sha256 relationship, both scheme names, both branches, envelope, safe errors).
- Will live-verify the 402 challenge against prod post-deploy (challenge creation only — no invoices paid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)