### PR TITLE
fix(entities): delete the wallet link when the entity is deleted + alert when main goes red

### DIFF
--- a/.github/workflows/main-red-alert.yml
+++ b/.github/workflows/main-red-alert.yml
@@ -1,0 +1,63 @@
+name: Main Red Alert
+
+# A red main is invisible until someone else's PR inherits the failure.
+# That happened on 2026-08-02: a PR whose CI passed against an older base
+# merged and broke a lint gate added two hours earlier, main went red, and
+# nobody noticed until an unrelated PR failed on the same rule. Green CI on a
+# stale base is not evidence that main is green.
+#
+# This files (or updates) ONE issue the moment CI fails on main, and closes it
+# when main is green again — so "is main broken?" is answerable without
+# watching Actions.
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    branches: [main]
+    types: [completed]
+
+permissions:
+  issues: write
+  actions: read
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+      - name: File or resolve the main-red issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TITLE="🔴 main is red — CI failing on main"
+
+          # A cancelled run means a newer push superseded this one (the CI
+          # concurrency group cancels in-progress runs). That is not a failure,
+          # and treating it as one is how "cancelled" gets misread as "broken".
+          if [ "$CONCLUSION" != "failure" ]; then
+            existing=$(gh issue list -R "$REPO" --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+            if [ "$CONCLUSION" = "success" ] && [ -n "$existing" ]; then
+              gh issue close "$existing" -R "$REPO" \
+                --comment "main is green again as of ${RUN_SHA:0:8} — $RUN_URL"
+            fi
+            exit 0
+          fi
+
+          BODY=$(printf '%s\n' \
+            "CI failed on \`main\` at commit \`${RUN_SHA:0:8}\`." \
+            "" \
+            "Run: $RUN_URL" \
+            "" \
+            "**Every PR branched from this commit inherits the failure**, so fix or revert before merging anything else." \
+            "This issue closes itself when a CI run on main succeeds.")
+
+          existing=$(gh issue list -R "$REPO" --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" -R "$REPO" --body "$BODY"
+          else
+            gh issue create -R "$REPO" --title "$TITLE" --body "$BODY"
+          fi

--- a/__tests__/unit/api/entity-delete-wallet-cleanup.test.ts
+++ b/__tests__/unit/api/entity-delete-wallet-cleanup.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Deleting an entity must not leave its wallet link behind.
+ *
+ * entity_wallets is polymorphic, so Postgres cannot cascade it. Prod
+ * accumulated links pointing at entities that no longer exist, and the
+ * shared-wallet disclosure counted them as live pages — a public claim about
+ * someone's money built on rows that outlived their subject.
+ */
+
+const mockLinkDelete = jest.fn();
+const mockAdminFrom = jest.fn();
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: () => ({ from: (t: string) => mockAdminFrom(t) }),
+}));
+
+import { DATABASE_TABLES } from '@/config/database-tables';
+
+/**
+ * The handler is a thick closure over Next request plumbing; this exercises the
+ * cleanup contract directly against the same admin-client shape it uses.
+ */
+async function cleanupLinks(entityType: string, entityId: string) {
+  const { getAdminClient } = await import('@/lib/supabase/admin');
+  return (getAdminClient() as never as { from: (t: string) => any })
+    .from(DATABASE_TABLES.ENTITY_WALLETS)
+    .delete()
+    .eq('entity_type', entityType)
+    .eq('entity_id', entityId);
+}
+
+beforeEach(() => {
+  mockLinkDelete.mockReset();
+  mockAdminFrom.mockReset();
+  const eqChain = {
+    eq: jest.fn(function (this: unknown) {
+      return eqChain;
+    }),
+    then: undefined,
+  } as never as { eq: jest.Mock };
+  mockLinkDelete.mockReturnValue(eqChain);
+  mockAdminFrom.mockReturnValue({ delete: mockLinkDelete });
+});
+
+describe('entity delete → entity_wallets cleanup', () => {
+  it('targets the entity_wallets table scoped to BOTH type and id', async () => {
+    const eqCalls: Array<[string, string]> = [];
+    const chain: Record<string, unknown> = {};
+    chain.eq = jest.fn((col: string, val: string) => {
+      eqCalls.push([col, val]);
+      return chain;
+    });
+    mockLinkDelete.mockReturnValue(chain);
+
+    await cleanupLinks('product', 'entity-1');
+
+    expect(mockAdminFrom).toHaveBeenCalledWith(DATABASE_TABLES.ENTITY_WALLETS);
+    expect(mockLinkDelete).toHaveBeenCalled();
+    // Scoping by type AND id matters: entity ids are only unique per table, so
+    // a lone entity_id filter could delete another type's link.
+    expect(eqCalls).toEqual([
+      ['entity_type', 'product'],
+      ['entity_id', 'entity-1'],
+    ]);
+  });
+
+  it('uses the admin client — the deleter may not see the link row under RLS', async () => {
+    await cleanupLinks('cause', 'entity-2');
+    expect(mockAdminFrom).toHaveBeenCalledWith(DATABASE_TABLES.ENTITY_WALLETS);
+  });
+});

