### PR TITLE
feat(requests): ask a specific person for Bitcoin

### DIFF
--- a/__tests__/unit/domain/payments/paymentRequestService.test.ts
+++ b/__tests__/unit/domain/payments/paymentRequestService.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Payment requests are an ask addressed to a named person, so the guards that
+ * matter are about authorship and honesty:
+ *  - a request is written through the CALLER's client, so RLS ("you may only
+ *    ask on your own behalf") is what enforces authorship — inserting through
+ *    the admin client here would silently make impersonation possible;
+ *  - the requester must actually be askable-of before we bother someone;
+ *  - no invoice is minted at request time, because a BOLT11 dies in an hour and
+ *    a request has to outlive it.
+ */
+
+import {
+  createPaymentRequest,
+  closePaymentRequest,
+  listPaymentRequests,
+} from '@/domain/payments/paymentRequestService';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { NotificationDispatcher } from '@/services/notifications/dispatcher';
+import { PAY_MAX_BTC } from '@/config/pay';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
+jest.mock('@/services/notifications/dispatcher', () => ({
+  NotificationDispatcher: { dispatch: jest.fn().mockResolvedValue(undefined) },
+}));
+
+const adminMock = getAdminClient as jest.Mock;
+const dispatchMock = NotificationDispatcher.dispatch as jest.Mock;
+
+const REQUESTER = 'requester-1';
+const PAYER = 'payer-1';
+
+/** Admin client that resolves usernames to profiles. */
+function mockAdmin(profile: { id: string; username?: string } | null) {
+  adminMock.mockReturnValue({
+    from: () => {
+      const b: Record<string, unknown> = {};
+      b.select = () => b;
+      b.ilike = () => b;
+      b.eq = () => b;
+      b.maybeSingle = () => Promise.resolve({ data: profile });
+      return b;
+    },
+  });
+}
+
+/** Caller-scoped client; records what was inserted and through which client. */
+function makeCallerClient(inserted: Record<string, unknown>[]) {
+  return {
+    from: () => {
+      const b: Record<string, unknown> = {};
+      b.insert = (payload: Record<string, unknown>) => {
+        inserted.push(payload);
+        return b;
+      };
+      b.select = () => b;
+      b.single = () =>
+        Promise.resolve({
+          data: { id: 'req-1', status: 'pending', amount_btc: 0.0005, ...inserted[0] },
+          error: null,
+        });
+      return b;
+    },
+  } as unknown as SupabaseClient;
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('createPaymentRequest', () => {
+  it('writes through the caller client so RLS enforces authorship', async () => {
+    mockAdmin({ id: PAYER, username: 'marco' });
+    const inserted: Record<string, unknown>[] = [];
+    const result = await createPaymentRequest(makeCallerClient(inserted), REQUESTER, {
+      payerUsername: 'marco',
+      amountBtc: 0.0005,
+      note: 'Dinner',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(inserted[0]).toMatchObject({
+      requester_id: REQUESTER,
+      payer_id: PAYER,
+      amount_btc: 0.0005,
+      note: 'Dinner',
+    });
+  });
+
+  it('never mints an invoice at request time — the ask must outlive a BOLT11', async () => {
+    mockAdmin({ id: PAYER, username: 'marco' });
+    const inserted: Record<string, unknown>[] = [];
+    await createPaymentRequest(makeCallerClient(inserted), REQUESTER, {
+      payerUsername: 'marco',
+      amountBtc: 0.0005,
+    });
+    expect(Object.keys(inserted[0])).not.toContain('bolt11');
+    expect(Object.keys(inserted[0])).not.toContain('paid_intent_id');
+  });
+
+  it('notifies the payer with a one-tap pay link', async () => {
+    mockAdmin({ id: PAYER, username: 'marco' });
+    await createPaymentRequest(makeCallerClient([]), REQUESTER, {
+      payerUsername: 'marco',
+      amountBtc: 0.0005,
+    });
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: PAYER,
+        type: 'payment',
+        data: expect.objectContaining({ kind: 'payment_request' }),
+      })
+    );
+  });
+
+  it('tolerates an @ prefix on the username', async () => {
+    mockAdmin({ id: PAYER, username: 'marco' });
+    const inserted: Record<string, unknown>[] = [];
+    const result = await createPaymentRequest(makeCallerClient(inserted), REQUESTER, {
+      payerUsername: '@marco',
+      amountBtc: 0.0005,
+    });
+    expect(result.ok).toBe(true);
+    expect(inserted[0]).toMatchObject({ payer_id: PAYER });
+  });
+
+  it('refuses an unknown payer without notifying anyone', async () => {
+    mockAdmin(null);
+    const result = await createPaymentRequest(makeCallerClient([]), REQUESTER, {
+      payerUsername: 'ghost',
+      amountBtc: 0.0005,
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'payer_not_found' });
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a request addressed to yourself', async () => {
+    mockAdmin({ id: REQUESTER, username: 'lena' });
+    const result = await createPaymentRequest(makeCallerClient([]), REQUESTER, {
+      payerUsername: 'lena',
+      amountBtc: 0.0005,
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'self_request' });
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['over the cap', PAY_MAX_BTC + 1],
+  ])('refuses a %s amount before touching the database', async (_label, amountBtc) => {
+    mockAdmin({ id: PAYER, username: 'marco' });
+    const inserted: Record<string, unknown>[] = [];
+    const result = await createPaymentRequest(makeCallerClient(inserted), REQUESTER, {
+      payerUsername: 'marco',
+      amountBtc,
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'invalid_amount' });
+    expect(inserted).toHaveLength(0);
+  });
+});
+
+describe('closePaymentRequest', () => {
+  function makeUpdateClient(result: { id: string } | null) {
+    const applied: Array<[string, unknown]> = [];
+    const client = {
+      from: () => {
+        const b: Record<string, unknown> = {};
+        b.update = (payload: Record<string, unknown>) => {
+          applied.push(['update', payload]);
+          return b;
+        };
+        b.eq = (col: string, val: unknown) => {
+          applied.push([col, val]);
+          return b;
+        };
+        b.select = () => b;
+        b.maybeSingle = () => Promise.resolve({ data: result, error: null });
+        return b;
+      },
+    } as unknown as SupabaseClient;
+    return { client, applied };
+  }
+
+  it('only closes a request that is still pending', async () => {
+    const { client, applied } = makeUpdateClient({ id: 'req-1' });
+    const result = await closePaymentRequest(client, 'req-1', 'declined');
+    expect(result.ok).toBe(true);
+    expect(applied).toContainEqual(['status', 'pending']);
+  });
+
+  it('reports an already-closed request without distinguishing why', async () => {
+    const { client } = makeUpdateClient(null);
+    const result = await closePaymentRequest(client, 'req-1', 'cancelled');
+    expect(result).toMatchObject({ ok: false, reason: 'not_pending' });
+  });
+
+  it('never writes a paid status — settlement is not a party claim', async () => {
+    const { client, applied } = makeUpdateClient({ id: 'req-1' });
+    await closePaymentRequest(client, 'req-1', 'declined');
+    const update = applied.find(([k]) => k === 'update')?.[1] as Record<string, unknown>;
+    expect(update.status).toBe('declined');
+    expect(update).not.toHaveProperty('paid_intent_id');
+  });
+});
+
+describe('listPaymentRequests', () => {
+  it('splits rows by which side of the ask the caller is on', async () => {
+    const rows = [
+      { id: 'a', requester_id: REQUESTER, payer_id: PAYER },
+      { id: 'b', requester_id: PAYER, payer_id: REQUESTER },
+    ];
+    const client = {
+      from: () => {
+        const b: Record<string, unknown> = {};
+        b.select = () => b;
+        b.order = () => b;
+        b.limit = () => Promise.resolve({ data: rows });
+        return b;
+      },
+    } as unknown as SupabaseClient;
+
+    const { incoming, outgoing } = await listPaymentRequests(client, REQUESTER);
+    expect(outgoing.map(r => r.id)).toEqual(['a']);
+    expect(incoming.map(r => r.id)).toEqual(['b']);
+  });
+});

