### PR TITLE
fix(profile): People tab queried a nonexistent column (400 on every load)

### DIFF
--- a/src/components/profile/ProfilePeopleTab.tsx
+++ b/src/components/profile/ProfilePeopleTab.tsx
@@ -77,7 +77,7 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
               profiles!follows_following_id_fkey (
                 id,
                 username,
-                display_name,
+                display_name:name,
                 bio,
                 avatar_url
               )
@@ -104,7 +104,7 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
               profiles!follows_follower_id_fkey (
                 id,
                 username,
-                display_name,
+                display_name:name,
                 bio,
                 avatar_url
               )


### PR DESCRIPTION
## Live production bug
`profiles` has a **`name`** column. The People tab's followers *and* following queries asked for **`display_name`**, so PostgREST rejected both:

```
400 {"code":"42703","message":"column profiles.display_name does not exist"}
```

The tab rendered **no connections at all**. Reproduced directly against production before and after.

## Fix
Use the PostgREST alias the rest of the codebase already uses (`display_name:name`) so the component keeps its field name and nothing else changes. The exact fixed query now returns **200 with rows** against prod.

Checked every other `display_name` usage: all others are already aliased correctly, and `actors.display_name` is a genuine column — this was the only broken one.

## How it was found
Surfaced while re-pointing the types at the live schema (Phase A). It is exactly the class of bug a hand-maintained schema type hides: the old type declared `display_name`, so this compiled cleanly while failing at runtime.

`npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)