### PR TITLE
fix(payments): bind L402 receipts to their entity, settle on preimage, never trust self-attestation

### DIFF
--- a/__tests__/unit/api/v1-pay-l402.test.ts
+++ b/__tests__/unit/api/v1-pay-l402.test.ts
@@ -181,6 +181,12 @@ describe('GET /api/v1/pay/{type}/{id}', () => {
     expect(body.data.verified_by).toBe('preimage');
     expect(body.data.status).toBe('paid');
     expect(mockCreateChallenge).not.toHaveBeenCalled();
+    // The route must hand the URL's entity to the verifier — that's what binds
+    // the receipt to the resource being paid for.
+    expect(mockVerify).toHaveBeenCalledWith(expect.anything(), {
+      entityType: 'product',
+      entityId: ENTITY_ID,
+    });
   });
 
   it('answers 402 again (no new intent) when the invoice is still unpaid', async () => {

--- a/__tests__/unit/payments/l402-verify.test.ts
+++ b/__tests__/unit/payments/l402-verify.test.ts
@@ -1,0 +1,140 @@
+/**
+ * verifyL402Payment — the security contract of the 402 receipt.
+ *
+ * Three behaviors pinned here, each of which shipped broken in #556:
+ *  1. A token is bound to ONE entity — replaying it against another URL is
+ *     an opaque 404, even with a cryptographically valid preimage.
+ *  2. A valid preimage SETTLES the intent (via settleVerifiedPayment) — the
+ *     receipt and the ledger can't diverge.
+ *  3. BUYER_CONFIRMED is the payer's own claim, not settlement — it must
+ *     never produce an ok receipt.
+ */
+
+import { createHash, randomBytes } from 'crypto';
+import { STATUS } from '@/config/database-constants';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockMaybeSingle = jest.fn();
+const queryChain: Record<string, jest.Mock> = {};
+queryChain.select = jest.fn(() => queryChain);
+queryChain.eq = jest.fn(() => queryChain);
+queryChain.maybeSingle = mockMaybeSingle;
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: () => ({ from: () => queryChain }),
+}));
+
+const mockCheckStatus = jest.fn();
+const mockSettle = jest.fn();
+jest.mock('@/domain/payments/paymentFlowService', () => ({
+  initiatePublicSupport: jest.fn(),
+  checkPublicPaymentStatus: (...args: unknown[]) => mockCheckStatus(...args),
+  hashPublicStatusToken: (t: string) => `hashed:${t}`,
+  settleVerifiedPayment: (...args: unknown[]) => mockSettle(...args),
+}));
+
+import { verifyL402Payment } from '@/domain/payments/l402';
+
+const ENTITY_ID = '11111111-2222-3333-4444-555555555555';
+const OTHER_ENTITY_ID = '99999999-8888-7777-6666-555555555555';
+
+const preimage = randomBytes(32).toString('hex');
+const paymentHash = createHash('sha256').update(Buffer.from(preimage, 'hex')).digest('hex');
+
+const creds = { paymentIntentId: 'pi-1', statusToken: 'tok', preimage };
+const expected = { entityType: 'product', entityId: ENTITY_ID };
+
+function intentRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pi-1',
+    entity_type: 'product',
+    entity_id: ENTITY_ID,
+    payment_hash: paymentHash,
+    status: 'invoice_ready',
+    paid_at: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockMaybeSingle.mockReset();
+  mockCheckStatus.mockReset();
+  mockSettle.mockReset().mockResolvedValue(undefined);
+});
+
+describe('verifyL402Payment — receipt binding', () => {
+  it('rejects a valid preimage replayed against a different entity (opaque 404)', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: intentRow() });
+    await expect(
+      verifyL402Payment(creds, { entityType: 'product', entityId: OTHER_ENTITY_ID })
+    ).rejects.toThrow('Payment not found');
+    expect(mockSettle).not.toHaveBeenCalled();
+    expect(mockCheckStatus).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token replayed against a different entity TYPE', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: intentRow() });
+    await expect(
+      verifyL402Payment(creds, { entityType: 'service', entityId: ENTITY_ID })
+    ).rejects.toThrow('Payment not found');
+  });
+
+  it('rejects an unknown token', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: null });
+    await expect(verifyL402Payment(creds, expected)).rejects.toThrow('Payment not found');
+  });
+});
+
+describe('verifyL402Payment — preimage branch settles', () => {
+  it('settles the intent and returns a paid receipt on a valid preimage', async () => {
+    const row = intentRow();
+    mockMaybeSingle.mockResolvedValue({ data: row });
+    const result = await verifyL402Payment(creds, expected);
+    expect(mockSettle).toHaveBeenCalledWith(row);
+    expect(result.ok).toBe(true);
+    expect(result.verified_by).toBe('preimage');
+    expect(result.status).toBe(STATUS.PAYMENT_INTENTS.PAID);
+    expect(result.paid_at).not.toBeNull();
+    expect(mockCheckStatus).not.toHaveBeenCalled();
+  });
+
+  it('falls back to settlement status on a wrong preimage', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: intentRow() });
+    mockCheckStatus.mockResolvedValue({ status: 'invoice_ready', paid_at: null });
+    const result = await verifyL402Payment(
+      { ...creds, preimage: 'f'.repeat(64) },
+      expected
+    );
+    expect(mockSettle).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.verified_by).toBeUndefined();
+  });
+});
+
+describe('verifyL402Payment — settlement fallback trust boundary', () => {
+  it('NEVER treats buyer_confirmed (self-attestation) as settlement', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: intentRow({ payment_hash: null }) });
+    mockCheckStatus.mockResolvedValue({
+      status: STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED,
+      paid_at: null,
+    });
+    const result = await verifyL402Payment(creds, expected);
+    expect(result.ok).toBe(false);
+    expect(result.verified_by).toBeUndefined();
+    expect(result.status).toBe(STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED);
+  });
+
+  it('accepts an observed PAID status for hashless rails', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: intentRow({ payment_hash: null }) });
+    mockCheckStatus.mockResolvedValue({
+      status: STATUS.PAYMENT_INTENTS.PAID,
+      paid_at: '2026-08-02T12:00:00Z',
+    });
+    const result = await verifyL402Payment(creds, expected);
+    expect(result.ok).toBe(true);
+    expect(result.verified_by).toBe('settlement');
+    expect(result.paid_at).toBe('2026-08-02T12:00:00Z');
+  });
+});

