### PR TITLE
ci: green PRs merge and deploy themselves

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,48 @@
+# Auto-merge — nobody is in the merge loop.
+#
+# Green, ready PRs merge themselves and deploy themselves. The owner does not
+# review PRs, and agent sessions are barred from merging by hand, so the policy
+# lives in scripts/ci/auto-merge-sweep.sh (read it — it defines exactly what
+# "ready" means and how a PR is held back).
+#
+# Two triggers, deliberately:
+#   workflow_run — merges within seconds of CI going green (the common path).
+#   schedule     — a safety net. Catches PRs whose checks finished while this
+#                  workflow was failing/disabled, and PRs whose last check was
+#                  an external status (Snyk/CodeQL) that reported after CI.
+#                  Without it, a PR that went green "off-cycle" waits forever.
+#
+# To stop all of this: delete this file, or add a `hold` label to a PR.
+
+name: Auto-merge
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # merge the PR
+  pull-requests: write # read PR state, delete the branch
+  actions: write # dispatch CI on main to re-arm CD
+
+# Never let two sweeps merge concurrently — they would race on the same PRs.
+concurrency:
+  group: auto-merge
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Merge every green, ready PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: bash scripts/ci/auto-merge-sweep.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ FleetCrown (rebranded from Cockpit) is a live customer project (see "FleetCrown"
 
 | Layer      | Technology                                                                          |
 | ---------- | ----------------------------------------------------------------------------------- |
-| Framework  | Next.js 16, React 19, TypeScript 5.8                                                          |
+| Framework  | Next.js 16, React 19, TypeScript 5.8                                                |
 | Styling    | Tailwind CSS 3.3                                                                    |
 | Database   | Self-hosted Supabase (PostgreSQL + Auth + RLS) — `supabase.orangecat.ch` on Hetzner |
 | Bitcoin    | Lightning Network, BTCPay, NWC                                                      |
@@ -59,3 +59,34 @@ grep -rn '\[#' src/
 # Find inline style hex violations
 grep -rn "style={{.*#" src/
 ```
+
+---
+
+## Shipping: nobody merges by hand
+
+**Do not merge PRs, and do not ask anyone to.** Open a PR and stop there —
+merging and deploying are automated end to end:
+
+```
+push branch → open PR → CI green → auto-merge.yml squash-merges it
+            → CI on main → CD deploys to bitbaum → health check
+```
+
+`.github/workflows/auto-merge.yml` (policy in `scripts/ci/auto-merge-sweep.sh`)
+merges **one** PR per sweep, and only when: it is not a draft, carries no hold
+label, every check has finished green, GitHub calls it cleanly mergeable, and
+main's own CI is currently green. One car per sweep is deliberate — a PR's
+checks prove that PR against the main it branched from, not against the other
+PRs queued beside it, so each merge is verified on main before the next couples.
+
+**Signal "not ready" by opening a draft PR**, or by labelling it `hold` /
+`no-automerge` / `do-not-merge` / `wip`. A draft waits forever. A red PR waits
+until it is green. Neither needs a human.
+
+Because of this, a green PR ships itself within minutes. Do not open a PR you
+would not want deployed. If work needs to land in a specific order, keep the
+later PRs as drafts until the earlier ones are on main.
+
+**Never remove the CI re-arm at the end of the sweep script.** A push made with
+the default `GITHUB_TOKEN` does not trigger workflows, and CD chains off CI — so
+without that explicit dispatch, merges land on main and silently never deploy.

--- a/scripts/ci/auto-merge-sweep.sh
+++ b/scripts/ci/auto-merge-sweep.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Merge every open PR that is ready and fully green, then re-arm CI on main.
+#
+# WHY THIS EXISTS
+# ---------------
+# Nobody reviews PRs on this repo — the owner explicitly does not want to be in
+# the merge loop, and agent sessions are barred from merging by hand. So the
+# policy lives here, in the repo, where it is visible, revocable, and applies
+# uniformly to every PR instead of depending on who opened it.
+#
+# THE POLICY
+#   merge a PR  <=>  it is not a draft
+#                    AND carries no hold label
+#                    AND has at least one check
+#                    AND every check has finished green
+#                    AND GitHub reports it cleanly mergeable
+#
+# Anything else is left alone for the next sweep. Nothing here forces a merge:
+# a red or pending PR simply waits, and a draft waits forever. To hold a ready
+# PR back, mark it a draft or add one of the hold labels below.
+#
+# ONE PR PER SWEEP, AND ONLY ONTO A GREEN MAIN
+# --------------------------------------------
+# A PR's checks prove *that PR against the main it branched from* — not against
+# the other eleven PRs sitting next to it. Merging a batch in one pass would put
+# a combination onto main that nothing ever built. So this script merges at most
+# one PR, then hands control back to CI: the merge train advances one car per
+# sweep, and every car is verified on main before the next one couples.
+#
+# For the same reason it refuses to merge while main's CI is red or still
+# running. Red main => stop adding changes until it is fixed; running CI => the
+# answer is not in yet. Both simply defer to the next sweep.
+#
+# THE CD RE-ARM (do not remove)
+#   A push made with the default GITHUB_TOKEN does NOT trigger workflows. CI
+#   runs on push-to-main and CD chains off CI, so a merge from this script would
+#   otherwise land on main and never deploy. The explicit workflow_dispatch of
+#   CI at the end restores that chain: CI runs on main -> CD fires -> box gets
+#   the new build. Silent no-deploy is the failure mode this guards against.
+
+set -euo pipefail
+
+REPO="${GH_REPO:-maonakamoto/orangecat}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+
+# A PR wearing any of these is never merged automatically.
+HOLD_LABELS='["hold","no-automerge","do-not-merge","wip"]'
+
+echo "[auto-merge] sweeping open PRs against ${BASE_BRANCH} in ${REPO}"
+
+# Never add changes to a base that is red or mid-verification.
+main_ci=$(gh run list --repo "$REPO" --workflow ci.yml --branch "$BASE_BRANCH" --limit 1 \
+  --json status,conclusion,headSha --jq '.[0] // empty')
+if [ -n "$main_ci" ]; then
+  main_status=$(printf '%s' "$main_ci" | jq -r '.status')
+  main_conclusion=$(printf '%s' "$main_ci" | jq -r '.conclusion // ""')
+  if [ "$main_status" != "completed" ]; then
+    echo "[auto-merge] ${BASE_BRANCH} CI is still running — deferring to the next sweep"
+    exit 0
+  fi
+  if [ "$main_conclusion" != "success" ]; then
+    echo "[auto-merge] ${BASE_BRANCH} CI is ${main_conclusion} — refusing to merge onto a broken base" >&2
+    exit 0
+  fi
+fi
+
+prs_json=$(gh pr list --repo "$REPO" --state open --base "$BASE_BRANCH" --limit 50 \
+  --json number,title,isDraft,mergeable,mergeStateStatus,labels,statusCheckRollup)
+
+count=$(printf '%s' "$prs_json" | jq 'length')
+if [ "$count" -eq 0 ]; then
+  echo "[auto-merge] no open PRs"
+  exit 0
+fi
+
+merged_any=0
+
+for number in $(printf '%s' "$prs_json" | jq -r '.[].number'); do
+  pr=$(printf '%s' "$prs_json" | jq -c --argjson n "$number" '.[] | select(.number == $n)')
+  title=$(printf '%s' "$pr" | jq -r '.title')
+
+  # A rollup entry is either a CheckRun (status + conclusion) or a commit
+  # StatusContext (state) — external services like Snyk report as the latter.
+  verdict=$(printf '%s' "$pr" | jq -r --argjson hold "$HOLD_LABELS" '
+    def ok:
+      if has("state") then (.state == "SUCCESS")
+      else ((.status == "COMPLETED")
+            and ((.conclusion // "") | test("^(SUCCESS|NEUTRAL|SKIPPED)$"))) end;
+    def pending:
+      if has("state") then (.state == "PENDING")
+      else (.status != "COMPLETED") end;
+
+    . as $pr
+    | (($pr.statusCheckRollup) // []) as $checks
+    | if $pr.isDraft then "skip: draft"
+      elif ([$pr.labels[]?.name] | any(. as $l | $hold | index($l) != null))
+        then "skip: hold label"
+      elif ($checks | length) == 0 then "skip: no checks reported yet"
+      elif ($checks | map(pending) | any) then "skip: checks still running"
+      elif (($checks | map(ok) | all) | not) then "skip: checks not green"
+      elif $pr.mergeable != "MERGEABLE"
+        then "skip: not mergeable (\($pr.mergeable)/\($pr.mergeStateStatus))"
+      else "merge" end
+  ')
+
+  if [ "$verdict" != "merge" ]; then
+    echo "[auto-merge] #${number} ${verdict} — ${title}"
+    continue
+  fi
+
+  echo "[auto-merge] #${number} green and ready — merging: ${title}"
+  if gh pr merge "$number" --repo "$REPO" --squash --delete-branch; then
+    merged_any=1
+    echo "[auto-merge] #${number} merged"
+    # One car per sweep: let CI verify this on main before coupling the next.
+    break
+  else
+    # Losing a race (someone merged first, or main moved underneath) is normal;
+    # the next sweep re-evaluates from fresh state.
+    echo "[auto-merge] #${number} merge failed — leaving for the next sweep" >&2
+  fi
+done
+
+if [ "$merged_any" -eq 1 ]; then
+  echo "[auto-merge] re-arming CI on ${BASE_BRANCH} so CD deploys the merge"
+  gh workflow run ci.yml --repo "$REPO" --ref "$BASE_BRANCH"
+else
+  echo "[auto-merge] nothing merged; CD not triggered"
+fi


### PR DESCRIPTION
You asked for merging and deploying to happen without your involvement. This is that, as repo automation rather than as a promise from whichever session happens to be running.

## How it works

```
push branch → open PR → CI green → auto-merge squash-merges it
            → CI on main → CD deploys to bitbaum
```

`.github/workflows/auto-merge.yml` runs on every CI completion (merges within seconds of green) plus a 10-minute cron safety net — that net matters because the *last* check to report is often an external status like Snyk or CodeQL, which lands after CI finishes; without it such a PR would sit green forever.

The policy itself lives in `scripts/ci/auto-merge-sweep.sh`, in the repo, readable and revocable.

## Two constraints that are load-bearing

**One PR per sweep.** There are 19 open PRs right now and 12 are currently mergeable, mostly Dependabot. Merging them in one pass would put a *combination* onto main that CI never built — each PR's checks only prove that PR against the main it branched from. So the train advances one car per sweep, and each is verified on main before the next couples. All 12 still land within a couple of hours, each one deployed and checked.

**An explicit CI re-arm after each merge.** A push made with the default `GITHUB_TOKEN` does not trigger workflows, and CD chains off CI (`workflow_run` on `CI` / `branches: [main]`). Without the `gh workflow run ci.yml --ref main` at the end of the sweep, every auto-merge would land on main and **silently never deploy**. That was the sharpest edge here and it is commented in both files so nobody removes it.

It also refuses to merge while main's CI is red or still running — red main means stop adding changes, running CI means the answer isn't in yet. Both just defer to the next sweep.

## Holding something back

A draft PR waits forever. So does one labelled `hold`, `no-automerge`, `do-not-merge`, or `wip`. Neither needs a human. `CLAUDE.md` documents this so future sessions open drafts for work-in-progress rather than trying to merge by hand.

The flip side, stated plainly: **a green PR now ships itself.** Don't open a PR you wouldn't want deployed.

## Verification

The decision logic was dry-run against all 19 live open PRs before this could merge anything — verdicts came out correct, including correctly refusing #595 (TypeScript 5.9.3 → 7.0.2, red) and the three PRs GitHub reports as `UNKNOWN` mergeability. The main-health guard reads real run data. `bash -n` and YAML parse clean; Prettier clean.

## One bootstrap merge, then never again

GitHub always runs the **default branch's** copy of a `workflow_run`/`schedule` workflow, so this PR cannot merge itself — the automation has to be on main before it can do anything. That makes this the last PR anyone merges by hand.

Merge this one, and #608 (Phase A, green and waiting) gets picked up by the sweep automatically, along with the Dependabot queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)