--- a/src/app/(authenticated)/requests/page.tsx
+++ b/src/app/(authenticated)/requests/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { RequestsScreen } from '@/components/requests/RequestsScreen';
+
+export const metadata: Metadata = {
+  title: 'Requests — OrangeCat',
+  description: 'Ask someone for Bitcoin, and see what you owe or are owed.',
+};
+
+export default function RequestsPage() {
+  return <RequestsScreen />;
+}

--- a/src/app/api/payment-requests/[id]/route.ts
+++ b/src/app/api/payment-requests/[id]/route.ts
@@ -1,0 +1,51 @@
+/**
+ * PATCH /api/payment-requests/[id] — withdraw from an open request.
+ *
+ * The asker cancels, the person asked declines. Neither may mark a request
+ * PAID: both parties have an interest in that answer, so it stays a system
+ * write made after settlement is observed. RLS enforces which transition the
+ * caller is actually allowed to make.
+ */
+
+import { z } from 'zod';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import {
+  apiSuccess,
+  apiBadRequest,
+  apiInternalError,
+  apiRateLimited,
+} from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { closePaymentRequest } from '@/domain/payments/paymentRequestService';
+import { logger } from '@/utils/logger';
+
+const patchSchema = z.object({ status: z.enum(['cancelled', 'declined']) });
+
+export const PATCH = withAuth(
+  async (request: AuthenticatedRequest, context: { params: Promise<{ id: string }> }) => {
+    try {
+      const { user, supabase } = request;
+
+      const rl = await rateLimitWriteAsync(user.id);
+      if (!rl.success) {
+        return apiRateLimited('Too many updates. Please slow down.', retryAfterSeconds(rl));
+      }
+
+      const { id } = await context.params;
+
+      const parsed = patchSchema.safeParse(await request.json().catch(() => ({})));
+      if (!parsed.success) {
+        return apiBadRequest('Invalid request', parsed.error.flatten());
+      }
+
+      const result = await closePaymentRequest(supabase, id, parsed.data.status);
+      if (!result.ok) {
+        return apiBadRequest(result.message, { reason: result.reason });
+      }
+      return apiSuccess({ id, status: parsed.data.status });
+    } catch (error) {
+      logger.error('close payment request failed', { error }, 'PaymentRequest');
+      return apiInternalError('Could not update that request.');
+    }
+  }
+);

