### PR TITLE
feat(ops): nightly data-invariant gate — test the rows prod has, not the rows mocks imagine

### DIFF
--- a/scripts/check-data-invariants.mjs
+++ b/scripts/check-data-invariants.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Nightly DATA-INVARIANT gate — assert against the rows production actually
+ * holds, not the rows the unit tests imagine.
+ *
+ * Every test in this repo runs against mocks. That is why the shared-wallet
+ * disclosure shipped wrong three times on 2026-08-02 with a fully green suite:
+ * the mocks encoded the data shape we assumed (one address per wallet row,
+ * links that point at live entities), and production held a different one
+ * (the same address across 2–11 wallet rows, 8 of 10 links pointing at deleted
+ * entities). No amount of unit testing finds that class — only reading prod
+ * does. This runs the reading on a schedule.
+ *
+ * Each invariant is a claim the product makes to users. A violation means we
+ * are showing someone something false about their money.
+ *
+ * Usage:
+ *   node scripts/check-data-invariants.mjs           # report, always exit 0
+ *   node scripts/check-data-invariants.mjs --gate    # exit 1 on any violation
+ *
+ * Env: NEXT_PUBLIC_SUPABASE_URL / SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ * (.env.local fallback for local runs, EnvironmentFile on the box).
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+
+function loadLocalEnvFallback() {
+  if (!existsSync('.env.local')) {
+    return;
+  }
+  for (const line of readFileSync('.env.local', 'utf8').split('\n')) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (m && process.env[m[1]] === undefined) {
+      process.env[m[1]] = m[2].replace(/^["']|["']$/g, '');
+    }
+  }
+}
+loadLocalEnvFallback();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const GATE = process.argv.includes('--gate');
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('check-data-invariants: missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(2);
+}
+
+async function rest(path) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { apikey: SERVICE_KEY, authorization: `Bearer ${SERVICE_KEY}` },
+  });
+  if (!res.ok) {
+    throw new Error(`PostgREST ${res.status} on ${path.split('?')[0]}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+/**
+ * entity_type → table. MUST mirror src/config/entity-registry.ts; a type
+ * missing here is reported as UNKNOWN rather than silently passing, so a new
+ * entity type cannot quietly opt out of the orphan check.
+ */
+const ENTITY_TABLES = {
+  product: 'user_products',
+  service: 'user_services',
+  project: 'projects',
+  cause: 'user_causes',
+  event: 'events',
+  asset: 'assets',
+  loan: 'loans',
+  investment: 'investments',
+  ai_assistant: 'ai_assistants',
+  research: 'research_projects',
+  wishlist: 'wishlists',
+  document: 'documents',
+  group: 'groups',
+  circle: 'circles',
+};
+
+const violations = [];
+const notes = [];
+
+function violation(name, detail, sample) {
+  violations.push({ name, detail, sample });
+}
+
+/**
+ * Orphaned wallet links. entity_wallets is polymorphic, so Postgres cannot
+ * cascade it — links outlive their entity unless the delete path removes them.
+ * These rows made the shared-wallet disclosure count pages that do not exist.
+ */
+async function checkOrphanedWalletLinks() {
+  const links = await rest('entity_wallets?select=id,entity_type,entity_id');
+  const byType = new Map();
+  for (const l of links) {
+    byType.set(l.entity_type, [...(byType.get(l.entity_type) ?? []), l]);
+  }
+
+  const orphans = [];
+  for (const [type, rows] of byType) {
+    const table = ENTITY_TABLES[type];
+    if (!table) {
+      violation(
+        'entity_wallets.unknown_entity_type',
+        `entity_wallets holds type "${type}" with no table mapping — add it to ENTITY_TABLES (and check the entity registry)`,
+        rows.slice(0, 3).map(r => r.entity_id)
+      );
+      continue;
+    }
+    const ids = rows.map(r => r.entity_id);
+    const found = await rest(`${table}?select=id&id=in.(${ids.join(',')})`);
+    const live = new Set(found.map(f => f.id));
+    orphans.push(...rows.filter(r => !live.has(r.entity_id)));
+  }
+
+  if (orphans.length > 0) {
+    violation(
+      'entity_wallets.orphaned_links',
+      `${orphans.length} wallet link(s) point at entities that no longer exist — the delete path is leaking again`,
+      orphans.slice(0, 5).map(o => `${o.entity_type}:${o.entity_id}`)
+    );
+  } else {
+    notes.push(`entity_wallets: ${links.length} link(s), all pointing at live entities`);
+  }
+}
+
+/**
+ * Two links flagged is_primary for the SAME entity. resolveLinkedEntityWallet
+ * orders by is_primary with no tiebreaker, so which wallet receives the next
+ * payment becomes nondeterministic — money routed by row order.
+ */
+async function checkDuplicatePrimaryLinks() {
+  const links = await rest('entity_wallets?select=entity_type,entity_id,is_primary&is_primary=is.true');
+  const seen = new Map();
+  const dupes = [];
+  for (const l of links) {
+    const key = `${l.entity_type}:${l.entity_id}`;
+    if (seen.has(key)) {
+      dupes.push(key);
+    }
+    seen.set(key, true);
+  }
+  if (dupes.length > 0) {
+    violation(
+      'entity_wallets.duplicate_primary',
+      `${dupes.length} entity/entities have more than one primary wallet link — payment routing is nondeterministic`,
+      [...new Set(dupes)].slice(0, 5)
+    );
+  } else {
+    notes.push(`entity_wallets: no entity has competing primary links`);
+  }
+}
+
+/**
+ * A wallet that can never receive: active, but holds neither a lightning
+ * address, nor an on-chain address/xpub, nor an NWC connection. The UI can
+ * still offer it, and resolution will silently skip to something else.
+ */
+async function checkUnpayableActiveWallets() {
+  const wallets = await rest(
+    'wallets?select=id,label,is_active,lightning_address,address_or_xpub,nwc_connection_uri&is_active=is.true'
+  );
+  const unpayable = wallets.filter(
+    w => !w.lightning_address && !w.address_or_xpub && !w.nwc_connection_uri
+  );
+  if (unpayable.length > 0) {
+    violation(
+      'wallets.active_but_unpayable',
+      `${unpayable.length} active wallet(s) have no lightning address, no on-chain address/xpub and no NWC connection`,
+      unpayable.slice(0, 5).map(w => `${w.id} (${w.label ?? 'unlabelled'})`)
+    );
+  } else {
+    notes.push(`wallets: all ${wallets.length} active wallet(s) have a usable receiving rail`);
+  }
+}
+
+/**
+ * Money-state divergence: an intent marked paid with no paid_at timestamp.
+ * The settlement transition sets both together, so a mismatch means something
+ * wrote the status outside claimPaidTransition.
+ */
+async function checkPaidWithoutTimestamp() {
+  const rows = await rest('payment_intents?select=id,status,paid_at&status=eq.paid&paid_at=is.null');
+  if (rows.length > 0) {
+    violation(
+      'payment_intents.paid_without_timestamp',
+      `${rows.length} intent(s) are status=paid with paid_at NULL — status was set outside the settlement transition`,
+      rows.slice(0, 5).map(r => r.id)
+    );
+  } else {
+    notes.push('payment_intents: every paid intent carries a settlement timestamp');
+  }
+}
+
+async function main() {
+  const checks = [
+    checkOrphanedWalletLinks,
+    checkDuplicatePrimaryLinks,
+    checkUnpayableActiveWallets,
+    checkPaidWithoutTimestamp,
+  ];
+
+  for (const check of checks) {
+    try {
+      await check();
+    } catch (err) {
+      // A check that cannot run is itself a finding — never let an exception
+      // read as "invariant holds".
+      violation(check.name, `check failed to run: ${err.message}`, []);
+    }
+  }
+
+  console.log('OrangeCat data invariants —', new Date().toISOString());
+  for (const n of notes) {
+    console.log(`  ok    ${n}`);
+  }
+  for (const v of violations) {
+    console.log(`  FAIL  ${v.name}: ${v.detail}`);
+    if (v.sample?.length) {
+      console.log(`        e.g. ${v.sample.join(', ')}`);
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log('All invariants hold.');
+    process.exit(0);
+  }
+  console.log(`${violations.length} invariant(s) violated.`);
+  process.exit(GATE ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('check-data-invariants failed:', err);
+  process.exit(2);
+});

--- a/scripts/deploy-selfhost.sh
+++ b/scripts/deploy-selfhost.sh
@@ -249,15 +249,20 @@ echo "=== ship ops scripts + nightly Cat-eval timer ==="
   scp "${SSH_OPTS[@]}" -q scripts/eval-cat.mjs "$OC_BOX:$OC_APP_BASE/scripts/eval-cat.mjs"
   scp "${SSH_OPTS[@]}" -q scripts/eval-cat-outcomes.mjs \
     "$OC_BOX:$OC_APP_BASE/scripts/eval-cat-outcomes.mjs"
+  scp "${SSH_OPTS[@]}" -q scripts/check-data-invariants.mjs \
+    "$OC_BOX:$OC_APP_BASE/scripts/check-data-invariants.mjs"
   scp "${SSH_OPTS[@]}" -q scripts/systemd/orangecat-cat-eval.service \
     scripts/systemd/orangecat-cat-eval.timer \
     scripts/systemd/orangecat-cat-outcomes.service \
-    scripts/systemd/orangecat-cat-outcomes.timer "$OC_BOX:/tmp/"
+    scripts/systemd/orangecat-cat-outcomes.timer \
+    scripts/systemd/orangecat-data-invariants.service \
+    scripts/systemd/orangecat-data-invariants.timer "$OC_BOX:/tmp/"
   ssh "${SSH_OPTS[@]}" "$OC_BOX" 'bash -s' <<'EVAL_UNITS'
 set -e
 changed=0
 for u in orangecat-cat-eval.service orangecat-cat-eval.timer \
-         orangecat-cat-outcomes.service orangecat-cat-outcomes.timer; do
+         orangecat-cat-outcomes.service orangecat-cat-outcomes.timer \
+         orangecat-data-invariants.service orangecat-data-invariants.timer; do
   if ! cmp -s "/tmp/$u" "/etc/systemd/system/$u" 2>/dev/null; then
     install -m 644 "/tmp/$u" "/etc/systemd/system/$u"; changed=1
   fi
@@ -266,8 +271,10 @@ done
 [ "$changed" = 1 ] && systemctl daemon-reload
 systemctl enable --now orangecat-cat-eval.timer >/dev/null
 systemctl enable --now orangecat-cat-outcomes.timer >/dev/null
+systemctl enable --now orangecat-data-invariants.timer >/dev/null
 echo "cat-eval timer: $(systemctl is-enabled orangecat-cat-eval.timer) / $(systemctl is-active orangecat-cat-eval.timer)"
 echo "cat-outcomes timer: $(systemctl is-enabled orangecat-cat-outcomes.timer) / $(systemctl is-active orangecat-cat-outcomes.timer)"
+echo "data-invariants timer: $(systemctl is-enabled orangecat-data-invariants.timer) / $(systemctl is-active orangecat-data-invariants.timer)"
 EVAL_UNITS
 } || echo "WARN: cat-eval ship step failed (non-fatal)" >&2
 

--- a/scripts/systemd/orangecat-data-invariants.service
+++ b/scripts/systemd/orangecat-data-invariants.service
@@ -1,0 +1,22 @@
+# Nightly DATA-INVARIANT gate — assert against the rows production actually has.
+# Runs scripts/check-data-invariants.mjs --gate (deployed to /opt/orangecat/scripts/
+# by scripts/deploy-selfhost.sh) against production. --gate exits non-zero when an
+# invariant is violated — the tripwire for the "green mocks, wrong prod data" class
+# that shipped a false public claim about shared wallets in August 2026.
+#
+# SSOT: this file lives in the repo at scripts/systemd/ and is installed to
+# /etc/systemd/system/ by deploy-selfhost.sh — edit it here, not on the box.
+[Unit]
+Description=OrangeCat nightly data-invariant gate (orphaned links, unpayable wallets, money-state drift)
+After=network-online.target
+Wants=network-online.target
+OnFailure=notify-failure@%n.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/opt/orangecat/app/.env
+ExecStart=/usr/bin/node /opt/orangecat/scripts/check-data-invariants.mjs --gate
+WorkingDirectory=/opt/orangecat/app
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/orangecat-data-invariants.timer
+++ b/scripts/systemd/orangecat-data-invariants.timer
@@ -1,0 +1,12 @@
+# SSOT: repo scripts/systemd/ — installed by deploy-selfhost.sh.
+# Runs at 05:00, after the 04:30 judgment eval and 04:45 outcome gate, so the
+# three nightly gates never overlap on the box.
+[Unit]
+Description=OrangeCat nightly data-invariant gate (05:00 UTC)
+
+[Timer]
+OnCalendar=*-*-* 05:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Every test in this repo runs against mocks, and that is precisely why the
shared-wallet disclosure shipped wrong three times today with a fully green
suite. The mocks encoded the data shape we assumed — one address per wallet
row, links pointing at live entities — while production held a different one:
the same address spread across 2 to 11 wallet rows, and 8 of 10 entity_wallets
links pointing at deleted entities. No amount of unit testing finds that class.
Only reading production does, so this puts the reading on a schedule.

Four invariants, each a claim the product makes to a user about their money:
- entity_wallets links point at entities that still exist (the orphan class
  fixed in #573 — this is its regression guard)
- no entity has two primary links (resolveLinkedEntityWallet has no tiebreaker,
  so duplicates make payment routing nondeterministic)
- every active wallet has some usable receiving rail
- every paid intent carries a settlement timestamp (status written outside
  claimPaidTransition is money-state divergence)

An unknown entity_type is reported rather than skipped, so a new entity type
cannot quietly opt out of the orphan check. A check that throws is recorded as
a finding — an exception must never read as "invariant holds".

Wired into deploy-selfhost.sh alongside the existing nightly gates, 05:00 UTC
so the three never overlap, with OnFailure notification like its siblings.

Verified against production both ways: passes clean on real data, and with a
deliberately inserted orphan row it correctly failed with exit 1 and named the
offending link (row removed afterwards; entity_wallets back to 2).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
