### PR TITLE
fix(ci): poll for mergeability instead of reading "not computed yet" as "no"

### DIFF
--- a/scripts/ci/auto-merge-sweep.sh
+++ b/scripts/ci/auto-merge-sweep.sh
@@ -99,13 +99,32 @@ for number in $(printf '%s' "$prs_json" | jq -r '.[].number'); do
       elif ($checks | length) == 0 then "skip: no checks reported yet"
       elif ($checks | map(pending) | any) then "skip: checks still running"
       elif (($checks | map(ok) | all) | not) then "skip: checks not green"
-      elif $pr.mergeable != "MERGEABLE"
-        then "skip: not mergeable (\($pr.mergeable)/\($pr.mergeStateStatus))"
       else "merge" end
   ')
 
   if [ "$verdict" != "merge" ]; then
     echo "[auto-merge] #${number} ${verdict} — ${title}"
+    continue
+  fi
+
+  # Mergeability is computed lazily by GitHub and is invalidated every time the
+  # base branch moves — so right after a merge (exactly when this workflow runs)
+  # every PR reports UNKNOWN. Poll until GitHub has an answer instead of
+  # treating "not computed yet" as "not mergeable"; otherwise the fast path can
+  # never merge anything and the whole train falls back to the cron.
+  mergeable=""
+  state=""
+  for attempt in 1 2 3 4 5 6; do
+    fresh=$(gh pr view "$number" --repo "$REPO" --json mergeable,mergeStateStatus)
+    mergeable=$(printf '%s' "$fresh" | jq -r '.mergeable')
+    state=$(printf '%s' "$fresh" | jq -r '.mergeStateStatus')
+    [ "$mergeable" != "UNKNOWN" ] && break
+    echo "[auto-merge] #${number} mergeability not computed yet (attempt ${attempt}) — waiting"
+    sleep 5
+  done
+
+  if [ "$mergeable" != "MERGEABLE" ]; then
+    echo "[auto-merge] #${number} skip: not mergeable (${mergeable}/${state}) — ${title}"
     continue
   fi
 


### PR DESCRIPTION
The first live sweep after #609 merged nothing — every one of the 20 open PRs reported `mergeable: UNKNOWN`.

GitHub computes mergeability **lazily**, and invalidates it for every open PR whenever the base branch moves. The fast path (`workflow_run` on CI completion) fires moments after a merge just moved main — precisely the window where nothing has been recomputed. Treating `UNKNOWN` as "not mergeable" meant the fast trigger could *never* merge anything, and the whole train silently degraded to the 10-minute cron.

So: poll the PR until GitHub has an answer (6 tries, 5s apart), then decide.

**Verified against a real case:** #608 reported `UNKNOWN` during the sweep, and `MERGEABLE/CLEAN` when asked again seconds later.

```
attempt 1: MERGEABLE/CLEAN
attempt 2: MERGEABLE/CLEAN
attempt 3: MERGEABLE/CLEAN
```

The check gates stay on the cheap list query — only the mergeability question, the one that is racy by design, gets re-asked per candidate. Nothing about the merge policy changes: still one PR per sweep, still only onto a green main, still draft/label to hold.

This is the automation from #609 catching its own bug on its first real run, which is roughly what the safety-net cron was there for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)