### PR TITLE
fix(ci): deploy after bot merges instead of stalling silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,3 +228,54 @@ jobs:
           npm audit --audit-level=critical --omit=dev
           npm audit --audit-level=high --omit=dev \
             || echo "::warning title=Dependency audit::HIGH-severity advisories present — triage and escalate this gate to blocking."
+
+  # Everything GitHub would have chained off this run, had it emitted the event.
+  #
+  # CD and Main Red Alert both trigger on `workflow_run` of CI. GitHub does not
+  # emit that event when the CI run was itself created with the default
+  # GITHUB_TOKEN — which is exactly how the auto-merge sweep re-arms CI after a
+  # bot merge (a GITHUB_TOKEN push triggers nothing, hence the dispatch). So on
+  # the automated path both consumers are dead, and dead *silently*: green CI,
+  # no red check, nothing deployed. That stranded 14 verified commits on main
+  # for eight hours on 2026-08-04 while the box served the old build.
+  #
+  # A dispatched run therefore does the handoff itself. The push path is left
+  # alone — its `workflow_run` fires normally, and is the better path there
+  # (CD downloads the exact artifact this run built). One trigger per path.
+  post-main:
+    needs: [build-and-smoke, security]
+    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write # dispatch cd.yml
+      issues: write # file/close the red-main issue
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve this run's verdict
+        id: verdict
+        run: |
+          if [ "${{ needs.build-and-smoke.result }}" = "success" ] \
+             && [ "${{ needs.security.result }}" = "success" ]; then
+            echo "conclusion=success" >> "$GITHUB_OUTPUT"
+          elif [ "${{ needs.build-and-smoke.result }}" = "cancelled" ] \
+             || [ "${{ needs.security.result }}" = "cancelled" ]; then
+            echo "conclusion=cancelled" >> "$GITHUB_OUTPUT"
+          else
+            echo "conclusion=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: File or resolve the main-red issue
+        env:
+          CONCLUSION: ${{ steps.verdict.outputs.conclusion }}
+          RUN_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/ci/main-red-alert.sh
+
+      - name: Arm CD
+        if: steps.verdict.outputs.conclusion == 'success'
+        run: bash scripts/ci/arm-cd.sh

--- a/.github/workflows/main-red-alert.yml
+++ b/.github/workflows/main-red-alert.yml
@@ -9,6 +9,12 @@ name: Main Red Alert
 # This files (or updates) ONE issue the moment CI fails on main, and closes it
 # when main is green again — so "is main broken?" is answerable without
 # watching Actions.
+#
+# This workflow covers the PUSH path only. A CI run dispatched by the auto-merge
+# sweep emits no `workflow_run` event (GitHub suppresses it for runs created
+# with GITHUB_TOKEN), so that path calls the same script from ci.yml's post-main
+# job instead. The policy itself lives in scripts/ci/main-red-alert.sh so the
+# two paths cannot drift.
 
 on:
   workflow_run:
