### PR TITLE
fix(wallets): disclose the owner-default FALLBACK, not just the is_primary flag

### DIFF
--- a/__tests__/unit/wallets/wallet-usage.test.ts
+++ b/__tests__/unit/wallets/wallet-usage.test.ts
@@ -157,3 +157,30 @@ describe('getSharedWalletUsage — defects found by verifying against prod data'
     expect(usage?.shared_count).toBe(1);
   });
 });
+
+describe('getSharedWalletUsage — owner-default detection', () => {
+  it('flags the owner-default fallback when the entity has NO explicit link', async () => {
+    // The FleetCrown case: two passes both resolve to orangecat@coinos.io via
+    // the fallback chain, with zero entity_wallets rows and a wallet row that
+    // is not flagged primary. Keying on is_primary alone disclosed nothing.
+    mockResolve.mockResolvedValue({ method: 'lightning_address', wallet_id: 'w1' });
+    walletRow = {
+      id: 'w1',
+      is_primary: false,
+      lightning_address: 'orangecat@coinos.io',
+      address_or_xpub: null,
+    };
+    addressTwins = [{ id: 'w1' }];
+    linkRows = []; // no link for this entity — fallback resolution
+    const usage = await getSharedWalletUsage(supabase, 'product', ENTITY_ID);
+    expect(usage?.is_owner_default).toBe(true);
+    expect(usage?.shared_count).toBe(0);
+  });
+
+  it('does NOT call an explicitly-linked, non-primary wallet the owner default', async () => {
+    mockResolve.mockResolvedValue({ method: 'onchain', wallet_id: 'w1' });
+    linkRows = [{ entity_type: 'product', entity_id: ENTITY_ID }]; // deliberate link
+    const usage = await getSharedWalletUsage(supabase, 'product', ENTITY_ID);
+    expect(usage?.is_owner_default).toBe(false);
+  });
+});

--- a/src/domain/wallets/walletUsage.ts
+++ b/src/domain/wallets/walletUsage.ts
@@ -134,9 +134,21 @@ export async function getSharedWalletUsage(
 
     const sharedCount = await countPubliclyVisible(supabase, siblings);
 
+    // No explicit link for THIS entity means resolveSellerWallet fell through
+    // to the owner-default chain — so every other unlinked page of the same
+    // owner lands on this identical address. That fallback, not the is_primary
+    // flag, is what actually makes a wallet the de-facto default: the two
+    // FleetCrown passes both display orangecat@coinos.io through it while the
+    // resolved wallet row is not flagged primary at all, so keying the
+    // disclosure on is_primary alone stayed silent on the platform's most
+    // visible reuse.
+    const hasExplicitLink = (links ?? []).some(
+      l => l.entity_type === entityType && l.entity_id === entityId
+    );
+
     return {
       shared_count: sharedCount,
-      is_owner_default: !!wallet.is_primary,
+      is_owner_default: !hasExplicitLink || !!wallet.is_primary,
       fresh_address_per_payment: resolved.method === 'onchain' && !!resolved.onchain_xpub,
     };
   } catch (error) {


### PR DESCRIPTION
Third browser check against prod: the FleetCrown Personal and Pro passes both
display orangecat@coinos.io and still disclosed nothing. The DB explains it —
those entities have ZERO entity_wallets rows, and the wallet the fallback chain
lands on is not flagged is_primary. So both signals the notice keyed on
(explicit sibling links, wallet.is_primary) were legitimately false while the
reuse a backer can see with their own eyes was real.

The signal that actually matters is HOW the wallet was resolved: when no
explicit link exists for this entity, resolveSellerWallet fell through to the
owner-default chain, which means every other unlinked page of that owner lands
on the identical address. That is the de-facto default regardless of how the
row is flagged, and it is the common case — explicit links are the exception.

is_owner_default is now `no explicit link for this entity || wallet.is_primary`,
derived from the link rows already fetched (no extra query). Two tests pin it:
the FleetCrown shape (no links, non-primary row) discloses, and a deliberately
linked non-primary wallet does not get called the owner default.

11 tests green; tsc + eslint clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
