### PR TITLE
fix(api): rate-limit + validate unguarded mutating routes, route-walker gate (audit slice 2)

### DIFF
--- a/__tests__/unit/api-route-guards.test.ts
+++ b/__tests__/unit/api-route-guards.test.ts
@@ -1,0 +1,122 @@
+/**
+ * API route guard gate — walks every route.ts under src/app/api and pins two
+ * invariants for mutating handlers (POST/PUT/PATCH/DELETE):
+ *
+ *   1. AUTH: the route authenticates the caller (or is explicitly allowlisted
+ *      as an intentionally-public mutator, each with a reason).
+ *   2. RATE LIMIT: the route rate-limits writes (directly, via the loan/entity
+ *      factories that limit internally, or is explicitly allowlisted).
+ *
+ * This is a source-level heuristic, not a runtime test: it can't prove a guard
+ * fires, but it makes silently shipping a new unguarded mutating route
+ * impossible. If this test fails on a new route, add the guard — only add an
+ * allowlist entry when the route is public/unlimited BY DESIGN, and say why.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const API_ROOT = path.join(process.cwd(), 'src', 'app', 'api');
+
+/** Collect every route.ts under src/app/api, as paths relative to API_ROOT. */
+function collectRouteFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectRouteFiles(full));
+    } else if (entry.name === 'route.ts') {
+      results.push(path.relative(API_ROOT, full).split(path.sep).join('/'));
+    }
+  }
+  return results;
+}
+
+/** Does the file export a mutating HTTP handler? */
+const MUTATING_EXPORT =
+  /export\s+(?:async\s+)?(?:function|const)\s+(?:POST|PUT|PATCH|DELETE)\b|export\s*\{[^}]*\b(?:POST|PUT|PATCH|DELETE)\b[^}]*\}/;
+
+/**
+ * Pure re-export routes (the /api/v1 façade) delegate their guards to the
+ * target internal route, which this walker also visits — skip them.
+ */
+const DELEGATED_REEXPORT = /export\s*\{[^}]*\}\s*from\s*['"]@\/app\/api\//;
+
+/**
+ * Evidence of authentication. Factory tokens count because the factories
+ * (entityCrudHandler / entityPostHandler) authenticate internally.
+ */
+const AUTH_TOKENS =
+  /withAuth|withOptionalAuth|createEntityCrudHandlers|createEntityPostHandler|entityPostHandler|resolveRequestAuth|verifyCronSecret|getAuthenticatedUserId|auth\.getUser|REINDEX_SECRET/;
+
+/** Intentionally-public mutating routes. Every entry needs a reason. */
+const AUTH_ALLOWLIST: Record<string, string> = {
+  // Session-establishing endpoints: they RECEIVE credentials, so cannot
+  // require an authenticated session; all three are per-IP rate limited.
+  'auth/callback/route.ts': 'session bootstrap — validates Supabase tokens itself',
+  'auth/verify-captcha/route.ts': 'pre-registration CAPTCHA check',
+  // Anonymous tipping is a product feature (easy UX, non-custodial); abuse is
+  // bounded per-IP and per-recipient instead of per-account.
+  'tips/invoice/route.ts': 'anonymous tip invoice mint by design',
+  'tips/status/route.ts': 'anonymous tip settlement poll by design',
+  // Public support/payment claim flow: anonymous payers hold a capability
+  // token (x-payment-token) instead of an account.
+  'v1/payments/public/route.ts': 'anonymous public-support initiation by design',
+  'v1/payments/public/[id]/route.ts': 'payment-token-gated claim action by design',
+};
+
+/**
+ * Evidence of write rate limiting. The case-insensitive token matches every
+ * limiter in @/lib/rate-limit (rateLimit*, apiRateLimited, loanWriteRateLimit)
+ * and the factories, which rate-limit internally.
+ */
+const RATE_LIMIT_TOKENS = /rateLimit|createEntityCrudHandlers|createEntityPostHandler/i;
+
+/** Mutating routes intentionally left without a write quota. Reasons required. */
+const RATE_LIMIT_ALLOWLIST: Record<string, string> = {
+  'admin/reindex-embeddings/route.ts':
+    'REINDEX_SECRET-gated machine reconciler driven by DB triggers — a quota would drop legitimate reindex bursts',
+};
+
+describe('API route guards (source-level gate)', () => {
+  const routeFiles = collectRouteFiles(API_ROOT);
+  const sources = new Map(
+    routeFiles.map(file => [file, fs.readFileSync(path.join(API_ROOT, file), 'utf8')])
+  );
+  const mutatingRoutes = routeFiles.filter(file => {
+    const source = sources.get(file)!;
+    return MUTATING_EXPORT.test(source) && !DELEGATED_REEXPORT.test(source);
+  });
+
+  it('finds API routes (sanity check that the walker works)', () => {
+    expect(routeFiles.length).toBeGreaterThan(50);
+    expect(mutatingRoutes.length).toBeGreaterThan(50);
+  });
+
+  it('every mutating route authenticates or is explicitly public', () => {
+    const unguarded = mutatingRoutes.filter(
+      file => !AUTH_TOKENS.test(sources.get(file)!) && !(file in AUTH_ALLOWLIST)
+    );
+    expect(unguarded).toEqual([]);
+  });
+
+  it('every mutating route rate-limits writes or is explicitly exempt', () => {
+    const unlimited = mutatingRoutes.filter(
+      file => !RATE_LIMIT_TOKENS.test(sources.get(file)!) && !(file in RATE_LIMIT_ALLOWLIST)
+    );
+    expect(unlimited).toEqual([]);
+  });
+
+  it('allowlists contain no stale entries', () => {
+    // An entry whose route no longer exists — or now carries the guard — is
+    // dead weight that would silently excuse a future regression.
+    const staleAuth = Object.keys(AUTH_ALLOWLIST).filter(
+      file => !mutatingRoutes.includes(file) || AUTH_TOKENS.test(sources.get(file) ?? '')
+    );
+    const staleRateLimit = Object.keys(RATE_LIMIT_ALLOWLIST).filter(
+      file => !mutatingRoutes.includes(file) || RATE_LIMIT_TOKENS.test(sources.get(file) ?? '')
+    );
+    expect(staleAuth).toEqual([]);
+    expect(staleRateLimit).toEqual([]);
+  });
+});

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest } from 'next/server';
 import { apiBadRequest, apiSuccess, apiInternalError } from '@/lib/api/standardResponse';