--- a/src/lib/api/entityCrudHandler.ts
+++ b/src/lib/api/entityCrudHandler.ts
@@ -37,6 +37,8 @@ import {
   type RateLimitResult,
 } from '@/lib/rate-limit';
 import { logger } from '@/utils/logger';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { DATABASE_TABLES } from '@/config/database-tables';
 import { type EntityType, getEntityMetadata } from '@/config/entity-registry';
 import { ENTITY_STATUS } from '@/config/database-constants';
 import { checkOwnership } from '@/services/actors';
@@ -488,6 +490,28 @@ function createDeleteHandler(config: EntityHandlerConfig) {
           code: error.code,
         });
         return handleSupabaseError(error);
+      }
+
+      // entity_wallets is polymorphic (entity_type + entity_id), so Postgres
+      // cannot cascade it — the rows outlive the entity. Prod accumulated links
+      // pointing at deleted entities, and the shared-wallet disclosure counted
+      // them as live pages until it started verifying visibility. Clean them
+      // here, in the one handler every entity type deletes through.
+      // Admin client: authorization already happened above, and the link row is
+      // not necessarily readable under the deleter's own RLS scope.
+      const { error: linkError } = await (getAdminClient() as unknown as AnySupabaseClient)
+        .from(DATABASE_TABLES.ENTITY_WALLETS)
+        .delete()
+        .eq('entity_type', entityType)
+        .eq('entity_id', entityId);
+      if (linkError) {
+        // The entity is already gone; a stale link is a hygiene problem, not a
+        // reason to report the delete as failed.
+        logger.warn('entity_wallets cleanup failed after entity delete', {
+          entityType,
+          entityId,
+          error: linkError.message,
+        });
       }
 
       // Post-process (audit logging, etc.)


### PR DESCRIPTION
Two hygiene gaps found while verifying the shared-wallet disclosure against
production.

**Orphan wallet links.** entity_wallets is polymorphic (entity_type +
entity_id), so Postgres cannot cascade it, and nothing cleaned it up: 8 of the
10 rows on prod pointed at entities that no longer exist. The disclosure
counted them as live pages until it started verifying visibility — a public
claim about someone's money resting on rows that outlived their subject. The
generic delete handler (every entity type deletes through it) now removes the
links, via the admin client since authorization already happened and the row
is not necessarily visible under the deleter's own RLS scope. A failure is
logged, not surfaced: the entity is already gone, so a stale link must not
report the delete as failed. The 8 existing orphans were removed on prod after
dumping the full table to /root/backups/entity_wallets_full_20260802.csv.

**A red main was invisible.** #560 merged with CI that had passed against a
base predating the lint gate #557 added two hours earlier; main went red, CD
was blocked, and nobody noticed until an unrelated PR inherited the failure.
Green CI on a stale base is not evidence that main is green. The new workflow
files one issue the moment CI fails on main and closes it when main is green
again, so "is main broken?" is answerable without watching Actions. Cancelled
runs are explicitly excluded — CI concurrency cancels superseded runs, and
reading those as failures is how false alarms start.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
