### PR TITLE
fix(wallets): count shared-wallet reuse by ADDRESS and only for live public pages

### DIFF
--- a/__tests__/unit/wallets/wallet-usage.test.ts
+++ b/__tests__/unit/wallets/wallet-usage.test.ts
@@ -15,39 +15,48 @@ jest.mock('@/domain/payments', () => ({
   resolveSellerWallet: (...args: unknown[]) => mockResolve(...args),
 }));
 
-// Admin client: route wallets vs entity_wallets queries to separate results.
-let walletRow: { id: string; is_primary: boolean } | null = null;
+// Admin client mock: wallets lookups (single row + address twins) and
+// entity_wallets link rows. Public client mock: RLS-visible sibling entities.
+let walletRow: Record<string, unknown> | null = null;
+let addressTwins: Array<{ id: string }> = [];
 let linkRows: Array<{ entity_type: string; entity_id: string }> = [];
+let visibleByTable: Record<string, string[]> = {};
+
 jest.mock('@/lib/supabase/admin', () => ({
   getAdminClient: () => ({
     from: (table: string) => {
-      const chain = {
-        select: () => chain,
-        eq: () => chain,
-        maybeSingle: async () => ({ data: walletRow }),
-        then: (resolve: (v: { data: unknown }) => void) =>
-          resolve({ data: table === 'entity_wallets' ? linkRows : null }),
-      };
-      return table === 'wallets'
-        ? chain
-        : {
-            select: () => ({
-              eq: async () => ({ data: linkRows }),
-            }),
-          };
+      if (table === 'wallets') {
+        return {
+          select: () => ({
+            eq: () => ({ maybeSingle: async () => ({ data: walletRow }) }),
+            or: async () => ({ data: addressTwins }),
+          }),
+        };
+      }
+      return { select: () => ({ in: async () => ({ data: linkRows }) }) };
     },
   }),
 }));
 
 import { getSharedWalletUsage } from '@/domain/wallets/walletUsage';
 