@@ -24,40 +30,13 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+
       - name: File or resolve the main-red issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_SHA: ${{ github.event.workflow_run.head_sha }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          TITLE="🔴 main is red — CI failing on main"
-
-          # A cancelled run means a newer push superseded this one (the CI
-          # concurrency group cancels in-progress runs). That is not a failure,
-          # and treating it as one is how "cancelled" gets misread as "broken".
-          if [ "$CONCLUSION" != "failure" ]; then
-            existing=$(gh issue list -R "$REPO" --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
-            if [ "$CONCLUSION" = "success" ] && [ -n "$existing" ]; then
-              gh issue close "$existing" -R "$REPO" \
-                --comment "main is green again as of ${RUN_SHA:0:8} — $RUN_URL"
-            fi
-            exit 0
-          fi
-
-          BODY=$(printf '%s\n' \
-            "CI failed on \`main\` at commit \`${RUN_SHA:0:8}\`." \
-            "" \
-            "Run: $RUN_URL" \
-            "" \
-            "**Every PR branched from this commit inherits the failure**, so fix or revert before merging anything else." \
-            "This issue closes itself when a CI run on main succeeds.")
-
-          existing=$(gh issue list -R "$REPO" --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" -R "$REPO" --body "$BODY"
-          else
-            gh issue create -R "$REPO" --title "$TITLE" --body "$BODY"
-          fi
+        run: bash scripts/ci/main-red-alert.sh

--- a/scripts/ci/arm-cd.sh
+++ b/scripts/ci/arm-cd.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Dispatch CD on main, and prove it actually started.
+#
+# WHY THIS EXISTS
+# ---------------
+# CD triggers on `workflow_run` of CI. GitHub does not emit that event when the
+# CI run was itself created with the default GITHUB_TOKEN — which is exactly how
+# the auto-merge sweep re-arms CI after every bot merge. The chain therefore
+# breaks precisely on the automated path, and breaks *silently*: CI is green, no
+# check is red, and nothing deploys. On 2026-08-04 that stranded 14 verified
+# commits on main for eight hours while the box kept serving the old build.
+#
+# So the dispatched run hands off explicitly instead of relying on the event.
+#
+# A dispatch that quietly creates no run is the same silent failure one level
+# down, so it is verified rather than assumed. If no run appears, exit non-zero:
+# CI goes red on main, which halts the merge train (auto-merge refuses a broken
+# base) and files the red-main issue. Stopping is the correct response to "we
+# can no longer ship" — piling up more unshippable merges is not.
+
+set -euo pipefail
+
+REPO="${REPO:?REPO is required}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+
+latest_cd_run() {
+  gh run list --repo "$REPO" --workflow cd.yml --limit 1 \
+    --json databaseId --jq '.[0].databaseId // 0'
+}
+
+before=$(latest_cd_run)
+echo "[arm-cd] latest CD run before dispatch: ${before}"
+
+gh workflow run cd.yml --repo "$REPO" --ref "$BASE_BRANCH"
+echo "[arm-cd] dispatched cd.yml on ${BASE_BRANCH}"
+
+for attempt in $(seq 1 12); do
+  sleep 5
+  after=$(latest_cd_run)
+  if [ "$after" != "$before" ]; then
+    echo "[arm-cd] CD armed — run ${after}"
+    exit 0
+  fi
+  echo "[arm-cd] no new CD run yet (attempt ${attempt})"
+done
+
+echo "::error title=CD not armed::Dispatched cd.yml on ${BASE_BRANCH} but no run appeared within 60s. Deploys are stalled; main is deliberately red until this is fixed."
+exit 1

--- a/scripts/ci/main-red-alert.sh
+++ b/scripts/ci/main-red-alert.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# File (or resolve) the single "main is red" issue.
+#
+# WHY THIS IS A SCRIPT AND NOT INLINE YAML
+# ----------------------------------------
+# Two different workflows have to reach this same verdict:
+#   * main-red-alert.yml, from the `workflow_run` event, when CI ran on a push;
+#   * ci.yml's post-main job, when CI was dispatched by the auto-merge sweep and
+#     GitHub therefore emits no `workflow_run` event at all (see that job).
+# One policy, one file. Duplicating it in YAML is how the two paths would drift.
+#
+# Inputs (env):
+#   REPO        owner/name
+#   CONCLUSION  success | failure | cancelled | ...
+#   RUN_SHA     commit the run was for
+#   RUN_URL     link to the run
+
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+: "${CONCLUSION:?CONCLUSION is required}"
+RUN_SHA="${RUN_SHA:-unknown}"
+RUN_URL="${RUN_URL:-}"
+
+TITLE="🔴 main is red — CI failing on main"
+
+existing=$(gh issue list -R "$REPO" --state open --search "$TITLE in:title" \
+  --json number --jq '.[0].number // empty')
+
+# A cancelled run means a newer push superseded this one (the CI concurrency
+# group cancels in-progress runs). That is not a failure, and treating it as one
+# is how "cancelled" gets misread as "broken".
+if [ "$CONCLUSION" != "failure" ]; then
+  if [ "$CONCLUSION" = "success" ] && [ -n "$existing" ]; then
+    gh issue close "$existing" -R "$REPO" \
+      --comment "main is green again as of ${RUN_SHA:0:8} — $RUN_URL"
+  fi
+  exit 0
+fi
+
+BODY=$(printf '%s\n' \
+  "CI failed on \`main\` at commit \`${RUN_SHA:0:8}\`." \
+  "" \
+  "Run: $RUN_URL" \
+  "" \
+  "**Every PR branched from this commit inherits the failure**, so fix or revert before merging anything else." \
+  "This issue closes itself when a CI run on main succeeds.")
+
+if [ -n "$existing" ]; then
+  gh issue comment "$existing" -R "$REPO" --body "$BODY"
+else
+  gh issue create -R "$REPO" --title "$TITLE" --body "$BODY"
+fi


### PR DESCRIPTION
## The bug

CD and Main Red Alert both trigger on `workflow_run` of CI. **GitHub does not emit that event when the CI run was itself created with the default `GITHUB_TOKEN`** — which is exactly how `auto-merge-sweep.sh` re-arms CI after every bot merge.

So on the automated path both consumers are dead, and dead *silently*: CI green, no check red, nothing deployed.

Evidence from yesterday — 14 consecutive `workflow_dispatch` CI runs on main, all green, **zero** CD runs:

```
2026-08-04T23:31Z workflow_dispatch 88899044 completed/success   CI
...  (12 more)  ...
2026-08-04T16:23Z workflow_dispatch f6a3a8df completed/success   CI

last CD run: 2026-08-04T15:10Z (a manual dispatch)
box /opt/orangecat/app: Aug  4 15:12
```

Auto-merge only survived the same suppression because it has a `schedule` cron. CD and the red-main alert have no fallback.

## The fix

A dispatched CI run does the handoff itself, in a new `post-main` job: file/close the red-main issue, then dispatch CD. The push path is untouched — its `workflow_run` fires normally and is the better path there (CD downloads the exact artifact CI built). **One trigger per path, never two.**

The dispatch is verified rather than assumed: no CD run within 60s → the job fails. Red main halts the merge train, which is the correct response to "we can no longer ship" — quietly piling up unshippable merges is not.

Alert policy extracted to `scripts/ci/main-red-alert.sh` so both callers share one definition instead of drifting copies.

## Verification

- Backlog deployed by hand first: box rebuilt 10:03 UTC, `https://orangecat.ch/api/health` → 200, all services operational.
- YAML parses; shell scripts pass `bash -n`.
- The real proof arrives on this PR's own merge: it should deploy itself with no human dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)