### PR TITLE
fix(eval): nightly Cat gate has been dead since Cat Credits shipped — pinned model is no longer free

### DIFF
--- a/__tests__/unit/scripts/eval-cat-model.test.ts
+++ b/__tests__/unit/scripts/eval-cat-model.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The nightly Cat eval pins its model as a LITERAL in scripts/eval-cat.mjs,
+ * because that script runs on the box where only the standalone build ships
+ * and src/ is absent — it cannot import the registry at runtime.
+ *
+ * That literal drifted once already and killed the gate: it pinned
+ * 'openai/gpt-oss-120b:free' long after the registry reclassified
+ * 'openai/gpt-oss-120b' as PAID (only the 20b variant stayed free). Every
+ * probe came back HTTP 402 INSUFFICIENT_CREDITS, which the harness reported
+ * as a "provider layer" failure — so the nightly quality gate was dead from
+ * the day Cat Credits shipped and the error pointed at the wrong layer.
+ *
+ * This test is the contract the literal cannot escape.
+ */
+
+import { readFileSync } from 'fs';
+import path from 'path';
+import { DEFAULT_FREE_MODEL_ID, AI_MODEL_REGISTRY } from '@/config/ai-models';
+
+describe('eval-cat.mjs pinned model', () => {
+  const source = readFileSync(path.join(process.cwd(), 'scripts/eval-cat.mjs'), 'utf8');
+
+  it('pins exactly the registry default free model', () => {
+    // The openrouter branch of the EVAL_MODEL default.
+    const match = source.match(/EVAL_PROVIDER === 'groq'\s*\?\s*'[^']+'\s*:\s*'([^']+)'/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe(DEFAULT_FREE_MODEL_ID);
+  });
+
+  it('pins a model the registry actually marks free — a paid pin means every probe 402s', () => {
+    const match = source.match(/EVAL_PROVIDER === 'groq'\s*\?\s*'[^']+'\s*:\s*'([^']+)'/);
+    const pinned = match![1];
+    const entry = (AI_MODEL_REGISTRY as Record<string, { isFree?: boolean; tier?: string }>)[pinned];
+    expect(entry).toBeDefined();
+    expect(entry.isFree === true || entry.tier === 'free').toBe(true);
+  });
+
+  it('the registry default free model is itself marked free', () => {
+    const entry = (AI_MODEL_REGISTRY as Record<string, { isFree?: boolean; tier?: string }>)[
+      DEFAULT_FREE_MODEL_ID
+    ];
+    expect(entry).toBeDefined();
+    expect(entry.isFree === true || entry.tier === 'free').toBe(true);
+  });
+});

--- a/scripts/eval-cat.mjs
+++ b/scripts/eval-cat.mjs
@@ -113,8 +113,13 @@ const JSON_OUT =
 
 const PROBE_TIMEOUT_MS = 120_000; // tool phase ≤25s + free-model generation
 const INTER_PROBE_DELAY_MS = 8_000; // be gentle to free-tier TPM
-const MAX_ATTEMPTS = 3; // per probe, on transient failures only
-const RETRY_BACKOFF_MS = [20_000, 45_000]; // free-tier 429s need a real pause
+const MAX_ATTEMPTS = 4; // per probe, on transient failures only
+// The free pool's own message is "Free AI capacity is maxed out right now.
+// Try again in a minute" — but the longest backoff was 45s, so retries gave
+// up just before capacity came back. Observed live: probes a–f passed and
+// g/h both exhausted their attempts inside ~65s. The final 90s step honours
+// what the provider actually asks for.
+const RETRY_BACKOFF_MS = [20_000, 45_000, 90_000];
 const PASS_THRESHOLD = 7; // per axis, out of 8
 
 if (!SUPABASE_URL || !ANON_KEY || !SERVICE_KEY) {

--- a/scripts/eval-cat.mjs
+++ b/scripts/eval-cat.mjs
@@ -87,9 +87,23 @@ const EVAL_PROVIDER =
 // Pin one provider/model for repeatability: the gate measures the Cat judgment
 // pipeline (rubric, tools, prefill, why-line), not whichever free-model fallback
 // is least congested tonight.
+// MUST equal DEFAULT_FREE_MODEL_ID in src/config/ai-models.ts. This script
+// runs on the box, where only the standalone build ships (no src/), so it
+// cannot import the registry at runtime — instead
+// __tests__/unit/scripts/eval-cat-model.test.ts asserts the two match, and
+// CI fails the moment they drift.
+//
+// The old literal
+// 'openai/gpt-oss-120b:free' silently stopped being a free model — the
+// registry now carries 'openai/gpt-oss-120b' as PAID and only the 20b variant
+// as free — so every probe was rejected by OrangeCat's own paywall with
+// HTTP 402 INSUFFICIENT_CREDITS, and the harness reported it as a
+// "provider layer" failure — the gate had been dead since Cat Credits went
+// live on 2026-08-01. Pinning the registry's default free model also means
+// the eval measures the model users actually get.
 const EVAL_MODEL =
   process.env.CAT_EVAL_MODEL ||
-  (EVAL_PROVIDER === 'groq' ? 'llama-3.3-70b-versatile' : 'openai/gpt-oss-120b:free');
+  (EVAL_PROVIDER === 'groq' ? 'llama-3.3-70b-versatile' : 'nvidia/nemotron-3-super-120b-a12b:free');
 const NOTIFY = process.env.CAT_EVAL_NOTIFY === '1';
 const NOTIFY_USER_ID =
   process.env.CAT_EVAL_NOTIFY_USER_ID || 'cec88bc9-557f-452b-92f1-e093092fecd6'; // founder mao


### PR DESCRIPTION
The nightly judgment gate has reported "HARNESS ERROR — 8/8 probes failed at
the provider layer" every night. It was not a provider outage. Every probe
came back:

  HTTP 402 {"code":"INSUFFICIENT_CREDITS","message":"This is a paid frontier
  model. Top up Cat Credits..."}

eval-cat.mjs pinned the literal 'openai/gpt-oss-120b:free'. The registry now
carries 'openai/gpt-oss-120b' as a PAID model and only the 20b variant as
free, so OrangeCat's own paywall — live since Cat Credits launched
2026-08-01 — rejected the gate's every request. The gate died the day the
product started charging, and its error message pointed at the wrong layer,
which is why it read as an upstream flake for days.

Pinned to the registry's DEFAULT_FREE_MODEL_ID value, which is also what
users get by default, so the eval measures the real thing.

The literal stays a literal on purpose: this script runs on the box, where
only the standalone build ships and src/ does not exist, so it cannot import
the registry at runtime. The drift is caught in CI instead —
__tests__/unit/scripts/eval-cat-model.test.ts asserts the pinned string
equals DEFAULT_FREE_MODEL_ID *and* that the registry actually marks it free.
Verified the test does its job: reintroducing the old
'openai/gpt-oss-120b:free' pin fails 2 of 3 assertions; restoring it passes 3
of 3.

This is the same free-model-rot class that has now bitten four times. The
difference here is that the blast radius was a quality gate reporting a
misleading cause, so nobody chased it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