-const supabase = {} as never;
+const supabase = {
+  from: (table: string) => ({
+    select: () => ({
+      in: async (_col: string, ids: string[]) => ({
+        data: (visibleByTable[table] ?? []).filter(id => ids.includes(id)).map(id => ({ id })),
+      }),
+    }),
+  }),
+} as never;
 const ENTITY_ID = '11111111-2222-3333-4444-555555555555';
 
 beforeEach(() => {
   mockResolve.mockReset();
-  walletRow = { id: 'w1', is_primary: false };
+  walletRow = { id: 'w1', is_primary: false, lightning_address: null, address_or_xpub: null };
+  addressTwins = [];
   linkRows = [];
+  visibleByTable = {};
 });
 
 describe('getSharedWalletUsage', () => {
@@ -63,6 +72,7 @@ describe('getSharedWalletUsage', () => {
       { entity_type: 'project', entity_id: 'other-1' },
       { entity_type: 'cause', entity_id: 'other-2' },
     ];
+    visibleByTable = { projects: ['other-1'], user_causes: ['other-2'] };
     const usage = await getSharedWalletUsage(supabase, 'product', ENTITY_ID);
     expect(usage).toEqual({
       shared_count: 2,
@@ -98,5 +108,52 @@ describe('getSharedWalletUsage', () => {
   it('degrades to null when resolution throws — disclosure never breaks the page', async () => {
     mockResolve.mockRejectedValue(new Error('rail down'));
     expect(await getSharedWalletUsage(supabase, 'product', ENTITY_ID)).toBeNull();
+  });
+});
+
+describe('getSharedWalletUsage — defects found by verifying against prod data', () => {
+  it('counts reuse across DIFFERENT wallet rows holding the SAME address', async () => {
+    // Prod really holds orangecat@coinos.io in two wallet rows (and one xpub in
+    // eleven). Per-wallet_id counting reported "not shared" for the platform's
+    // most visible reuse — the FleetCrown/OrangeCat case.
+    mockResolve.mockResolvedValue({ method: 'lightning_address', wallet_id: 'w1' });
+    walletRow = {
+      id: 'w1',
+      is_primary: false,
+      lightning_address: 'orangecat@coinos.io',
+      address_or_xpub: null,
+    };
+    addressTwins = [{ id: 'w1' }, { id: 'w2' }];
+    linkRows = [
+      { entity_type: 'product', entity_id: ENTITY_ID }, // self, wallet w1
+      { entity_type: 'product', entity_id: 'twin-linked' }, // via wallet w2
+    ];
+    visibleByTable = { user_products: ['twin-linked'] };
+    const usage = await getSharedWalletUsage(supabase, 'product', ENTITY_ID);
+    expect(usage?.shared_count).toBe(1);
+  });
+
+  it('never counts links whose entity no longer exists (orphan rows)', async () => {
+    // All nine links on one prod wallet pointed at deleted entities; the raw
+    // count would have claimed "8 other pages" that a backer cannot open.
+    mockResolve.mockResolvedValue({ method: 'onchain', wallet_id: 'w1' });
+    linkRows = [
+      { entity_type: 'product', entity_id: 'deleted-1' },
+      { entity_type: 'cause', entity_id: 'deleted-2' },
+    ];
+    visibleByTable = {}; // RLS/existence returns nothing
+    const usage = await getSharedWalletUsage(supabase, 'product', ENTITY_ID);
+    expect(usage?.shared_count).toBe(0);
+  });
+
+  it('counts only the publicly visible siblings, not drafts', async () => {
+    mockResolve.mockResolvedValue({ method: 'onchain', wallet_id: 'w1' });
+    linkRows = [
+      { entity_type: 'product', entity_id: 'published' },
+      { entity_type: 'product', entity_id: 'draft-hidden-by-rls' },
+    ];
+    visibleByTable = { user_products: ['published'] };
+    const usage = await getSharedWalletUsage(supabase, 'product', ENTITY_ID);
+    expect(usage?.shared_count).toBe(1);
   });
 });

--- a/src/domain/wallets/walletUsage.ts
+++ b/src/domain/wallets/walletUsage.ts
@@ -17,7 +17,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { getAdminClient } from '@/lib/supabase/admin';
 import { resolveSellerWallet } from '@/domain/payments';
-import type { EntityType } from '@/config/entity-registry';
+import { getEntityMetadata, type EntityType } from '@/config/entity-registry';
 import { logger } from '@/utils/logger';
 
 export interface SharedWalletUsage {
@@ -33,6 +33,46 @@ export interface SharedWalletUsage {
    * reused address, so payments are NOT linkable on-chain. No warning needed.
    */
   fresh_address_per_payment: boolean;
+}
+
+/**
+ * Count the sibling links that are actually PUBLIC pages, using the caller's
+ * RLS-scoped client so the database's own visibility rules decide — the same
+ * gate the payment surface uses.
+ *
+ * Two ways the raw link count lies, both observed in prod: entity_wallets keeps
+ * rows for entities that were deleted (all nine links on one wallet pointed at
+ * rows that no longer exist), and a draft page isn't publicly linkable at all.
+ * Claiming "also receives funds for 8 other pages" when none are visible is
+ * exactly the fabricated-confidence failure this disclosure exists to prevent.
+ */
+async function countPubliclyVisible(
+  supabase: SupabaseClient,
+  siblings: Array<{ entity_type: EntityType; entity_id: string }>
+): Promise<number> {
+  if (siblings.length === 0) {
+    return 0;
+  }
+  const byType = new Map<EntityType, string[]>();
+  for (const s of siblings) {
+    byType.set(s.entity_type, [...(byType.get(s.entity_type) ?? []), s.entity_id]);
+  }
+
+  const counts = await Promise.all(
+    Array.from(byType.entries()).map(async ([type, ids]) => {
+      try {
+        const { data } = await supabase
+          .from(getEntityMetadata(type).tableName)
+          .select('id')
+          .in('id', ids);
+        return data?.length ?? 0;
+      } catch {
+        // An unknown/unreadable type contributes nothing rather than inflating.
+        return 0;
+      }
+    })
+  );
+  return counts.reduce((sum, n) => sum + n, 0);
 }
 
 /**
@@ -59,21 +99,40 @@ export async function getSharedWalletUsage(
     // we correctly return null (treasury sharing isn't a privacy leak).
     const { data: wallet } = await admin
       .from(DATABASE_TABLES.WALLETS)
-      .select('id, is_primary')
+      .select('id, is_primary, lightning_address, address_or_xpub')
       .eq('id', resolved.wallet_id)
       .maybeSingle();
     if (!wallet) {
       return null;
     }
 
+    // Count by ADDRESS, not by wallet row. The on-chain linkability a backer
+    // cares about is a property of the address itself, and prod really does
+    // hold the same address in several wallet rows (one lightning address in
+    // two rows, one xpub in eleven) — counting per wallet_id reports "not
+    // shared" for the most visible reuse on the platform.
+    const address = wallet.lightning_address || wallet.address_or_xpub || null;
+    let walletIds = [resolved.wallet_id];
+    if (address) {
+      const { data: twins } = await admin
+        .from(DATABASE_TABLES.WALLETS)
+        .select('id')
+        .or(`lightning_address.eq.${address},address_or_xpub.eq.${address}`);
+      if (twins?.length) {
+        walletIds = Array.from(new Set(twins.map(t => t.id as string)));
+      }
+    }
+
     const { data: links } = await admin
       .from(DATABASE_TABLES.ENTITY_WALLETS)
       .select('entity_type, entity_id')
-      .eq('wallet_id', resolved.wallet_id);
+      .in('wallet_id', walletIds);
 
-    const sharedCount = (links ?? []).filter(
+    const siblings = (links ?? []).filter(
       l => !(l.entity_type === entityType && l.entity_id === entityId)
-    ).length;
+    ) as Array<{ entity_type: EntityType; entity_id: string }>;
+
+    const sharedCount = await countPubliclyVisible(supabase, siblings);
 
     return {
       shared_count: sharedCount,


### PR DESCRIPTION
Browser-verifying #564 against prod found the disclosure both silent where it
mattered most and primed to overstate elsewhere. Both defects came from
counting entity_wallets rows per wallet_id and trusting them:

1. Reuse across wallet ROWS holding the SAME address was invisible. Prod holds
   orangecat@coinos.io in two wallet rows (and one xpub in eleven), so the
   platform's most visible reuse — FleetCrown Personal and FleetCrown Pro both
   showing orangecat@coinos.io — disclosed nothing. On-chain linkability is a
   property of the address, not the row: now all wallet rows sharing the
   resolved address contribute links.

2. The raw count would have claimed pages that do not exist. All nine links on
   one prod wallet point at deleted entities; the notice would have read "also
   receives funds for 8 other pages" a backer cannot open — fabricated
   confidence, which is the exact failure this disclosure exists to prevent.
   Siblings are now counted through the caller's RLS-scoped client, so the
   database's own visibility rules decide what is a public page (drafts and
   deleted rows contribute nothing), matching the #536 payment gate.

Three regression tests pin both directions: twin-address reuse counts, orphan
links count zero, drafts excluded. 9 tests green; tsc + eslint clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
