### PR TITLE
chore(ssot): sweep api/app-route/currency literals into their SSOTs + lint gate (audit slice 3)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,51 @@ import unusedImports from 'eslint-plugin-unused-imports';
 // was removed in Next 16, so this replaces .eslintrc.json + .eslintignore. The
 // rule set is carried over verbatim; eslint-config-next 16's native flat configs
 // are composed directly (FlatCompat crashes on the react plugin's circular object).
+
+// Shared no-restricted-syntax selectors. Flat config REPLACES (not merges) a
+// rule's options when a later block redefines it, so any scoped block that adds
+// a selector must spread these to keep the base set active there.
+const restrictedSyntaxSelectors = [
+  {
+    selector: 'Identifier[name=/[Cc]ampaign/]',
+    message:
+      "CLAUDE.md bans 'Campaign' terminology — use 'Project' instead. The canonical entity name is in ENTITY_REGISTRY.project.",
+  },
+  {
+    selector: 'Identifier[name=/[Cc]rowdfund/]',
+    message:
+      "CLAUDE.md bans 'crowdfund' terminology — use 'fund' / 'funding' / 'project' instead.",
+  },
+  {
+    selector:
+      'Literal[value=/dark:(?:bg|text|border|ring|from|to|via|fill|stroke)-(?:gray|slate|zinc|neutral|stone)-\\d+/]',
+    message:
+      'Raw Tailwind gray in dark: variant — use a semantic token (bg-muted, bg-border, border, text-foreground, text-muted-foreground, etc.). See globals.css :root for available tokens. Add eslint-disable-next-line with a reason comment if this is an intentional design exception.',
+  },
+  {
+    selector: 'Literal[value=/dark:(?:bg|text|border|ring)-\\[#[0-9a-fA-F]+\\]/]',
+    message:
+      'Arbitrary hex color in dark: variant — define a CSS custom property in globals.css and use a semantic Tailwind class instead.',
+  },
+  {
+    selector: 'Literal[value=/\\btext-\\[10px\\]/]',
+    message:
+      "Arbitrary text-[10px] — use the text-2xs token (10px, defined in tailwind.config.ts). It exists for exactly this; don't bypass it.",
+  },
+  {
+    // Close the keystroke-hijack class (2026-07 dogfood): a global keyboard
+    // shortcut's "is the user typing?" guard must inspect the COMPOSED path
+    // leaf, not e.target. When a keystroke crosses a shadow-DOM boundary
+    // (e.g. the embedded FleetCrown feedback widget), e.target is retargeted
+    // to the shadow host, so the guard misreads a text field as "not typing"
+    // and the shortcut fires and eats the keystroke. Pass e.composedPath()[0].
+    selector:
+      "CallExpression[callee.name='isTypingTarget'] > MemberExpression.arguments[property.name='target']",
+    message:
+      'Pass the composed-path leaf to isTypingTarget (e.composedPath()[0] ?? e.target), not a bare e.target — a bare .target is shadow-DOM-blind and reintroduces the keystroke-hijack bug.',
+  },
+];
+
 const eslintConfig = [
   {
     // Translated from the former .eslintignore (flat config ignores it).
@@ -88,44 +133,7 @@ const eslintConfig = [
       'no-script-url': 'error',
       'no-restricted-syntax': [
         'error',
-        {
-          selector: 'Identifier[name=/[Cc]ampaign/]',
-          message:
-            "CLAUDE.md bans 'Campaign' terminology — use 'Project' instead. The canonical entity name is in ENTITY_REGISTRY.project.",
-        },
-        {
-          selector: 'Identifier[name=/[Cc]rowdfund/]',
-          message:
-            "CLAUDE.md bans 'crowdfund' terminology — use 'fund' / 'funding' / 'project' instead.",
-        },
-        {
-          selector:
-            'Literal[value=/dark:(?:bg|text|border|ring|from|to|via|fill|stroke)-(?:gray|slate|zinc|neutral|stone)-\\d+/]',
-          message:
-            'Raw Tailwind gray in dark: variant — use a semantic token (bg-muted, bg-border, border, text-foreground, text-muted-foreground, etc.). See globals.css :root for available tokens. Add eslint-disable-next-line with a reason comment if this is an intentional design exception.',
-        },
-        {
-          selector: 'Literal[value=/dark:(?:bg|text|border|ring)-\\[#[0-9a-fA-F]+\\]/]',
-          message:
-            'Arbitrary hex color in dark: variant — define a CSS custom property in globals.css and use a semantic Tailwind class instead.',
-        },
-        {
-          selector: 'Literal[value=/\\btext-\\[10px\\]/]',
-          message:
-            "Arbitrary text-[10px] — use the text-2xs token (10px, defined in tailwind.config.ts). It exists for exactly this; don't bypass it.",
-        },
-        {
-          // Close the keystroke-hijack class (2026-07 dogfood): a global keyboard
-          // shortcut's "is the user typing?" guard must inspect the COMPOSED path
-          // leaf, not e.target. When a keystroke crosses a shadow-DOM boundary
-          // (e.g. the embedded FleetCrown feedback widget), e.target is retargeted
-          // to the shadow host, so the guard misreads a text field as "not typing"
-          // and the shortcut fires and eats the keystroke. Pass e.composedPath()[0].
-          selector:
-            "CallExpression[callee.name='isTypingTarget'] > MemberExpression.arguments[property.name='target']",
-          message:
-            'Pass the composed-path leaf to isTypingTarget (e.composedPath()[0] ?? e.target), not a bare e.target — a bare .target is shadow-DOM-blind and reintroduces the keystroke-hijack bug.',
-        },
+        ...restrictedSyntaxSelectors,
       ],
       // Lock @deprecated count at 0.
       'no-warning-comments': ['error', { terms: ['@deprecated'], location: 'anywhere' }],
@@ -140,6 +148,34 @@ const eslintConfig = [
       'react-hooks/preserve-manual-memoization': 'off',
       'react-hooks/static-components': 'off',
       'react-hooks/purity': 'off',
+    },
+  },
+  {
+    // SSOT gate (never-twice): internal '/api/…' paths must come from
+    // API_ROUTES (src/config/api-routes.ts) or PUBLIC_API_BASE
+    // (src/config/public-api.ts) — never hardcoded strings. Exempt: the SSOT
+    // configs themselves, the route handlers under src/app/api/ (they ARE the
+    // paths), middleware/robots (path-matching infrastructure), and tests.
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: [
+      'src/config/**',
+      'src/app/api/**',
+      'src/middleware.ts',
+      'src/app/robots.ts',
+      '**/__tests__/**',
+      '**/*.test.*',
+      '**/*.spec.*',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        ...restrictedSyntaxSelectors,
+        {
+          selector: 'Literal[value=/^\\u002Fapi\\u002F/]',
+          message:
+            "Hardcoded '/api/…' path — import API_ROUTES from '@/config/api-routes' (or PUBLIC_API_BASE from '@/config/public-api' for versioned v1 URLs) and reference the endpoint there. Add the entry if it's missing.",
+        },
+      ],
     },
   },
   {

--- a/src/app/(authenticated)/dashboard/analytics/components/AnalyticsInsights.tsx
+++ b/src/app/(authenticated)/dashboard/analytics/components/AnalyticsInsights.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
 import { BarChart3, Activity, TrendingUp, Target, Users } from 'lucide-react';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { ROUTES } from '@/config/routes';
 import type { Project } from '@/stores/projectStore';
 
@@ -93,6 +94,7 @@ const CHART_COLORS = [
 ];
 
 function FundingProgressChart({ projects }: { projects: Project[] }) {
+  const { formatAmountBtc } = useDisplayCurrency();
   const projectsWithGoal = projects.filter(p => p.goal_amount && p.goal_amount > 0);
 
   if (projectsWithGoal.length === 0) {
@@ -142,8 +144,8 @@ function FundingProgressChart({ projects }: { projects: Project[] }) {
               />
             </div>
             <div className="flex justify-between mt-0.5">
-              <span className="text-xs text-fg-secondary">{raised.toFixed(4)} BTC raised</span>
-              <span className="text-xs text-fg-secondary">{goal.toFixed(4)} BTC goal</span>
+              <span className="text-xs text-fg-secondary">{formatAmountBtc(raised)} raised</span>
+              <span className="text-xs text-fg-secondary">{formatAmountBtc(goal)} goal</span>
             </div>
           </div>
         );

--- a/src/app/(authenticated)/dashboard/bookings/page.tsx
+++ b/src/app/(authenticated)/dashboard/bookings/page.tsx
@@ -9,6 +9,7 @@ import EntityListShell from '@/components/entity/EntityListShell';
 import { logger } from '@/utils/logger';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { STATUS } from '@/config/database-constants';
+import { ROUTES } from '@/config/routes';
 import { API_ROUTES } from '@/config/api-routes';
 import BookingTabs from './components/BookingTabs';
 import BookingCard from './components/BookingCard';
@@ -154,7 +155,7 @@ export default function BookingsDashboardPage() {
               processingId={processingId}
               formatBtc={formatAmountBtc}
               onAction={handleAction}
-              onViewDetails={id => router.push(`/dashboard/bookings/${id}`)}
+              onViewDetails={id => router.push(ROUTES.DASHBOARD.BOOKINGS_VIEW(id))}
             />
           ))}
         </div>

--- a/src/app/(authenticated)/dashboard/projects/page.tsx
+++ b/src/app/(authenticated)/dashboard/projects/page.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/ui/Button';
 import { Target, Heart } from 'lucide-react';
 import { projectEntityConfig, type ProjectListItem } from '@/config/entities/projects';
 import { PROJECT_STATUS } from '@/config/project-statuses';
+import { API_ROUTES } from '@/config/api-routes';
 import { ROUTES } from '@/config/routes';
 
 export default function ProjectsDashboardPage() {
@@ -22,7 +23,7 @@ export default function ProjectsDashboardPage() {
           id: 'favorites',
           label: 'Favorites',
           icon: Heart,
-          apiEndpoint: '/api/projects/favorites',
+          apiEndpoint: API_ROUTES.PROJECTS.FAVORITES,
           allowBulkSelect: false,
           hideStatusFilter: true,
           emptyState: {

--- a/src/app/(authenticated)/dashboard/tasks/analytics/page.tsx
+++ b/src/app/(authenticated)/dashboard/tasks/analytics/page.tsx
@@ -174,7 +174,7 @@ export default function TaskAnalyticsPage() {
                 <div
                   key={item.task.id}
                   className="flex items-center gap-4 p-3 bg-surface-raised/50 rounded-lg hover:bg-surface-raised transition-colors cursor-pointer"
-                  onClick={() => router.push(`/dashboard/tasks/${item.task.id}`)}
+                  onClick={() => router.push(ROUTES.DASHBOARD.TASKS_VIEW(item.task.id))}
                 >
                   <FairnessIndicator level={item.fairnessLevel} />
                   <div className="flex-1 min-w-0">

--- a/src/app/(authenticated)/dashboard/tasks/page.tsx
+++ b/src/app/(authenticated)/dashboard/tasks/page.tsx
@@ -275,7 +275,7 @@ export default function TasksPage() {
               task={task}
               onComplete={() => handleComplete(task.id)}
               onFlagAttention={() => handleFlagAttention(task.id)}
-              onClick={() => router.push(`/dashboard/tasks/${task.id}`)}
+              onClick={() => router.push(ROUTES.DASHBOARD.TASKS_VIEW(task.id))}
             />
           ))}
         </div>

--- a/src/app/(authenticated)/dashboard/wallets/hooks/useReceiveStatus.ts
+++ b/src/app/(authenticated)/dashboard/wallets/hooks/useReceiveStatus.ts
@@ -8,6 +8,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
+import { API_ROUTES } from '@/config/api-routes';
 import { logger } from '@/utils/logger';
 
 export interface ReceiveStatus {
@@ -27,7 +28,7 @@ export function useReceiveStatus(walletsSignature: string, enabled: boolean) {
       return;
     }
     try {
-      const res = await fetch('/api/wallets/receive-status');
+      const res = await fetch(API_ROUTES.WALLETS.RECEIVE_STATUS);
       if (!res.ok) {
         throw new Error(`status ${res.status}`);
       }

--- a/src/app/(authenticated)/settings/integrations/page.tsx
+++ b/src/app/(authenticated)/settings/integrations/page.tsx
@@ -20,6 +20,7 @@ import Link from 'next/link';
 import { KeyRound, LogIn, Webhook } from 'lucide-react';
 import { useRequireAuth } from '@/hooks/useAuth';
 import { useMessagingActors } from '@/features/messaging/hooks/useMessagingActors';
+import { PUBLIC_API_BASE, PUBLIC_API_OPENAPI_PATH } from '@/config/public-api';
 import { ROUTES } from '@/config/routes';
 import Loading from '@/components/Loading';
 import Button from '@/components/ui/Button';
@@ -76,7 +77,7 @@ export default function IntegrationsPage() {
         <p className="mt-2 text-xs text-fg-secondary">
           API contract:{' '}
           <a
-            href="/api/v1/openapi.json"
+            href={PUBLIC_API_OPENAPI_PATH}
             className="underline hover:text-fg-primary"
             target="_blank"
             rel="noreferrer"
@@ -85,7 +86,7 @@ export default function IntegrationsPage() {
           </a>{' '}
           ·{' '}
           <a
-            href="/api/v1"
+            href={PUBLIC_API_BASE}
             className="underline hover:text-fg-primary"
             target="_blank"
             rel="noreferrer"

--- a/src/app/(authenticated)/settings/usage/page.tsx
+++ b/src/app/(authenticated)/settings/usage/page.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Gauge, KeyRound, Sparkles, Wallet } from 'lucide-react';
+import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
 import { useCatQuota } from '@/components/ai-chat/ModernChatPanel/hooks/useCatQuota';
 import { API_ROUTES } from '@/config/api-routes';
 import { ROUTES } from '@/config/routes';
@@ -60,6 +61,7 @@ function useCreditBalance(): { balanceBtc: number | null; isLoading: boolean } {
 export default function UsageSettingsPage() {
   const { quota, isLoading: quotaLoading } = useCatQuota();
   const { balanceBtc } = useCreditBalance();
+  const { formatAmountBtc } = useDisplayCurrency();
 
   /** Which CAT_PLANS card is the user's current reality. */
   const activePlanId: CatPlanId | null = quota
@@ -205,7 +207,7 @@ export default function UsageSettingsPage() {
               {balanceBtc !== null ? (
                 <>
                   Balance:{' '}
-                  <span className="font-medium text-fg-primary">{balanceBtc.toFixed(8)} BTC</span>
+                  <span className="font-medium text-fg-primary">{formatAmountBtc(balanceBtc)}</span>
                 </>
               ) : (
                 'Prepaid balance for managed frontier models, billed per message.'

--- a/src/app/(public)/study-bitcoin/page.tsx
+++ b/src/app/(public)/study-bitcoin/page.tsx
@@ -30,7 +30,7 @@ export default function StudyBitcoinPage() {
         description="From basics to advanced concepts, learn everything you need to know about Bitcoin and the future of money."
       >
         <div className="flex flex-col sm:flex-row gap-4 justify-center mt-8">
-          <Button href="/bitcoin-wallet-guide" size="lg" className="min-h-12">
+          <Button href={ROUTES.BITCOIN_WALLET_GUIDE} size="lg" className="min-h-12">
             <Wallet className="w-5 h-5 mr-2" />
             Start with Wallets
           </Button>
@@ -131,7 +131,7 @@ export default function StudyBitcoinPage() {
             Bitcoin
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button href="/bitcoin-wallet-guide" size="lg" className="min-h-12">
+            <Button href={ROUTES.BITCOIN_WALLET_GUIDE} size="lg" className="min-h-12">
               <Wallet className="w-5 h-5 mr-2" />
               Get Your First Wallet
             </Button>

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
+import { ROUTES } from '@/config/routes';
 import Card from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
 import { PageLayout, PageHeader, PageSection } from '@/components/layout/PageLayout';
@@ -118,7 +119,7 @@ export default function EventsPage() {
     if (session) {
       _router.push(`${ENTITY_REGISTRY['event'].publicBasePath}/create`);
     } else {
-      _router.push(`/auth?mode=login&redirect=${ENTITY_REGISTRY['event'].publicBasePath}/create`);
+      _router.push(`${ROUTES.AUTH_LOGIN}&redirect=${ENTITY_REGISTRY['event'].publicBasePath}/create`);
     }
   };
 

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -4,8 +4,8 @@ export default function Loading() {
   return (
     <div className="space-y-12">
       <div className="space-y-4 text-center py-16">
-        <Skeleton className="h-12 w-80 mx-auto" />
-        <Skeleton className="h-5 w-96 mx-auto" />
+        <Skeleton className="h-12 w-80 max-w-full mx-auto" />
+        <Skeleton className="h-5 w-96 max-w-full mx-auto" />
         <Skeleton className="h-12 w-48 mx-auto rounded-full mt-4" />
       </div>
       <div className="px-4 md:px-6">

--- a/src/components/ai-chat/ModernChatPanel/components/UpgradeNudge.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/UpgradeNudge.tsx
@@ -56,7 +56,7 @@ export function UpgradeNudge() {
         type="button"
         onClick={dismiss}
         aria-label="Dismiss upgrade suggestion"
-        className="flex-shrink-0 rounded p-0.5 text-fg-tertiary hover:bg-surface-raised hover:text-fg-primary"
+        className="flex-shrink-0 min-h-11 min-w-11 flex items-center justify-center rounded p-0.5 text-fg-tertiary hover:bg-surface-raised hover:text-fg-primary"
       >
         <X className="h-3.5 w-3.5" />
       </button>

--- a/src/components/ai/CatCreditsPanel.tsx
+++ b/src/components/ai/CatCreditsPanel.tsx
@@ -69,7 +69,7 @@ export function CatCreditsPanel() {
     <section className="rounded-lg border border-default bg-surface-base p-6">
       <div className="mb-4 flex items-start gap-3">
         <div className="rounded-md bg-surface-raised p-2">
-          <Coins className="h-5 w-5 text-bitcoinOrange" />
+          <Coins className="h-5 w-5 text-fg-secondary" />
         </div>
         <div className="flex-1">
           <h2 className="text-lg font-semibold text-fg-primary">Cat Credits</h2>
@@ -87,7 +87,7 @@ export function CatCreditsPanel() {
           {isLoading ? (
             <Loader2 className="mt-1 h-5 w-5 animate-spin text-fg-secondary" />
           ) : (
-            <p className="mt-0.5 text-2xl font-semibold text-bitcoinOrange">
+            <p className="mt-0.5 text-2xl font-semibold text-fg-primary">
               {formatAmountBtc(balanceBtc)}
             </p>
           )}
@@ -99,7 +99,7 @@ export function CatCreditsPanel() {
           title={topupEnabled ? 'Top up with Lightning' : 'Lightning top-up is coming soon'}
           className={
             topupEnabled
-              ? 'rounded-md bg-bitcoinOrange px-4 py-2 text-sm font-medium text-white hover:bg-bitcoinOrange/90'
+              ? 'rounded-md bg-accent-warm px-4 py-2 text-sm font-medium text-white hover:bg-accent-warm-hover'
               : 'cursor-not-allowed rounded-md border border-subtle px-4 py-2 text-sm font-medium text-fg-tertiary opacity-60'
           }
         >

--- a/src/components/create/DynamicSidebar.tsx
+++ b/src/components/create/DynamicSidebar.tsx
@@ -17,7 +17,7 @@ import React, { useState, useEffect } from 'react';
 import { CheckCircle2, ArrowLeftRight, TrendingUp } from 'lucide-react';
 import Card from '@/components/ui/Card';
 import type { FieldGuidanceContent, DefaultContent } from '@/lib/project-guidance';
-import { currencyConverter } from '@/services/currency';
+import { currencyConverter, formatCurrency } from '@/services/currency';
 import type { ExchangeRates } from '@/services/currency/types';
 
 export type FieldType = string | null;
@@ -85,7 +85,7 @@ function CurrencyBreakdown({ amount, currency }: { amount: number; currency: str
       <div className="space-y-2 text-sm">
         <div className="flex justify-between">
           <span className="text-fg-secondary">Bitcoin (BTC)</span>
-          <span className="font-mono font-semibold">₿ {btc.toFixed(8)}</span>
+          <span className="font-mono font-semibold">{formatCurrency(btc, 'BTC')}</span>
         </div>
         <div className="border-t border-subtle pt-2 space-y-1 text-xs">
           <div className="flex justify-between text-fg-secondary">

--- a/src/components/create/collateral/CollateralSelector.tsx
+++ b/src/components/create/collateral/CollateralSelector.tsx
@@ -41,7 +41,7 @@ export function CollateralSelector({
   disabled = false,
 }: CollateralSelectorProps) {
   const { profile } = useAuth();
-  const { formatAmountBtc } = useDisplayCurrency();
+  const { formatAmountBtc, formatPrice } = useDisplayCurrency();
 
   const {
     assets,
@@ -69,7 +69,7 @@ export function CollateralSelector({
       id: a.id,
       label: a.title,
       sublabel: a.estimated_value
-        ? `${a.estimated_value.toLocaleString()} ${a.currency || PLATFORM_DEFAULT_CURRENCY}`
+        ? formatPrice(a.estimated_value, a.currency || PLATFORM_DEFAULT_CURRENCY)
         : undefined,
     }));
 
@@ -99,11 +99,7 @@ export function CollateralSelector({
             <div className="flex items-center justify-between mb-2">
               <span className="text-sm font-medium text-fg-primary">Total Collateral Value</span>
               <span className="text-lg font-bold text-fg-primary">
-                {totalCollateral.toLocaleString(undefined, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-                })}{' '}
-                {loanCurrency}
+                {formatPrice(totalCollateral, loanCurrency)}
               </span>
             </div>
             {loanAmount && coveragePercentage !== null && (
@@ -181,11 +177,7 @@ export function CollateralSelector({
                       </Badge>
                     </div>
                     <span className="text-xs text-fg-secondary">
-                      {item.value.toLocaleString(undefined, {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}{' '}
-                      {item.currency}
+                      {formatPrice(item.value, item.currency)}
                     </span>
                   </div>
                 </div>

--- a/src/components/dashboard/SmartQuestionsPanel.tsx
+++ b/src/components/dashboard/SmartQuestionsPanel.tsx
@@ -92,7 +92,7 @@ function QuestionCard({ question, onDismiss }: { question: SmartQuestion; onDism
 
         <button
           onClick={onDismiss}
-          className="p-1 text-fg-tertiary hover:text-fg-primary rounded opacity-0 group-hover:opacity-100 transition-opacity min-h-11 min-w-11 flex items-center justify-center"
+          className="p-1 text-fg-tertiary hover:text-fg-primary rounded min-h-11 min-w-11 flex items-center justify-center"
           aria-label="Dismiss question"
         >
           <X className="w-4 h-4" />

--- a/src/components/integrations/FleetCrownBuildCta.tsx
+++ b/src/components/integrations/FleetCrownBuildCta.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { ArrowUpRight, Bot } from 'lucide-react';
 import Button from '@/components/ui/Button';
+import { API_ROUTES } from '@/config/api-routes';
 import { ORANGECAT_FLEETCROWN_INTEGRATION } from '@/config/entity-registry';
 import type { EntityType } from '@/config/entity-registry';
 
@@ -53,7 +54,7 @@ export default function FleetCrownBuildCta({
     setLoading(true);
     setError('');
     try {
-      const response = await fetch('/api/integrations/fleetcrown/build-intents', {
+      const response = await fetch(API_ROUTES.INTEGRATIONS.FLEETCROWN_BUILD_INTENTS, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/messaging/ConversationListItem.tsx
+++ b/src/components/messaging/ConversationListItem.tsx
@@ -202,7 +202,7 @@ export function ConversationListItem({
             <button
               type="button"
               aria-label="Delete conversation"
-              className="p-1 rounded-md text-fg-tertiary hover:text-status-negative hover:bg-status-negative/10 self-start"
+              className="p-1 min-h-11 min-w-11 flex items-center justify-center rounded-md text-fg-tertiary hover:text-status-negative hover:bg-status-negative/10 self-start"
               onClick={e => {
                 e.stopPropagation();
                 onDeleteRequest();

--- a/src/components/messaging/MessagePanel.tsx
+++ b/src/components/messaging/MessagePanel.tsx
@@ -193,7 +193,7 @@ export default function MessagePanel({
                 return;
               }
               setSelectedConversationId(conversationId);
-              router.push(`/messages?id=${conversationId}`, { scroll: false });
+              router.push(ROUTES.MESSAGES_WITH_CONVERSATION(conversationId), { scroll: false });
             }}
           />
         </div>
@@ -260,7 +260,7 @@ export default function MessagePanel({
           setSelectedConversationId(convId);
           setShowNewModal(false);
           setRefreshSignal(s => s + 1);
-          router.push(`/messages?id=${convId}`, { scroll: false });
+          router.push(ROUTES.MESSAGES_WITH_CONVERSATION(convId), { scroll: false });
         }}
       />
     </div>

--- a/src/components/nostr/NostrConnectionCard.tsx
+++ b/src/components/nostr/NostrConnectionCard.tsx
@@ -90,7 +90,7 @@ export function NostrConnectionCard() {
                     {shortenNpub(npub)}
                     <button
                       onClick={handleCopyNpub}
-                      className="p-0.5 hover:text-fg-primary transition-colors"
+                      className="p-0.5 min-h-11 min-w-11 inline-flex items-center justify-center hover:text-fg-primary transition-colors"
                       title="Copy npub"
                     >
                       {copied ? (

--- a/src/components/onboarding/IntelligentOnboarding.tsx
+++ b/src/components/onboarding/IntelligentOnboarding.tsx
@@ -25,6 +25,7 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { ProfileService } from '@/services/profile';
 import { logger } from '@/utils/logger';
+import { API_ROUTES } from '@/config/api-routes';
 import { ROUTES } from '@/config/routes';
 import { FEATURES } from '@/config/features';
 import { ONBOARDING_METHOD } from '@/config/onboarding';
@@ -83,7 +84,7 @@ export default function IntelligentOnboarding() {
     setIsGenerating(true);
     persistProfile();
     try {
-      const res = await fetch('/api/cat/offers-from-text', {
+      const res = await fetch(API_ROUTES.CAT.OFFERS_FROM_TEXT, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: description.trim() }),

--- a/src/components/payment/OwnerCollectPanel.tsx
+++ b/src/components/payment/OwnerCollectPanel.tsx
@@ -17,6 +17,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { API_ROUTES } from '@/config/api-routes';
 import { ROUTES } from '@/config/routes';
 import type { EntityType } from '@/config/entity-registry';
 
@@ -59,7 +60,7 @@ export function OwnerCollectPanel({
   priceAmount,
   priceCurrency,
 }: OwnerCollectPanelProps) {
-  const { formatPrice } = useDisplayCurrency();
+  const { formatPrice, formatAmountBtc } = useDisplayCurrency();
   const { copied: linkCopied, copy: copyLink } = useCopyToClipboard();
   const { copied: addrCopied, copy: copyAddr } = useCopyToClipboard();
   const [shareUrl, setShareUrl] = useState('');
@@ -78,7 +79,7 @@ export function OwnerCollectPanel({
     let cancelled = false;
     setLoading(true);
     fetch(
-      `/api/payments/receive-info?entity_type=${encodeURIComponent(entityType)}&entity_id=${encodeURIComponent(entityId)}`
+      `${API_ROUTES.PAYMENTS.RECEIVE_INFO}?entity_type=${encodeURIComponent(entityType)}&entity_id=${encodeURIComponent(entityId)}`
     )
       .then(res => (res.ok ? res.json() : null))
       .then(body => {
@@ -103,7 +104,7 @@ export function OwnerCollectPanel({
 
   useEffect(() => {
     fetch(
-      `/api/payments/recipient-confirmations?entity_type=${encodeURIComponent(entityType)}&entity_id=${encodeURIComponent(entityId)}`
+      `${API_ROUTES.PAYMENTS.RECIPIENT_CONFIRMATIONS}?entity_type=${encodeURIComponent(entityType)}&entity_id=${encodeURIComponent(entityId)}`
     )
       .then(res => (res.ok ? res.json() : null))
       .then(body => setConfirmations((body?.data as RecipientConfirmation[]) ?? []))
@@ -112,7 +113,7 @@ export function OwnerCollectPanel({
 
   const confirmReceipt = async (id: string) => {
     setConfirmingId(id);
-    const response = await fetch(`/api/payments/${id}`, {
+    const response = await fetch(API_ROUTES.PAYMENTS.BY_ID(id), {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ action: 'seller_confirm' }),
@@ -229,7 +230,7 @@ export function OwnerCollectPanel({
                   className="flex items-center justify-between gap-3 rounded-md border border-default p-3"
                 >
                   <span className="font-mono text-sm text-fg-primary">
-                    {Number(item.amount_btc)} BTC
+                    {formatAmountBtc(Number(item.amount_btc))}
                   </span>
                   <Button
                     size="sm"

--- a/src/components/payment/PublicSupportPanel.tsx
+++ b/src/components/payment/PublicSupportPanel.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { PaymentQRCode } from './PaymentQRCode';
 import { PaymentStatusIndicator } from './PaymentStatusIndicator';
+import { PUBLIC_API_BASE } from '@/config/public-api';
 import { CONTRIBUTION_QUICK_AMOUNTS_BTC } from '@/config/payment-presets';
 import { displayBTC } from '@/services/currency';
 import type { EntityType } from '@/config/entity-registry';
@@ -66,7 +67,7 @@ export function PublicSupportPanel({
 
     let stopped = false;
     const check = async () => {
-      const response = await fetch(`/api/v1/payments/public/${intent.payment_intent.id}`, {
+      const response = await fetch(`${PUBLIC_API_BASE}/payments/public/${intent.payment_intent.id}`, {
         headers: { 'x-payment-token': intent.status_token },
         cache: 'no-store',
       });
@@ -100,7 +101,7 @@ export function PublicSupportPanel({
     setPhase('creating');
     setError('');
     try {
-      const response = await fetch('/api/v1/payments/public', {
+      const response = await fetch(`${PUBLIC_API_BASE}/payments/public`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
@@ -125,7 +126,7 @@ export function PublicSupportPanel({
     if (!intent) {
       return;
     }
-    const response = await fetch(`/api/v1/payments/public/${intent.payment_intent.id}`, {
+    const response = await fetch(`${PUBLIC_API_BASE}/payments/public/${intent.payment_intent.id}`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',

--- a/src/components/project/ProjectHeader.tsx
+++ b/src/components/project/ProjectHeader.tsx
@@ -52,16 +52,16 @@ export default function ProjectHeader({
   const router = useRouter();
   const statusInfo = getStatusInfo(project.status);
   const creatorProfileUrl = project.profiles?.username
-    ? `/profile/${project.profiles.username}`
+    ? ROUTES.PROFILE.VIEW(project.profiles.username)
     : project.profiles?.id
-      ? `/profile/${project.profiles.id}`
-      : `/profile/${project.user_id}`;
+      ? ROUTES.PROFILE.VIEW(project.profiles.id)
+      : ROUTES.PROFILE.VIEW(project.user_id);
 
   // Handle contact/message the project creator
   const handleContact = async () => {
     if (!user) {
       toast.info('Please sign in to send a message');
-      router.push(`/auth?mode=login&from=/projects/${project.id}`);
+      router.push(`${ROUTES.AUTH_LOGIN}&from=${ROUTES.PROJECTS.VIEW(project.id)}`);
       return;
     }
 
@@ -80,7 +80,7 @@ export default function ProjectHeader({
       }
 
       const { conversationId } = await response.json();
-      router.push(`/messages/${conversationId}`);
+      router.push(ROUTES.MESSAGE_CONVERSATION(conversationId));
     } catch {
       toast.error('Failed to start conversation. Please try again.');
     }

--- a/src/components/public/detail-configs/asset.tsx
+++ b/src/components/public/detail-configs/asset.tsx
@@ -2,7 +2,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/badge';
 import type { EntityDetailConfig } from '@/components/public/PublicEntityDetailPage';
 import { ROUTES } from '@/config/routes';
-import { displayBTC } from '@/services/currency';
+import { displayBTC, formatCurrency } from '@/services/currency';
+import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
 import {
   ASSET_TYPE_LABELS,
   ASSET_VERIFICATION_COLORS,
@@ -72,7 +73,7 @@ export const assetDetailConfig: EntityDetailConfig = {
             <div className="flex justify-between items-center">
               <span className="text-sm text-fg-secondary">Estimated Value</span>
               <span className="font-semibold">
-                {Number(entity.estimated_value).toLocaleString()} {String(entity.currency || 'CHF')}
+                {formatCurrency(Number(entity.estimated_value), String(entity.currency || PLATFORM_DEFAULT_CURRENCY))}
               </span>
             </div>
           )}

--- a/src/components/settings/WebhookDeliveriesDrawer.tsx
+++ b/src/components/settings/WebhookDeliveriesDrawer.tsx
@@ -125,7 +125,7 @@ export default function WebhookDeliveriesDrawer({ endpointId }: Props) {
       setError(null);
       try {
         const res = await fetch(
-          `/api/webhook-endpoints/${endpointId}/deliveries/${deliveryId}/replay`,
+          API_ROUTES.WEBHOOK_ENDPOINTS.DELIVERY_REPLAY(endpointId, deliveryId),
           { method: 'POST', credentials: 'include' }
         );
         if (!res.ok) {

--- a/src/components/timeline/ComposerImageAttachment.tsx
+++ b/src/components/timeline/ComposerImageAttachment.tsx
@@ -133,7 +133,7 @@ export function ComposerImageAttachment({
             onClick={onRemove}
             disabled={disabled}
             aria-label="Remove image"
-            className="absolute right-2 top-2 rounded-full border border-subtle bg-surface-base/90 p-1 text-fg-primary transition-colors hover:bg-surface-base"
+            className="absolute right-2 top-2 min-h-11 min-w-11 flex items-center justify-center rounded-full border border-subtle bg-surface-base/90 p-1 text-fg-primary transition-colors hover:bg-surface-base"
           >
             <X className="h-4 w-4" />
           </button>

--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -12,8 +12,8 @@ export function Alert({ children, variant = 'info', className }: AlertProps) {
   const variants = {
     success: 'border-success/25 bg-success/10 text-success',
     error: 'border-destructive/25 bg-destructive/10 text-destructive',
-    warning: 'border-warning/30 bg-warning/10 text-foreground',
-    info: 'border-border-subtle bg-muted/30 text-foreground',
+    warning: 'border-warning/30 bg-warning/10 text-fg-primary',
+    info: 'border-border-subtle bg-muted/30 text-fg-primary',
     destructive: 'border-destructive/25 bg-destructive/10 text-destructive',
   };
 

--- a/src/components/ui/BTCAmountDisplay.tsx
+++ b/src/components/ui/BTCAmountDisplay.tsx
@@ -86,7 +86,7 @@ export default function BTCAmountDisplay({
   }
 
   return (
-    <span className={`inline-flex items-center gap-1 text-xs text-muted-foreground ${className}`}>
+    <span className={`inline-flex items-center gap-1 text-xs text-fg-secondary ${className}`}>
       {showIcon && <Bitcoin className="w-3 h-3 text-bitcoinOrange" />}
       <span>{btcAmount}</span>
     </span>

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -134,7 +134,7 @@ export default function BottomSheet({
         {/* Sheet */}
         <div
           ref={sheetRef}
-          className="relative w-full bg-card rounded-t-lg shadow-sm transition-transform duration-300 ease-out"
+          className="relative w-full bg-surface-base rounded-t-lg shadow-sm transition-transform duration-300 ease-out"
           style={{
             maxHeight,
             transform: isOpen ? 'translateY(0)' : 'translateY(100%)',
@@ -151,14 +151,14 @@ export default function BottomSheet({
           {/* Header */}
           {(title || showCloseButton) && (
             <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-              <h2 id="bottom-sheet-title" className="text-lg font-semibold text-foreground">
+              <h2 id="bottom-sheet-title" className="text-lg font-semibold text-fg-primary">
                 {title || ''}
               </h2>
 
               {showCloseButton && (
                 <button
                   onClick={onClose}
-                  className="text-muted-dim hover:text-foreground min-h-11 min-w-11 flex items-center justify-center"
+                  className="text-muted-dim hover:text-fg-primary min-h-11 min-w-11 flex items-center justify-center"
                   aria-label="Close"
                 >
                   <X className="w-5 h-5" />

--- a/src/components/ui/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb.tsx
@@ -29,11 +29,11 @@ export function Breadcrumb({ items, className = '' }: BreadcrumbProps) {
     // items-center context share one vertical axis by construction.
     <nav
       aria-label="Breadcrumb"
-      className={`flex flex-wrap items-center gap-1.5 text-sm leading-none text-muted-foreground ${className}`}
+      className={`flex flex-wrap items-center gap-1.5 text-sm leading-none text-fg-secondary ${className}`}
     >
       <Link
         href={ROUTES.DASHBOARD.HOME}
-        className="inline-flex items-center gap-1.5 hover:text-foreground transition-colors"
+        className="inline-flex items-center gap-1.5 hover:text-fg-primary transition-colors"
       >
         <Home className="h-3.5 w-3.5 shrink-0" />
         <span>Home</span>
@@ -41,7 +41,7 @@ export function Breadcrumb({ items, className = '' }: BreadcrumbProps) {
 
       {items.map((item, i) => (
         <Fragment key={i}>
-          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-fg-secondary/60" />
           {/* inline-flex items-center: globals.css forces a{min-height:44px} (touch
               targets), and a plain block link top-aligns its text inside that box
               while the Home link centers — THE breadcrumb misalignment. Center all
@@ -49,12 +49,12 @@ export function Breadcrumb({ items, className = '' }: BreadcrumbProps) {
           {item.href ? (
             <Link
               href={item.href}
-              className="inline-flex items-center hover:text-foreground transition-colors"
+              className="inline-flex items-center hover:text-fg-primary transition-colors"
             >
               {item.label}
             </Link>
           ) : (
-            <span className="inline-flex items-center text-foreground font-medium">
+            <span className="inline-flex items-center text-fg-primary font-medium">
               {item.label}
             </span>
           )}

--- a/src/components/ui/CurrencyDisplay.tsx
+++ b/src/components/ui/CurrencyDisplay.tsx
@@ -28,7 +28,7 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
   showSymbol = true,
 }) => {
   const currencyColorClass =
-    currency === 'BTC' ? 'text-bitcoinOrange font-medium' : 'text-muted-foreground';
+    currency === 'BTC' ? 'text-bitcoinOrange font-medium' : 'text-fg-secondary';
 
   const sizeClasses = {
     sm: 'text-sm',

--- a/src/components/ui/CurrencyInput.tsx
+++ b/src/components/ui/CurrencyInput.tsx
@@ -78,7 +78,7 @@ export function CurrencyInput({
   return (
     <div className="space-y-2">
       {label && (
-        <label htmlFor={id} className="block text-sm font-medium text-foreground">
+        <label htmlFor={id} className="block text-sm font-medium text-fg-primary">
           {label}
         </label>
       )}
@@ -103,7 +103,7 @@ export function CurrencyInput({
               value={inputCurrency}
               onChange={e => handleCurrencyChange(e.target.value as Currency)}
               disabled={disabled}
-              className="px-3 py-2 border border-l-0 border-border-strong rounded-r-md bg-muted text-sm font-medium text-foreground focus:ring-2 focus:ring-ring focus:border-ring cursor-pointer"
+              className="px-3 py-2 border border-l-0 border-border-strong rounded-r-md bg-muted text-sm font-medium text-fg-primary focus:ring-2 focus:ring-ring focus:border-ring cursor-pointer"
             >
               {ALL_CURRENCIES.map(curr => (
                 <option key={curr} value={curr}>
@@ -112,7 +112,7 @@ export function CurrencyInput({
               ))}
             </select>
           ) : (
-            <div className="px-3 py-2 border border-l-0 border-border-strong rounded-r-md bg-muted text-sm font-medium text-foreground">
+            <div className="px-3 py-2 border border-l-0 border-border-strong rounded-r-md bg-muted text-sm font-medium text-fg-primary">
               {inputCurrency}
             </div>
           )}
@@ -120,10 +120,10 @@ export function CurrencyInput({
       </div>
 
       {error && <p className="text-destructive text-sm">{error}</p>}
-      {hint && !error && <p className="text-xs text-muted-foreground">{hint}</p>}
+      {hint && !error && <p className="text-xs text-fg-secondary">{hint}</p>}
 
       {isGoal && !error && !hint && value && value > 0 && (
-        <div className="text-xs text-muted-foreground mt-1">
+        <div className="text-xs text-fg-secondary mt-1">
           <span className="flex items-center gap-1">
             <Info className="w-3 h-3" />
             <span>{getGoalExplanation(inputCurrency)}</span>
@@ -135,7 +135,7 @@ export function CurrencyInput({
         <div className="mt-3 p-3 rounded-lg bg-bitcoinOrange/5 border border-bitcoinOrange/20">
           <div className="flex items-center gap-2 mb-2">
             <ArrowLeftRight className="w-4 h-4 text-bitcoinOrange" />
-            <span className="text-xs font-semibold text-foreground">
+            <span className="text-xs font-semibold text-fg-primary">
               Equivalent in other currencies
             </span>
           </div>
@@ -143,7 +143,7 @@ export function CurrencyInput({
           <div className="grid grid-cols-2 gap-2 text-xs">
             {inputCurrency !== 'BTC' && (
               <div className="flex justify-between items-center">
-                <span className="text-muted-foreground flex items-center gap-1">
+                <span className="text-fg-secondary flex items-center gap-1">
                   <Bitcoin className="w-3 h-3" />
                   BTC
                 </span>
@@ -157,8 +157,8 @@ export function CurrencyInput({
               .slice(0, inputCurrency === 'BTC' ? 3 : 2)
               .map(([curr, amount]) => (
                 <div key={curr} className="flex justify-between items-center">
-                  <span className="text-muted-foreground">{curr}</span>
-                  <span className="font-mono font-medium text-foreground">
+                  <span className="text-fg-secondary">{curr}</span>
+                  <span className="font-mono font-medium text-fg-primary">
                     {formatCurrency(amount, curr as Currency, { showSymbol: false })}
                   </span>
                 </div>
@@ -167,7 +167,7 @@ export function CurrencyInput({
 
           <div className="mt-2 pt-2 border-t border-bitcoinOrange/20 flex items-start gap-1">
             <Info className="w-3 h-3 text-bitcoinOrange mt-0.5 flex-shrink-0" />
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-fg-secondary">
               All transactions settle in Bitcoin. Amounts shown are estimates based on current
               exchange rates.
             </p>

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -23,8 +23,8 @@ export default function EmptyState({
       <div className="oc-icon-tile mb-4 h-12 w-12">
         <Icon className="w-6 h-6 text-muted-dim" />
       </div>
-      <h3 className="text-lg font-semibold text-foreground mb-2">{title}</h3>
-      {description && <p className="text-muted-foreground mb-6 max-w-md">{description}</p>}
+      <h3 className="text-lg font-semibold text-fg-primary mb-2">{title}</h3>
+      {description && <p className="text-fg-secondary mb-6 max-w-md">{description}</p>}
       {action}
     </div>
   );

--- a/src/components/ui/LocationInput.tsx
+++ b/src/components/ui/LocationInput.tsx
@@ -67,7 +67,7 @@ export function LocationInput({
       {showSuggestions && suggestions.length > 0 && (
         <div
           ref={suggestionsRef}
-          className="absolute z-50 w-full mt-1 bg-card border border-border rounded-lg shadow-sm max-h-60 overflow-y-auto"
+          className="absolute z-50 w-full mt-1 bg-surface-base border border-border rounded-lg shadow-sm max-h-60 overflow-y-auto"
         >
           {suggestions.map(suggestion => (
             <button
@@ -79,9 +79,9 @@ export function LocationInput({
               <div className="flex items-start gap-3">
                 <MapPin className="w-4 h-4 text-muted-dim mt-0.5 flex-shrink-0" />
                 <div className="flex-1 min-w-0">
-                  <div className="font-medium text-foreground truncate">{suggestion.mainText}</div>
+                  <div className="font-medium text-fg-primary truncate">{suggestion.mainText}</div>
                   {suggestion.secondaryText && (
-                    <div className="text-sm text-muted-foreground truncate">
+                    <div className="text-sm text-fg-secondary truncate">
                       {suggestion.secondaryText}
                     </div>
                   )}
@@ -93,8 +93,8 @@ export function LocationInput({
       )}
 
       {showSuggestions && inputValue.length >= 2 && suggestions.length === 0 && !isLoading && (
-        <div className="absolute z-50 w-full mt-1 bg-card border border-border rounded-lg shadow-sm p-4">
-          <div className="text-sm text-muted-foreground text-center">
+        <div className="absolute z-50 w-full mt-1 bg-surface-base border border-border rounded-lg shadow-sm p-4">
+          <div className="text-sm text-fg-secondary text-center">
             No locations found. Try typing a city name or address.
           </div>
         </div>

--- a/src/components/ui/RouteError.tsx
+++ b/src/components/ui/RouteError.tsx
@@ -39,7 +39,7 @@ export function RouteError({ error, reset, context }: RouteErrorProps) {
     <div className="flex flex-col items-center justify-center min-h-[60vh] p-6 text-center">
       <AlertCircle className="h-12 w-12 text-destructive mb-4" />
       <h2 className="text-xl font-semibold mb-2">Something went wrong</h2>
-      <p className="text-muted-foreground mb-4 max-w-md">
+      <p className="text-fg-secondary mb-4 max-w-md">
         There was a problem loading this page. Please try again.
       </p>
 
@@ -60,7 +60,7 @@ export function RouteError({ error, reset, context }: RouteErrorProps) {
         </button>
         <Link
           href={recoveryHref}
-          className="inline-flex items-center gap-2 rounded-md border border-border-strong bg-card px-4 py-2 text-foreground transition-colors hover:bg-muted"
+          className="inline-flex items-center gap-2 rounded-md border border-border-strong bg-surface-base px-4 py-2 text-fg-primary transition-colors hover:bg-muted"
         >
           <Home className="h-4 w-4" />
           {recoveryLabel}

--- a/src/components/ui/UserProfileDropdown.tsx
+++ b/src/components/ui/UserProfileDropdown.tsx
@@ -179,14 +179,14 @@ export default function UserProfileDropdown({
           ref={buttonRef}
           onClick={toggle}
           disabled={false}
-          className="flex items-center space-x-2 text-foreground focus:outline-none disabled:opacity-50"
+          className="flex items-center space-x-2 text-fg-primary focus:outline-none disabled:opacity-50"
         >
           <span className="text-sm font-medium">{displayName}</span>
           <ChevronDown className={`h-4 w-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
         </button>
 
         {isOpen && (
-          <div className="absolute right-0 mt-2 w-48 rounded-md shadow-sm bg-card ring-1 ring-black ring-opacity-5 dark:ring-border dark:ring-opacity-100 z-50">
+          <div className="absolute right-0 mt-2 w-48 rounded-md shadow-sm bg-surface-base ring-1 ring-black ring-opacity-5 dark:ring-border dark:ring-opacity-100 z-50">
             <div className="py-1" role="menu" aria-orientation="vertical">
               {menuItems.map(item => {
                 const Icon = item.icon;
@@ -194,7 +194,7 @@ export default function UserProfileDropdown({
                   <button
                     key={item.label}
                     onClick={() => handleNavigation(item.href)}
-                    className="flex items-center w-full px-4 py-2 text-sm text-foreground hover:bg-muted"
+                    className="flex items-center w-full px-4 py-2 text-sm text-fg-primary hover:bg-muted"
                     role="menuitem"
                   >
                     <Icon className="w-4 h-4 mr-3" />
@@ -205,7 +205,7 @@ export default function UserProfileDropdown({
               <hr className="my-1 border-border-subtle" />
               <button
                 onClick={handleSignOut}
-                className="flex items-center w-full px-4 py-2 text-sm text-foreground hover:bg-muted"
+                className="flex items-center w-full px-4 py-2 text-sm text-fg-primary hover:bg-muted"
                 role="menuitem"
               >
                 <LogOut className="w-4 h-4 mr-3" />

--- a/src/components/ui/UserProfileDropdownPanel.tsx
+++ b/src/components/ui/UserProfileDropdownPanel.tsx
@@ -57,7 +57,7 @@ export function UserProfileDropdownPanel({
 }: UserProfileDropdownPanelProps) {
   return (
     <div
-      className="fixed z-50 rounded-lg shadow-sm bg-card border border-border-subtle animate-in fade-in slide-in-from-top-2 zoom-in-95 duration-200 origin-top-right overflow-hidden"
+      className="fixed z-50 rounded-lg shadow-sm bg-surface-base border border-border-subtle animate-in fade-in slide-in-from-top-2 zoom-in-95 duration-200 origin-top-right overflow-hidden"
       style={{
         top: buttonRef.current ? buttonRef.current.getBoundingClientRect().bottom + 12 : 'auto',
         right: buttonRef.current
@@ -102,13 +102,13 @@ export function UserProfileDropdownPanel({
                 onClick={handlePublicProfileClick}
                 className="group flex items-center space-x-2 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 rounded-lg p-1 -m-1"
               >
-                <h3 className="font-semibold text-lg text-foreground group-hover:underline underline-offset-4 truncate">
+                <h3 className="font-semibold text-lg text-fg-primary group-hover:underline underline-offset-4 truncate">
                   {displayName}
                 </h3>
-                <ExternalLink className="w-4 h-4 text-muted-dim group-hover:text-foreground transition-all duration-200 opacity-0 group-hover:opacity-100 transform group-hover:scale-110" />
+                <ExternalLink className="w-4 h-4 text-muted-dim group-hover:text-fg-primary transition-all duration-200 opacity-0 group-hover:opacity-100 transform group-hover:scale-110" />
               </button>
-              {username && <p className="text-sm font-medium text-muted-foreground">@{username}</p>}
-              {email && <p className="text-xs text-muted-foreground truncate mt-1">{email}</p>}
+              {username && <p className="text-sm font-medium text-fg-secondary">@{username}</p>}
+              {email && <p className="text-xs text-fg-secondary truncate mt-1">{email}</p>}
             </div>
           </div>
         </div>
@@ -134,14 +134,14 @@ export function UserProfileDropdownPanel({
               `}
             >
               <div className="oc-icon-tile mr-4 h-10 w-10">
-                <Icon className="w-5 h-5 text-fg-secondary transition-colors duration-200 group-hover:text-foreground" />
+                <Icon className="w-5 h-5 text-fg-secondary transition-colors duration-200 group-hover:text-fg-primary" />
               </div>
               <div className="flex-1 text-left">
-                <div className="font-semibold text-foreground transition-colors duration-200">
+                <div className="font-semibold text-fg-primary transition-colors duration-200">
                   {item.label}
                 </div>
                 {showDescriptions && (
-                  <div className="text-sm text-muted-foreground group-hover:text-muted-foreground transition-colors duration-200">
+                  <div className="text-sm text-fg-secondary group-hover:text-fg-secondary transition-colors duration-200">
                     {item.description}
                   </div>
                 )}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -126,7 +126,7 @@ const FormDescription = React.forwardRef<
     <p
       ref={ref}
       id={formDescriptionId}
-      className={cn('text-[0.8rem] text-muted-foreground', className)}
+      className={cn('text-[0.8rem] text-fg-secondary', className)}
       {...props}
     />
   );

--- a/src/components/ui/skeletons/component-variants.tsx
+++ b/src/components/ui/skeletons/component-variants.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '../Skeleton';
 
 export function ProjectCardSkeleton() {
   return (
-    <div className="flex flex-col overflow-hidden rounded-lg border border-border-subtle bg-card shadow-sm">
+    <div className="flex flex-col overflow-hidden rounded-lg border border-border-subtle bg-surface-base shadow-sm">
       <Skeleton className="aspect-[16/10] w-full rounded-t-lg" />
       <div className="flex flex-col gap-4 p-5">
         <Skeleton className="h-6 w-20 rounded-full" />
@@ -30,7 +30,7 @@ export function ProjectCardSkeleton() {
 
 export function TimelinePostSkeleton() {
   return (
-    <div className="flex gap-3 px-4 py-4 border-b border-border bg-card">
+    <div className="flex gap-3 px-4 py-4 border-b border-border bg-surface-base">
       <Skeleton className="h-11 w-11 rounded-full flex-shrink-0" />
       <div className="flex-1 space-y-3">
         <div className="flex items-center gap-2">
@@ -71,7 +71,7 @@ export function ProfileHeaderSkeleton() {
 
 export function DashboardStatSkeleton() {
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-border bg-card p-6">
+    <div className="flex flex-col gap-2 rounded-lg border border-border bg-surface-base p-6">
       <Skeleton className="h-4 w-24 mb-2" />
       <Skeleton className="h-8 w-32" />
       <Skeleton className="h-3 w-20 mt-2" />
@@ -120,7 +120,7 @@ export function PageHeaderSkeleton() {
 export function LoanCardSkeleton({ viewMode = 'grid' }: { viewMode?: 'grid' | 'list' }) {
   if (viewMode === 'list') {
     return (
-      <div className="flex items-center gap-4 p-4 rounded-lg border border-border bg-card">
+      <div className="flex items-center gap-4 p-4 rounded-lg border border-border bg-surface-base">
         <Skeleton className="w-12 h-12 rounded-full flex-shrink-0" />
         <div className="flex-1 min-w-0 space-y-2">
           <Skeleton className="h-5 w-48" />
@@ -135,7 +135,7 @@ export function LoanCardSkeleton({ viewMode = 'grid' }: { viewMode?: 'grid' | 'l
   }
 
   return (
-    <div className="flex flex-col overflow-hidden rounded-lg border border-border-subtle bg-card shadow-sm p-4">
+    <div className="flex flex-col overflow-hidden rounded-lg border border-border-subtle bg-surface-base shadow-sm p-4">
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-2">
           <Skeleton className="h-8 w-8 rounded-full" />
@@ -172,7 +172,7 @@ export function LoanCardSkeleton({ viewMode = 'grid' }: { viewMode?: 'grid' | 'l
 export function ProfileCardSkeleton({ viewMode = 'grid' }: { viewMode?: 'grid' | 'list' }) {
   if (viewMode === 'list') {
     return (
-      <div className="flex items-center gap-4 p-4 rounded-lg border border-border bg-card">
+      <div className="flex items-center gap-4 p-4 rounded-lg border border-border bg-surface-base">
         <Skeleton className="w-12 h-12 rounded-full flex-shrink-0" />
         <div className="flex-1 min-w-0 space-y-2">
           <div className="flex items-center gap-2">
@@ -188,7 +188,7 @@ export function ProfileCardSkeleton({ viewMode = 'grid' }: { viewMode?: 'grid' |
   }
 
   return (
-    <div className="p-6 rounded-lg border border-border bg-card">
+    <div className="p-6 rounded-lg border border-border bg-surface-base">
       <div className="text-center">
         <Skeleton className="w-20 h-20 rounded-full mx-auto mb-4" />
         <div className="flex items-center justify-center gap-2 mb-2">

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -15,10 +15,10 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-sm',
-          description: 'group-[.toast]:text-muted-foreground',
+            'group toast group-[.toaster]:bg-surface-page group-[.toaster]:text-fg-primary group-[.toaster]:border-border group-[.toaster]:shadow-sm',
+          description: 'group-[.toast]:text-fg-secondary',
           actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
-          cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+          cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-fg-secondary',
         },
       }}
       {...props}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -19,7 +19,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
+        'pointer-events-none block h-4 w-4 rounded-full bg-surface-page shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
       )}
     />
   </SwitchPrimitives.Root>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+      'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-fg-secondary',
       className
     )}
     {...props}
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-surface-page data-[state=active]:text-fg-primary data-[state=active]:shadow',
       className
     )}
     {...props}

--- a/src/components/wallets/LightningAddressCard.tsx
+++ b/src/components/wallets/LightningAddressCard.tsx
@@ -16,6 +16,7 @@
 
 import { useState } from 'react';
 import { Zap, Copy, Check, AlertTriangle } from 'lucide-react';
+import { API_ROUTES } from '@/config/api-routes';
 import type { ReceiveStatus } from '@/app/(authenticated)/dashboard/wallets/hooks/useReceiveStatus';
 
 interface LightningAddressCardProps {
@@ -65,7 +66,7 @@ export function LightningAddressCard({ status, isLoading }: LightningAddressCard
     setTestResult(null);
     try {
       const res = await fetch(
-        `/api/lnurlp/${encodeURIComponent(status.username ?? '')}/callback?amount=${TEST_AMOUNT_MSAT}`
+        `${API_ROUTES.LNURLP.CALLBACK(status.username ?? '')}?amount=${TEST_AMOUNT_MSAT}`
       );
       const body = (await res.json()) as { pr?: string; status?: string; reason?: string };
       setTestResult(

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -26,6 +26,7 @@ export const API_ROUTES = {
     NUDGES: '/api/cat/nudges',
     CONVERSATIONS: '/api/cat/conversations',
     CONVERSATION: (id: string) => `/api/cat/conversations/${id}`,
+    OFFERS_FROM_TEXT: '/api/cat/offers-from-text',
   },
   SEARCH: {
     LOG: '/api/search/log',
@@ -38,6 +39,8 @@ export const API_ROUTES = {
     BASE: '/api/webhook-endpoints',
     BY_ID: (id: string) => `/api/webhook-endpoints/${id}`,
     DELIVERIES: (id: string) => `/api/webhook-endpoints/${id}/deliveries`,
+    DELIVERY_REPLAY: (id: string, deliveryId: string) =>
+      `/api/webhook-endpoints/${id}/deliveries/${deliveryId}/replay`,
   },
   DISCOVER: {
     COUNTS: '/api/discover/counts',
@@ -59,6 +62,7 @@ export const API_ROUTES = {
     BASE: ENTITY_REGISTRY['wallet'].apiEndpoint,
     TRANSFER: '/api/wallets/transfer',
     ENTITY_VISIBILITY: '/api/wallets/entity-visibility',
+    RECEIVE_STATUS: '/api/wallets/receive-status',
   },
   ENTITY_WALLETS: '/api/entity-wallets',
   NOTIFICATIONS: {
@@ -95,6 +99,11 @@ export const API_ROUTES = {
     FORM_PREFILL: '/api/ai/form-prefill',
     IMAGES_GENERATE: '/api/ai/images/generate',
     IMAGES_SUGGEST: '/api/ai/images/suggest',
+    WRITING: {
+      TOPICS: '/api/ai/writing/topics',
+      DRAFT: '/api/ai/writing/draft',
+      REVISE: '/api/ai/writing/revise',
+    },
   },
   AUTH: {
     CALLBACK: '/api/auth/callback',
@@ -120,10 +129,26 @@ export const API_ROUTES = {
   },
   USER: {
     API_KEYS: '/api/user/api-keys',
+    AVAILABLE_MODELS: '/api/user/available-models',
     STATS: '/api/users/me/stats',
   },
   PAYMENTS: {
     BASE: '/api/payments',
+    BY_ID: (id: string) => `/api/payments/${id}`,
+    RECEIVE_INFO: '/api/payments/receive-info',
+    RECIPIENT_CONFIRMATIONS: '/api/payments/recipient-confirmations',
+    CAN_RECEIVE: '/api/payments/can-receive',
+  },
+  TIPS: {
+    RECEIVE_INFO: '/api/tips/receive-info',
+    INVOICE: '/api/tips/invoice',
+    STATUS: '/api/tips/status',
+  },
+  INTEGRATIONS: {
+    FLEETCROWN_BUILD_INTENTS: '/api/integrations/fleetcrown/build-intents',
+  },
+  LNURLP: {
+    CALLBACK: (username: string) => `/api/lnurlp/${encodeURIComponent(username)}/callback`,
   },
   PROJECTS: {
     BASE: ENTITY_REGISTRY['project'].apiEndpoint,

--- a/src/config/cat-actions.ts
+++ b/src/config/cat-actions.ts
@@ -33,6 +33,7 @@ import {
   ShieldAlert,
   type LucideIcon,
 } from 'lucide-react';
+import { API_ROUTES } from '@/config/api-routes';
 import { getApiEndpoint } from '@/config/entity-registry';
 
 // ==================== ACTION TYPES ====================
@@ -654,7 +655,7 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
       'Send a thank you to my supporter',
       'Reach out to that Bitcoin developer',
     ],
-    apiEndpoint: '/api/messages',
+    apiEndpoint: API_ROUTES.MESSAGES.BASE,
     enabled: true,
   },
 
@@ -834,7 +835,7 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
       'Set up a group for collaborators',
       'Start a company on OrangeCat',
     ],
-    apiEndpoint: '/api/groups',
+    apiEndpoint: API_ROUTES.GROUPS.BASE,
     enabled: true,
   },
 
@@ -1016,7 +1017,7 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
       'Add a high priority task to follow up with investors',
       'Remind me to update my service listing by Friday',
     ],
-    apiEndpoint: '/api/tasks',
+    apiEndpoint: API_ROUTES.TASKS.BASE,
     enabled: true,
   },
 
@@ -1047,7 +1048,7 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
       'I finished the invoice task, mark it complete',
       'Done with that — check it off',
     ],
-    apiEndpoint: '/api/tasks/:id/complete',
+    apiEndpoint: API_ROUTES.TASKS.COMPLETE(':id'),
     enabled: true,
   },
 

--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -164,6 +164,7 @@ export const DATABASE_TABLES = {
 
   // Search / embeddings
   CONTENT_EMBEDDINGS: 'content_embeddings',
+  MATCH_INTRODUCTIONS: 'match_introductions',
 
   // Collaboration
   PROJECT_ROLES: 'project_roles',

--- a/src/config/entities/assets.tsx
+++ b/src/config/entities/assets.tsx
@@ -16,6 +16,7 @@ import { Asset } from '@/types/asset';
 import Link from 'next/link';
 import Button from '@/components/ui/Button';
 import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
+import { formatCurrency } from '@/services/currency';
 import { ROUTES } from '@/config/routes';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { GRADIENTS } from '@/config/gradients';
@@ -39,7 +40,7 @@ export const assetEntityConfig: EntityConfig<Asset> = {
   makeCardProps: asset => {
     // Build value label
     const valueLabel = asset.estimated_value
-      ? `${asset.estimated_value.toLocaleString()} ${asset.currency || PLATFORM_DEFAULT_CURRENCY}`
+      ? formatCurrency(asset.estimated_value, asset.currency || PLATFORM_DEFAULT_CURRENCY)
       : undefined;
 
     // Format asset type for display

--- a/src/config/entities/loans.tsx
+++ b/src/config/entities/loans.tsx
@@ -11,6 +11,7 @@ import { Loan } from '@/types/loans';
 import Link from 'next/link';
 import Button from '@/components/ui/Button';
 import { PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
+import { formatCurrency } from '@/services/currency';
 import { ROUTES } from '@/config/routes';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { getStatusBadge } from '@/config/entity-status';
@@ -34,7 +35,7 @@ export const loanEntityConfig: EntityConfig<Loan> = {
   makeCardProps: loan => {
     // Build remaining balance label
     const balanceLabel = loan.remaining_balance
-      ? `${loan.remaining_balance.toLocaleString()} ${loan.currency || PLATFORM_DEFAULT_CURRENCY} remaining`
+      ? `${formatCurrency(loan.remaining_balance, loan.currency || PLATFORM_DEFAULT_CURRENCY)} remaining`
       : undefined;
 
     // Build metadata parts

--- a/src/config/public-api.ts
+++ b/src/config/public-api.ts
@@ -15,6 +15,13 @@ import type { EntityType } from '@/config/entity-registry';
 
 export const PUBLIC_API_VERSION = 'v1' as const;
 export const PUBLIC_API_BASE = `/api/${PUBLIC_API_VERSION}` as const;
+/**
+ * v1 OpenAPI document (served by src/app/api/v1/openapi.json/route.ts).
+ * Written as a static literal so audit:routes can resolve it; the type
+ * annotation compile-errors if it ever drifts from PUBLIC_API_BASE.
+ */
+export const PUBLIC_API_OPENAPI_PATH: `${typeof PUBLIC_API_BASE}/openapi.json` =
+  '/api/v1/openapi.json';
 
 /**
  * Entity types whose POST is part of the v1 contract.

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -269,6 +269,7 @@ export const ROUTES = {
   WALLETS: '/wallets',
   CREATE: '/create',
   STUDY_BITCOIN: '/study-bitcoin',
+  BITCOIN_WALLET_GUIDE: '/bitcoin-wallet-guide',
   ONBOARDING: {
     // /onboarding is a redirect-only entry point (legacy bookmarks).
     // The live surface is INTELLIGENT — the standard multi-step wizard
@@ -379,9 +380,11 @@ export const ROUTES = {
     WISHLISTS: ENTITY_REGISTRY['wishlist'].basePath,
     TASKS: '/dashboard/tasks',
     TASKS_NEW: '/dashboard/tasks/new',
+    TASKS_VIEW: (id: string) => `/dashboard/tasks/${id}`,
     TASKS_ANALYTICS: '/dashboard/tasks/analytics',
     RESEARCH: ENTITY_REGISTRY['research'].basePath,
     BOOKINGS: '/dashboard/bookings',
+    BOOKINGS_VIEW: (id: string) => `/dashboard/bookings/${id}`,
     CAT: '/dashboard/cat',
     CAT_PERMISSIONS: '/dashboard/cat',
     // Post-auth landing for new users — Cat is the primary interface.
@@ -417,6 +420,8 @@ export const ROUTES = {
   // Messages routes
   MESSAGES: '/messages',
   MESSAGE_CONVERSATION: (conversationId: string) => `/messages/${conversationId}`,
+  // Same conversation via query param (keeps the split-pane list view mounted)
+  MESSAGES_WITH_CONVERSATION: (conversationId: string) => `/messages?id=${conversationId}`,
 
   // Settings routes
   SETTINGS: '/settings',

--- a/src/features/messaging/hooks/usePresenceActivity.ts
+++ b/src/features/messaging/hooks/usePresenceActivity.ts
@@ -62,6 +62,10 @@ export function usePresenceActivity({
     };
 
     const handleBeforeUnload = () => {
+      // Pre-existing dead endpoint: no /api/presence/offline handler exists, so this
+      // beacon 404s silently. Kept as a literal (not in API_ROUTES) so audit:routes
+      // doesn't declare a phantom route; remove or implement the handler to close this.
+      // eslint-disable-next-line no-restricted-syntax -- see above
       navigator.sendBeacon?.('/api/presence/offline', JSON.stringify({ userId }));
     };
 

--- a/src/hooks/useAvailableModels.ts
+++ b/src/hooks/useAvailableModels.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { API_ROUTES } from '@/config/api-routes';
 import type { ModelAccess } from '@/services/cat/model-access';
 
 /**
@@ -17,7 +18,7 @@ export function useAvailableModels(): { access: ModelAccess | null; loading: boo
     let alive = true;
     (async () => {
       try {
-        const res = await fetch('/api/user/available-models');
+        const res = await fetch(API_ROUTES.USER.AVAILABLE_MODELS);
         if (!res.ok) {
           return;
         }

--- a/src/hooks/useProfileTheme.ts
+++ b/src/hooks/useProfileTheme.ts
@@ -2,6 +2,7 @@
 
 import { fromTable } from '@/lib/supabase/untyped';
 import { useEffect, useCallback, useRef } from 'react';
+import { logger } from '@/utils/logger';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { useTheme } from 'next-themes';
 import { useAuth } from '@/hooks/useAuth';
@@ -50,8 +51,8 @@ export function useProfileTheme() {
       const { error } = await fromTable(supabase, DATABASE_TABLES.PROFILES)
         .update({ preferences: { ...currentPrefs, theme: newTheme } })
         .eq('id', user.id);
-      if (error && process.env.NODE_ENV === 'development') {
-        console.warn('[useProfileTheme] failed to save theme preference:', error.message);
+      if (error) {
+        logger.warn('failed to save theme preference', error.message, 'useProfileTheme');
       }
     },
     [user?.id]

--- a/src/hooks/useSellerPaymentMethods.ts
+++ b/src/hooks/useSellerPaymentMethods.ts
@@ -11,6 +11,7 @@
 
 'use client';
 
+import { API_ROUTES } from '@/config/api-routes';
 import { useState, useEffect } from 'react';
 
 interface SellerPaymentInfo {
@@ -32,7 +33,7 @@ export function useSellerPaymentMethods(sellerProfileId: string | null): SellerP
     async function check() {
       try {
         const res = await fetch(
-          `/api/payments/can-receive?profile_id=${encodeURIComponent(sellerProfileId!)}`
+          `${API_ROUTES.PAYMENTS.CAN_RECEIVE}?profile_id=${encodeURIComponent(sellerProfileId!)}`
         );
         const body = res.ok ? await res.json() : null;
         if (!cancelled) {

--- a/src/services/articles/ai-client.ts
+++ b/src/services/articles/ai-client.ts
@@ -3,6 +3,7 @@
  * typed drafts/topics, or throw a friendly Error the composer can surface.
  */
 
+import { API_ROUTES } from '@/config/api-routes';
 import type {
   ArticleDraft,
   PostDraft,
@@ -36,18 +37,18 @@ export function fetchWritingTopics(opts: {
   count?: number;
   focus?: string;
 }): Promise<ProposedTopic[]> {
-  return postJson<{ topics: ProposedTopic[] }>('/api/ai/writing/topics', opts).then(d => d.topics);
+  return postJson<{ topics: ProposedTopic[] }>(API_ROUTES.AI.WRITING.TOPICS, opts).then(d => d.topics);
 }
 
 export function fetchArticleDraft(opts: { topic?: string; focus?: string }): Promise<ArticleDraft> {
-  return postJson<{ draft: ArticleDraft }>('/api/ai/writing/draft', {
+  return postJson<{ draft: ArticleDraft }>(API_ROUTES.AI.WRITING.DRAFT, {
     mode: 'article',
     ...opts,
   }).then(d => d.draft);
 }
 
 export function fetchPostDraft(opts: { topic?: string; focus?: string }): Promise<PostDraft> {
-  return postJson<{ draft: PostDraft }>('/api/ai/writing/draft', { mode: 'post', ...opts }).then(
+  return postJson<{ draft: PostDraft }>(API_ROUTES.AI.WRITING.DRAFT, { mode: 'post', ...opts }).then(
     d => d.draft
   );
 }
@@ -61,7 +62,7 @@ export function fetchReplyDraft(opts: {
   parentAuthor?: string;
   intent?: ReplyIntent;
 }): Promise<PostDraft> {
-  return postJson<{ draft: PostDraft }>('/api/ai/writing/draft', {
+  return postJson<{ draft: PostDraft }>(API_ROUTES.AI.WRITING.DRAFT, {
     mode: 'reply',
     ...opts,
   }).then(d => d.draft);
@@ -81,12 +82,12 @@ export function reviseArticleText(opts: {
   /** 'post' for short timeline posts (short + length-clamped); default 'article'. */
   kind?: 'post' | 'article';
 }): Promise<string> {
-  return postJson<{ result: string }>('/api/ai/writing/revise', opts).then(d => d.result);
+  return postJson<{ result: string }>(API_ROUTES.AI.WRITING.REVISE, opts).then(d => d.result);
 }
 
 /** Suggest sharper headline options grounded in the article body. */
 export function suggestArticleTitles(body: string): Promise<string[]> {
-  return postJson<{ suggestions: string[] }>('/api/ai/writing/revise', {
+  return postJson<{ suggestions: string[] }>(API_ROUTES.AI.WRITING.REVISE, {
     action: 'title',
     text: body,
   }).then(d => d.suggestions);
@@ -94,7 +95,7 @@ export function suggestArticleTitles(body: string): Promise<string[]> {
 
 /** Generate a one-line excerpt/hook from the article body. */
 export function generateArticleExcerpt(body: string, title?: string): Promise<string> {
-  return postJson<{ result: string }>('/api/ai/writing/revise', {
+  return postJson<{ result: string }>(API_ROUTES.AI.WRITING.REVISE, {
     action: 'excerpt',
     text: body,
     title,

--- a/src/services/match/reverseMatch.ts
+++ b/src/services/match/reverseMatch.ts
@@ -98,7 +98,7 @@ export async function introduceMatches(
 
       // Idempotency: introduce each (supply, demand) pair at most once. The
       // unique constraint turns a duplicate into an insert error we skip on.
-      const { error: dupErr } = await supabase.from('match_introductions').insert({
+      const { error: dupErr } = await supabase.from(DATABASE_TABLES.MATCH_INTRODUCTIONS).insert({
         supply_type: supply.entity_type,
         supply_id: supply.entity_id,
         demand_type: demand.entity_type,

--- a/src/services/timeline/formatters/index.ts
+++ b/src/services/timeline/formatters/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { LucideIcon } from 'lucide-react';
+import { formatCurrency } from '@/services/currency';
 import {
   Heart,
   MessageCircle,
@@ -161,7 +162,7 @@ export function getEventDisplayType(eventType: TimelineEventType): string {
  */
 export function formatAmount(event: TimelineEvent): string | undefined {
   if (event.amountBtc) {
-    return `₿${event.amountBtc.toFixed(8)}`;
+    return formatCurrency(event.amountBtc, 'BTC');
   }
   return undefined;
 }

--- a/src/services/tips/tip-client.ts
+++ b/src/services/tips/tip-client.ts
@@ -3,6 +3,7 @@
  * shapes (erased at compile — no server code pulled into the bundle).
  */
 
+import { API_ROUTES } from '@/config/api-routes';
 import type { TipInvoice, TipReceiveInfo, TipStatusResult } from '@/domain/tips/tip-service';
 
 export type { TipInvoice, TipReceiveInfo, TipStatusResult } from '@/domain/tips/tip-service';
@@ -19,7 +20,7 @@ function errorMessage(json: { error?: unknown }, fallback: string): string {
 }
 
 export async function fetchTipReceiveInfo(username: string): Promise<TipReceiveInfo> {
-  const res = await fetch(`/api/tips/receive-info?username=${encodeURIComponent(username)}`);
+  const res = await fetch(`${API_ROUTES.TIPS.RECEIVE_INFO}?username=${encodeURIComponent(username)}`);
   const json = await readJson(res);
   if (!res.ok || !json.success) {
     throw new Error(errorMessage(json, 'Could not load tip info.'));
@@ -28,7 +29,7 @@ export async function fetchTipReceiveInfo(username: string): Promise<TipReceiveI
 }
 
 export async function fetchTipInvoice(username: string, amountBtc: number): Promise<TipInvoice> {
-  const res = await fetch('/api/tips/invoice', {
+  const res = await fetch(API_ROUTES.TIPS.INVOICE, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, amountBtc }),
@@ -42,7 +43,7 @@ export async function fetchTipInvoice(username: string, amountBtc: number): Prom
 
 /** Poll whether a tip has settled, using the intent id + bearer token. */
 export async function fetchTipStatus(intentId: string, token: string): Promise<TipStatusResult> {
-  const res = await fetch('/api/tips/status', {
+  const res = await fetch(API_ROUTES.TIPS.STATUS, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ intentId, token }),


### PR DESCRIPTION
## Audit slice 3 — literal sweep + enforcement (see docs/AUDIT_REPORT.md, 2026-08-02)

- **API_ROUTES**: ~20 new entries (AI writing, tips, payments, wallets receive-status, webhook delivery replay, FleetCrown build-intents, LNURL callback, offers-from-text), all 33 audited `/api/` literals swept — plus one adjacent find (`useSellerPaymentMethods`).
- **ROUTES**: param-fns added (messages conversation, task view, booking view) and 20 app-route literals swept.
- **Currency SSOT**: components → `useDisplayCurrency`; services/config → `formatCurrency` from `@/services/currency`; stray `'CHF'` literal → `PLATFORM_DEFAULT_CURRENCY`.
- **Singletons**: `DATABASE_TABLES.MATCH_INTRODUCTIONS` (last raw table name), `useProfileTheme` → logger, 320px skeleton overflow, CatCreditsPanel de-Bitcoin-Oranged (credits ≠ Bitcoin balances; CTA → `bg-accent-warm`), 5 touch targets to ≥44px, hover-only dismiss made touch-visible.
- **Legacy class tail**: all 16 `ui/` primitives converted — repo-wide count of `bg-card`/`text-foreground`/`text-muted-foreground`/`bg-background` is now **0**. (`tiffany` config colors deliberately untouched — separate design decision.)
- **Never-twice**: ESLint `no-restricted-syntax` gate bans new `/api/` string literals outside `src/config` + `src/app/api` (+middleware/robots/tests). Proven to fire on a synthetic violation.

### Found along the way
`/api/presence/offline` (unload beacon in `usePresenceActivity`) has **no route handler** — it has always 404'd silently. Left as an eslint-disabled literal with a comment; implement-or-remove is a small follow-up.

## Verification
`npm run verify` fully green in an isolated worktree: type-check ✓, route audit 0 broken, lint 0 errors (warning count identical to main baseline), 1454/1454 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)