### PR TITLE
fix(pay): a mistyped pay link 404s honestly, and costs one query not two

### DIFF
--- a/src/app/(public)/pay/[username]/page.tsx
+++ b/src/app/(public)/pay/[username]/page.tsx
@@ -13,7 +13,7 @@
 
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { Suspense } from 'react';
+import { cache, Suspense } from 'react';
 import { Loader2 } from 'lucide-react';
 import { getAdminClient } from '@/lib/supabase/admin';
 import { DATABASE_TABLES } from '@/config/database-tables';
@@ -30,7 +30,9 @@ interface PayRecipient {
   displayName: string;
 }
 
-async function getRecipient(username: string): Promise<PayRecipient | null> {
+// cache() dedupes the lookup across generateMetadata and the page body, which
+// both need the recipient — otherwise every pay link costs two profile queries.
+const getRecipient = cache(async (username: string): Promise<PayRecipient | null> => {
   const { data } = await getAdminClient()
     .from(DATABASE_TABLES.PROFILES)
     .select('username, display_name:name')
@@ -42,13 +44,17 @@ async function getRecipient(username: string): Promise<PayRecipient | null> {
     return null;
   }
   return { username: row.username, displayName: row.display_name || row.username };
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { username } = await params;
   const recipient = await getRecipient(username);
   if (!recipient) {
-    return { title: `Pay — ${APP_NAME}`, robots: { index: false, follow: false } };
+    // generateMetadata resolves before the page's streaming boundary, so
+    // notFound() here sends a real 404 — the same call inside the streamed page
+    // body gets forced to a 200 "soft 404" by the root loading.tsx. A payment
+    // link to a mistyped name should fail honestly.
+    notFound();
   }
   const title = `${PAY_COPY.title(recipient.displayName)} — ${APP_NAME}`;
   return {


### PR DESCRIPTION
Follow-up to #577, found during live verification on production. (Replaces #582, which conflicted after #577 was squash-merged.)

`/pay/<unknown-username>` rendered the not-found UI but returned **HTTP 200** — the root `loading.tsx` streaming boundary turns a page-body `notFound()` into a soft 404. Moved the existence check into `generateMetadata`, which resolves before that boundary, so a link to a name that doesn't exist fails with a real status. Same pattern the articles page already documents.

Also wrapped the profile lookup in `cache()`: `generateMetadata` and the page body both need the recipient, so every pay-link load ran the query twice.

Verify green: 1604 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)