### PR TITLE
fix(profile): People tab crashed profile pages for signed-out visitors

### DIFF
--- a/src/components/profile/ProfilePeopleTab.tsx
+++ b/src/components/profile/ProfilePeopleTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { logger } from '@/utils/logger';
 import { API_ROUTES } from '@/config/api-routes';
+import { extractProfiles, type Connection, type FollowWithProfile } from './followProfiles';
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
@@ -17,24 +18,6 @@ interface ProfilePeopleTabProps {
   profile: ScalableProfile;
   isOwnProfile?: boolean;
 }
-
-interface Connection {
-  id: string;
-  username: string;
-  name: string;
-  avatar_url: string | null;
-  bio: string | null;
-}
-
-type FollowWithProfile = {
-  profiles: {
-    id: string;
-    username: string;
-    display_name?: string;
-    bio?: string | null;
-    avatar_url?: string | null;
-  } | null;
-};
 
 /**
  * ProfilePeopleTab Component
@@ -77,7 +60,7 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
               profiles!follows_following_id_fkey (
                 id,
                 username,
-                display_name:name,
+                name,
                 bio,
                 avatar_url
               )
@@ -89,10 +72,8 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
             return;
           }
           if (!followingError && followingData) {
-            const followingProfiles = (followingData as FollowWithProfile[])
-              .map(item => item.profiles)
-              .filter((p): p is NonNullable<typeof p> => p !== null);
-            setFollowing(followingProfiles as Connection[]);
+            const followingProfiles = extractProfiles(followingData as FollowWithProfile[]);
+            setFollowing(followingProfiles);
           }
 
           // Fetch followers
@@ -104,7 +85,7 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
               profiles!follows_follower_id_fkey (
                 id,
                 username,
-                display_name:name,
+                name,
                 bio,
                 avatar_url
               )
@@ -116,10 +97,8 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
             return;
           }
           if (!followersError && followersData) {
-            const followerProfiles = (followersData as FollowWithProfile[])
-              .map(item => item.profiles)
-              .filter((p): p is NonNullable<typeof p> => p !== null);
-            setFollowers(followerProfiles as Connection[]);
+            const followerProfiles = extractProfiles(followersData as FollowWithProfile[]);
+            setFollowers(followerProfiles);
           }
         } else {
           // For other profiles, use API (will work if public data)
@@ -135,10 +114,8 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
             }
             if (followingData.success && followingData.data && followingData.data.data) {
               // Extract profiles from nested structure
-              const followingProfiles = (followingData.data.data as FollowWithProfile[])
-                .map(item => item.profiles)
-                .filter((p): p is NonNullable<typeof p> => p !== null);
-              setFollowing(followingProfiles as Connection[]);
+              const followingProfiles = extractProfiles(followingData.data.data as FollowWithProfile[]);
+              setFollowing(followingProfiles);
             }
           }
 
@@ -154,10 +131,8 @@ export default function ProfilePeopleTab({ profile, isOwnProfile }: ProfilePeopl
             }
             if (followersData.success && followersData.data && followersData.data.data) {
               // Extract profiles from nested structure
-              const followerProfiles = (followersData.data.data as FollowWithProfile[])
-                .map(item => item.profiles)
-                .filter((p): p is NonNullable<typeof p> => p !== null);
-              setFollowers(followerProfiles as Connection[]);
+              const followerProfiles = extractProfiles(followersData.data.data as FollowWithProfile[]);
+              setFollowers(followerProfiles);
             }
           }
         }

--- a/src/components/profile/followProfiles.ts
+++ b/src/components/profile/followProfiles.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared shapes + extraction for the People tab's follow data.
+ *
+ * Split out of ProfilePeopleTab so the component stays under the size gate.
+ */
+
+/** A person shown in the People tab. */
+export interface Connection {
+  id: string;
+  username: string;
+  /** profiles.name — the column really is `name`; there is no display_name. */
+  name?: string;
+  avatar_url: string | null;
+  bio: string | null;
+}
+
+type JoinedProfile = {
+  id: string;
+  username: string;
+  name?: string | null;
+  bio?: string | null;
+  avatar_url?: string | null;
+};
+
+/** `profiles` when queried directly; `profile` when it comes from /api/social/*. */
+export type FollowWithProfile = {
+  profiles?: JoinedProfile | null;
+  profile?: JoinedProfile | null;
+};
+
+/**
+ * Pull the joined profile out of a follow row.
+ *
+ * The two data paths disagree on the key: querying supabase directly gives
+ * `profiles`, while /api/social/* aliases it to `profile` (singular). The
+ * component only ever read `profiles`, so on the API path every row yielded
+ * `undefined` — and the old `!== null` filter let undefined through, so the
+ * render crashed on `.username` and signed-out visitors got the error boundary
+ * instead of a profile page. Accept either key and drop anything falsy.
+ */
+export function extractProfiles(rows: FollowWithProfile[]): Connection[] {
+  return rows
+    .map(row => row.profile ?? row.profiles)
+    .filter((p): p is JoinedProfile => Boolean(p)) as Connection[];
+}


### PR DESCRIPTION
## Live production bug
Profile pages rendered the **error boundary** ("Oops! Something went wrong") for signed-out visitors:

```
TypeError: Cannot read properties of undefined (reading 'username')  at Array.map
```

Two data paths disagree on one key. Querying supabase directly returns `profiles`; `/api/social/*` aliases it to **`profile`** (singular) — and the API path is the one every signed-out visitor takes. The component only read `profiles`, so each row mapped to `undefined`, the `!== null` filter let `undefined` through, and the render threw.

## Fix
- `extractProfiles()` accepts either key and drops anything falsy
- selects now ask for **`name`** — the real column — instead of aliasing it to a key the component never reads; `Connection.name` and the render now agree (previously the displayed name silently fell back to the username)
- shapes + helper extracted to `followProfiles.ts`, keeping the component under the size gate

## Note
Pre-existing, not from tonight's work: `git show` on the pre-refactor route confirms the API has always returned `profile` (singular). It only became *visible* once the column bug in #586 was fixed and these queries started returning data at all.

`npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)