### PR TITLE
feat(receive): one-tap get-paid screen — static address QR + exact-amount requests

### DIFF
--- a/__tests__/unit/api/receive-request.test.ts
+++ b/__tests__/unit/api/receive-request.test.ts
@@ -1,0 +1,135 @@
+/**
+ * POST /api/receive/request — the owner-side "get paid" mint.
+ *
+ * Guards under test:
+ *  - amount bounds enforced (same sane caps as tips);
+ *  - a wallet_id is resolved ONLY within the authenticated user's own active
+ *    wallets (someone else's wallet id → clean 400, no intent minted);
+ *  - no usable wallet → clean 400, not a 500;
+ *  - happy path returns the invoice shape from the shared tips engine.
+ */
+
+import { POST } from '@/app/api/receive/request/route';
+import {
+  resolveUserWallet,
+  resolveSpecificUserWallet,
+} from '@/domain/payments/walletResolutionService';
+import { initiateTip } from '@/domain/payments/paymentFlowService';
+import { RECEIVE_MAX_BTC } from '@/config/receive';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/lib/api/withAuth', () => ({
+  withAuth:
+    (handler: (req: unknown) => Promise<unknown>) =>
+    (req: unknown): Promise<unknown> =>
+      handler(Object.assign(req as object, { user: { id: 'owner-1' }, supabase: {} })),
+}));
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimitWriteAsync: jest.fn().mockResolvedValue({ success: true }),
+  retryAfterSeconds: () => 0,
+}));
+jest.mock('@/lib/api/standardResponse', () => ({
+  apiSuccess: jest.fn((data: unknown) => ({ status: 200, data })),
+  apiBadRequest: jest.fn((error: string) => ({ status: 400, error })),
+  apiRateLimited: jest.fn(() => ({ status: 429 })),
+  apiInternalError: jest.fn(() => ({ status: 500 })),
+}));
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: jest.fn(() => ({
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest
+        .fn()
+        .mockResolvedValue({ data: { username: 'lena', display_name: 'Lena' }, error: null }),
+    })),
+  })),
+}));
+jest.mock('@/domain/payments/walletResolutionService', () => ({
+  resolveUserWallet: jest.fn(),
+  resolveSpecificUserWallet: jest.fn(),
+}));
+jest.mock('@/domain/payments/paymentFlowService', () => ({
+  initiateTip: jest.fn(),
+}));
+
+const resolvePrimaryMock = resolveUserWallet as jest.Mock;
+const resolveSpecificMock = resolveSpecificUserWallet as jest.Mock;
+const initiateTipMock = initiateTip as jest.Mock;
+
+const WALLET = { method: 'lightning_address', wallet_id: 'w1', lightning_address: 'a@b.c' };
+const TIP_RESULT = {
+  payment_intent: { id: 'pi-1', payment_method: 'lightning_address' },
+  status_token: 'tok',
+  qr_data: 'LNBC...',
+  method_label: 'Lightning Address',
+  expires_in_seconds: 3600,
+};
+
+function makeRequest(body: unknown) {
+  return { json: () => Promise.resolve(body) } as never;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  initiateTipMock.mockResolvedValue(TIP_RESULT);
+});
+
+describe('POST /api/receive/request', () => {
+  it('mints a request against the primary wallet by default', async () => {
+    resolvePrimaryMock.mockResolvedValue(WALLET);
+    const res = (await POST(makeRequest({ amount_btc: 0.0001 }))) as {
+      status: number;
+      data: Record<string, unknown>;
+    };
+    expect(res.status).toBe(200);
+    expect(res.data.intentId).toBe('pi-1');
+    expect(resolveSpecificMock).not.toHaveBeenCalled();
+    expect(initiateTipMock).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientUserId: 'owner-1', amountBtc: 0.0001, wallet: WALLET })
+    );
+  });
+
+  it('resolves an explicit wallet_id only within the owner scope', async () => {
+    resolveSpecificMock.mockResolvedValue(WALLET);
+    const res = (await POST(
+      makeRequest({ amount_btc: 0.0001, wallet_id: '550e8400-e29b-41d4-a716-446655440000' })
+    )) as { status: number };
+    expect(res.status).toBe(200);
+    expect(resolveSpecificMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'owner-1',
+      '550e8400-e29b-41d4-a716-446655440000'
+    );
+    expect(resolvePrimaryMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a wallet_id that isn't the owner's (resolver returns null) — no intent minted", async () => {
+    resolveSpecificMock.mockResolvedValue(null);
+    const res = (await POST(
+      makeRequest({ amount_btc: 0.0001, wallet_id: '550e8400-e29b-41d4-a716-446655440000' })
+    )) as { status: number };
+    expect(res.status).toBe(400);
+    expect(initiateTipMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses when no wallet can receive — clean 400, not a 500', async () => {
+    resolvePrimaryMock.mockResolvedValue(null);
+    const res = (await POST(makeRequest({ amount_btc: 0.0001 }))) as { status: number };
+    expect(res.status).toBe(400);
+    expect(initiateTipMock).not.toHaveBeenCalled();
+  });
+
+  it('enforces amount bounds', async () => {
+    resolvePrimaryMock.mockResolvedValue(WALLET);
+    const over = (await POST(makeRequest({ amount_btc: RECEIVE_MAX_BTC + 1 }))) as {
+      status: number;
+    };
+    expect(over.status).toBe(400);
+    const zero = (await POST(makeRequest({ amount_btc: 0 }))) as { status: number };
+    expect(zero.status).toBe(400);
+    expect(initiateTipMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/domain/payments/resolveSpecificUserWallet.test.ts
+++ b/__tests__/unit/domain/payments/resolveSpecificUserWallet.test.ts
@@ -1,0 +1,89 @@
+/**
+ * resolveSpecificUserWallet — the /receive wallet switcher's resolver.
+ *
+ * The owner picked a wallet explicitly, so no cross-wallet priority applies —
+ * but ownership is non-negotiable: a wallet id belonging to someone else (or
+ * inactive) must resolve to null, never to a payable rail.
+ */
+
+import { resolveSpecificUserWallet } from '@/domain/payments/walletResolutionService';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
+jest.mock('@/domain/payments/encryptionService', () => ({
+  decrypt: jest.fn((v: string) => `decrypted:${v}`),
+  canDecrypt: jest.fn(() => true),
+}));
+
+const USER = 'user-1';
+const WALLET = 'wallet-1';
+
+/** Client whose maybeSingle returns the given row; records applied filters. */
+function makeSupabase(row: Record<string, unknown> | null) {
+  const filters: Array<[string, unknown]> = [];
+  const builder: Record<string, unknown> = {};
+  builder.select = jest.fn(() => builder);
+  builder.eq = jest.fn((col: string, val: unknown) => {
+    filters.push([col, val]);
+    return builder;
+  });
+  builder.maybeSingle = jest.fn(() => Promise.resolve({ data: row, error: null }));
+  return {
+    client: { from: jest.fn(() => builder) } as unknown as SupabaseClient,
+    filters,
+  };
+}
+
+describe('resolveSpecificUserWallet', () => {
+  it('scopes the query to owner + active — ownership is part of the query', async () => {
+    const { client, filters } = makeSupabase(null);
+    const res = await resolveSpecificUserWallet(client, USER, WALLET);
+    expect(res).toBeNull();
+    expect(filters).toEqual(
+      expect.arrayContaining([
+        ['id', WALLET],
+        ['profile_id', USER],
+        ['is_active', true],
+      ])
+    );
+  });
+
+  it('resolves NWC first within the wallet', async () => {
+    const { client } = makeSupabase({
+      id: WALLET,
+      nwc_connection_uri: 'enc',
+      lightning_address: 'a@b.c',
+      address_or_xpub: null,
+    });
+    const res = await resolveSpecificUserWallet(client, USER, WALLET);
+    expect(res).toEqual({ method: 'nwc', wallet_id: WALLET, nwc_uri: 'decrypted:enc' });
+  });
+
+  it('falls back to the Lightning address, then on-chain', async () => {
+    const { client } = makeSupabase({
+      id: WALLET,
+      nwc_connection_uri: null,
+      lightning_address: 'a@b.c',
+      address_or_xpub: null,
+    });
+    const res = await resolveSpecificUserWallet(client, USER, WALLET);
+    expect(res).toEqual({
+      method: 'lightning_address',
+      wallet_id: WALLET,
+      lightning_address: 'a@b.c',
+    });
+  });
+
+  it('returns null for a wallet with no usable payment detail', async () => {
+    const { client } = makeSupabase({
+      id: WALLET,
+      nwc_connection_uri: null,
+      lightning_address: null,
+      address_or_xpub: '',
+    });
+    expect(await resolveSpecificUserWallet(client, USER, WALLET)).toBeNull();
+  });
+});

--- a/src/app/(authenticated)/dashboard/wallets/components/WalletsPageHeader.tsx
+++ b/src/app/(authenticated)/dashboard/wallets/components/WalletsPageHeader.tsx
@@ -9,16 +9,24 @@
 
 'use client';
 
-import { Wallet as WalletIcon } from 'lucide-react';
+import { Wallet as WalletIcon, QrCode } from 'lucide-react';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
+import { Button } from '@/components/ui/Button';
+import { ROUTES } from '@/config/routes';
 
 export function WalletsPageHeader() {
   return (
     <div className="mb-6 lg:mb-8">
       <Breadcrumb items={[{ label: 'Wallets' }]} className="mb-4" />
-      <div className="flex items-center gap-3 mb-2">
-        <WalletIcon className="w-8 h-8 text-bitcoinOrange" />
-        <h1 className="text-2xl lg:text-3xl font-bold text-fg-primary">Manage Wallets</h1>
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <div className="flex items-center gap-3">
+          <WalletIcon className="w-8 h-8 text-bitcoinOrange" />
+          <h1 className="text-2xl lg:text-3xl font-bold text-fg-primary">Manage Wallets</h1>
+        </div>
+        <Button variant="accent" size="sm" href={ROUTES.RECEIVE}>
+          <QrCode className="mr-2 h-4 w-4" />
+          Receive
+        </Button>
       </div>
       {/* Desktop: Full description, Mobile: Shortened */}
       <p className="hidden lg:block text-fg-secondary mb-4 max-w-2xl">

--- a/src/app/(authenticated)/receive/page.tsx
+++ b/src/app/(authenticated)/receive/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { ReceiveScreen } from '@/components/receive/ReceiveScreen';
+
+export const metadata: Metadata = {
+  title: 'Receive — OrangeCat',
+  description: 'Get paid in Bitcoin, straight to your own wallet.',
+};
+
+export default function ReceivePage() {
+  return <ReceiveScreen />;
+}

--- a/src/app/api/receive/request/route.ts
+++ b/src/app/api/receive/request/route.ts
@@ -1,0 +1,95 @@
+/**
+ * POST /api/receive/request { amount_btc, wallet_id? } — owner-side "get paid".
+ *
+ * Mints an exact-amount payment request against the AUTHENTICATED user's own
+ * wallet (a specific one when wallet_id is given, else the same primary-first
+ * resolution every payer gets). It is the tips engine pointed at yourself:
+ * an entity-less payment_intent riding the shared invoice + settle path, so
+ * the owner gets live "paid" feedback and the standard settle notification.
+ * Non-custodial: the QR pays straight into their wallet.
+ */
+
+import { z } from 'zod';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import {
+  apiSuccess,
+  apiBadRequest,
+  apiInternalError,
+  apiRateLimited,
+} from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { RECEIVE_MIN_BTC, RECEIVE_MAX_BTC } from '@/config/receive';
+import {
+  resolveUserWallet,
+  resolveSpecificUserWallet,
+} from '@/domain/payments/walletResolutionService';
+import { initiateTip } from '@/domain/payments/paymentFlowService';
+import { logger } from '@/utils/logger';
+
+const bodySchema = z.object({
+  amount_btc: z.number().positive().min(RECEIVE_MIN_BTC).max(RECEIVE_MAX_BTC),
+  wallet_id: z.string().uuid().optional(),
+});
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  try {
+    const { user } = request;
+
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many payment requests. Please slow down.', retryAfterSeconds(rl));
+    }
+
+    const parsed = bodySchema.safeParse(await request.json().catch(() => ({})));
+    if (!parsed.success) {
+      return apiBadRequest('Invalid request', parsed.error.flatten());
+    }
+
+    const admin = getAdminClient() as unknown as SupabaseClient;
+
+    // Wallet resolution runs on the admin client (secrets are server-only);
+    // resolveSpecificUserWallet scopes by profile_id, so a wallet id belonging
+    // to someone else resolves to null instead of a payable rail.
+    const wallet = parsed.data.wallet_id
+      ? await resolveSpecificUserWallet(admin, user.id, parsed.data.wallet_id)
+      : await resolveUserWallet(admin, user.id);
+    if (!wallet) {
+      return apiBadRequest(
+        parsed.data.wallet_id
+          ? 'That wallet cannot receive payments.'
+          : 'Connect a wallet before receiving payments.'
+      );
+    }
+
+    const { data: profile } = await admin
+      .from(DATABASE_TABLES.PROFILES)
+      .select('username, display_name:name')
+      .eq('id', user.id)
+      .maybeSingle();
+    const row = profile as { username?: string | null; display_name?: string | null } | null;
+    const recipientName = row?.display_name || row?.username || 'you';
+
+    const res = await initiateTip({
+      recipientUserId: user.id,
+      recipientName,
+      wallet,
+      amountBtc: parsed.data.amount_btc,
+    });
+
+    return apiSuccess({
+      intentId: res.payment_intent.id,
+      statusToken: res.status_token,
+      qrData: res.qr_data,
+      methodLabel: res.method_label,
+      amountBtc: parsed.data.amount_btc,
+      expiresInSeconds: res.expires_in_seconds,
+      paymentMethod: res.payment_intent.payment_method,
+    });
+  } catch (error) {
+    logger.error('receive/request failed', { error }, 'Receive');
+    return apiInternalError('Could not create a payment request.');
+  }
+});

--- a/src/components/receive/ReceiveScreen.tsx
+++ b/src/components/receive/ReceiveScreen.tsx
@@ -1,0 +1,348 @@
+'use client';
+
+/**
+ * ReceiveScreen — the owner-side "get paid" surface (/receive).
+ *
+ * One tap from the sidebar to a scannable QR. Two modes:
+ *  - "My address": static QR of <username>@orangecat.ch — never expires, any
+ *    wallet, payer picks the amount. Rendered only when the server's payment
+ *    resolution says the address actually works (never claim a dead rail).
+ *  - "Request amount": exact-amount invoice / fresh on-chain address with live
+ *    settlement feedback, optionally from a specific wallet.
+ *
+ * Non-custodial: every QR pays straight into the owner's wallet.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { CheckCircle2, Clock, Copy, Check, Loader2, Share2, Wallet, Zap } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { PaymentQRCode } from '@/components/payment/PaymentQRCode';
+import { ContributionAmountInput } from '@/components/payment/ContributionAmountInput';
+import { useRequireAuth } from '@/hooks/useAuth';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import {
+  fetchReceiveOverview,
+  fetchReceiveWallets,
+  createReceiveRequest,
+  fetchReceiveStatus,
+  type OwnerReceiveOverview,
+  type ReceiveWalletOption,
+  type ReceiveRequest,
+} from '@/services/receive/receive-client';
+import {
+  RECEIVE_COPY,
+  RECEIVE_MIN_BTC,
+  RECEIVE_MAX_BTC,
+  RECEIVE_POLL_INTERVAL_MS,
+} from '@/config/receive';
+import { DEFAULT_TIP_BTC } from '@/config/tips';
+import { ROUTES } from '@/config/routes';
+
+type Tab = 'address' | 'request';
+type SettleState = 'pending' | 'paid' | 'expired';
+
+export function ReceiveScreen() {
+  const { user, isLoading: authLoading } = useRequireAuth();
+  const { copied, copy } = useCopyToClipboard();
+
+  const [loading, setLoading] = useState(true);
+  const [overview, setOverview] = useState<OwnerReceiveOverview | null>(null);
+  const [wallets, setWallets] = useState<ReceiveWalletOption[]>([]);
+  const [tab, setTab] = useState<Tab>('address');
+
+  const [amount, setAmount] = useState(DEFAULT_TIP_BTC);
+  const [walletId, setWalletId] = useState<string | undefined>(undefined);
+  const [request, setRequest] = useState<ReceiveRequest | null>(null);
+  const [settleState, setSettleState] = useState<SettleState>('pending');
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+    let active = true;
+    Promise.all([fetchReceiveOverview(), fetchReceiveWallets(user.id).catch(() => [])])
+      .then(([ov, ws]) => {
+        if (!active) {
+          return;
+        }
+        setOverview(ov);
+        setWallets(ws);
+        if (!ov.lightningAddressActive) {
+          setTab('request');
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setOverview(null);
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [user?.id]);
+
+  // Live settlement polling while an unpaid request is showing.
+  const requestRef = useRef(request);
+  requestRef.current = request;
+  useEffect(() => {
+    if (!request || settleState !== 'pending') {
+      return;
+    }
+    let active = true;
+    const id = setInterval(async () => {
+      const current = requestRef.current;
+      if (!current) {
+        return;
+      }
+      try {
+        const { status } = await fetchReceiveStatus(current.intentId, current.statusToken);
+        if (!active) {
+          return;
+        }
+        if (status === 'paid') {
+          setSettleState('paid');
+        } else if (status === 'expired' || status === 'failed') {
+          setSettleState('expired');
+        }
+      } catch {
+        // Transient — keep polling; interval clears on settle/reset.
+      }
+    }, RECEIVE_POLL_INTERVAL_MS);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [request, settleState]);
+
+  const handleGenerate = useCallback(async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      setRequest(await createReceiveRequest(amount, walletId));
+      setSettleState('pending');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not create a payment request.');
+    } finally {
+      setGenerating(false);
+    }
+  }, [amount, walletId]);
+
+  const address = overview?.lightningAddress ?? null;
+
+  const handleShare = useCallback(async () => {
+    if (!address) {
+      return;
+    }
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: 'Pay me with Bitcoin', text: address });
+        return;
+      } catch {
+        // User cancelled or share failed — fall through to copy.
+      }
+    }
+    void copy(address);
+  }, [address, copy]);
+
+  if (authLoading || loading) {
+    return (
+      <div className="flex justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-fg-tertiary" />
+      </div>
+    );
+  }
+
+  const canReceive = !!overview?.rail;
+  if (!canReceive) {
+    return (
+      <div className="mx-auto flex max-w-md flex-col items-center gap-4 px-4 py-16 text-center">
+        <Wallet className="h-12 w-12 text-fg-tertiary" />
+        <h2 className="text-lg font-semibold text-fg-primary">{RECEIVE_COPY.noWalletTitle}</h2>
+        <p className="text-sm text-fg-secondary">{RECEIVE_COPY.noWalletBody}</p>
+        <Button variant="accent" href={ROUTES.DASHBOARD.WALLETS}>
+          {RECEIVE_COPY.noWalletCta}
+        </Button>
+      </div>
+    );
+  }
+
+  const showAddressTab = !!overview?.lightningAddressActive && !!address;
+  const activeTab: Tab = showAddressTab ? tab : 'request';
+
+  return (
+    <div className="mx-auto w-full max-w-md px-4 py-6">
+      <h1 className="text-2xl font-bold text-fg-primary">{RECEIVE_COPY.title}</h1>
+      <p className="mt-1 text-sm text-fg-secondary">{RECEIVE_COPY.subtitle}</p>
+
+      {showAddressTab && (
+        <div className="mt-5 grid grid-cols-2 gap-1 rounded-lg bg-surface-raised p-1">
+          {(['address', 'request'] as const).map(t => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={`min-h-11 rounded-md px-3 text-sm font-medium transition-colors ${
+                activeTab === t
+                  ? 'bg-surface-base text-fg-primary shadow-sm'
+                  : 'text-fg-secondary hover:text-fg-primary'
+              }`}
+            >
+              {t === 'address' ? RECEIVE_COPY.addressTab : RECEIVE_COPY.requestTab}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {activeTab === 'address' && address ? (
+        <div className="mt-6 flex flex-col items-center gap-4">
+          <div className="rounded-lg bg-surface-base p-4 shadow-sm">
+            <QRCodeSVG
+              value={`lightning:${address}`}
+              size={256}
+              level="M"
+              includeMargin
+              bgColor="#FFFFFF"
+              fgColor="#000000"
+            />
+          </div>
+          <p className="flex items-center gap-2 font-mono text-sm text-fg-primary">
+            <Zap className="h-4 w-4 text-bitcoinOrange" />
+            {address}
+          </p>
+          <p className="text-center text-xs text-fg-tertiary">{RECEIVE_COPY.addressHint}</p>
+          <div className="flex gap-3">
+            <Button variant="outline" onClick={() => void copy(address)}>
+              {copied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
+              {copied ? RECEIVE_COPY.copied : RECEIVE_COPY.copy}
+            </Button>
+            <Button variant="accent" onClick={handleShare}>
+              <Share2 className="mr-2 h-4 w-4" />
+              {RECEIVE_COPY.share}
+            </Button>
+          </div>
+        </div>
+      ) : request && settleState === 'paid' ? (
+        <div className="mt-8 flex flex-col items-center gap-3 text-center">
+          <CheckCircle2 className="h-16 w-16 text-status-positive" />
+          <p className="text-xl font-semibold text-fg-primary">{RECEIVE_COPY.paidTitle}</p>
+          <p className="text-sm text-fg-secondary">{RECEIVE_COPY.paidBody}</p>
+          <Button
+            variant="accent"
+            className="mt-2"
+            onClick={() => {
+              setRequest(null);
+              setSettleState('pending');
+            }}
+          >
+            {RECEIVE_COPY.again}
+          </Button>
+        </div>
+      ) : request && settleState === 'expired' ? (
+        <div className="mt-8 flex flex-col items-center gap-3 text-center">
+          <Clock className="h-12 w-12 text-fg-tertiary" />
+          <p className="text-lg font-semibold text-fg-primary">{RECEIVE_COPY.expiredTitle}</p>
+          <p className="text-sm text-fg-secondary">{RECEIVE_COPY.expiredBody}</p>
+          <Button
+            variant="outline"
+            className="mt-2"
+            onClick={() => {
+              setRequest(null);
+              setSettleState('pending');
+            }}
+          >
+            {RECEIVE_COPY.again}
+          </Button>
+        </div>
+      ) : request ? (
+        <div className="mt-6 space-y-4">
+          <PaymentQRCode
+            qrData={request.qrData}
+            methodLabel={request.methodLabel}
+            amountBtc={request.amountBtc}
+            expiresInSeconds={request.expiresInSeconds ?? undefined}
+          />
+          <p className="flex items-center justify-center gap-2 text-center text-sm text-fg-secondary">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            {RECEIVE_COPY.scan}
+          </p>
+          {request.paymentMethod === 'onchain' && (
+            <p className="text-center text-xs text-fg-tertiary">{RECEIVE_COPY.onchainNote}</p>
+          )}
+          <div className="flex justify-center">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setRequest(null);
+                setSettleState('pending');
+              }}
+            >
+              {RECEIVE_COPY.again}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-6 space-y-4">
+          <ContributionAmountInput
+            value={amount}
+            onChange={setAmount}
+            minBtc={RECEIVE_MIN_BTC}
+            maxBtc={RECEIVE_MAX_BTC}
+          />
+          {wallets.length > 1 && (
+            <div>
+              <p className="mb-2 text-sm font-medium text-fg-secondary">
+                {RECEIVE_COPY.walletLabel}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => setWalletId(undefined)}
+                  className={`min-h-11 rounded-full border px-4 text-sm transition-colors ${
+                    walletId === undefined
+                      ? 'border-accent-primary bg-accent-primary/10 text-fg-primary'
+                      : 'border-default text-fg-secondary hover:text-fg-primary'
+                  }`}
+                >
+                  Primary
+                </button>
+                {wallets.map(w => (
+                  <button
+                    key={w.id}
+                    type="button"
+                    onClick={() => setWalletId(w.id)}
+                    className={`min-h-11 rounded-full border px-4 text-sm transition-colors ${
+                      walletId === w.id
+                        ? 'border-accent-primary bg-accent-primary/10 text-fg-primary'
+                        : 'border-default text-fg-secondary hover:text-fg-primary'
+                    }`}
+                  >
+                    {w.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          {error && <p className="text-sm text-status-negative">{error}</p>}
+          <p className="text-center text-xs text-fg-tertiary">{RECEIVE_COPY.requestHint}</p>
+          <Button
+            variant="accent"
+            className="w-full"
+            onClick={handleGenerate}
+            disabled={generating || amount <= 0}
+            isLoading={generating}
+          >
+            {generating ? RECEIVE_COPY.generating : RECEIVE_COPY.generate}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -20,6 +20,7 @@ import { ROUTES } from './routes';
 import { XBrandIcon, GitHubIcon } from '@/components/icons/BrandIcons';
 import {
   Home,
+  QrCode,
   Users,
   Settings,
   User as UserIcon,
@@ -200,6 +201,15 @@ const simplifiedSections: NavSection[] = [
         href: ROUTES.DASHBOARD.HOME,
         icon: Home,
         description: 'Your dashboard',
+        requiresAuth: true,
+      },
+      {
+        // "Get paid" is a primary verb on an economic platform — one tap from
+        // anywhere to a scannable QR (the in-person receive flow).
+        name: 'Receive',
+        href: ROUTES.RECEIVE,
+        icon: QrCode,
+        description: 'Show a QR to get paid',
         requiresAuth: true,
       },
       {

--- a/src/config/receive.ts
+++ b/src/config/receive.ts
@@ -1,0 +1,54 @@
+/**
+ * Receive — SSOT for the owner-side "get paid" surface (/receive).
+ *
+ * Receiving is the mirror of the tips/payment stack, pointed at yourself: a
+ * receive request is an entity-less payment_intent against YOUR OWN wallet,
+ * minted through the exact same wallet-resolution + invoice + settle path a
+ * tipper would use. OrangeCat never touches the funds — the QR pays straight
+ * into the owner's wallet.
+ *
+ * Two modes:
+ *  - "My address": a static QR of <username>@orangecat.ch. Never expires,
+ *    works with any Lightning wallet, payer picks the amount. It is an ALIAS —
+ *    only alive while a real receiving wallet is configured behind it.
+ *  - "Request amount": an exact-amount invoice (or fresh on-chain address)
+ *    with live settlement feedback, so the payer can't fat-finger the amount.
+ */
+
+import { TIP_MIN_BTC, TIP_MAX_BTC, TIP_POLL_INTERVAL_MS } from './tips';
+
+/** Same sane bounds as tips — a receive request is the same economic object. */
+export const RECEIVE_MIN_BTC = TIP_MIN_BTC;
+export const RECEIVE_MAX_BTC = TIP_MAX_BTC;
+export const RECEIVE_POLL_INTERVAL_MS = TIP_POLL_INTERVAL_MS;
+
+export const RECEIVE_COPY = {
+  title: 'Receive',
+  subtitle: 'Get paid straight to your wallet — OrangeCat never holds your money.',
+  addressTab: 'My address',
+  requestTab: 'Request amount',
+  addressHint: 'Any amount, any Lightning wallet. This QR never expires.',
+  addressCaption: (address: string) => address,
+  requestHint: 'Exact amount — you’ll see it the moment it’s paid.',
+  amountLabel: 'Amount',
+  walletLabel: 'Receive with',
+  generate: 'Show payment QR',
+  generating: 'Creating…',
+  scan: 'Waiting for payment…',
+  paidTitle: 'Paid!',
+  paidBody: 'The payment reached your wallet.',
+  expiredTitle: 'Request expired',
+  expiredBody: 'No payment was detected before the invoice expired. Create a new one.',
+  again: 'New request',
+  share: 'Share',
+  copied: 'Copied',
+  copy: 'Copy',
+  onchainNote: 'On-chain payments need block confirmations — not ideal for in-person speed.',
+  onchainSeen: 'Payment seen — waiting for confirmation…',
+  undetectableNote:
+    'This wallet can’t report payments automatically — confirm receipt in your wallet app.',
+  noWalletTitle: 'Connect a wallet to start receiving',
+  noWalletBody:
+    'Add a Lightning or Bitcoin wallet — payments go directly to it, OrangeCat never holds funds.',
+  noWalletCta: 'Set up receiving',
+} as const;

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -409,6 +409,8 @@ export const ROUTES = {
 
   // Timeline routes
   TIMELINE: '/timeline',
+  /** Owner's "get paid" screen — one tap to a scannable QR. */
+  RECEIVE: '/receive',
   // Personalized "Following" home feed (people/projects you follow)
   FEED: '/home',
   // Open-roles collaborator board (project_roles)

--- a/src/domain/payments/walletResolutionService.ts
+++ b/src/domain/payments/walletResolutionService.ts
@@ -430,6 +430,32 @@ export async function resolveUserWallet(
 }
 
 /**
+ * Resolve ONE SPECIFIC wallet of a user into a payment method — the owner
+ * picked it explicitly (e.g. the /receive wallet switcher), so no cross-wallet
+ * priority applies; only the within-wallet NWC > Lightning > on-chain order.
+ * Ownership is part of the query: a wallet id belonging to someone else (or an
+ * inactive wallet) resolves to null, never to a payable rail.
+ */
+export async function resolveSpecificUserWallet(
+  supabase: SupabaseClient,
+  userId: string,
+  walletId: string
+): Promise<ResolvedWallet | null> {
+  const { data: wallet } = await supabase
+    .from(DATABASE_TABLES.WALLETS)
+    .select('id, nwc_connection_uri, lightning_address, address_or_xpub')
+    .eq('id', walletId)
+    .eq('profile_id', userId)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (!wallet) {
+    return null;
+  }
+  return pickMethodFromWallet(wallet as WalletRow);
+}
+
+/**
  * Resolve best wallet for a group from the group_wallets table.
  * Priority: Lightning Address > On-chain (group_wallets has no NWC support)
  */

--- a/src/services/receive/receive-client.ts
+++ b/src/services/receive/receive-client.ts
@@ -1,0 +1,85 @@
+/**
+ * Browser client for the owner-side /receive surface.
+ * Settlement polling reuses the tips status endpoint — a receive request IS
+ * the tips engine pointed at yourself (same intent, same bearer token).
+ */
+
+export { fetchTipStatus as fetchReceiveStatus } from '@/services/tips/tip-client';
+
+export interface ReceiveRequest {
+  intentId: string;
+  statusToken: string;
+  qrData: string;
+  methodLabel: string;
+  amountBtc: number;
+  expiresInSeconds: number | null;
+  paymentMethod: 'nwc' | 'lightning_address' | 'onchain';
+}
+
+export interface OwnerReceiveOverview {
+  username: string | null;
+  lightningAddress: string | null;
+  rail: 'nwc' | 'lightning_address' | 'onchain' | null;
+  lightningAddressActive: boolean;
+}
+
+export interface ReceiveWalletOption {
+  id: string;
+  label: string;
+  wallet_type: string | null;
+  is_primary: boolean;
+}
+
+async function readJson(
+  res: Response
+): Promise<{ success?: boolean; data?: unknown; error?: unknown }> {
+  return (await res.json().catch(() => null)) ?? {};
+}
+
+function errorMessage(json: { error?: unknown }, fallback: string): string {
+  const err = json.error;
+  return (typeof err === 'string' ? err : (err as { message?: string })?.message) || fallback;
+}
+
+/** Can I be paid right now, and what is my @orangecat.ch address? */
+export async function fetchReceiveOverview(): Promise<OwnerReceiveOverview> {
+  const res = await fetch('/api/wallets/receive-status');
+  const json = await readJson(res);
+  if (!res.ok || !json.success) {
+    throw new Error(errorMessage(json, 'Could not load your receiving setup.'));
+  }
+  return json.data as OwnerReceiveOverview;
+}
+
+/** The owner's active wallets, for the receive-with switcher. */
+export async function fetchReceiveWallets(profileId: string): Promise<ReceiveWalletOption[]> {
+  const res = await fetch(`/api/wallets?profile_id=${encodeURIComponent(profileId)}`);
+  const json = await readJson(res);
+  if (!res.ok || !json.success) {
+    throw new Error(errorMessage(json, 'Could not load your wallets.'));
+  }
+  const rows = (json.data as Array<Record<string, unknown>>) ?? [];
+  return rows.map(w => ({
+    id: String(w.id),
+    label: String(w.label ?? 'Wallet'),
+    wallet_type: (w.wallet_type as string | null) ?? null,
+    is_primary: !!w.is_primary,
+  }));
+}
+
+/** Mint an exact-amount payment request against my own wallet. */
+export async function createReceiveRequest(
+  amountBtc: number,
+  walletId?: string
+): Promise<ReceiveRequest> {
+  const res = await fetch('/api/receive/request', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ amount_btc: amountBtc, ...(walletId ? { wallet_id: walletId } : {}) }),
+  });
+  const json = await readJson(res);
+  if (!res.ok || !json.success) {
+    throw new Error(errorMessage(json, 'Could not create a payment request.'));
+  }
+  return json.data as ReceiveRequest;
+}


### PR DESCRIPTION
## What

`/receive` — the owner-side "get paid" surface. One tap from the sidebar (or the wallets page header) to a scannable QR.

**Two modes:**
- **My address** — static QR of `<username>@orangecat.ch`. Never expires, payer picks the amount. Rendered only when the server's own payment resolution confirms the address actually works (never claim a dead rail).
- **Request amount** — exact-amount Lightning invoice / fresh on-chain address with live settlement feedback ("Payment received" the moment it settles), optionally minted from a specific wallet via a wallet switcher.

## How

- `POST /api/receive/request` = the tips engine pointed at yourself: an entity-less `payment_intent` riding the shared invoice + settle path, so live paid feedback and the standard settle notification come for free. Non-custodial — every QR pays straight into the owner's own wallet.
- New `resolveSpecificUserWallet(admin, userId, walletId)` scopes by `profile_id` + `is_active` in the query itself — a wallet id belonging to someone else resolves to null, never to a payable rail.
- Reuses `/api/wallets/receive-status` (capability truth), `PaymentQRCode`, `ContributionAmountInput`, the tips status endpoint + bearer token for polling.
- Config SSOT in `src/config/receive.ts` (bounds = tip bounds, poll interval, all copy).

## Tests

- 5 route-guard tests (`receive-request.test.ts`): default primary mint, owner-scoped explicit wallet, foreign wallet id → 400 no mint, no wallet → 400, amount bounds.
- 4 resolver tests (`resolveSpecificUserWallet.test.ts`): ownership filters asserted in the query, NWC-first, lightning fallback, unusable → null.
- Full verify green: 146 suites / 1468 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)