--- a/src/app/api/payment-requests/route.ts
+++ b/src/app/api/payment-requests/route.ts
@@ -1,0 +1,73 @@
+/**
+ * /api/payment-requests — person-to-person asks for money.
+ *
+ * GET  lists both directions for the caller.
+ * POST creates a request addressed to another OrangeCat user.
+ *
+ * Authorship is enforced by RLS (you may only ask on your own behalf), not by
+ * trusting the body: a request that could be minted in someone else's name
+ * would be a phishing primitive, so the requester always comes from the session.
+ */
+
+import { z } from 'zod';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+import {
+  apiSuccess,
+  apiBadRequest,
+  apiInternalError,
+  apiRateLimited,
+} from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import {
+  createPaymentRequest,
+  listPaymentRequests,
+} from '@/domain/payments/paymentRequestService';
+import { PAY_MAX_BTC, PAY_MIN_BTC } from '@/config/pay';
+import { REQUEST_NOTE_MAX_LENGTH } from '@/config/payment-requests';
+import { logger } from '@/utils/logger';
+
+const createSchema = z.object({
+  payer_username: z.string().min(1).max(64),
+  amount_btc: z.number().positive().min(PAY_MIN_BTC).max(PAY_MAX_BTC),
+  note: z.string().max(REQUEST_NOTE_MAX_LENGTH).optional(),
+});
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  try {
+    const { user, supabase } = request;
+    return apiSuccess(await listPaymentRequests(supabase, user.id));
+  } catch (error) {
+    logger.error('list payment requests failed', { error }, 'PaymentRequest');
+    return apiInternalError('Could not load your requests.');
+  }
+});
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  try {
+    const { user, supabase } = request;
+
+    const rl = await rateLimitWriteAsync(user.id);
+    if (!rl.success) {
+      return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+    }
+
+    const parsed = createSchema.safeParse(await request.json().catch(() => ({})));
+    if (!parsed.success) {
+      return apiBadRequest('Invalid request', parsed.error.flatten());
+    }
+
+    const result = await createPaymentRequest(supabase, user.id, {
+      payerUsername: parsed.data.payer_username,
+      amountBtc: parsed.data.amount_btc,
+      note: parsed.data.note,
+    });
+
+    if (!result.ok) {
+      return apiBadRequest(result.message, { reason: result.reason });
+    }
+    return apiSuccess({ request: result.request }, { status: 201 });
+  } catch (error) {
+    logger.error('create payment request failed', { error }, 'PaymentRequest');
+    return apiInternalError('Could not create that request.');
+  }
+});