--- a/src/app/api/entity-wallets/route.ts
+++ b/src/app/api/entity-wallets/route.ts
@@ -6,7 +6,7 @@ import {
   apiBadRequest,
   apiRateLimited,
 } from '@/lib/api/standardResponse';
-import { DATABASE_TABLES } from '@/config/database-tables';
+import { DATABASE_TABLES, WALLET_CLIENT_COLUMNS } from '@/config/database-tables';
 import { logger } from '@/utils/logger';
 import { entityWalletLinkSchema } from '@/lib/validation/finance';
 import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
@@ -57,7 +57,12 @@ export const GET = withAuth(async (request: AuthenticatedRequest) => {
   // Get wallets linked to a specific entity, with joined wallet data
   const { data, error } = await supabase
     .from(DATABASE_TABLES.ENTITY_WALLETS)
-    .select(`*, wallet:${DATABASE_TABLES.WALLETS}(*)`)
+    // wallets(*) breaks under the column-grant lockdown (20260802120000): the
+    // authenticated role holds only WALLET_CLIENT_COLUMNS, and a star-select
+    // against a column-subset grant is 42501 — which made this endpoint error,
+    // the edit form lose the existing link, and saves create duplicate
+    // is_primary rows. Embed exactly the granted columns.
+    .select(`*, wallet:${DATABASE_TABLES.WALLETS}(${WALLET_CLIENT_COLUMNS})`)
     .eq('entity_type', entityType)
     .eq('entity_id', entityId);
 

--- a/src/app/api/v1/pay/[entity_type]/[entity_id]/route.ts
+++ b/src/app/api/v1/pay/[entity_type]/[entity_id]/route.ts
@@ -46,7 +46,10 @@ export async function GET(
   const creds = parseL402Authorization(request.headers.get('authorization'));
   if (creds) {
     try {
-      const result = await verifyL402Payment(creds);
+      const result = await verifyL402Payment(creds, {
+        entityType: entity_type,
+        entityId: entity_id,
+      });
       if (result.ok) {
         return apiSuccess(
           {

--- a/src/domain/payments/l402.ts
+++ b/src/domain/payments/l402.ts
@@ -31,8 +31,9 @@ import {
   initiatePublicSupport,
   checkPublicPaymentStatus,
   hashPublicStatusToken,
+  settleVerifiedPayment,
 } from './paymentFlowService';
-import type { InitiatePublicSupportInput } from './types';
+import type { InitiatePublicSupportInput, PaymentIntent } from './types';
 
 export {
   parseL402Authorization,
@@ -103,34 +104,54 @@ export interface L402VerifyResult {
  * notices settlement); settled status is the fallback for hashless rails.
  * Throws 'Payment not found' when the token doesn't match — same opacity as
  * the public status endpoint.
+ *
+ * The receipt is bound to ONE resource: the intent's own entity must match the
+ * entity in the request URL. Without that check, one cheap payment mints valid
+ * receipts for every resource on the platform. A mismatch throws the same
+ * opaque error as a bad token, so probing can't confirm the token is valid
+ * elsewhere.
  */
-export async function verifyL402Payment(creds: L402Credentials): Promise<L402VerifyResult> {
+export async function verifyL402Payment(
+  creds: L402Credentials,
+  expected: { entityType: string; entityId: string }
+): Promise<L402VerifyResult> {
   const admin = getAdminClient() as unknown as SupabaseClient;
-  const { data: intent } = await admin
+  const { data } = await admin
     .from(DATABASE_TABLES.PAYMENT_INTENTS)
-    .select('id, payment_hash, status, paid_at')
+    .select('*')
     .eq('id', creds.paymentIntentId)
     .eq('public_status_token_hash', hashPublicStatusToken(creds.statusToken))
     .maybeSingle();
-  if (!intent) {
+  if (!data) {
+    throw new Error('Payment not found');
+  }
+  const intent = data as PaymentIntent;
+  if (intent.entity_type !== expected.entityType || intent.entity_id !== expected.entityId) {
     throw new Error('Payment not found');
   }
 
   if (intent.payment_hash && preimageMatchesHash(creds.preimage, intent.payment_hash)) {
+    // A valid preimage is cryptographic proof the invoice settled — so settle
+    // the ledger NOW (order → paid, inventory, notifications, webhooks) instead
+    // of returning a paid receipt over a row that still says invoice_ready.
+    // Idempotent: the paid transition itself is the lock, so a second retry or
+    // a concurrent poller is a safe no-op.
+    await settleVerifiedPayment(intent);
     return {
       ok: true,
       verified_by: 'preimage',
-      status: intent.status,
-      paid_at: intent.paid_at ?? null,
+      status: STATUS.PAYMENT_INTENTS.PAID,
+      paid_at: intent.paid_at ?? new Date().toISOString(),
     };
   }
 
   // No (or wrong) preimage proof — fall back to live settlement status, which
   // also runs the rail checks (LUD-21 / NWC / chain) and updates the row.
+  // Only PAID is settlement: BUYER_CONFIRMED is the payer's own unverified
+  // claim (reachable with the same bearer token this endpoint hands out) and
+  // must never mint a receipt.
   const refreshed = await checkPublicPaymentStatus(creds.paymentIntentId, creds.statusToken);
-  const settled =
-    refreshed.status === STATUS.PAYMENT_INTENTS.PAID ||
-    refreshed.status === STATUS.PAYMENT_INTENTS.BUYER_CONFIRMED;
+  const settled = refreshed.status === STATUS.PAYMENT_INTENTS.PAID;
   return {
     ok: settled,
     verified_by: settled ? 'settlement' : undefined,

--- a/src/domain/payments/paymentFlowService.ts
+++ b/src/domain/payments/paymentFlowService.ts
@@ -824,6 +824,16 @@ async function claimPaidTransition(paymentIntentId: string): Promise<boolean> {
 }
 
 /**
+ * Settle a payment verified OUTSIDE the polling loop — e.g. an L402 preimage
+ * proof. Callers must hold cryptographic (or rail-confirmed) evidence of
+ * settlement; this is NOT a way to mark a payment paid on a caller's say-so.
+ * Idempotent via {@link claimPaidTransition}.
+ */
+export async function settleVerifiedPayment(paymentIntent: PaymentIntent): Promise<void> {
+  await handlePaymentConfirmed(paymentIntent);
+}
+
+/**
  * Handle side-effects when a payment is confirmed as paid.
  *
  * Runs at most once per payment intent — see {@link claimPaidTransition}.


### PR DESCRIPTION
## What

Closes the three receipt-integrity holes an independent fresh-eyes security review found in #556's L402 surface (all unauthenticated, all live), plus the #544-induced break of `GET /api/entity-wallets`.

### 1. Receipt bound to the resource (critical)
`verifyL402Payment` looked up the intent by `token` only; the route echoed the **URL's** entity into the 200 receipt. Exploit: pay once for the cheapest listing, replay `Authorization: L402 <token>:<preimage>` against any other `/api/v1/pay/{type}/{id}` → unlimited valid receipts. Now the intent's own `entity_type`/`entity_id` must equal the URL's, with the same opaque `Payment not found` on mismatch (no oracle).

### 2. Self-attestation is not settlement (critical)
The fallback treated `BUYER_CONFIRMED` as settled — but that status is reachable via `POST /api/v1/payments/public/{id}` using the **same bearer token the 402 challenge hands out** (on bare lightning-address rails). Full no-money-moves exploit chain confirmed in review. Only `PAID` settles now — same trust-boundary rule `buyerConfirmPayment` already enforces.

### 3. Preimage receipts settle the ledger (important)
A cryptographically valid preimage returned `ok:true` while the row still said `invoice_ready`: no order → paid, no inventory decrement, no seller notification, no `payment.settled` webhook, no funding-stats credit — the exact money-state divergence #534 fixed, reintroduced on a new surface. The preimage branch now runs the existing settlement via a new `settleVerifiedPayment` export (idempotent — `claimPaidTransition` is the lock).

### 4. entity-wallets embed un-broken (important, money-routing)
`wallets(*)` inside `GET /api/entity-wallets` fails with 42501 since #544's column-grant lockdown → edit form loses the existing wallet link → save POSTs a **second** `is_primary` row → which wallet gets paid becomes nondeterministic. Embed now uses `WALLET_CLIENT_COLUMNS`.

## Tests
New `__tests__/unit/payments/l402-verify.test.ts` pins: cross-entity replay (valid preimage!) → opaque 404; entity-type mismatch → 404; preimage → `settleVerifiedPayment` called + paid receipt; wrong preimage → fallback; `buyer_confirmed` → **never** ok; hashless `PAID` → ok. Route test asserts the URL entity reaches the verifier. 95 payment-area tests green, tsc/lint clean.

## Not in this PR (tracked separately)
Recipient-side invoice-spam limiter on the 402 + public-support routes, spoofable leftmost-XFF rate-limit key, settled-side-effects outbox, WALLET_CLIENT_COLUMNS drift guard, public xpub exposure via `/api/wallets?profile_id=` — being filed as a ranked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)