### PR TITLE
feat(wallets): address-reuse warning for owners + shared-wallet disclosure for backers

### DIFF
--- a/__tests__/unit/wallets/wallet-usage.test.ts
+++ b/__tests__/unit/wallets/wallet-usage.test.ts
@@ -1,0 +1,102 @@
+/**
+ * getSharedWalletUsage — the shared-wallet disclosure contract.
+ *
+ * Pins: bare-count semantics (self excluded), the owner-default flag,
+ * xpub → fresh-address (no warning), group wallets → null, and that a
+ * resolution failure degrades to null instead of breaking the page.
+ */
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockResolve = jest.fn();
+jest.mock('@/domain/payments', () => ({
+  resolveSellerWallet: (...args: unknown[]) => mockResolve(...args),
+}));
+
+// Admin client: route wallets vs entity_wallets queries to separate results.
+let walletRow: { id: string; is_primary: boolean } | null = null;
+let linkRows: Array<{ entity_type: string; entity_id: string }> = [];
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: () => ({
+    from: (table: string) => {
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        maybeSingle: async () => ({ data: walletRow }),
+        then: (resolve: (v: { data: unknown }) => void) =>
+          resolve({ data: table === 'entity_wallets' ? linkRows : null }),
+      };
+      return table === 'wallets'
+        ? chain
+        : {
+            select: () => ({
+              eq: async () => ({ data: linkRows }),
+            }),
+          };
+    },
+  }),
+}));
+
+import { getSharedWalletUsage } from '@/domain/wallets/walletUsage';
+
+const supabase = {} as never;
+const ENTITY_ID = '11111111-2222-3333-4444-555555555555';
+
+beforeEach(() => {
+  mockResolve.mockReset();
+  walletRow = { id: 'w1', is_primary: false };
+  linkRows = [];
+});
+
+describe('getSharedWalletUsage', () => {
+  it('returns null when no wallet resolves', async () => {
+    mockResolve.mockResolvedValue(null);
+    expect(await getSharedWalletUsage(supabase, 'product', ENTITY_ID)).toBeNull();
+  });
+
+  it('counts sibling links but never the entity itself', async () => {
+    mockResolve.mockResolvedValue({ method: 'onchain', wallet_id: 'w1' });
+    linkRows = [
+      { entity_type: 'product', entity_id: ENTITY_ID }, // self — excluded
+      { entity_type: 'project', entity_id: 'other-1' },
+      { entity_type: 'cause', entity_id: 'other-2' },
+    ];
+    const usage = await getSharedWalletUsage(supabase, 'product', ENTITY_ID);
+    expect(usage).toEqual({
+      shared_count: 2,
+      is_owner_default: false,
+      fresh_address_per_payment: false,
+    });
+  });
+
+  it('flags the owner-default wallet (implicit sharing beyond explicit links)', async () => {
+    mockResolve.mockResolvedValue({ method: 'lightning_address', wallet_id: 'w1' });
+    walletRow = { id: 'w1', is_primary: true };
+    const usage = await getSharedWalletUsage(supabase, 'product', ENTITY_ID);
+    expect(usage?.is_owner_default).toBe(true);
+    expect(usage?.shared_count).toBe(0);
+  });
+
+  it('flags xpub wallets as fresh-address (payments not linkable)', async () => {
+    mockResolve.mockResolvedValue({
+      method: 'onchain',
+      wallet_id: 'w1',
+      onchain_xpub: 'zpub6xyz',
+    });
+    const usage = await getSharedWalletUsage(supabase, 'product', ENTITY_ID);
+    expect(usage?.fresh_address_per_payment).toBe(true);
+  });
+
+  it('returns null for group treasuries (wallet not in wallets table)', async () => {
+    mockResolve.mockResolvedValue({ method: 'nwc', wallet_id: 'gw1' });
+    walletRow = null;
+    expect(await getSharedWalletUsage(supabase, 'group', ENTITY_ID)).toBeNull();
+  });
+
+  it('degrades to null when resolution throws — disclosure never breaks the page', async () => {
+    mockResolve.mockRejectedValue(new Error('rail down'));
+    expect(await getSharedWalletUsage(supabase, 'product', ENTITY_ID)).toBeNull();
+  });
+});