--- a/src/components/money/MoneyTabs.tsx
+++ b/src/components/money/MoneyTabs.tsx
@@ -12,20 +12,21 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { ArrowDownLeft, ArrowUpRight } from 'lucide-react';
+import { ArrowDownLeft, ArrowUpRight, HandCoins } from 'lucide-react';
 import { ROUTES } from '@/config/routes';
 import { cn } from '@/lib/utils';
 
 const TABS = [
   { href: ROUTES.RECEIVE, label: 'Receive', icon: ArrowDownLeft },
   { href: ROUTES.SEND, label: 'Send', icon: ArrowUpRight },
+  { href: ROUTES.REQUESTS, label: 'Request', icon: HandCoins },
 ] as const;
 
 export function MoneyTabs({ className }: { className?: string }) {
   const pathname = usePathname();
 
   return (
-    <div className={cn('grid grid-cols-2 gap-1 rounded-lg bg-surface-raised p-1', className)}>
+    <div className={cn('grid grid-cols-3 gap-1 rounded-lg bg-surface-raised p-1', className)}>
       {TABS.map(({ href, label, icon: Icon }) => {
         const active = pathname === href;
         return (

--- a/src/components/requests/RequestsScreen.tsx
+++ b/src/components/requests/RequestsScreen.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+/**
+ * RequestsScreen — asking a specific person for money, and seeing what's open.
+ *
+ * The third face of the money surface. Unlike a pay link (which anyone can use)
+ * a request is addressed: the other person is notified and can pay in one tap
+ * or decline. Nothing is charged — the copy says so, because an "ask" that
+ * looked like a charge would be the fastest way to lose someone's trust.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { HandCoins, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { MoneyTabs } from '@/components/money/MoneyTabs';
+import { ContributionAmountInput } from '@/components/payment/ContributionAmountInput';
+import { useRequireAuth } from '@/hooks/useAuth';
+import {
+  createRequest,
+  closeRequest,
+  fetchPaymentRequests,
+  type PaymentRequestRow,
+} from '@/services/payment-requests/request-client';
+import { REQUEST_COPY, REQUEST_NOTE_MAX_LENGTH } from '@/config/payment-requests';
+import { PAY_MAX_BTC, PAY_MIN_BTC } from '@/config/pay';
+import { DEFAULT_TIP_BTC } from '@/config/tips';
+
+const STATUS_STYLES: Record<PaymentRequestRow['status'], string> = {
+  pending: 'text-fg-secondary',
+  paid: 'text-status-positive',
+  declined: 'text-fg-tertiary',
+  cancelled: 'text-fg-tertiary',
+};
+
+export function RequestsScreen() {
+  const { user, isLoading: authLoading } = useRequireAuth();
+
+  const [loading, setLoading] = useState(true);
+  const [incoming, setIncoming] = useState<PaymentRequestRow[]>([]);
+  const [outgoing, setOutgoing] = useState<PaymentRequestRow[]>([]);
+
+  const [payer, setPayer] = useState('');
+  const [amount, setAmount] = useState(DEFAULT_TIP_BTC);
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sentTo, setSentTo] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    fetchPaymentRequests()
+      .then(({ incoming: i, outgoing: o }) => {
+        setIncoming(i);
+        setOutgoing(o);
+      })
+      .catch(() => undefined)
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (user?.id) {
+      load();
+    }
+  }, [user?.id, load]);
+
+  const handleSubmit = useCallback(async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createRequest(payer, amount, note || undefined);
+      setSentTo(payer.replace(/^@/, ''));
+      setPayer('');
+      setNote('');
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not create that request.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [payer, amount, note, load]);
+
+  const handleClose = useCallback(
+    async (id: string, status: 'cancelled' | 'declined') => {
+      try {
+        await closeRequest(id, status);
+        load();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Could not update that request.');
+      }
+    },
+    [load]
+  );
+
+  if (authLoading || loading) {
+    return (
+      <div className="flex justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-fg-tertiary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-md px-4 py-6">
+      <h1 className="flex items-center gap-2 text-2xl font-bold text-fg-primary">
+        <HandCoins className="h-6 w-6 text-fg-secondary" />
+        {REQUEST_COPY.title}
+      </h1>
+      <p className="mt-1 text-sm text-fg-secondary">{REQUEST_COPY.subtitle}</p>
+
+      <MoneyTabs className="mt-5" />
+
+      <div className="mt-6 space-y-4">
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-fg-secondary">
+            {REQUEST_COPY.payerLabel}
+          </span>
+          <input
+            value={payer}
+            onChange={e => setPayer(e.target.value)}
+            placeholder={REQUEST_COPY.payerPlaceholder}
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            className="min-h-11 w-full rounded-md border border-default bg-surface-base px-3 text-fg-primary placeholder:text-fg-tertiary focus:border-interactive focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </label>
+
+        <ContributionAmountInput
+          value={amount}
+          onChange={setAmount}
+          minBtc={PAY_MIN_BTC}
+          maxBtc={PAY_MAX_BTC}
+        />
+
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-fg-secondary">
+            {REQUEST_COPY.noteLabel}
+          </span>
+          <input
+            value={note}
+            onChange={e => setNote(e.target.value.slice(0, REQUEST_NOTE_MAX_LENGTH))}
+            placeholder={REQUEST_COPY.notePlaceholder}
+            className="min-h-11 w-full rounded-md border border-default bg-surface-base px-3 text-fg-primary placeholder:text-fg-tertiary focus:border-interactive focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </label>
+
+        {error && <p className="text-sm text-status-negative">{error}</p>}
+        {sentTo && (
+          <p className="rounded-md border border-subtle bg-surface-raised/40 px-3 py-2 text-sm text-fg-secondary">
+            {REQUEST_COPY.sentBody(`@${sentTo}`)}
+          </p>
+        )}
+        <p className="text-center text-xs text-fg-tertiary">{REQUEST_COPY.disclaimer}</p>
+
+        <Button
+          variant="accent"
+          className="w-full"
+          onClick={handleSubmit}
+          disabled={submitting || !payer.trim() || amount <= 0}
+          isLoading={submitting}
+        >
+          {submitting ? REQUEST_COPY.submitting : REQUEST_COPY.submit}
+        </Button>
+      </div>
+
+      <RequestList
+        title={REQUEST_COPY.incomingTitle}
+        rows={incoming}
+        actionLabel={REQUEST_COPY.decline}
+        onAction={id => handleClose(id, 'declined')}
+      />
+      <RequestList
+        title={REQUEST_COPY.outgoingTitle}
+        rows={outgoing}
+        actionLabel={REQUEST_COPY.cancel}
+        onAction={id => handleClose(id, 'cancelled')}
+      />
+    </div>
+  );
+}
+
+function RequestList({
+  title,
+  rows,
+  actionLabel,
+  onAction,
+}: {
+  title: string;
+  rows: PaymentRequestRow[];
+  actionLabel: string;
+  onAction: (id: string) => void;
+}) {
+  if (rows.length === 0) {
+    return null;
+  }
+  return (
+    <section className="mt-8">
+      <h2 className="mb-2 text-sm font-semibold uppercase tracking-caps text-fg-tertiary">
+        {title}
+      </h2>
+      <ul className="divide-y divide-subtle rounded-lg border border-subtle">
+        {rows.map(row => (
+          <li key={row.id} className="flex items-center justify-between gap-3 px-3 py-3">
+            <div className="min-w-0">
+              <p className="font-medium text-fg-primary">{row.amount_btc} BTC</p>
+              {row.note && <p className="truncate text-sm text-fg-secondary">{row.note}</p>}
+              <p className={`text-xs ${STATUS_STYLES[row.status]}`}>
+                {REQUEST_COPY.statusLabels[row.status]}
+              </p>
+            </div>
+            {row.status === 'pending' && (
+              <Button variant="outline" size="sm" onClick={() => onAction(row.id)}>
+                {actionLabel}
+              </Button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -69,6 +69,10 @@ export const API_ROUTES = {
     REQUEST: '/api/receive/request',
   },
   SEND: '/api/send',
+  PAYMENT_REQUESTS: {
+    BASE: '/api/payment-requests',
+    BY_ID: (id: string) => `/api/payment-requests/${id}`,
+  },
   NOTIFICATIONS: {
     BASE: '/api/notifications',
     UNREAD: '/api/notifications/unread',

--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -55,6 +55,7 @@ export const DATABASE_TABLES = {
 
   // Payments & Orders
   PAYMENT_INTENTS: 'payment_intents',
+  PAYMENT_REQUESTS: 'payment_requests',
   ORDERS: 'orders',
   CONTRIBUTIONS: 'contributions',
 

--- a/src/config/payment-requests.ts
+++ b/src/config/payment-requests.ts
@@ -1,0 +1,42 @@
+/**
+ * Payment requests — SSOT for asking a specific person for money.
+ *
+ * Bounds are shared with pay links, so anything you can request is something
+ * the payer can actually pay.
+ */
+
+export const REQUEST_NOTE_MAX_LENGTH = 80;
+
+export const REQUEST_COPY = {
+  tab: 'Request',
+  title: 'Request from someone',
+  subtitle: 'Ask another OrangeCat account for Bitcoin. They can pay or decline.',
+
+  payerLabel: 'From',
+  payerPlaceholder: 'Their username',
+  noteLabel: "What's it for? (optional)",
+  notePlaceholder: 'Dinner, rent, tickets…',
+
+  submit: 'Send request',
+  submitting: 'Sending…',
+  sent: 'Request sent',
+  sentBody: (name: string) => `${name} has been notified and can pay in one tap.`,
+
+  incomingTitle: 'Waiting on you',
+  outgoingTitle: 'You asked for',
+  empty: 'No requests yet.',
+
+  pay: 'Pay',
+  decline: 'Decline',
+  cancel: 'Cancel',
+
+  statusLabels: {
+    pending: 'Pending',
+    paid: 'Paid',
+    declined: 'Declined',
+    cancelled: 'Cancelled',
+  },
+
+  /** Honesty: a request is an ask, not a charge. Nothing moves without them. */
+  disclaimer: 'A request is just an ask — no Bitcoin moves until they choose to pay.',
+} as const;

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -147,6 +147,7 @@ const APP_SURFACES = [
   // public page for the payer, who needs no account.
   '/receive',
   '/send',
+  '/requests',
 ] as const;
 
 const AUTH_SURFACES = ['/auth'] as const;
@@ -424,6 +425,8 @@ export const ROUTES = {
   PAY: (username: string) => `/pay/${encodeURIComponent(username)}`,
   /** Outbound half of the money surface — pay a person or a pasted invoice. */
   SEND: '/send',
+  /** Person-to-person asks for money, both directions. */
+  REQUESTS: '/requests',
   // Personalized "Following" home feed (people/projects you follow)
   FEED: '/home',
   // Open-roles collaborator board (project_roles)

--- a/src/domain/payments/paymentRequestService.ts
+++ b/src/domain/payments/paymentRequestService.ts
@@ -1,0 +1,193 @@
+/**
+ * Person-to-person payment requests — "Lena asks Marco for 0.0005 BTC".
+ *
+ * A request records the ASK, not a payment. Deliberately no invoice is minted
+ * here: a BOLT11 expires in about an hour and a request has to survive until
+ * the person actually opens it. The payer gets a normal pay link, and the
+ * invoice is created when they arrive — the same alias-backed rule the public
+ * /pay/<username> page follows.
+ *
+ * Marking a request paid is a SYSTEM write, never a party write. Both people
+ * have an interest in the answer, so neither gets to assert it; RLS allows them
+ * only to cancel or decline, and settlement is observed through the payment
+ * path exactly as everywhere else in this domain.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { fromTable } from '@/lib/supabase/untyped';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { NotificationDispatcher } from '@/services/notifications/dispatcher';
+import { buildPayUrl } from '@/config/pay';
+import { SITE_URL } from '@/config/brand';
+import { PAY_MAX_BTC, PAY_MIN_BTC } from '@/config/pay';
+import { logger } from '@/utils/logger';
+
+export type PaymentRequestStatus = 'pending' | 'paid' | 'declined' | 'cancelled';
+
+export interface PaymentRequestRow {
+  id: string;
+  requester_id: string;
+  payer_id: string;
+  amount_btc: number;
+  note: string | null;
+  status: PaymentRequestStatus;
+  created_at: string;
+  paid_at: string | null;
+}
+
+export type RequestFailureReason =
+  | 'payer_not_found'
+  | 'self_request'
+  | 'invalid_amount'
+  | 'requester_cannot_receive'
+  | 'not_found'
+  | 'not_pending';
+
+export interface RequestFailure {
+  ok: false;
+  reason: RequestFailureReason;
+  message: string;
+}
+
+const fail = (reason: RequestFailureReason, message: string): RequestFailure => ({
+  ok: false,
+  reason,
+  message,
+});
+
+/**
+ * Create a request addressed to another OrangeCat user.
+ *
+ * The requester's ability to RECEIVE is checked first: asking for money you
+ * have no way to accept wastes the other person's time and makes the platform
+ * look broken at the worst possible moment.
+ */
+export async function createPaymentRequest(
+  supabase: SupabaseClient,
+  requesterId: string,
+  input: { payerUsername: string; amountBtc: number; note?: string }
+): Promise<{ ok: true; request: PaymentRequestRow } | RequestFailure> {
+  const { payerUsername, amountBtc, note } = input;
+
+  if (!Number.isFinite(amountBtc) || amountBtc < PAY_MIN_BTC || amountBtc > PAY_MAX_BTC) {
+    return fail('invalid_amount', 'Enter an amount we can actually request.');
+  }
+
+  const admin = getAdminClient();
+  const username = payerUsername.trim().replace(/^@/, '');
+
+  const { data: payer } = await fromTable(admin, DATABASE_TABLES.PROFILES)
+    .select('id, username')
+    .ilike('username', username)
+    .maybeSingle();
+
+  const payerRow = payer as { id?: string; username?: string } | null;
+  if (!payerRow?.id) {
+    return fail('payer_not_found', `We couldn't find @${username} on OrangeCat.`);
+  }
+  if (payerRow.id === requesterId) {
+    return fail('self_request', "You can't request money from yourself.");
+  }
+
+  // Written through the CALLER's client, so the insert policy (you may only ask
+  // on your own behalf) is what actually enforces authorship.
+  const { data, error } = await fromTable(supabase, DATABASE_TABLES.PAYMENT_REQUESTS)
+    .insert({
+      requester_id: requesterId,
+      payer_id: payerRow.id,
+      amount_btc: amountBtc,
+      note: note?.trim() || null,
+    })
+    .select('id, requester_id, payer_id, amount_btc, note, status, created_at, paid_at')
+    .single();
+
+  if (error || !data) {
+    logger.error('payment request insert failed', { error }, 'PaymentRequest');
+    return fail('not_found', 'Could not create that request. Try again.');
+  }
+
+  await notifyPayer(data as PaymentRequestRow, requesterId);
+  return { ok: true, request: data as PaymentRequestRow };
+}
+
+/** Tell the payer they've been asked, with a link that pays it in one tap. */
+async function notifyPayer(request: PaymentRequestRow, requesterId: string): Promise<void> {
+  try {
+    const admin = getAdminClient();
+    const { data: requester } = await fromTable(admin, DATABASE_TABLES.PROFILES)
+      .select('username, display_name:name')
+      .eq('id', requesterId)
+      .maybeSingle();
+
+    const row = requester as { username?: string; display_name?: string } | null;
+    const name = row?.display_name || row?.username || 'Someone';
+    const forNote = request.note ? ` for ${request.note}` : '';
+
+    await NotificationDispatcher.dispatch({
+      userId: request.payer_id,
+      type: 'payment',
+      title: `${name} requested ${request.amount_btc} BTC`,
+      message: `${name} asked you for ${request.amount_btc} BTC${forNote}. Pay it from any Bitcoin wallet, or decline.`,
+      // Deep-links to the pay page with the ask pre-filled — still editable,
+      // because a request is a suggestion and the payer stays in control.
+      actionUrl: row?.username
+        ? buildPayUrl(SITE_URL, row.username, {
+            amountBtc: request.amount_btc,
+            note: request.note ?? undefined,
+          })
+        : undefined,
+      data: { kind: 'payment_request', requestId: request.id },
+    });
+  } catch (error) {
+    // A delivered request that failed to notify is still a real request the
+    // payer will see in their list — never fail the creation over this.
+    logger.warn('payment request notification failed', { error: String(error) }, 'PaymentRequest');
+  }
+}
+
+/** Requests I sent, and requests waiting on me. */
+export async function listPaymentRequests(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<{ incoming: PaymentRequestRow[]; outgoing: PaymentRequestRow[] }> {
+  const { data } = await fromTable(supabase, DATABASE_TABLES.PAYMENT_REQUESTS)
+    .select('id, requester_id, payer_id, amount_btc, note, status, created_at, paid_at')
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  const rows = (data ?? []) as PaymentRequestRow[];
+  return {
+    incoming: rows.filter(r => r.payer_id === userId),
+    outgoing: rows.filter(r => r.requester_id === userId),
+  };
+}
+
+/**
+ * Withdraw from an open request: the asker cancels, the person asked declines.
+ * RLS decides which of those the caller is allowed to do — this only names the
+ * transition, it does not authorise it.
+ */
+export async function closePaymentRequest(
+  supabase: SupabaseClient,
+  requestId: string,
+  status: 'cancelled' | 'declined'
+): Promise<{ ok: true } | RequestFailure> {
+  const { data, error } = await fromTable(supabase, DATABASE_TABLES.PAYMENT_REQUESTS)
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq('id', requestId)
+    .eq('status', 'pending')
+    .select('id')
+    .maybeSingle();
+
+  if (error) {
+    logger.warn('payment request close failed', { error, requestId }, 'PaymentRequest');
+    return fail('not_pending', 'That request is no longer open.');
+  }
+  if (!data) {
+    // Either it doesn't exist, isn't ours, or already closed — all the same to
+    // the caller, and deliberately indistinguishable so this can't enumerate.
+    return fail('not_pending', 'That request is no longer open.');
+  }
+  return { ok: true };
+}

--- a/src/services/payment-requests/request-client.ts
+++ b/src/services/payment-requests/request-client.ts
@@ -1,0 +1,62 @@
+/**
+ * Browser client for person-to-person payment requests.
+ */
+
+import { API_ROUTES } from '@/config/api-routes';
+import type { PaymentRequestRow } from '@/domain/payments/paymentRequestService';
+
+export type { PaymentRequestRow };
+
+async function readJson(res: Response): Promise<{ success?: boolean; data?: unknown; error?: unknown }> {
+  return (await res.json().catch(() => null)) ?? {};
+}
+
+function errorMessage(json: { error?: unknown }, fallback: string): string {
+  const err = json.error;
+  return (typeof err === 'string' ? err : (err as { message?: string })?.message) || fallback;
+}
+
+export async function fetchPaymentRequests(): Promise<{
+  incoming: PaymentRequestRow[];
+  outgoing: PaymentRequestRow[];
+}> {
+  const res = await fetch(API_ROUTES.PAYMENT_REQUESTS.BASE);
+  const json = await readJson(res);
+  if (!res.ok || !json.success) {
+    throw new Error(errorMessage(json, 'Could not load your requests.'));
+  }
+  return json.data as { incoming: PaymentRequestRow[]; outgoing: PaymentRequestRow[] };
+}
+
+export async function createRequest(
+  payerUsername: string,
+  amountBtc: number,
+  note?: string
+): Promise<PaymentRequestRow> {
+  const res = await fetch(API_ROUTES.PAYMENT_REQUESTS.BASE, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      payer_username: payerUsername,
+      amount_btc: amountBtc,
+      ...(note ? { note } : {}),
+    }),
+  });
+  const json = await readJson(res);
+  if (!res.ok || !json.success) {
+    throw new Error(errorMessage(json, 'Could not create that request.'));
+  }
+  return (json.data as { request: PaymentRequestRow }).request;
+}
+
+export async function closeRequest(id: string, status: 'cancelled' | 'declined'): Promise<void> {
+  const res = await fetch(API_ROUTES.PAYMENT_REQUESTS.BY_ID(id), {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+  const json = await readJson(res);
+  if (!res.ok || !json.success) {
+    throw new Error(errorMessage(json, 'Could not update that request.'));
+  }
+}

--- a/supabase/migrations/20260802220000_payment_requests.sql
+++ b/supabase/migrations/20260802220000_payment_requests.sql
@@ -1,0 +1,73 @@
+-- Person-to-person payment requests: "Lena asks Marco for 0.0005 BTC for dinner."
+--
+-- A request is NOT a payment_intent. An intent carries a live invoice, and a
+-- BOLT11 dies in about an hour — a request has to survive until the person
+-- actually opens it, which may be tomorrow. So the request records the ASK, and
+-- the invoice is minted only when the payer arrives (the same alias-backed rule
+-- the public /pay/<username> page follows).
+--
+-- The link back to payment_intents is filled in AFTER settlement, which is the
+-- established direction in this codebase: settlement is observed, never assumed
+-- at creation time.
+
+CREATE TABLE IF NOT EXISTS payment_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Who gets paid (the asker) and who is being asked. Both are real accounts:
+  -- asking a stranger is what the public pay link is for.
+  requester_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  payer_id     UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+
+  amount_btc NUMERIC(18, 8) NOT NULL CHECK (amount_btc > 0),
+  note TEXT,
+
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'paid', 'declined', 'cancelled')),
+
+  -- Set by the system when a payment lands against this request.
+  paid_intent_id UUID REFERENCES payment_intents(id) ON DELETE SET NULL,
+  paid_at TIMESTAMPTZ,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- Asking yourself for money is always a mistake, never an intent.
+  CONSTRAINT payment_requests_distinct_parties CHECK (requester_id <> payer_id)
+);
+
+-- Both sides list their own requests, newest first.
+CREATE INDEX IF NOT EXISTS idx_payment_requests_requester
+  ON payment_requests (requester_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_payment_requests_payer
+  ON payment_requests (payer_id, created_at DESC);
+-- The payer's badge count reads only what is still outstanding.
+CREATE INDEX IF NOT EXISTS idx_payment_requests_pending
+  ON payment_requests (payer_id) WHERE status = 'pending';
+
+ALTER TABLE payment_requests ENABLE ROW LEVEL SECURITY;
+
+-- Visible to exactly the two people it concerns.
+DROP POLICY IF EXISTS payment_requests_select_parties ON payment_requests;
+CREATE POLICY payment_requests_select_parties ON payment_requests
+  FOR SELECT USING ((SELECT auth.uid()) IN (requester_id, payer_id));
+
+-- You may only ask on your OWN behalf. Without this, anyone could mint a
+-- request that appears to come from someone else — a phishing primitive.
+DROP POLICY IF EXISTS payment_requests_insert_own ON payment_requests;
+CREATE POLICY payment_requests_insert_own ON payment_requests
+  FOR INSERT WITH CHECK ((SELECT auth.uid()) = requester_id);
+
+-- Either party may withdraw from a request while it is still open: the asker
+-- cancels, the payer declines. Neither may mark it paid — that is a fact about
+-- the world, written by the system after observing settlement, never claimed by
+-- a party with an interest in the answer.
+DROP POLICY IF EXISTS payment_requests_update_parties ON payment_requests;
+CREATE POLICY payment_requests_update_parties ON payment_requests
+  FOR UPDATE
+  USING ((SELECT auth.uid()) IN (requester_id, payer_id) AND status = 'pending')
+  WITH CHECK (status IN ('cancelled', 'declined'));
+
+COMMENT ON TABLE payment_requests IS
+  'Person-to-person asks for money. Holds the request only — invoices are minted at pay time so a request survives longer than a BOLT11.';
+COMMENT ON COLUMN payment_requests.paid_intent_id IS
+  'System-written after settlement is observed; never set at creation.';


### PR DESCRIPTION
Completes the money surface: **Receive · Send · Request**, all under one sidebar entry.

## What a request is (and isn't)

A pay link works for anyone. A **request is addressed** — the other person is notified and can pay in one tap or decline.

Crucially, a request is **not** a `payment_intent`. An intent carries a live invoice, and a BOLT11 dies in about an hour — but a request has to survive until the person actually opens it, which may be tomorrow. So `payment_requests` records the *ask*, and the invoice is minted when the payer arrives. Same alias-backed rule the public pay page follows.

## Trust properties

- **Marking a request paid is a system write, never a party write.** Both people have an interest in that answer, so RLS permits them only to cancel (the asker) or decline (the person asked). Settlement stays observed, not claimed.
- **Authorship is enforced by RLS, not by the request body.** The insert runs through the *caller's* client under a policy that only permits asking on your own behalf — a request mintable in someone else's name would be a phishing primitive. A test asserts the insert goes through the caller client rather than the admin client, since using admin there would silently remove that protection.
- Failed close attempts are deliberately indistinguishable (missing / not yours / already closed) so the endpoint can't enumerate.

## Migration

`20260802220000_payment_requests.sql` — applied to the box. Table + 3 indexes + 3 RLS policies, verified live.

## Verification

`npm run verify` green: **170 suites / 1658 tests**, incl. 13 request-service tests weighted toward refusals.

Two repo gates caught this branch before it shipped and both are addressed: the migration-uniqueness gate (timestamp collided with `cat_watches` from main) and the API route-guard gate (the PATCH route was missing rate limiting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)