### PR TITLE
fix(auth): make the hydration ceiling absolute — flapping store reset it forever

### DIFF
--- a/src/hooks/useAuthRedirects.ts
+++ b/src/hooks/useAuthRedirects.ts
@@ -26,15 +26,20 @@ const HYDRATION_TIMEOUT_MS = 4_000;
  * HYDRATION_TIMEOUT_MS, so consumers can stop gating on `!hydrated` forever.
  * Shared by useRequireAuth and useAuth so both hook families honor the ceiling.
  */
-export function useHydrationCeiling(hydrated: boolean, isLoading: boolean): boolean {
+export function useHydrationCeiling(_hydrated: boolean, _isLoading: boolean): boolean {
   const [hydrationTimedOut, setHydrationTimedOut] = useState(false);
+  // ONE absolute timer from mount — deliberately not keyed on auth state.
+  // The previous version cleared + restarted the timer whenever hydrated/
+  // isLoading changed, so a FLAPPING auth store (a wedged Supabase session
+  // whose token refresh 400s and retries, toggling isLoading) reset the
+  // ceiling forever and auth-gated pages pinned on their spinner — the
+  // exact failure the ceiling exists to end. Firing after auth resolved
+  // normally is harmless: consumers read real state first and the flag only
+  // widens the exit. Params kept (unused) so call sites stay stable.
   useEffect(() => {
-    if (hydrated && !isLoading) {
-      return undefined;
-    }
     const timer = setTimeout(() => setHydrationTimedOut(true), HYDRATION_TIMEOUT_MS);
     return () => clearTimeout(timer);
-  }, [hydrated, isLoading]);
+  }, []);
   return hydrationTimedOut;
 }
 


### PR DESCRIPTION
## Problem

`useHydrationCeiling` restarted its 4s escape timer on every `[hydrated, isLoading]` change. A wedged Supabase session (refresh-token 400 retry loop) flaps `isLoading`, so the timer reset forever and every auth-gated page (`/settings/ai`, dashboard subpages) pinned on its full-screen spinner — the exact failure the ceiling was built to end. Observed live: `/settings/ai` unrenderable in a real browser session while `/settings/usage` (no client auth gate) rendered instantly.

## Fix

One absolute timer from mount (`[]` deps), never keyed on auth state. Firing after auth resolved normally is harmless: consumers read real state first and the flag only widens the exit. Params kept (unused, underscore-prefixed) so call sites stay stable. Middleware already 307s logged-out users away from `/settings/*`, so the client gate is belt-and-braces — freeing it at 4s is safe.

## Verify

`npm run verify` green — 0 lint errors, 1463/1463 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)