+import { rateLimit, createRateLimitResponse } from '@/lib/rate-limit';
 import { createServerClient } from '@/lib/supabase/server';
 import { logger } from '@/utils/logger';
 
 export async function POST(request: NextRequest) {
   try {
+    // Unauthenticated session mutation — per-IP limit against token-stuffing.
+    const rl = await rateLimit(request);
+    if (!rl.success) {
+      return createRateLimitResponse(rl);
+    }
+
     const supabase = await createServerClient();
 
     // Safely parse JSON with error handling

--- a/src/app/api/auth/sync/route.ts
+++ b/src/app/api/auth/sync/route.ts
@@ -7,9 +7,16 @@ import {
   apiSuccess,
   apiInternalError,
 } from '@/lib/api/standardResponse';
+import { rateLimit, createRateLimitResponse } from '@/lib/rate-limit';
 
 export async function POST(request: NextRequest) {
   try {
+    // Unauthenticated session mutation — per-IP limit against token-stuffing.
+    const rl = await rateLimit(request);
+    if (!rl.success) {
+      return createRateLimitResponse(rl);
+    }
+
     let body: { accessToken?: string; refreshToken?: string };
     try {
       body = await request.json();

--- a/src/app/api/auth/verify-captcha/route.ts
+++ b/src/app/api/auth/verify-captcha/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { verifyCaptchaToken } from '@/lib/captcha';
 import { logger } from '@/utils/logger';
 import { apiSuccess, apiBadRequest, apiInternalError } from '@/lib/api/standardResponse';
+import { rateLimit, createRateLimitResponse } from '@/lib/rate-limit';
 
 /**
  * POST /api/auth/verify-captcha
@@ -11,6 +12,13 @@ import { apiSuccess, apiBadRequest, apiInternalError } from '@/lib/api/standardR
  */
 export async function POST(request: NextRequest) {
   try {
+    // Unauthenticated + triggers an outbound Turnstile verification per call —
+    // per-IP limit so it can't be used as a verification-spam relay.
+    const rl = await rateLimit(request);
+    if (!rl.success) {
+      return createRateLimitResponse(rl);
+    }
+
     let body: { token?: string };
     try {
       body = await request.json();

--- a/src/app/api/cat/nudges/route.ts
+++ b/src/app/api/cat/nudges/route.ts
@@ -9,6 +9,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextResponse } from 'next/server';
 import { DATABASE_TABLES } from '@/config/database-tables';
+import { apiRateLimited } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { createServerClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { generateNudges } from '@/services/cat/nudges';
@@ -108,6 +110,10 @@ export async function POST(request: Request) {
   } = await auth.auth.getUser();
   if (!user) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
   }
   const body = await request.json().catch(() => ({}));
   if (body?.action !== 'dismiss' || !body?.id) {

--- a/src/app/api/cat/offers-from-text/route.ts
+++ b/src/app/api/cat/offers-from-text/route.ts
@@ -17,6 +17,8 @@
 
 import { NextResponse } from 'next/server';
 import { DATABASE_TABLES } from '@/config/database-tables';
+import { apiRateLimited } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { createServerClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { generateOffers } from '@/services/cat/offer-engine';
@@ -33,6 +35,12 @@ export async function POST(request: Request) {
   } = await auth.auth.getUser();
   if (!user) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Every call triggers an LLM completion — per-user write limit.
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
   }
 
   let body: unknown;

--- a/src/app/api/delete-user/route.ts
+++ b/src/app/api/delete-user/route.ts
@@ -10,14 +10,26 @@
  * remain orphaned-but-inaccessible; the account itself can no longer sign in.
  */
 
-import { apiSuccess, apiInternalError, handleApiError } from '@/lib/api/standardResponse';
+import {
+  apiSuccess,
+  apiInternalError,
+  apiRateLimited,
+  handleApiError,
+} from '@/lib/api/standardResponse';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { getAdminClient } from '@/lib/supabase/admin';
 import { logger } from '@/utils/logger';
 
 export const POST = withAuth(async (request: AuthenticatedRequest) => {
   try {
     const { user } = request;
+
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+    }
+
     const admin = getAdminClient();
 
     const { error } = await admin.auth.admin.deleteUser(user.id);

--- a/src/app/api/groups/[slug]/members/route.ts
+++ b/src/app/api/groups/[slug]/members/route.ts
@@ -73,7 +73,6 @@ export const POST = withAuth(async (request: AuthenticatedRequest, context: Rout
       return apiRateLimited('Too many requests. Please slow down.', retryAfter);
     }
 
-    const _body = await request.json();
     const supabase = request.supabase;
 
     // Get group first

--- a/src/app/api/integration-keys/[id]/rotate/route.ts
+++ b/src/app/api/integration-keys/[id]/rotate/route.ts
@@ -20,8 +20,10 @@ import {
   apiUnauthorized,
   apiNotFound,
   apiForbidden,
+  apiRateLimited,
   handleApiError,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { rotateIntegrationKey, ActorNotPermittedError } from '@/services/auth/integrationKeys';
 
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -32,6 +34,10 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     } = await supabase.auth.getUser();
     if (!user) {
       return apiUnauthorized();
+    }
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
     }
     const { id } = await params;
     try {

--- a/src/app/api/integration-keys/[id]/route.ts
+++ b/src/app/api/integration-keys/[id]/route.ts
@@ -12,8 +12,10 @@ import {
   apiSuccess,
   apiUnauthorized,
   apiNotFound,
+  apiRateLimited,
   handleApiError,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { revokeIntegrationKey } from '@/services/auth/integrationKeys';
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -24,6 +26,10 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
     } = await supabase.auth.getUser();
     if (!user) {
       return apiUnauthorized();
+    }
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
     }
     const { id } = await params;
     const ok = await revokeIntegrationKey(id, user.id);

--- a/src/app/api/integration-keys/route.ts
+++ b/src/app/api/integration-keys/route.ts
@@ -19,8 +19,10 @@ import {
   apiSuccess,
   apiUnauthorized,
   apiForbidden,
+  apiRateLimited,
   handleApiError,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import {
   createIntegrationKey,
   listIntegrationKeys,
@@ -68,6 +70,10 @@ export const POST = compose(
     const user = await requireSessionUser();
     if (!user) {
       return apiUnauthorized();
+    }
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
     }
     const { name, actor_id, scopes, is_test } = ctx.body as {
       name: string;

--- a/src/app/api/integrations/fleetcrown/build-intents/route.ts
+++ b/src/app/api/integrations/fleetcrown/build-intents/route.ts
@@ -2,9 +2,11 @@ import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import {
   apiBadRequest,
   apiForbidden,
+  apiRateLimited,
   apiServiceUnavailable,
   apiSuccess,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { getEntityMetadata, isValidEntityType } from '@/config/entity-registry';
 import { getAdminClient } from '@/lib/supabase/admin';
 import { getSellerUserId } from '@/domain/payments';
@@ -16,6 +18,11 @@ import type { AnySupabaseClient } from '@/lib/supabase/types';
 const NON_ACTIONABLE = new Set(['wallet', 'document']);
 
 export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  const rl = await rateLimitWriteAsync(request.user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
   const body = (await request.json()) as {
     entity_type?: string;
     entity_id?: string;

--- a/src/app/api/loans/obligation/route.ts
+++ b/src/app/api/loans/obligation/route.ts
@@ -13,6 +13,7 @@ import {
   apiNotFound,
   apiInternalError,
 } from '@/lib/api/standardResponse';
+import { loanWriteRateLimit } from '@/lib/api/loanRoutes';
 import { createObligationLoanSchema } from '@/config/loan-obligation';
 import { createObligationLoan } from '@/domain/loans/obligation';
 import { logger } from '@/utils/logger';
@@ -20,6 +21,11 @@ import { logger } from '@/utils/logger';
 export const POST = withAuth(async (request: AuthenticatedRequest) => {
   try {
     const { user, supabase } = request;
+
+    const limited = await loanWriteRateLimit(user.id);
+    if (limited) {
+      return limited;
+    }
 
     let body: unknown;
     try {

--- a/src/app/api/loans/offers/[id]/respond/route.ts
+++ b/src/app/api/loans/offers/[id]/respond/route.ts
@@ -4,7 +4,7 @@
 
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { apiSuccess, apiInternalError } from '@/lib/api/standardResponse';
-import { loanDomainFailureResponse, parseLoanBody } from '@/lib/api/loanRoutes';
+import { loanDomainFailureResponse, loanWriteRateLimit, parseLoanBody } from '@/lib/api/loanRoutes';
 import { respondToLoanOfferSchema } from '@/config/loan-offers';
 import { respondToLoanOffer } from '@/domain/loans/offers';
 import { logger } from '@/utils/logger';
@@ -17,6 +17,11 @@ export const POST = withAuth(async (request: AuthenticatedRequest, { params }: R
   try {
     const { user, supabase } = request;
     const { id: offerId } = await params;
+
+    const limited = await loanWriteRateLimit(user.id);
+    if (limited) {
+      return limited;
+    }
 
     const parsed = await parseLoanBody(request, respondToLoanOfferSchema);
     if (!parsed.ok) {

--- a/src/app/api/loans/offers/[id]/route.ts
+++ b/src/app/api/loans/offers/[id]/route.ts
@@ -4,7 +4,7 @@
 
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { apiSuccess, apiInternalError } from '@/lib/api/standardResponse';
-import { loanDomainFailureResponse, parseLoanBody } from '@/lib/api/loanRoutes';
+import { loanDomainFailureResponse, loanWriteRateLimit, parseLoanBody } from '@/lib/api/loanRoutes';
 import { updateLoanOfferSchema } from '@/config/loan-offers';
 import { updateLoanOffer } from '@/domain/loans/offers';
 import { logger } from '@/utils/logger';
@@ -17,6 +17,11 @@ export const PUT = withAuth(async (request: AuthenticatedRequest, { params }: Ro
   try {
     const { user, supabase } = request;
     const { id: offerId } = await params;
+
+    const limited = await loanWriteRateLimit(user.id);
+    if (limited) {
+      return limited;
+    }
 
     const parsed = await parseLoanBody(request, updateLoanOfferSchema);
     if (!parsed.ok) {

--- a/src/app/api/loans/offers/route.ts
+++ b/src/app/api/loans/offers/route.ts
@@ -4,7 +4,7 @@
 
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { apiCreated, apiInternalError } from '@/lib/api/standardResponse';
-import { loanDomainFailureResponse, parseLoanBody } from '@/lib/api/loanRoutes';
+import { loanDomainFailureResponse, loanWriteRateLimit, parseLoanBody } from '@/lib/api/loanRoutes';
 import { createLoanOfferSchema } from '@/config/loan-offers';
 import { createLoanOffer } from '@/domain/loans/offers';
 import { logger } from '@/utils/logger';
@@ -12,6 +12,11 @@ import { logger } from '@/utils/logger';
 export const POST = withAuth(async (request: AuthenticatedRequest) => {
   try {
     const { user, supabase } = request;
+
+    const limited = await loanWriteRateLimit(user.id);
+    if (limited) {
+      return limited;
+    }
 
     const parsed = await parseLoanBody(request, createLoanOfferSchema);
     if (!parsed.ok) {

--- a/src/app/api/loans/payments/[id]/complete/route.ts
+++ b/src/app/api/loans/payments/[id]/complete/route.ts
@@ -6,7 +6,7 @@
  */
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { apiSuccess, apiInternalError } from '@/lib/api/standardResponse';
-import { loanDomainFailureResponse, parseLoanBody } from '@/lib/api/loanRoutes';
+import { loanDomainFailureResponse, loanWriteRateLimit, parseLoanBody } from '@/lib/api/loanRoutes';
 import { completeLoanPaymentSchema } from '@/config/loan-payments';
 import { completeLoanPayment } from '@/domain/loans/payments';
 import { logger } from '@/utils/logger';
@@ -19,6 +19,11 @@ export const POST = withAuth(async (request: AuthenticatedRequest, { params }: R
   try {
     const { user, supabase } = request;
     const { id: paymentId } = await params;
+
+    const limited = await loanWriteRateLimit(user.id);
+    if (limited) {
+      return limited;
+    }
 
     // An empty body is valid here — completion without obligation creation.
     const parsed = await parseLoanBody(request, completeLoanPaymentSchema, { allowEmpty: true });

--- a/src/app/api/loans/payments/route.ts
+++ b/src/app/api/loans/payments/route.ts
@@ -3,7 +3,7 @@
  */
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { apiCreated, apiInternalError } from '@/lib/api/standardResponse';
-import { loanDomainFailureResponse, parseLoanBody } from '@/lib/api/loanRoutes';
+import { loanDomainFailureResponse, loanWriteRateLimit, parseLoanBody } from '@/lib/api/loanRoutes';
 import { createLoanPaymentSchema } from '@/config/loan-payments';
 import { createLoanPayment } from '@/domain/loans/payments';
 import { logger } from '@/utils/logger';
@@ -11,6 +11,11 @@ import { logger } from '@/utils/logger';
 export const POST = withAuth(async (request: AuthenticatedRequest) => {
   try {
     const { user, supabase } = request;
+
+    const limited = await loanWriteRateLimit(user.id);
+    if (limited) {
+      return limited;
+    }
 
     const parsed = await parseLoanBody(request, createLoanPaymentSchema);
     if (!parsed.ok) {

--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -7,6 +7,7 @@
  * Thin HTTP layer — business rules live in @/services/notifications/preferences.server.
  */
 
+import { z } from 'zod';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { createAdminClient } from '@/lib/supabase/admin';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
@@ -24,6 +25,10 @@ import {
   updatePreferences,
   type PreferencesResult,
 } from '@/services/notifications/preferences.server';
+
+// Field-level rules live in updatePreferences (the service is the SSOT); this
+// guard only rejects malformed JSON / non-object bodies so they 400, not 500.
+const preferencesBodySchema = z.record(z.unknown());
 
 /** Map a domain PreferencesResult onto the matching HTTP response. */
 function toResponse<T>(result: PreferencesResult<T>) {
@@ -55,7 +60,11 @@ export const PUT = withAuth(async (req: AuthenticatedRequest) => {
       return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
     }
 
-    const body = (await req.json()) as NotificationPreferencesUpdate;
+    const parsed = preferencesBodySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) {
+      return apiBadRequest('Request body must be a JSON object');
+    }
+    const body = parsed.data as NotificationPreferencesUpdate;
     const admin = createAdminClient() as unknown as AnySupabaseClient;
     return toResponse(await updatePreferences(admin, user.id, body));
   } catch (error) {

--- a/src/app/api/project-roles/[id]/route.ts
+++ b/src/app/api/project-roles/[id]/route.ts
@@ -3,7 +3,8 @@
  * Update a role's status (project owner only).
  */
 import { NextRequest } from 'next/server';
-import { apiSuccess, apiError } from '@/lib/api/standardResponse';
+import { apiSuccess, apiError, apiRateLimited } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { getAuthenticatedUserId } from '@/lib/api/authHelpers';
 import { isRoleStatus } from '@/config/project-roles';
 import {
@@ -17,6 +18,10 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   const userId = await getAuthenticatedUserId();
   if (!userId) {
     return apiError('Unauthorized', 'UNAUTHORIZED', 401);
+  }
+  const rl = await rateLimitWriteAsync(userId);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
   }
   try {
     const { id } = await params;

--- a/src/app/api/project-roles/route.ts
+++ b/src/app/api/project-roles/route.ts
@@ -6,7 +6,8 @@
  *      — create a role (project owner only).
  */
 import { NextRequest } from 'next/server';
-import { apiSuccess, apiError } from '@/lib/api/standardResponse';
+import { apiSuccess, apiError, apiRateLimited } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { getAuthenticatedUserId } from '@/lib/api/authHelpers';
 import { isEngagementType } from '@/config/project-roles';
 import {
@@ -36,6 +37,10 @@ export async function POST(request: NextRequest) {
   const userId = await getAuthenticatedUserId();
   if (!userId) {
     return apiError('Unauthorized', 'UNAUTHORIZED', 401);
+  }
+  const rl = await rateLimitWriteAsync(userId);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
   }
   try {
     const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;

--- a/src/app/api/projects/[id]/status/route.ts
+++ b/src/app/api/projects/[id]/status/route.ts
@@ -7,6 +7,7 @@
  * Last Modified Summary: Refactored to use withAuth middleware
  */
 
+import { z } from 'zod';
 import {
   apiSuccess,
   apiUnauthorized,
@@ -28,6 +29,10 @@ interface RouteContext {
   params: Promise<{ id: string }>;
 }
 
+// Value membership + transition rules are checked below against the
+// entity-status config — this only pins the body shape.
+const statusBodySchema = z.object({ status: z.string().min(1) });
+
 // PATCH /api/projects/[id]/status - Update project status
 export const PATCH = withAuth(async (request: AuthenticatedRequest, context: RouteContext) => {
   try {
@@ -45,15 +50,12 @@ export const PATCH = withAuth(async (request: AuthenticatedRequest, context: Rou
     if (idValidation) {
       return idValidation;
     }
-    const body = await request.json();
-    const { status } = body;
-
-    // Validate status
-    if (!status || typeof status !== 'string') {
+    const parsed = statusBodySchema.safeParse(await request.json().catch(() => ({})));
+    if (!parsed.success) {
       return apiValidationError('Status is required');
     }
 
-    const normalizedStatus = status.toLowerCase() as ProjectStatus;
+    const normalizedStatus = parsed.data.status.toLowerCase() as ProjectStatus;
     if (!VALID_PROJECT_STATUSES.includes(normalizedStatus)) {
       return apiValidationError(
         `Invalid status. Must be one of: ${VALID_PROJECT_STATUSES.join(', ')}`

--- a/src/app/api/search/log/route.ts
+++ b/src/app/api/search/log/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { rateLimitWriteAsync } from '@/lib/rate-limit';
 import { createServerClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { DATABASE_TABLES } from '@/config/database-tables';
@@ -17,6 +18,13 @@ export async function POST(request: Request) {
       data: { user },
     } = await auth.auth.getUser();
     if (!user) {
+      return NextResponse.json({ success: true });
+    }
+
+    // Over-quota callers get the same always-success contract — just skip the
+    // write. Logging must never disrupt search, but writes stay bounded.
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
       return NextResponse.json({ success: true });
     }
 

--- a/src/app/api/social/follow/route.ts
+++ b/src/app/api/social/follow/route.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { logger } from '@/utils/logger';
 import {
@@ -9,10 +10,15 @@ import {
   apiRateLimited,
 } from '@/lib/api/standardResponse';
 import { applyRateLimitHeaders, rateLimitSocialAsync, retryAfterSeconds } from '@/lib/rate-limit';
-import { validateUUID, getValidationError } from '@/lib/api/validation';
 import { auditSuccess, AUDIT_ACTIONS } from '@/lib/api/auditLog';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { NotificationDispatcher } from '@/services/notifications/dispatcher';
+
+const followBodySchema = z.object({
+  following_id: z
+    .string({ required_error: 'following_id is required' })
+    .uuid('Invalid following_id format'),
+});
 
 async function handleFollow(request: AuthenticatedRequest) {
   try {
@@ -27,13 +33,11 @@ async function handleFollow(request: AuthenticatedRequest) {
       );
     }
 
-    const { following_id } = await request.json();
-
-    // Validate input using centralized validator
-    const validationError = getValidationError(validateUUID(following_id, 'following_id'));
-    if (validationError) {
-      return validationError;
+    const parsed = followBodySchema.safeParse(await request.json().catch(() => ({})));
+    if (!parsed.success) {
+      return apiBadRequest(parsed.error.errors[0]?.message ?? 'Invalid following_id');
     }
+    const { following_id } = parsed.data;
 
     // Prevent self-following
     if (user.id === following_id) {

--- a/src/app/api/social/unfollow/route.ts
+++ b/src/app/api/social/unfollow/route.ts
@@ -1,10 +1,21 @@
+import { z } from 'zod';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 import { logger } from '@/utils/logger';
-import { apiSuccess, apiInternalError, apiRateLimited } from '@/lib/api/standardResponse';
+import {
+  apiSuccess,
+  apiBadRequest,
+  apiInternalError,
+  apiRateLimited,
+} from '@/lib/api/standardResponse';
 import { applyRateLimitHeaders, rateLimitSocialAsync, retryAfterSeconds } from '@/lib/rate-limit';
-import { validateUUID, getValidationError } from '@/lib/api/validation';
 import { auditSuccess, AUDIT_ACTIONS } from '@/lib/api/auditLog';
 import { DATABASE_TABLES } from '@/config/database-tables';
+
+const unfollowBodySchema = z.object({
+  following_id: z
+    .string({ required_error: 'following_id is required' })
+    .uuid('Invalid following_id format'),
+});
 
 async function handleUnfollow(request: AuthenticatedRequest) {
   try {
@@ -19,13 +30,11 @@ async function handleUnfollow(request: AuthenticatedRequest) {
       );
     }
 
-    const { following_id } = await request.json();
-
-    // Validate input using centralized validator
-    const validationError = getValidationError(validateUUID(following_id, 'following_id'));
-    if (validationError) {
-      return validationError;
+    const parsed = unfollowBodySchema.safeParse(await request.json().catch(() => ({})));
+    if (!parsed.success) {
+      return apiBadRequest(parsed.error.errors[0]?.message ?? 'Invalid following_id');
     }
+    const { following_id } = parsed.data;
 
     // Delete follow relationship
     const { error } = await supabase

--- a/src/app/api/stakeholders/[id]/route.ts
+++ b/src/app/api/stakeholders/[id]/route.ts
@@ -18,7 +18,9 @@ import {
   apiValidationError,
   apiNotFound,
   apiInternalError,
+  apiRateLimited,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { logger } from '@/utils/logger';
 
 const patchSchema = z
@@ -41,7 +43,13 @@ const patchSchema = z
 
 export const PATCH = withAuth(async (request: AuthenticatedRequest, context: unknown) => {
   try {
-    const { supabase } = request;
+    const { user, supabase } = request;
+
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+    }
+
     const { params } = context as { params: Promise<{ id: string }> };
     const { id } = await params;
 
@@ -102,7 +110,13 @@ export const PATCH = withAuth(async (request: AuthenticatedRequest, context: unk
 
 export const DELETE = withAuth(async (request: AuthenticatedRequest, context: unknown) => {
   try {
-    const { supabase } = request;
+    const { user, supabase } = request;
+
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+    }
+
     const { params } = context as { params: Promise<{ id: string }> };
     const { id } = await params;
 

--- a/src/app/api/stakeholders/route.ts
+++ b/src/app/api/stakeholders/route.ts
@@ -32,8 +32,10 @@ import {
   apiValidationError,
   apiNotFound,
   apiInternalError,
+  apiRateLimited,
   apiUnauthorized,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { logger } from '@/utils/logger';
 import { createStakeholderSchema } from '@/config/stakeholders';
 import {
@@ -70,6 +72,11 @@ export const GET = withAuth(async (request: AuthenticatedRequest) => {
 export const POST = withAuth(async (request: AuthenticatedRequest) => {
   try {
     const { user, supabase } = request;
+
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+    }
 
     let body: unknown;
     try {

--- a/src/app/api/v1/payments/public/[id]/route.ts
+++ b/src/app/api/v1/payments/public/[id]/route.ts
@@ -1,6 +1,7 @@
 import {
   apiBadRequest,
   apiNotFound,
+  apiRateLimited,
   apiSuccess,
 } from '@/lib/api/standardResponse';
 import {
@@ -9,6 +10,13 @@ import {
 } from '@/domain/payments';
 import { publicPaymentActionSchema } from '@/lib/validation/finance';
 import { validateUUID, getValidationError } from '@/lib/api/validation';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+
+// Same per-IP keying as ../route.ts — anonymous callers, so IP is the only handle.
+function requestKey(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  return `public-payment-action:${forwarded || request.headers.get('x-real-ip') || 'anonymous'}`;
+}
 
 function readToken(request: Request): string | null {
   const token = request.headers.get('x-payment-token');
@@ -40,6 +48,14 @@ export async function POST(
   request: Request,
   context: { params: Promise<{ id: string }> }
 ) {
+  const limit = await rateLimitWriteAsync(requestKey(request));
+  if (!limit.success) {
+    return apiRateLimited(
+      'Too many payment requests. Please try again shortly.',
+      retryAfterSeconds(limit)
+    );
+  }
+
   const { id } = await context.params;
   const idError = getValidationError(validateUUID(id, 'payment ID'));
   if (idError) {

--- a/src/app/api/v1/stakeholders/route.ts
+++ b/src/app/api/v1/stakeholders/route.ts
@@ -8,7 +8,12 @@
  */
 import { NextRequest } from 'next/server';
 import { resolveRequestAuth, hasScope } from '@/lib/api/resolveRequestAuth';
-import { apiCreated, apiSuccess, apiError } from '@/lib/api/standardResponse';
+import { apiCreated, apiSuccess, apiError, apiRateLimited } from '@/lib/api/standardResponse';
+import {
+  rateLimitIntegrationKeyWrite,
+  rateLimitWriteAsync,
+  retryAfterSeconds,
+} from '@/lib/rate-limit';
 import { createStakeholderSchema } from '@/config/stakeholders';
 import {
   listStakeholderRelationshipsForUser,
@@ -66,6 +71,16 @@ export async function POST(request: NextRequest) {
   }
   if (!auth.userId) {
     return apiError('Authenticated identity has no user id', 'UNAUTHORIZED', 401);
+  }
+
+  // Same bucket split as entityPostHandler: per-key for integration keys so
+  // one buggy key can't starve the user's other keys; per-user otherwise.
+  const rl =
+    auth.source === 'integration_key' && auth.integrationKeyId
+      ? await rateLimitIntegrationKeyWrite(auth.integrationKeyId)
+      : await rateLimitWriteAsync(auth.userId);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
   }
 
   let body: unknown;

--- a/src/app/api/v1/timeline/publish/route.ts
+++ b/src/app/api/v1/timeline/publish/route.ts
@@ -12,7 +12,12 @@
  */
 import { NextRequest } from 'next/server';
 import { resolveRequestAuth, hasScope } from '@/lib/api/resolveRequestAuth';
-import { apiCreated, apiSuccess, apiError } from '@/lib/api/standardResponse';
+import { apiCreated, apiSuccess, apiError, apiRateLimited } from '@/lib/api/standardResponse';
+import {
+  rateLimitIntegrationKeyWrite,
+  rateLimitWriteAsync,
+  retryAfterSeconds,
+} from '@/lib/rate-limit';
 import { externalPublishSchema, isAllowedSourceUrl } from '@/config/external-publish';
 import { ingestExternalEvent } from '@/services/timeline/externalPublish';
 import { logger } from '@/utils/logger';
@@ -32,6 +37,16 @@ export async function POST(request: NextRequest) {
   // an orphaned row.
   if (!auth.userId) {
     return apiError('Authenticated identity has no user id', 'UNAUTHORIZED', 401);
+  }
+
+  // Same bucket split as entityPostHandler: per-key for integration keys so
+  // one buggy key can't starve the user's other keys; per-user otherwise.
+  const rl =
+    auth.source === 'integration_key' && auth.integrationKeyId
+      ? await rateLimitIntegrationKeyWrite(auth.integrationKeyId)
+      : await rateLimitWriteAsync(auth.userId);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
   }
 
   let body: unknown;

--- a/src/app/api/wallets/route.ts
+++ b/src/app/api/wallets/route.ts
@@ -97,7 +97,9 @@ export const POST = withAuth(async (request: AuthenticatedRequest) => {
       );
     }
 
-    const rawBody = await request.json();
+    // Malformed JSON becomes null → walletCreateSchema (the validation SSOT,
+    // applied inside createWallet) rejects it with a 400 instead of a 500.
+    const rawBody = await request.json().catch(() => null);
     const { response } = await createWallet(supabase, user, rawBody);
     return applyRateLimitHeaders(response, rateLimitResult);
   } catch (error) {

--- a/src/app/api/webhook-endpoints/[id]/deliveries/[deliveryId]/replay/route.ts
+++ b/src/app/api/webhook-endpoints/[id]/deliveries/[deliveryId]/replay/route.ts
@@ -25,8 +25,10 @@ import {
   apiUnauthorized,
   apiNotFound,
   apiError,
+  apiRateLimited,
   handleApiError,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { userOwnsEndpoint } from '@/services/webhooks/webhookEndpointsService';
 import {
   deliveryBelongsToEndpoint,
@@ -44,6 +46,11 @@ export async function POST(
     } = await supabase.auth.getUser();
     if (!user) {
       return apiUnauthorized();
+    }
+
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
     }
 
     const { id: endpointId, deliveryId } = await params;

--- a/src/app/api/webhook-endpoints/[id]/route.ts
+++ b/src/app/api/webhook-endpoints/[id]/route.ts
@@ -14,8 +14,10 @@ import {
   apiSuccess,
   apiUnauthorized,
   apiNotFound,
+  apiRateLimited,
   handleApiError,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { revokeWebhookEndpoint } from '@/services/webhooks/webhookEndpointsService';
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -26,6 +28,10 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
     } = await supabase.auth.getUser();
     if (!user) {
       return apiUnauthorized();
+    }
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
     }
     const { id } = await params;
     const ok = await revokeWebhookEndpoint(id, user.id);

--- a/src/app/api/webhook-endpoints/route.ts
+++ b/src/app/api/webhook-endpoints/route.ts
@@ -22,8 +22,10 @@ import {
   apiSuccess,
   apiUnauthorized,
   apiForbidden,
+  apiRateLimited,
   handleApiError,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import {
   createWebhookEndpoint,
   listWebhookEndpoints,
@@ -74,6 +76,10 @@ export const POST = compose(
     const user = await requireSessionUser();
     if (!user) {
       return apiUnauthorized();
+    }
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
     }
     const body = ctx.body as {
       name: string;

--- a/src/lib/api/loanRoutes.ts
+++ b/src/lib/api/loanRoutes.ts
@@ -14,9 +14,11 @@ import {
   apiForbidden,
   apiInternalError,
   apiNotFound,
+  apiRateLimited,
   apiValidationError,
   type ApiErrorResponse,
 } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
 import { logger } from '@/utils/logger';
 
 type ErrorResponse = NextResponse<ApiErrorResponse>;
@@ -49,6 +51,18 @@ export function loanDomainFailureResponse(
       logger.error(`${logLabel} failed`, { message: failure.message }, 'LoansAPI');
       return apiInternalError(failure.message);
   }
+}
+
+/**
+ * Per-user write quota shared by every mutating `/api/loans` route. Returns the
+ * 429 response to send, or null when the caller is within quota.
+ */
+export async function loanWriteRateLimit(userId: string): Promise<ErrorResponse | null> {
+  const rl = await rateLimitWriteAsync(userId);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+  return null;
 }
 
 /**

--- a/tests/unit/app/api/integration-keys/rotate.test.ts
+++ b/tests/unit/app/api/integration-keys/rotate.test.ts
@@ -11,6 +11,15 @@
  * Created: 2026-06-04
  */
 
+// Mocked so importing the route doesn't pull the real Upstash client (ESM-only
+// dep jest can't parse). Within-quota by default; branch tests set overrides.
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimitWriteAsync: jest
+    .fn()
+    .mockResolvedValue({ success: true, limit: 30, remaining: 29, resetTime: Date.now() + 60_000 }),
+  retryAfterSeconds: jest.fn(() => 1),
+}));
+
 jest.mock('@/lib/supabase/server', () => ({
   createServerClient: jest.fn(),
 }));

--- a/tests/unit/app/api/webhook-endpoints/deliveries.test.ts
+++ b/tests/unit/app/api/webhook-endpoints/deliveries.test.ts
@@ -12,6 +12,15 @@
  * Created: 2026-06-04
  */
 
+// Mocked so importing the route doesn't pull the real Upstash client (ESM-only
+// dep jest can't parse). Within-quota by default; branch tests set overrides.
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimitWriteAsync: jest
+    .fn()
+    .mockResolvedValue({ success: true, limit: 30, remaining: 29, resetTime: Date.now() + 60_000 }),
+  retryAfterSeconds: jest.fn(() => 1),
+}));
+
 jest.mock('@/lib/supabase/server', () => ({
   createServerClient: jest.fn(),
 }));

--- a/tests/unit/app/api/webhook-endpoints/route.test.ts
+++ b/tests/unit/app/api/webhook-endpoints/route.test.ts
@@ -12,6 +12,15 @@
  * Created: 2026-06-04
  */
 
+// Mocked so importing the route doesn't pull the real Upstash client (ESM-only
+// dep jest can't parse). Within-quota by default; branch tests set overrides.
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimitWriteAsync: jest
+    .fn()
+    .mockResolvedValue({ success: true, limit: 30, remaining: 29, resetTime: Date.now() + 60_000 }),
+  retryAfterSeconds: jest.fn(() => 1),
+}));
+
 jest.mock('@/lib/supabase/server', () => ({
   createServerClient: jest.fn(),
 }));


### PR DESCRIPTION
## Audit slice 2 — API security gaps (see docs/AUDIT_REPORT.md, 2026-08-02)

The audit found **0 missing-auth routes** but ~22 mutating routes with no rate limiting and ~15 without boundary validation. This closes them and pins both invariants forever.

### Rate limiting
- **Per-IP** on the unauthenticated session surface: `auth/verify-captcha` (outbound Turnstile call per request), `auth/sync`, `auth/callback`
- **Per-user write** limits: `cat/offers-from-text` (LLM invocation per request — cost amplification), all six loan writes via one shared `loanWriteRateLimit` helper, stakeholders POST/PATCH/DELETE, webhook-endpoints incl. delivery **replay** (fires outbound HTTP), integration-keys incl. rotate
- **Integration-key write** limits on `v1/stakeholders` + `v1/timeline/publish` — matching what `entityPostHandler` already did

### Validation
- zod `safeParse` at the boundary for the raw-body mutators: `projects/[id]/status`, `notifications/preferences`, `social/follow` + `unfollow`, `wallets` POST; dead unused `_body` parse removed from `groups/[slug]/members`

### The gate (never-twice)
`__tests__/unit/api-route-guards.test.ts` walks every `src/app/api/**/route.ts` and asserts: every mutating route **authenticates** (or is allowlisted with a reason — session bootstrap, anonymous tips by design) and every mutating route **rate-limits** (directly or via a factory). Shipping a new unguarded mutating route now fails plain CI.

## Verification
- `npm run verify` green in an isolated worktree (docs scans, type-check, route audit, lint at main baseline, full unit suite)
- Rebased onto main incl. #557; gate test green post-rebase; pre-push hook (full unit suite) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)