### PR TITLE
fix(cat): forget verb clears the economic profile on the TOOL-CALL path too

### DIFF
--- a/__tests__/unit/cat/tool-executor-forget.test.ts
+++ b/__tests__/unit/cat/tool-executor-forget.test.ts
@@ -1,0 +1,106 @@
+/**
+ * forget_memories on the TOOL-CALL dispatch path must clear BOTH stores.
+ *
+ * #545's commit message promised "clears BOTH stores", but the fix landed only
+ * in the exec_action handler — the tool-call path silently skipped the
+ * economic profile, so a "removed" skill kept driving suggestions. This suite
+ * pins the both-stores contract on the path that missed it.
+ */
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockForgetMemories = jest.fn();
+jest.mock('@/services/cat/memory', () => ({
+  forgetMemoriesMatching: (...args: unknown[]) => mockForgetMemories(...args),
+}));
+
+const mockRemoveProfile = jest.fn();
+jest.mock('@/services/cat/economic-profile', () => ({
+  removeFromEconomicProfile: (...args: unknown[]) => mockRemoveProfile(...args),
+}));
+
+import { executeToolCall } from '@/services/cat/tool-executor';
+
+const supabase = {} as never;
+const USER_ID = 'user-1';
+
+function forgetCall(facts: unknown) {
+  return {
+    id: 'tc-1',
+    function: { name: 'forget_memories', arguments: JSON.stringify({ facts }) },
+  } as never;
+}
+
+beforeEach(() => {
+  mockForgetMemories.mockReset();
+  mockRemoveProfile.mockReset();
+});
+
+describe('executeToolCall forget_memories', () => {
+  it('clears BOTH stores and reports the union in the tool result', async () => {
+    mockForgetMemories.mockResolvedValue({
+      deleted: ['Does photography'],
+      notFound: ['speaks French'],
+    });
+    mockRemoveProfile.mockResolvedValue({
+      removed: ['skill: photography'],
+      notFound: ['speaks French'],
+    });
+
+    const events: Array<Record<string, unknown>> = [];
+    const result = await executeToolCall(
+      supabase,
+      USER_ID,
+      forgetCall(['photography', 'speaks French']),
+      'forget my photography skills',
+      e => events.push(e as unknown as Record<string, unknown>)
+    );
+
+    expect(mockForgetMemories).toHaveBeenCalledWith(supabase, USER_ID, [
+      'photography',
+      'speaks French',
+    ]);
+    expect(mockRemoveProfile).toHaveBeenCalledWith(supabase, USER_ID, [
+      'photography',
+      'speaks French',
+    ]);
+
+    const outcome = JSON.parse(result.content.split('\n')[0]);
+    expect(outcome.deleted).toEqual(['Does photography']);
+    expect(outcome.removedProfileEntries).toEqual(['skill: photography']);
+    // notFound only lists facts BOTH stores missed.
+    expect(outcome.notFound).toEqual(['speaks French']);
+
+    const completed = events.find(e => e.status === 'completed');
+    expect(completed).toBeDefined();
+    // resultCount covers both stores, not just memories.
+    expect(completed?.resultCount).toBe(2);
+  });
+
+  it('counts a profile-only removal as a success, not no_results', async () => {
+    mockForgetMemories.mockResolvedValue({ deleted: [], notFound: ['welding'] });
+    mockRemoveProfile.mockResolvedValue({ removed: ['skill: welding'], notFound: [] });
+
+    const events: Array<Record<string, unknown>> = [];
+    await executeToolCall(supabase, USER_ID, forgetCall(['welding']), 'forget welding', e =>
+      events.push(e as unknown as Record<string, unknown>)
+    );
+
+    expect(events.some(e => e.status === 'completed')).toBe(true);
+    expect(events.some(e => e.status === 'no_results')).toBe(false);
+  });
+
+  it('reports no_results only when BOTH stores found nothing', async () => {
+    mockForgetMemories.mockResolvedValue({ deleted: [], notFound: ['x'] });
+    mockRemoveProfile.mockResolvedValue({ removed: [], notFound: ['x'] });
+
+    const events: Array<Record<string, unknown>> = [];
+    await executeToolCall(supabase, USER_ID, forgetCall(['x']), 'forget x', e =>
+      events.push(e as unknown as Record<string, unknown>)
+    );
+
+    expect(events.some(e => e.status === 'no_results')).toBe(true);
+  });
+});

--- a/src/services/cat/tool-executor.ts
+++ b/src/services/cat/tool-executor.ts
@@ -232,19 +232,36 @@ Explain this to the user in plain language: which provider is healthy, degraded,
 
     let content: string;
     try {
-      const { forgetMemoriesMatching } = await import('./memory');
-      const outcome = await forgetMemoriesMatching(supabase, userId, facts);
+      // One user verb must clear BOTH stores — free-form memories AND the
+      // structured economic profile — exactly like the exec_action handler.
+      // This path once cleared only memories, so a "removed" skill kept
+      // driving suggestions (the dispatch-drift bug class).
+      const [{ forgetMemoriesMatching }, { removeFromEconomicProfile }] = await Promise.all([
+        import('./memory'),
+        import('./economic-profile'),
+      ]);
+      const [mem, profile] = await Promise.all([
+        forgetMemoriesMatching(supabase, userId, facts),
+        removeFromEconomicProfile(supabase, userId, facts),
+      ]);
+      const outcome = {
+        deleted: mem.deleted,
+        removedProfileEntries: profile.removed,
+        notFound: facts.filter(f => mem.notFound.includes(f) && profile.notFound.includes(f)),
+      };
       content =
         JSON.stringify(outcome) +
-        '\n\nReport ONLY what "deleted" confirms was removed, quoting the deleted memories. ' +
-        'For anything in "notFound", say plainly that no matching stored memory was found and ' +
-        'that the full list is at Settings → AI → What Cat remembers. Never claim other changes.';
-      if (outcome.deleted.length > 0) {
+        '\n\nReport ONLY what "deleted" and "removedProfileEntries" confirm was removed, ' +
+        'quoting the deleted items. For anything in "notFound", say plainly that no matching ' +
+        'stored memory or profile entry was found and that the full list is at ' +
+        'Settings → AI → What Cat remembers. Never claim other changes.';
+      const removedCount = outcome.deleted.length + outcome.removedProfileEntries.length;
+      if (removedCount > 0) {
         onToolCall?.({
           id: toolCall.id,
           name: toolName,
           status: 'completed',
-          resultCount: outcome.deleted.length,
+          resultCount: removedCount,
           results: [],
         });
       } else {


### PR DESCRIPTION
#545 registered forget_memories in both dispatch systems and promised it
"clears BOTH stores" — but the both-stores composition landed only in the
exec_action handler. The tool-call path (the default for tool-capable
providers) called forgetMemoriesMatching alone, so a "removed" skill kept
living in user_economic_profile and kept driving offers/interview prompts:
the exact half-forgotten failure the fix was written to end, surviving on
the other dispatch path.

The tool-call branch now runs forgetMemoriesMatching AND
removeFromEconomicProfile in parallel (mirroring handlers/context.ts),
reports both result sets in the tool content, only lists a fact as notFound
when BOTH stores missed it, and counts profile-only removals as success
instead of no_results.

Deliberately touches only tool-executor.ts + a new test — no overlap with
the open #555 matcher rework (memory.ts / context.ts), which carries the
shared-matcher refactor blockers separately.

New suite pins the both-stores contract on this path: union reporting,
profile-only success, and both-missed no_results. 428 cat-area tests green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