--- a/src/components/create/wallet-selector/WalletSelectorField.tsx
+++ b/src/components/create/wallet-selector/WalletSelectorField.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Wallet as WalletIcon, PenLine, Loader2 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { Input } from '@/components/ui/Input';
-import type { Wallet } from '@/types/wallet';
+import { detectWalletType, type Wallet } from '@/types/wallet';
 import { WalletCard } from './WalletCard';
 import { API_ROUTES } from '@/config/api-routes';
 
@@ -96,6 +96,42 @@ export function WalletSelectorField({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- run once after wallets load
   }, [wallets]);
 
+  // Reuse warning: attaching a wallet that already collects for other pages
+  // makes those pages publicly linkable on-chain. Warn at the moment of
+  // attachment — including the silent auto-preselect above — so reuse is a
+  // choice, not an accident. Best-effort: a failed lookup shows no warning.
+  const [reuseInfo, setReuseInfo] = useState<{ count: number; isXpubWallet: boolean } | null>(
+    null
+  );
+  useEffect(() => {
+    if (!selectedWalletId) {
+      setReuseInfo(null);
+      return;
+    }
+    const wallet = wallets.find(w => w.id === selectedWalletId);
+    const isXpubWallet = wallet?.address_or_xpub
+      ? detectWalletType(wallet.address_or_xpub) === 'xpub'
+      : false;
+    let cancelled = false;
+    fetch(`${API_ROUTES.ENTITY_WALLETS}?wallet_id=${selectedWalletId}`)
+      .then(res => (res.ok ? res.json() : null))
+      .then(result => {
+        if (cancelled || !result) {return;}
+        const rows: Array<{ entity_id: string }> = Array.isArray(result.data) ? result.data : [];
+        // In edit mode the entity's own existing link must not count as reuse.
+        const currentEntityId = formData.id as string | undefined;
+        const count = rows.filter(r => r.entity_id !== currentEntityId).length;
+        setReuseInfo({ count, isXpubWallet });
+      })
+      .catch(() => {
+        if (!cancelled) {setReuseInfo(null);}
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- formData.id is stable per form
+  }, [selectedWalletId, wallets]);
+
   const handleSelectWallet = (wallet: Wallet) => {
     setSelectedWalletId(wallet.id);
     onFieldChange('bitcoin_address', wallet.address_or_xpub);
@@ -165,17 +201,35 @@ export function WalletSelectorField({
 
       {/* Select mode */}
       {mode === 'select' && wallets.length > 0 && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-          {wallets.map(wallet => (
-            <WalletCard
-              key={wallet.id}
-              wallet={wallet}
-              selected={selectedWalletId === wallet.id}
-              onSelect={() => handleSelectWallet(wallet)}
-              disabled={disabled}
-            />
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {wallets.map(wallet => (
+              <WalletCard
+                key={wallet.id}
+                wallet={wallet}
+                selected={selectedWalletId === wallet.id}
+                onSelect={() => handleSelectWallet(wallet)}
+                disabled={disabled}
+              />
+            ))}
+          </div>
+          {reuseInfo && reuseInfo.count > 0 && !reuseInfo.isXpubWallet && (
+            <p className="rounded-lg border border-status-warning/40 bg-status-warning-subtle px-3 py-2 text-xs text-fg-secondary">
+              This wallet already receives funds for {reuseInfo.count} other{' '}
+              {reuseInfo.count === 1 ? 'page' : 'pages'}. On-chain payments to the same address
+              are publicly linkable — anyone can connect these pages on the blockchain. For
+              separate identities, pick a different wallet, or use an xpub wallet to get a fresh
+              address per payment.
+            </p>
+          )}
+          {reuseInfo && reuseInfo.count > 0 && reuseInfo.isXpubWallet && (
+            <p className="text-xs text-fg-secondary">
+              This wallet collects for {reuseInfo.count} other{' '}
+              {reuseInfo.count === 1 ? 'page' : 'pages'}, but it derives a fresh address per
+              payment — payments aren&apos;t linkable on-chain.
+            </p>
+          )}
+        </>
       )}
 
       {/* Manual mode */}

--- a/src/components/payment/PublicEntityPaymentSection.tsx
+++ b/src/components/payment/PublicEntityPaymentSection.tsx
@@ -21,6 +21,8 @@ import { SellerWalletBanner } from './SellerWalletBanner';
 import { OwnerCollectPanel } from './OwnerCollectPanel';
 import { PublicPayPanel } from './PublicPayPanel';
 import { PublicSupportPanel } from './PublicSupportPanel';
+import { SharedWalletNotice } from './SharedWalletNotice';
+import type { SharedWalletUsage } from '@/domain/wallets/walletUsage';
 import { getEntityMetadata, type EntityType } from '@/config/entity-registry';
 import { ROUTES } from '@/config/routes';
 
@@ -41,6 +43,11 @@ interface PublicEntityPaymentSectionProps {
    * the anonymous pay-direct panel. `address` is null for NWC-only sellers.
    */
   sellerReceive: { method: 'nwc' | 'lightning_address' | 'onchain'; address: string | null } | null;
+  /**
+   * How shared the resolved receiving wallet is (resolved server-side).
+   * Drives the backer-facing address-reuse disclosure next to the address.
+   */
+  sharedWalletUsage?: SharedWalletUsage | null;
   /** Fixed price converted to BTC, for the anonymous BIP21 amount. */
   priceAmountBtc?: number;
   /** Redirect path after sign-in */
@@ -56,6 +63,7 @@ export function PublicEntityPaymentSection({
   sellerProfileId,
   sellerUserId,
   sellerReceive,
+  sharedWalletUsage = null,
   priceAmountBtc,
   signInRedirect,
 }: PublicEntityPaymentSectionProps) {
@@ -115,6 +123,7 @@ export function PublicEntityPaymentSection({
             address={sellerReceive.address}
             signInHref={`${ROUTES.AUTH}?mode=login&from=${signInRedirect}`}
           />
+          <SharedWalletNotice usage={sharedWalletUsage} />
           {meta.canReceiveSupport && meta.paymentPattern === 'fixed_price' && (
             <PublicSupportPanel
               entityType={entityType}

--- a/src/components/payment/SharedWalletNotice.tsx
+++ b/src/components/payment/SharedWalletNotice.tsx
@@ -1,0 +1,34 @@
+import { Info } from 'lucide-react';
+import type { SharedWalletUsage } from '@/domain/wallets/walletUsage';
+
+/**
+ * Backer-facing shared-wallet disclosure, shown next to a revealed receiving
+ * address. Bare count only — sibling entities are never named (see
+ * walletUsage.ts for why). Renders nothing when there is nothing to disclose
+ * or when payments derive a fresh address each time (xpub wallets).
+ */
+export function SharedWalletNotice({ usage }: { usage: SharedWalletUsage | null }) {
+  if (!usage || usage.fresh_address_per_payment) {
+    return null;
+  }
+  if (usage.shared_count === 0 && !usage.is_owner_default) {
+    return null;
+  }
+
+  const sharedLine =
+    usage.shared_count > 0
+      ? `This wallet also receives funds for ${usage.shared_count} other ${
+          usage.shared_count === 1 ? 'page' : 'pages'
+        } on OrangeCat.`
+      : 'This is the recipient’s default wallet — their other pages may share it.';
+
+  return (
+    <p className="flex items-start gap-1.5 text-xs text-fg-secondary">
+      <Info className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden />
+      <span>
+        {sharedLine} On-chain payments to a shared address are publicly linkable on the
+        blockchain.
+      </span>
+    </p>
+  );
+}

--- a/src/components/public/PublicEntityDetailPage.tsx
+++ b/src/components/public/PublicEntityDetailPage.tsx
@@ -20,6 +20,7 @@ import PublicEntityOwnerCard from '@/components/public/PublicEntityOwnerCard';
 import PublicEntityHero from '@/components/public/PublicEntityHero';
 import { PublicEntityPaymentSection } from '@/components/payment';
 import { resolveSellerReceiveInfo, type SellerReceiveInfo } from '@/domain/payments';
+import { getSharedWalletUsage, type SharedWalletUsage } from '@/domain/wallets/walletUsage';
 import { currencyConverter } from '@/services/currency';
 import { type CurrencyCode } from '@/config/currencies';
 import { fetchEntityOwner } from '@/lib/entities/fetchEntityOwner';
@@ -146,10 +147,16 @@ export default async function PublicEntityDetailPage({
   const price = config.getPrice?.(entity) ?? null;
   const priceAmount = price && price.amount > 0 ? price.amount : undefined;
   let sellerReceive: SellerReceiveInfo | null = null;
+  let sharedWalletUsage: SharedWalletUsage | null = null;
   let priceAmountBtc: number | undefined;
   const hasPaymentSurface = config.showPaymentSection !== false || meta.canReceiveSupport;
   if (hasPaymentSurface) {
     sellerReceive = await resolveSellerReceiveInfo(supabase, config.entityType, id);
+    // Address-reuse disclosure — only worth resolving when an address will
+    // actually be shown (NWC reveals no static address to link).
+    if (sellerReceive?.address) {
+      sharedWalletUsage = await getSharedWalletUsage(supabase, config.entityType, id);
+    }
     if (priceAmount !== undefined && price) {
       priceAmountBtc =
         (price.currency || 'BTC') === 'BTC'
@@ -288,6 +295,7 @@ export default async function PublicEntityDetailPage({
                     sellerProfileId={owner?.id ?? null}
                     sellerUserId={owner?.user_id ?? null}
                     sellerReceive={sellerReceive}
+                    sharedWalletUsage={sharedWalletUsage}
                     priceAmountBtc={priceAmountBtc}
                     signInRedirect={viewRoute}
                   />

--- a/src/domain/wallets/walletUsage.ts
+++ b/src/domain/wallets/walletUsage.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared-wallet usage — the honesty layer for Bitcoin address reuse.
+ *
+ * On-chain payments to the same address are publicly linkable by anyone with a
+ * block explorer. When an owner routes several entities into one wallet, a
+ * backer paying entity A can see (on-chain) that the address also collects for
+ * B and C — so the platform should say so up front rather than let backers
+ * discover it later.
+ *
+ * Deliberately disclosed as a BARE COUNT, never a list: naming the sibling
+ * entities here would hand out an owner's full portfolio in one call — a
+ * reverse-lookup the platform intentionally does not offer. The blockchain
+ * only ever reveals payments actually made; we match that bar, not lower it.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { resolveSellerWallet } from '@/domain/payments';
+import type { EntityType } from '@/config/entity-registry';
+import { logger } from '@/utils/logger';
+
+export interface SharedWalletUsage {
+  /** Other entities explicitly linked to the same receiving wallet. */
+  shared_count: number;
+  /**
+   * The wallet is its owner's default (is_primary) — entities with no explicit
+   * link fall back to it too, so sharing extends beyond the linked count.
+   */
+  is_owner_default: boolean;
+  /**
+   * Wallet is configured with an xpub: every payment derives a fresh, never
+   * reused address, so payments are NOT linkable on-chain. No warning needed.
+   */
+  fresh_address_per_payment: boolean;
+}
+
+/**
+ * Resolve how shared an entity's receiving wallet is, using the SAME wallet
+ * resolution the payment flow uses (SSOT) — what we disclose is what actually
+ * receives the money. Returns null when no wallet resolves, when resolution
+ * fails, or for group treasuries (a group wallet is expected to be shared —
+ * that's what a treasury is, and it lives outside entity_wallets).
+ */
+export async function getSharedWalletUsage(
+  supabase: SupabaseClient,
+  entityType: EntityType,
+  entityId: string
+): Promise<SharedWalletUsage | null> {
+  try {
+    const resolved = await resolveSellerWallet(supabase, entityType, entityId);
+    if (!resolved) {
+      return null;
+    }
+
+    const admin = getAdminClient() as unknown as SupabaseClient;
+
+    // Group wallets live in group_wallets — a wallets-table lookup misses and
+    // we correctly return null (treasury sharing isn't a privacy leak).
+    const { data: wallet } = await admin
+      .from(DATABASE_TABLES.WALLETS)
+      .select('id, is_primary')
+      .eq('id', resolved.wallet_id)
+      .maybeSingle();
+    if (!wallet) {
+      return null;
+    }
+
+    const { data: links } = await admin
+      .from(DATABASE_TABLES.ENTITY_WALLETS)
+      .select('entity_type, entity_id')
+      .eq('wallet_id', resolved.wallet_id);
+
+    const sharedCount = (links ?? []).filter(
+      l => !(l.entity_type === entityType && l.entity_id === entityId)
+    ).length;
+
+    return {
+      shared_count: sharedCount,
+      is_owner_default: !!wallet.is_primary,
+      fresh_address_per_payment: resolved.method === 'onchain' && !!resolved.onchain_xpub,
+    };
+  } catch (error) {
+    // Disclosure is best-effort: a failure here must never break the page or
+    // the payment flow it annotates.
+    logger.warn('getSharedWalletUsage failed', { entityType, entityId, error });
+    return null;
+  }
+}


### PR DESCRIPTION
One Bitcoin address across several entities makes every payment publicly
linkable on-chain — anyone with a block explorer can connect a backer's
payment for entity A to entities B and C. Today that reuse is the silent
default (auto-preselected primary wallet + resolveSellerWallet fallback), and
neither side is told. This slice makes reuse a visible, informed choice on
both sides:

Owner side (WalletSelectorField): selecting or auto-preselecting a wallet now
looks up its existing entity links (GET /api/entity-wallets?wallet_id=) and
warns when the wallet already collects for other pages, with the concrete
escape hatches — pick another wallet, or use an xpub wallet (fresh address
per payment, detected via detectWalletType, which flips the warning into a
reassurance instead).

Backer side: new domain service getSharedWalletUsage (src/domain/wallets/
walletUsage.ts) resolves the entity's wallet through the SAME resolveSellerWallet
chain the payment flow uses (SSOT — we disclose what actually receives the
money), then reports a BARE COUNT of sibling links + an is-owner-default flag.
PublicEntityDetailPage fetches it server-side only when an address will be
shown, and SharedWalletNotice renders it under the pay panel. xpub wallets and
group treasuries disclose nothing (fresh addresses aren't linkable; a treasury
is shared by definition).

Design decision, on purpose: there is NO public reverse-lookup ("show me all
entities behind this wallet") and the disclosure never names sibling entities —
that would hand out an owner's full portfolio in one call, strictly more than
the blockchain reveals (which only ever shows payments actually made). The
count matches that bar without lowering it.

Best-effort by construction: any lookup failure renders no notice rather than
breaking the page or the payment flow.

Tests: 6-case suite pins self-exclusion in the count, owner-default flag,
xpub fresh-address flag, group-treasury null, and failure→null degradation.
1493 wallet-area tests green; tsc + eslint clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
