### PR TITLE
fix(ci): stop the auto-merge re-arm from leaving main red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,22 @@ jobs:
 
       - name: Secret scan (gitleaks)
         # Free for public repos; no license needed. Fails the job on any finding.
+        #
+        # Skipped on workflow_dispatch, and only there. On push and pull_request
+        # the action scans the incoming commits; a dispatched run has no such
+        # range, so it falls back to scanning all ~2.6k commits of history and
+        # fails on ~173 pre-existing findings (2025-era .env commits) that only
+        # a history rewrite can clear — see the security audit, not CI's job.
+        #
+        # This costs nothing in coverage: every commit still gets scanned in its
+        # PR run before it can merge. The alternative — baselining those 173
+        # findings in .gitleaksignore — would mean allowlisting real historical
+        # credentials, which that file explicitly forbids.
+        #
+        # Auto-merge dispatches CI on main after each merge (a GITHUB_TOKEN push
+        # triggers nothing), so without this every automated merge left main red
+        # and CD, which chains off green CI, never deployed.
+        if: github.event_name != 'workflow_dispatch'
         uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/ci/auto-merge-sweep.sh
+++ b/scripts/ci/auto-merge-sweep.sh
@@ -99,13 +99,32 @@ for number in $(printf '%s' "$prs_json" | jq -r '.[].number'); do
       elif ($checks | length) == 0 then "skip: no checks reported yet"
       elif ($checks | map(pending) | any) then "skip: checks still running"
       elif (($checks | map(ok) | all) | not) then "skip: checks not green"
-      elif $pr.mergeable != "MERGEABLE"
-        then "skip: not mergeable (\($pr.mergeable)/\($pr.mergeStateStatus))"
       else "merge" end
   ')
 
   if [ "$verdict" != "merge" ]; then
     echo "[auto-merge] #${number} ${verdict} — ${title}"
+    continue
+  fi
+
+  # Mergeability is computed lazily by GitHub and is invalidated every time the
+  # base branch moves — so right after a merge (exactly when this workflow runs)
+  # every PR reports UNKNOWN. Poll until GitHub has an answer instead of
+  # treating "not computed yet" as "not mergeable"; otherwise the fast path can
+  # never merge anything and the whole train falls back to the cron.
+  mergeable=""
+  state=""
+  for attempt in 1 2 3 4 5 6; do
+    fresh=$(gh pr view "$number" --repo "$REPO" --json mergeable,mergeStateStatus)
+    mergeable=$(printf '%s' "$fresh" | jq -r '.mergeable')
+    state=$(printf '%s' "$fresh" | jq -r '.mergeStateStatus')
+    [ "$mergeable" != "UNKNOWN" ] && break
+    echo "[auto-merge] #${number} mergeability not computed yet (attempt ${attempt}) — waiting"
+    sleep 5
+  done
+
+  if [ "$mergeable" != "MERGEABLE" ]; then
+    echo "[auto-merge] #${number} skip: not mergeable (${mergeable}/${state}) — ${title}"
     continue
   fi
 

--- a/scripts/ci/auto-merge-sweep.sh
+++ b/scripts/ci/auto-merge-sweep.sh
@@ -50,11 +50,27 @@ HOLD_LABELS='["hold","no-automerge","do-not-merge","wip"]'
 echo "[auto-merge] sweeping open PRs against ${BASE_BRANCH} in ${REPO}"
 
 # Never add changes to a base that is red or mid-verification.
+#
+# The run has to belong to the CURRENT tip of the base branch. Checking only
+# "the latest CI run" is a trap: right after a merge, the newest run is still
+# the *previous* commit's — and it is green — so the guard would wave through a
+# second merge onto a commit nothing has verified yet. That is exactly the
+# batching this script exists to prevent.
+main_sha=$(gh api "repos/${REPO}/commits/${BASE_BRANCH}" --jq '.sha')
 main_ci=$(gh run list --repo "$REPO" --workflow ci.yml --branch "$BASE_BRANCH" --limit 1 \
   --json status,conclusion,headSha --jq '.[0] // empty')
-if [ -n "$main_ci" ]; then
+
+if [ -z "$main_ci" ]; then
+  echo "[auto-merge] no CI history for ${BASE_BRANCH} — proceeding"
+else
   main_status=$(printf '%s' "$main_ci" | jq -r '.status')
   main_conclusion=$(printf '%s' "$main_ci" | jq -r '.conclusion // ""')
+  main_ci_sha=$(printf '%s' "$main_ci" | jq -r '.headSha')
+
+  if [ "$main_ci_sha" != "$main_sha" ]; then
+    echo "[auto-merge] ${BASE_BRANCH} is at ${main_sha:0:8} but the newest CI run is for ${main_ci_sha:0:8} — waiting for CI to catch up"
+    exit 0
+  fi
   if [ "$main_status" != "completed" ]; then
     echo "[auto-merge] ${BASE_BRANCH} CI is still running — deferring to the next sweep"
     exit 0


### PR DESCRIPTION
Two bugs the first automated merge exposed, both introduced by #609/#611. Main is currently red because of the first one, which also means **CD has not deployed since the automation went live**.

## 1. A dispatched CI run scans all of git history for secrets

gitleaks scans the *incoming commits* on `push` and `pull_request`. A `workflow_dispatch` run has no such range, so it falls back to scanning the full ~2,600-commit history and fails on ~173 pre-existing findings (2025-era `.env` / `.env.example` commits).

Auto-merge dispatches CI on main after every merge — a `GITHUB_TOKEN` push triggers nothing — so **every automated merge left main red, and CD, which chains off green CI, never fired.**

The evidence is clean:

| commit | merged by | CI event | security |
|---|---|---|---|
| `8a705f1f` | human | `push` | ✅ |
| `d05d992a` | bot | `workflow_dispatch` | ❌ 173 leaks |

Fix: skip the scan on `workflow_dispatch`, and only there. **Coverage is unchanged** — every commit is still scanned in its PR run before it can merge.

Deliberately *not* fixed by baselining those findings in `.gitleaksignore`: that file says "Only for confirmed FALSE POSITIVES — never allowlist a real credential here," and these are real historical credentials. Clearing them is a history-rewrite job (already tracked in the security audit), not something CI should paper over.

## 2. The green-base guard checked the wrong commit

It read the newest CI run on main without checking *which commit* that run belonged to. Right after a merge, the newest run is still the **previous** commit's — and it is green — so the guard would happily wave a second merge onto a tip nothing had verified. That is precisely the batching the one-PR-per-sweep rule exists to prevent.

Fix: require the run's `headSha` to equal the current tip; otherwise wait for CI to catch up.

## Also in this PR

The mergeability polling from #611 (already merged) — this branch carries it forward.

---

Both bugs are the automation catching itself on its first real run, which is the argument for having built it as observable repo code rather than as a one-off action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)