### PR TITLE
fix(messages): self-conversation creation 500'd in production under RLS

### DIFF
--- a/src/app/api/messages/self/route.ts
+++ b/src/app/api/messages/self/route.ts
@@ -10,15 +10,18 @@ async function insertConversationAndParticipant(
   client: AnySupabaseClient,
   userId: string
 ): Promise<string> {
-  const { data: convIns, error: convErr } = await client
+  // The id is generated here, NOT read back from the insert: the conversations
+  // SELECT policy requires an active participant row, and that row cannot exist
+  // until the conversation does. `.insert().select()` therefore returned nothing
+  // under RLS and this whole path 500'd in production for anyone who did not
+  // already have a self-conversation.
+  const conversationId = crypto.randomUUID();
+  const { error: convErr } = await client
     .from(DATABASE_TABLES.CONVERSATIONS)
-    .insert({ created_by: userId, is_group: false })
-    .select('id')
-    .single();
-  if (convErr || !convIns?.id) {
-    throw convErr || new Error('conv insert failed');
+    .insert({ id: conversationId, created_by: userId, is_group: false });
+  if (convErr) {
+    throw convErr;
   }
-  const conversationId = convIns.id as string;
   const { error: partErr } = await client
     .from(DATABASE_TABLES.CONVERSATION_PARTICIPANTS)
     .insert({ conversation_id: conversationId, user_id: userId, role: 'member' });


### PR DESCRIPTION
Found by prod verification at the end of the audit sweep. **Pre-existing** — the find-query rewrite in #569 did not touch this path.

## The bug
`GET /api/messages/self` returned **500 "Failed to create conversation"** for any user without an existing self-conversation ("message yourself" / self-notes was broken for new users).

Root cause is a chicken-and-egg with RLS:
- `conversations` SELECT policy requires an **active participant row**
- the participant row can't exist until the conversation does
- so `.insert({...}).select('id').single()` inserted fine but **read back nothing**, the code threw `conv insert failed`, and the admin fallback is gated to `NODE_ENV !== 'production'` — leaving prod with a hard 500

## The fix
Generate the conversation id in the app and insert it explicitly, so there's no read-back at all. No policy change, no migration, no new admin-client usage.

## Verification
Type-check + lint clean; route-guard gate test passes (route keeps its auth). Will re-test the endpoint on prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)