### PR TITLE
fix(ci): re-run cancelled checks instead of stranding the PR forever

### DIFF
--- a/scripts/ci/auto-merge-sweep.sh
+++ b/scripts/ci/auto-merge-sweep.sh
@@ -120,6 +120,31 @@ for number in $(printf '%s' "$prs_json" | jq -r '.[].number'); do
 
   if [ "$verdict" != "merge" ]; then
     echo "[auto-merge] #${number} ${verdict} — ${title}"
+
+    # A CANCELLED check is not a verdict, it is noise: CI uses
+    # `concurrency: cancel-in-progress`, so an unrelated newer run on the same
+    # ref can kill a PR's build. Nothing ever re-runs it, the PR is never green,
+    # and it sits in this queue forever — which is exactly how #603 and #604
+    # stranded. Re-run it and let a later sweep judge the real result. Genuine
+    # failures are left alone; only a run with no real failure is retried.
+    if [ "$verdict" = "skip: checks not green" ]; then
+      retry_urls=$(printf '%s' "$pr" | jq -r '
+        [ .statusCheckRollup[]?
+          | select(has("state") | not)
+          | select((.conclusion // "") == "CANCELLED")
+          | .detailsUrl ] as $cancelled
+        | [ .statusCheckRollup[]?
+            | select(((.conclusion // .state // "")
+                      | test("^(FAILURE|TIMED_OUT|ACTION_REQUIRED|STARTUP_FAILURE|ERROR)$"))) ] as $failed
+        | if ($failed | length) == 0 then $cancelled[] else empty end
+      ')
+      for url in $retry_urls; do
+        run_id=$(printf '%s' "$url" | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+' || true)
+        [ -z "$run_id" ] && continue
+        echo "[auto-merge] #${number} re-running cancelled run ${run_id}"
+        gh run rerun "$run_id" --repo "$REPO" || echo "[auto-merge] #${number} could not re-run ${run_id}" >&2
+      done
+    fi
     continue
   fi
 


### PR DESCRIPTION
Found while clearing the queue: `#603` and `#604` were not failing — their `build-and-smoke` runs were **cancelled**, collateral from CI's `concurrency: cancel-in-progress` when a newer run started on the same ref.

Nothing ever re-runs a cancelled check. So the PR is permanently not-green, the sweep skips it on every pass, and it sits in the queue forever. Both had to be re-run by hand today. That is a class, not two incidents — every future PR caught by the concurrency group would strand the same way.

Now: a PR whose only non-green checks are cancelled gets those runs re-triggered, and a later sweep judges the real result.

**Deliberately narrow.** If any check is a genuine `FAILURE` / `TIMED_OUT` / `ACTION_REQUIRED` / `STARTUP_FAILURE` / `ERROR`, the retry is skipped entirely — so it can never paper over a real failure, and can never loop on one. Verified against fixtures:

| rollup | result |
|---|---|
| cancelled only | retries that run |
| cancelled + real failure | no retry |
| failing external status (Snyk-style) | no retry |

Also confirms run-id extraction from the check `detailsUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)