### PR TITLE
feat(cat): interest graph — what Cat learns can make you findable

### DIFF
--- a/__tests__/unit/cat/discovery.test.ts
+++ b/__tests__/unit/cat/discovery.test.ts
@@ -25,14 +25,24 @@ interface Row {
   [k: string]: unknown;
 }
 
-/** Supabase mock: rpc returns match rows; from() serves per-table lookups. */
+/**
+ * Supabase mock: rpc is routed BY NAME — match_content (entities) and
+ * match_interested_people (declared interests) are separate channels and a
+ * mock that conflated them would hide exactly the bug worth catching.
+ */
 function mockSupabase(opts: {
   matches?: Row[];
   rpcError?: unknown;
+  interestRows?: Row[];
   tables?: Record<string, Row | null>;
 }) {
   const client = {
-    rpc: async () => ({ data: opts.matches ?? [], error: opts.rpcError ?? null }),
+    rpc: async (name: string) => {
+      if (name === 'match_interested_people') {
+        return { data: opts.interestRows ?? [], error: null };
+      }
+      return { data: opts.matches ?? [], error: opts.rpcError ?? null };
+    },
     from: (table: string) => {
       const builder: Record<string, unknown> = {};
       const chain = () => builder;
@@ -103,7 +113,12 @@ describe('exploreTopic', () => {
         },
       ],
       tables: {
-        projects: { id: 'p1', title: 'My own longevity project', actor_id: null, user_id: 'viewer-1' },
+        projects: {
+          id: 'p1',
+          title: 'My own longevity project',
+          actor_id: null,
+          user_id: 'viewer-1',
+        },
         profiles: { username: 'me', name: 'Me' },
       },
     });
@@ -143,11 +158,75 @@ describe('exploreTopic', () => {
         },
       ],
       tables: {
-        user_products: { id: 't1', title: 'Test product', actor_id: null, user_id: 'x', is_test: true },
+        user_products: {
+          id: 't1',
+          title: 'Test product',
+          actor_id: null,
+          user_id: 'x',
+          is_test: true,
+        },
       },
     });
     const result = await exploreTopic(client, 'viewer-1', 'longevity');
     expect(result.hits).toEqual([]);
+  });
+
+  it('finds someone who published NOTHING but declared the interest', async () => {
+    // The case the platform actually has: 148 profiles, 5 bios, no longevity
+    // entities. Without this channel the answer is "nobody", which is wrong.
+    const client = mockSupabase({
+      matches: [],
+      interestRows: [{ user_id: 'u2', topic: 'longevity research', similarity: 0.8 }],
+      tables: { profiles: { id: 'u2', username: 'ada', name: 'Ada' } },
+    });
+    const result = await exploreTopic(client, 'viewer-1', 'longevity');
+    expect(result.hits).toEqual([]);
+    expect(result.people).toHaveLength(1);
+    expect(result.people[0].username).toBe('ada');
+
+    // And the digest must not tell the model the platform is empty.
+    const digest = formatDiscoveryForModel(result);
+    expect(digest).toContain('Ada');
+    expect(digest).not.toContain('No public entities or people');
+  });
+
+  it('keeps BOTH reasons when someone matches by work and by interest', async () => {
+    const client = mockSupabase({
+      matches: [
+        {
+          entity_type: 'research',
+          entity_id: 'r1',
+          title: 'Biomarkers study',
+          url: '/research/r1',
+          text_preview: '',
+          similarity: 0.7,
+        },
+      ],
+      interestRows: [{ user_id: 'owner-1', topic: 'longevity', similarity: 0.9 }],
+      tables: {
+        research_entities: {
+          id: 'r1',
+          title: 'Biomarkers study',
+          actor_id: null,
+          user_id: 'owner-1',
+        },
+        profiles: { id: 'owner-1', username: 'ada', name: 'Ada' },
+      },
+    });
+    const result = await exploreTopic(client, 'viewer-1', 'longevity');
+    expect(result.people).toHaveLength(1);
+    expect(result.people[0].via.join(' ')).toContain('Interested in longevity');
+    expect(result.people[0].via.join(' ')).toContain('Biomarkers study');
+  });
+
+  it('an empty topic search still offers being findable + a watch', async () => {
+    const client = mockSupabase({ matches: [], interestRows: [] });
+    const digest = formatDiscoveryForModel(
+      await exploreTopic(client, 'viewer-1', 'basket weaving')
+    );
+    expect(digest).toContain('publish_interest');
+    expect(digest).toContain('watch_topic');
+    expect(digest).toContain('never publish silently');
   });
 
   it('reports degraded (not "nothing found") when the index is unreachable', async () => {
@@ -171,9 +250,7 @@ describe('discovery wiring', () => {
   it('explore_topic is a declared platform tool', () => {
     const def = PLATFORM_TOOL_DEFINITION.find(t => t.function.name === 'explore_topic');
     expect(def).toBeDefined();
-    expect(
-      (def!.function.parameters as { required: string[] }).required
-    ).toEqual(['topic']);
+    expect((def!.function.parameters as { required: string[] }).required).toEqual(['topic']);
   });
 
   it('interest phrasings reach the tool pass (they did not before)', () => {

--- a/__tests__/unit/cat/interests.test.ts
+++ b/__tests__/unit/cat/interests.test.ts
@@ -163,3 +163,31 @@ describe('publishing safety', () => {
     }
   });
 });
+
+describe('publishing closes the loop immediately', () => {
+  it('tells the user who else is already into it', async () => {
+    const client = mockSupabase({
+      existing: [],
+      rpcRows: [{ user_id: 'u2', topic: 'longevity', similarity: 0.9 }],
+      profiles: [{ id: 'u2', username: 'ada', name: 'Ada' }],
+    });
+    const result = await ACTION_HANDLERS.publish_interest!(client, 'u1', 'actor-1', {
+      topic: 'longevity',
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as { peers: unknown[]; message: string };
+    expect(data.peers).toHaveLength(1);
+    expect(data.message).toContain('Ada');
+    expect(data.message).toContain('@ada');
+  });
+
+  it('says nothing about peers when there are none', async () => {
+    const client = mockSupabase({ existing: [], rpcRows: [], profiles: [] });
+    const result = await ACTION_HANDLERS.publish_interest!(client, 'u1', 'actor-1', {
+      topic: 'basket weaving',
+    });
+    const data = result.data as { peers: unknown[]; message: string };
+    expect(data.peers).toEqual([]);
+    expect(data.message).not.toContain('into this too');
+  });
+});

--- a/__tests__/unit/cat/interests.test.ts
+++ b/__tests__/unit/cat/interests.test.ts
@@ -1,0 +1,165 @@
+import {
+  normalizeTopic,
+  cleanTopic,
+  isValidTopic,
+  publishInterest,
+  findPeopleByInterest,
+  MAX_INTERESTS_PER_USER,
+} from '@/services/cat/interests';
+import { CAT_ACTIONS } from '@/config/cat-actions';
+import { ACTION_HANDLERS } from '@/services/cat/handlers';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+
+/**
+ * Interests are the only Cat-written data other people can see, so these tests
+ * pin two things: that the same interest phrased differently dedupes, and that
+ * publishing can never happen without an explicit confirmation.
+ */
+
+jest.mock('@/services/ai/embeddings', () => ({
+  embeddingsEnabled: () => true,
+  embedText: async () => new Array(1536).fill(0.01),
+}));
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+interface Row {
+  [k: string]: unknown;
+}
+
+function mockSupabase(opts: {
+  existing?: Row[];
+  insertError?: unknown;
+  rpcRows?: Row[];
+  profiles?: Row[];
+  onInsert?: (payload: Row) => void;
+}) {
+  const client = {
+    rpc: async () => ({ data: opts.rpcRows ?? [], error: null }),
+    from: (table: string) => {
+      const rows = table === 'profiles' ? (opts.profiles ?? []) : (opts.existing ?? []);
+      const builder: Record<string, unknown> = {};
+      for (const m of ['select', 'eq', 'in', 'order', 'limit', 'delete']) {
+        builder[m] = () => builder;
+      }
+      builder.insert = async (payload: Row) => {
+        opts.onInsert?.(payload);
+        return { error: opts.insertError ?? null };
+      };
+      builder.then = (resolve: (v: unknown) => void) => resolve({ data: rows, error: null });
+      return builder;
+    },
+  } as unknown as AnySupabaseClient;
+  return client;
+}
+
+describe('topic normalization', () => {
+  it('strips lead-in filler so the stored phrase is the topic itself', () => {
+    expect(normalizeTopic("I'm really interested in longevity research")).toBe(
+      'longevity research'
+    );
+    expect(normalizeTopic('into Bitcoin education')).toBe('bitcoin education');
+    expect(cleanTopic('I am passionate about Tattoo Art.')).toBe('Tattoo Art');
+  });
+
+  it('treats differently-phrased versions of one interest as the same row', () => {
+    expect(normalizeTopic('Longevity')).toBe(normalizeTopic('  interested in   longevity  '));
+  });
+
+  it('never stems — "longevity" and "longevity research" stay distinct interests', () => {
+    expect(normalizeTopic('longevity')).not.toBe(normalizeTopic('longevity research'));
+  });
+
+  it('rejects topics that are empty or absurdly long', () => {
+    expect(isValidTopic('')).toBe(false);
+    expect(isValidTopic('a')).toBe(false);
+    expect(isValidTopic('x'.repeat(200))).toBe(false);
+    expect(isValidTopic('longevity')).toBe(true);
+  });
+});
+
+describe('publishInterest', () => {
+  it('stores the cleaned phrase and its embedding', async () => {
+    let captured: Row | null = null;
+    const client = mockSupabase({ existing: [], onInsert: p => (captured = p) });
+    const result = await publishInterest(client, 'u1', "I'm interested in longevity research");
+    expect(result).toMatchObject({ ok: true, alreadyPublished: false });
+    expect(captured).not.toBeNull();
+    expect((captured as unknown as Row).topic).toBe('longevity research');
+    expect((captured as unknown as Row).user_id).toBe('u1');
+    expect((captured as unknown as Row).embedding).toBeTruthy();
+  });
+
+  it('is idempotent — re-publishing does not create a second row', async () => {
+    let inserts = 0;
+    const client = mockSupabase({
+      existing: [
+        { id: '1', topic: 'longevity', normalized: 'longevity', source: 'cat', created_at: 'x' },
+      ],
+      onInsert: () => (inserts += 1),
+    });
+    const result = await publishInterest(client, 'u1', 'Interested in longevity');
+    expect(result).toMatchObject({ ok: true, alreadyPublished: true });
+    expect(inserts).toBe(0);
+  });
+
+  it('refuses past the per-user cap', async () => {
+    const existing = Array.from({ length: MAX_INTERESTS_PER_USER }, (_, i) => ({
+      id: String(i),
+      topic: `t${i}`,
+      normalized: `t${i}`,
+      source: 'cat',
+      created_at: 'x',
+    }));
+    const client = mockSupabase({ existing });
+    const result = await publishInterest(client, 'u1', 'one more');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects an unusable topic instead of publishing junk', async () => {
+    const client = mockSupabase({ existing: [] });
+    expect((await publishInterest(client, 'u1', 'a')).ok).toBe(false);
+  });
+});
+
+describe('findPeopleByInterest', () => {
+  it('surfaces a person who published NOTHING but declared the interest', async () => {
+    const client = mockSupabase({
+      rpcRows: [{ user_id: 'u2', topic: 'longevity research', similarity: 0.8 }],
+      profiles: [{ id: 'u2', username: 'ada', name: 'Ada' }],
+    });
+    const people = await findPeopleByInterest(client, 'u1', 'longevity');
+    expect(people).toHaveLength(1);
+    expect(people[0].username).toBe('ada');
+    expect(people[0].profileUrl).toBe('/profiles/ada');
+    expect(people[0].via[0]).toBe('Interested in longevity research');
+  });
+
+  it('drops matches with no readable profile rather than showing a ghost', async () => {
+    const client = mockSupabase({
+      rpcRows: [{ user_id: 'ghost', topic: 'longevity', similarity: 0.9 }],
+      profiles: [],
+    });
+    expect(await findPeopleByInterest(client, 'u1', 'longevity')).toEqual([]);
+  });
+});
+
+describe('publishing safety', () => {
+  it('publish_interest is high-risk and always confirms — it cannot be automated', () => {
+    const action = CAT_ACTIONS.publish_interest;
+    expect(action).toBeDefined();
+    expect(action.riskLevel).toBe('high');
+    expect(action.requiresConfirmation).toBe(true);
+  });
+
+  it('removing an interest never requires confirmation — opting out must be frictionless', () => {
+    expect(CAT_ACTIONS.unpublish_interest.requiresConfirmation).toBe(false);
+  });
+
+  it('every interest action has a handler', () => {
+    for (const id of ['publish_interest', 'unpublish_interest', 'watch_topic']) {
+      expect(ACTION_HANDLERS[id]).toBeInstanceOf(Function);
+    }
+  });
+});

--- a/src/app/(authenticated)/settings/ai/page.tsx
+++ b/src/app/(authenticated)/settings/ai/page.tsx
@@ -27,6 +27,7 @@ import { CatCreditsPanel } from '@/components/ai/CatCreditsPanel';
 import { CatCustomInstructions } from '@/components/ai/CatCustomInstructions';
 import { CatMemoryManager } from '@/components/ai/CatMemoryManager';
 import { CatMemoryImport } from '@/components/ai/CatMemoryImport';
+import { CatInterestsManager } from '@/components/ai/CatInterestsManager';
 import { LocalRuntimePanel } from '@/components/ai/LocalRuntimePanel';
 import { AiUsageStrip } from '@/components/ai/AiUsageStrip';
 
@@ -115,7 +116,10 @@ export default function AISettingsPage() {
         </div>
 
         {/* ── BYOK ──────────────────────────────────────────────────────── */}
-        <section id="byok" className="scroll-mt-24 rounded-lg border border-default bg-surface-base p-6">
+        <section
+          id="byok"
+          className="scroll-mt-24 rounded-lg border border-default bg-surface-base p-6"
+        >
           <div className="mb-4 flex items-start gap-3">
             <div className="rounded-md bg-surface-raised p-2">
               <Server className="h-5 w-5 text-fg-primary" />
@@ -154,7 +158,10 @@ export default function AISettingsPage() {
         </section>
 
         {/* ── Local ─────────────────────────────────────────────────────── */}
-        <section id="local" className="scroll-mt-24 rounded-lg border border-default bg-surface-base p-6">
+        <section
+          id="local"
+          className="scroll-mt-24 rounded-lg border border-default bg-surface-base p-6"
+        >
           <div className="mb-4 flex items-start gap-3">
             <div className="rounded-md bg-surface-raised p-2">
               <Terminal className="h-5 w-5 text-fg-primary" />
@@ -181,8 +188,10 @@ export default function AISettingsPage() {
             What Cat knows
           </h2>
           <p className="mt-1 text-sm text-fg-secondary">
-            Cat&apos;s memory is yours: review it, delete any of it, export it, or bring context
-            over from another AI. Standing instructions steer how Cat behaves in every chat.
+            Cat&apos;s memory is yours and private: review it, delete any of it, export it, or bring
+            context over from another AI. Standing instructions steer how Cat behaves in every chat.
+            Interests are the deliberate exception — the one part you choose to make public so other
+            people can find you.
           </p>
         </div>
 
@@ -203,6 +212,8 @@ export default function AISettingsPage() {
         />
 
         <CatMemoryImport onImported={() => setMemoryReloadKey(k => k + 1)} />
+
+        <CatInterestsManager />
       </section>
 
       {/* Privacy footnote */}

--- a/src/app/api/cat/interests/route.ts
+++ b/src/app/api/cat/interests/route.ts
@@ -1,0 +1,71 @@
+/**
+ * Cat Interests API — the user's PUBLIC discoverability surface.
+ *
+ * GET    /api/cat/interests              - What you are publicly findable for
+ * POST   /api/cat/interests              - Publish a topic  { topic }
+ * DELETE /api/cat/interests?topic=<t>    - Stop being findable for it
+ *
+ * Interests are the one thing the Cat writes that other people can see, so
+ * they must be inspectable and revocable outside the chat — a control you can
+ * only reach by asking an AI nicely is not a control.
+ */
+
+import { listInterests, publishInterest, unpublishInterest } from '@/services/cat/interests';
+import { apiSuccess, apiError, apiRateLimited, handleApiError } from '@/lib/api/standardResponse';
+import { rateLimitWriteAsync, retryAfterSeconds } from '@/lib/rate-limit';
+import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
+
+export const GET = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+  try {
+    return apiSuccess({ interests: await listInterests(supabase, user.id) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const POST = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
+  try {
+    const body = (await request.json()) as { topic?: unknown };
+    const topic = typeof body.topic === 'string' ? body.topic : '';
+    if (!topic.trim()) {
+      return apiError('Provide a topic', 'BAD_REQUEST', 400);
+    }
+    const result = await publishInterest(supabase, user.id, topic);
+    return result.ok
+      ? apiSuccess({ topic: result.topic, alreadyPublished: result.alreadyPublished })
+      : apiError(result.error, 'BAD_REQUEST', 400);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const DELETE = withAuth(async (request: AuthenticatedRequest) => {
+  const { user, supabase } = request;
+
+  const rl = await rateLimitWriteAsync(user.id);
+  if (!rl.success) {
+    return apiRateLimited('Too many requests. Please slow down.', retryAfterSeconds(rl));
+  }
+
+  const topic = new URL(request.url).searchParams.get('topic');
+  if (!topic) {
+    return apiError('Provide ?topic=<topic>', 'BAD_REQUEST', 400);
+  }
+
+  try {
+    const result = await unpublishInterest(supabase, user.id, topic);
+    return result.ok
+      ? apiSuccess({ removed: result.removed })
+      : apiError('That interest is not published', 'NOT_FOUND', 404);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/src/components/ai/CatInterestsManager.tsx
+++ b/src/components/ai/CatInterestsManager.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+/**
+ * CatInterestsManager — see and control what you are publicly findable for.
+ *
+ * Interests are the one thing Cat writes that other people can see, so this
+ * panel states that plainly and makes removal one click. Add is here too: a
+ * user should never have to talk to an AI to change what is public about them.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Compass, Loader2, Plus, X } from 'lucide-react';
+import { toast } from 'sonner';
+import Button from '@/components/ui/Button';
+import { logger } from '@/utils/logger';
+import { API_ROUTES } from '@/config/api-routes';
+
+interface Interest {
+  id: string;
+  topic: string;
+  source: 'cat' | 'manual';
+}
+
+export function CatInterestsManager() {
+  const [interests, setInterests] = useState<Interest[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [removing, setRemoving] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+  const [isAdding, setIsAdding] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(API_ROUTES.CAT.INTERESTS);
+      if (!res.ok) {
+        throw new Error('failed');
+      }
+      const json = await res.json();
+      setInterests((json?.data?.interests ?? []) as Interest[]);
+    } catch (err) {
+      logger.error('Failed to load interests', err, 'CatInterests');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleAdd = useCallback(async () => {
+    const topic = draft.trim();
+    if (!topic) {
+      return;
+    }
+    setIsAdding(true);
+    try {
+      const res = await fetch(API_ROUTES.CAT.INTERESTS, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        toast.error(json?.error ?? 'Could not add that interest');
+        return;
+      }
+      setDraft('');
+      await load();
+      toast.success(
+        json?.data?.alreadyPublished
+          ? 'You already had that interest'
+          : `"${json?.data?.topic ?? topic}" is now discoverable`
+      );
+    } catch (err) {
+      logger.error('Failed to add interest', err, 'CatInterests');
+      toast.error('Could not add that interest');
+    } finally {
+      setIsAdding(false);
+    }
+  }, [draft, load]);
+
+  const handleRemove = useCallback(async (interest: Interest) => {
+    setRemoving(interest.id);
+    try {
+      const res = await fetch(
+        `${API_ROUTES.CAT.INTERESTS}?topic=${encodeURIComponent(interest.topic)}`,
+        { method: 'DELETE' }
+      );
+      if (!res.ok) {
+        throw new Error('failed');
+      }
+      setInterests(prev => prev.filter(i => i.id !== interest.id));
+      toast.success(`Removed "${interest.topic}"`);
+    } catch (err) {
+      logger.error('Failed to remove interest', err, 'CatInterests');
+      toast.error('Could not remove that interest');
+    } finally {
+      setRemoving(null);
+    }
+  }, []);
+
+  return (
+    <section className="rounded-lg border border-default bg-surface-base p-6">
+      <div className="mb-4 flex items-start gap-3">
+        <div className="rounded-md bg-surface-raised p-2">
+          <Compass className="h-5 w-5 text-fg-primary" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-lg font-semibold text-fg-primary">What you&apos;re findable for</h2>
+          <p className="mt-1 text-sm text-fg-secondary">
+            These topics are <strong className="text-fg-primary">public</strong> — anyone signed in
+            who searches them can find you, which is how people working on the same things meet.
+            Unlike Cat&apos;s memory, this is not private. Remove any of it anytime.
+          </p>
+        </div>
+      </div>
+
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row">
+        <input
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void handleAdd();
+            }
+          }}
+          maxLength={80}
+          placeholder="e.g. longevity research"
+          aria-label="Add an interest"
+          className="min-w-0 flex-1 rounded-md border border-default bg-surface-raised px-3 py-2 text-sm text-fg-primary placeholder:text-fg-tertiary focus:border-accent-warm focus:outline-none"
+        />
+        <Button
+          onClick={() => void handleAdd()}
+          disabled={!draft.trim() || isAdding}
+          className="shrink-0"
+        >
+          {isAdding ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <>
+              <Plus className="mr-1 h-4 w-4" /> Add
+            </>
+          )}
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-fg-secondary">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+        </div>
+      ) : interests.length === 0 ? (
+        <p className="text-sm text-fg-tertiary">
+          Nothing published yet — nobody can find you by topic. Add one above, or just tell Cat what
+          you&apos;re into and it will offer.
+        </p>
+      ) : (
+        <ul className="flex flex-wrap gap-2">
+          {interests.map(interest => (
+            <li
+              key={interest.id}
+              className="inline-flex max-w-full items-center gap-2 rounded-full border border-default bg-surface-raised px-3 py-1.5"
+            >
+              <span className="truncate text-sm text-fg-primary">{interest.topic}</span>
+              <button
+                type="button"
+                onClick={() => void handleRemove(interest)}
+                disabled={removing === interest.id}
+                aria-label={`Remove ${interest.topic}`}
+                className="shrink-0 rounded-full p-0.5 text-fg-tertiary hover:bg-surface-base hover:text-status-negative"
+              >
+                {removing === interest.id ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <X className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -22,6 +22,7 @@ export const API_ROUTES = {
     CREDITS_TOPUP: '/api/cat/credits/topup',
     MEMORIES: '/api/cat/memories',
     MEMORIES_IMPORT: '/api/cat/memories/import',
+    INTERESTS: '/api/cat/interests',
     DIAGNOSE: '/api/cat/diagnose',
     NUDGES: '/api/cat/nudges',
     CONVERSATIONS: '/api/cat/conversations',

--- a/src/config/cat-actions.ts
+++ b/src/config/cat-actions.ts
@@ -19,6 +19,7 @@ import {
   Send,
   Megaphone,
   Users,
+  Eye,
   Wallet,
   Settings,
   FileText,
@@ -809,7 +810,8 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
         name: 'entity_type',
         type: 'string',
         required: true,
-        description: 'Type of the entity from the discovery results (project, research, service, …)',
+        description:
+          'Type of the entity from the discovery results (project, research, service, …)',
       },
       {
         name: 'entity_id',
@@ -828,6 +830,76 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
     examples: [
       'Introduce me to whoever is running that longevity study',
       'Put me in touch with the person behind that project',
+    ],
+    enabled: true,
+  },
+
+  publish_interest: {
+    id: 'publish_interest',
+    name: 'Publish Interest',
+    description:
+      "Add a topic to the user's PUBLIC interests so other people searching that topic can find them. Offer this when they express an interest ('I'm into longevity') or when explore_topic finds nothing — being findable is the fix for an empty result. This makes something public: state plainly that it goes on their public profile and wait for a clear yes. Never publish a topic they only mentioned in passing, and never publish anything sensitive (health, finances, relationships, politics, anything they asked you to keep private).",
+    category: 'context',
+    icon: Users,
+    riskLevel: 'high',
+    requiresConfirmation: true,
+    parameters: [
+      {
+        name: 'topic',
+        type: 'string',
+        required: true,
+        description:
+          'Short topic in the user\'s own words, 2–80 chars, no lead-in ("longevity research", not "I am interested in longevity research")',
+      },
+    ],
+    examples: [
+      'Make my interest in longevity discoverable',
+      'Add Bitcoin education to my interests',
+    ],
+    enabled: true,
+  },
+
+  unpublish_interest: {
+    id: 'unpublish_interest',
+    name: 'Remove Interest',
+    description:
+      "Remove a topic from the user's public interests — they stop being discoverable for it. Always honour this immediately and without argument.",
+    category: 'context',
+    icon: Users,
+    riskLevel: 'low',
+    requiresConfirmation: false,
+    parameters: [
+      {
+        name: 'topic',
+        type: 'string',
+        required: true,
+        description: 'The interest to remove (matched loosely against what they published)',
+      },
+    ],
+    examples: ['Remove longevity from my interests', 'Stop showing that I am into tattoo art'],
+    enabled: true,
+  },
+
+  watch_topic: {
+    id: 'watch_topic',
+    name: 'Watch Topic',
+    description:
+      "Notify the user when someone new appears on OrangeCat working on a topic. Offer this whenever explore_topic comes back empty — it turns 'nothing here yet' into a standing subscription instead of a dead end.",
+    category: 'context',
+    icon: Eye,
+    riskLevel: 'low',
+    requiresConfirmation: false,
+    parameters: [
+      {
+        name: 'topic',
+        type: 'string',
+        required: true,
+        description: 'The topic to watch, 2–80 chars',
+      },
+    ],
+    examples: [
+      'Tell me when someone posts about longevity',
+      'Let me know if anyone starts a Bitcoin meetup here',
     ],
     enabled: true,
   },

--- a/src/config/database-tables.ts
+++ b/src/config/database-tables.ts
@@ -147,6 +147,7 @@ export const DATABASE_TABLES = {
   CAT_MEMORIES: 'cat_memories',
   CAT_FORGOTTEN_FACTS: 'cat_forgotten_facts',
   CAT_WATCHES: 'cat_watches',
+  CAT_INTERESTS: 'cat_interests',
   USER_ECONOMIC_PROFILE: 'user_economic_profile',
   CAT_CREDIT_ENTRIES: 'cat_credit_entries',
   CAT_CREDIT_TOPUPS: 'cat_credit_topups',

--- a/src/services/cat/discovery-types.ts
+++ b/src/services/cat/discovery-types.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared discovery shapes.
+ *
+ * Extracted so `discovery` (entities → owners) and `interests` (declared
+ * interests → people) can both speak the same "person" language without
+ * importing each other.
+ */
+
+import type { EntityType } from '@/config/entity-registry';
+
+export interface DiscoveryPerson {
+  userId: string | null;
+  displayName: string;
+  username: string | null;
+  profileUrl: string | null;
+  /** Why they surfaced — published work and/or a declared interest. */
+  via: string[];
+}
+
+export interface DiscoveryHit {
+  entityType: EntityType;
+  entityId: string;
+  title: string;
+  description: string | null;
+  url: string;
+  similarity: number;
+  owner: DiscoveryPerson | null;
+}
+
+export interface DiscoveryResult {
+  topic: string;
+  hits: DiscoveryHit[];
+  people: DiscoveryPerson[];
+  /** True when the semantic index could not be consulted at all. */
+  degraded: boolean;
+}

--- a/src/services/cat/discovery.ts
+++ b/src/services/cat/discovery.ts
@@ -10,6 +10,11 @@
  *    owners behind the hits — someone into longevity is discoverable through
  *    the research they published, which is also the stronger signal.
  *
+ *    Published interests are the second channel, and they cover the case work
+ *    cannot: someone who has shipped nothing yet but said what they care about
+ *    is still findable from day one. Both channels merge into one person list,
+ *    each carrying its own `via` reason.
+ *
  * 2. Everything surfaced here is PUBLIC. Each type's public predicate mirrors
  *    the discover/search SSOT (see fetchDiscoverCounts + the public-surface
  *    filtering contract test); test rows are excluded. This service runs with
@@ -21,6 +26,10 @@ import { ENTITY_REGISTRY, isValidEntityType, type EntityType } from '@/config/en
 import { embeddingsEnabled, embedText } from '@/services/ai/embeddings';
 import { logger } from '@/utils/logger';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { findPeopleByInterest } from './interests';
+import type { DiscoveryHit, DiscoveryPerson, DiscoveryResult } from './discovery-types';
+
+export type { DiscoveryHit, DiscoveryPerson, DiscoveryResult };
 
 const LOG_SOURCE = 'CatDiscovery';
 
@@ -31,33 +40,6 @@ const MIN_SIMILARITY = 0.3;
 /** Cap what reaches the model, so the digest stays readable. */
 const MAX_ENTITIES_RETURNED = 12;
 const MAX_PEOPLE_RETURNED = 8;
-
-export interface DiscoveryPerson {
-  userId: string | null;
-  displayName: string;
-  username: string | null;
-  profileUrl: string | null;
-  /** What they published that matched — why they're relevant. */
-  via: string[];
-}
-
-export interface DiscoveryHit {
-  entityType: EntityType;
-  entityId: string;
-  title: string;
-  description: string | null;
-  url: string;
-  similarity: number;
-  owner: DiscoveryPerson | null;
-}
-
-export interface DiscoveryResult {
-  topic: string;
-  hits: DiscoveryHit[];
-  people: DiscoveryPerson[];
-  /** True when the semantic index could not be consulted at all. */
-  degraded: boolean;
-}
 
 interface MatchRow {
   entity_type: string;
@@ -119,7 +101,9 @@ async function resolveOwner(
       displayName = a?.display_name ?? null;
     }
     if (!userId) {
-      return displayName ? { userId: null, displayName, username: null, profileUrl: null, via: [] } : null;
+      return displayName
+        ? { userId: null, displayName, username: null, profileUrl: null, via: [] }
+        : null;
     }
 
     const { data: profile } = await supabase
@@ -142,10 +126,7 @@ async function resolveOwner(
 }
 
 /** Re-read a matched row so the card has live, public, owner-attributed data. */
-async function enrichHit(
-  supabase: AnySupabaseClient,
-  row: MatchRow
-): Promise<DiscoveryHit | null> {
+async function enrichHit(supabase: AnySupabaseClient, row: MatchRow): Promise<DiscoveryHit | null> {
   if (!isValidEntityType(row.entity_type)) {
     return null;
   }
@@ -159,7 +140,9 @@ async function enrichHit(
       .select(`id, ${titleCol}, description, actor_id, user_id, is_test`)
       .eq('id', row.entity_id);
     q = applyPublicGate(q, type) as typeof q;
-    const { data, error } = await (q as unknown as { maybeSingle: () => Promise<{ data: unknown; error: unknown }> }).maybeSingle();
+    const { data, error } = await (
+      q as unknown as { maybeSingle: () => Promise<{ data: unknown; error: unknown }> }
+    ).maybeSingle();
     if (error || !data) {
       // Row is gone or no longer public — the index lagged. Drop it.
       return null;
@@ -230,11 +213,16 @@ export async function exploreTopic(
   }
 
   let rows: MatchRow[] = [];
+  // People who *declared* this interest. Resolved from the same vector as the
+  // entity search, and independent of it: the index being empty for a topic
+  // says nothing about who cares about it.
+  let interestPeople: DiscoveryPerson[] = [];
   try {
     const vec = await embedText(topic);
     if (!vec) {
       return { ...empty, degraded: true };
     }
+    interestPeople = await findPeopleByInterest(supabase, viewerUserId, topic, vec);
     const { data, error } = await supabase.rpc('match_content', {
       query_embedding: JSON.stringify(vec),
       match_count: MATCH_COUNT,
@@ -243,12 +231,14 @@ export async function exploreTopic(
     });
     if (error) {
       logger.warn('match_content failed', { error }, LOG_SOURCE);
-      return { ...empty, degraded: true };
+      // Entity index down, but people who declared the interest still count —
+      // hand back what we do have rather than nothing.
+      return { ...empty, people: interestPeople, degraded: true };
     }
     rows = (data ?? []) as MatchRow[];
   } catch (err) {
     logger.warn('exploreTopic threw', { err }, LOG_SOURCE);
-    return { ...empty, degraded: true };
+    return { ...empty, people: interestPeople, degraded: true };
   }
 
   // Profiles that matched on their own text are people directly; everything
@@ -288,10 +278,31 @@ export async function exploreTopic(
     }
   }
 
+  // Someone can arrive by both channels — published work AND a declared
+  // interest. Keep both reasons; that combination is the strongest signal
+  // there is, so those people sort first.
+  for (const p of interestPeople) {
+    if (!p.userId) {
+      continue;
+    }
+    const existing = peopleByUser.get(p.userId);
+    if (existing) {
+      existing.via = [...p.via, ...existing.via].slice(0, 3);
+    } else {
+      peopleByUser.set(p.userId, p);
+    }
+  }
+  const interestUserIds = new Set(interestPeople.map(p => p.userId));
+  const people = [...peopleByUser.values()].sort((a, b) => {
+    const score = (p: DiscoveryPerson) =>
+      (interestUserIds.has(p.userId) ? 2 : 0) + (p.via.length > 1 ? 1 : 0);
+    return score(b) - score(a);
+  });
+
   return {
     topic,
     hits,
-    people: [...peopleByUser.values()].slice(0, MAX_PEOPLE_RETURNED),
+    people: people.slice(0, MAX_PEOPLE_RETURNED),
     degraded: false,
   };
 }
@@ -302,7 +313,13 @@ export function formatDiscoveryForModel(result: DiscoveryResult): string {
     return `TOPIC SEARCH UNAVAILABLE for "${result.topic}" — the semantic index could not be reached. Tell the user honestly that you could not search right now; do NOT claim the platform has nothing on this topic.`;
   }
   if (result.hits.length === 0 && result.people.length === 0) {
-    return `No public entities or people on OrangeCat match "${result.topic}" yet. Say so plainly — and note that this makes them early here, which is an opportunity to be the first (offer to help them create something in this space).`;
+    return [
+      `No public entities or people on OrangeCat match "${result.topic}" yet. Say so plainly — being early is the honest framing, not a failure.`,
+      `Then offer BOTH of these, briefly, in one breath:`,
+      `1. publish_interest("${result.topic}") — so the next person who searches this finds THEM. Say what it does in plain words ("it goes on your public profile") and get a clear yes first; never publish silently.`,
+      `2. watch_topic("${result.topic}") — you'll tell them the moment someone shows up.`,
+      `Also offer to help them create the first entity in this space if that fits.`,
+    ].join('\n');
   }
 
   const byType = new Map<EntityType, DiscoveryHit[]>();
@@ -311,21 +328,32 @@ export function formatDiscoveryForModel(result: DiscoveryResult): string {
   }
 
   const parts: string[] = [`RELATED TO "${result.topic}" ON ORANGECAT (all public):`];
+  if (result.hits.length === 0) {
+    parts.push(
+      `\nNo published entities on this topic yet — but the people below said they are into it, which is exactly who to talk to.`
+    );
+  }
   for (const [type, hits] of byType) {
     const meta = ENTITY_REGISTRY[type];
     parts.push(`\n${meta.namePlural}:`);
     for (const h of hits) {
-      const who = h.owner ? ` — by ${h.owner.displayName}${h.owner.username ? ` (@${h.owner.username})` : ''}` : '';
+      const who = h.owner
+        ? ` — by ${h.owner.displayName}${h.owner.username ? ` (@${h.owner.username})` : ''}`
+        : '';
       const desc = h.description ? ` :: ${h.description.slice(0, 160)}` : '';
       parts.push(`- "${h.title}"${who} [${h.url}] (relevance ${h.similarity.toFixed(2)})${desc}`);
     }
   }
 
   if (result.people.length > 0) {
-    parts.push(`\nPEOPLE working on this (introduce these — use entity_id from above with request_introduction):`);
+    parts.push(
+      `\nPEOPLE into this (offer an introduction — request_introduction takes an entity_id from above; for someone who surfaced only via a declared interest, suggest following them or opening a conversation instead):`
+    );
     for (const p of result.people) {
       const handle = p.username ? `@${p.username}` : p.displayName;
-      parts.push(`- ${p.displayName} (${handle})${p.via.length > 0 ? ` — ${p.via.join('; ')}` : ''}`);
+      parts.push(
+        `- ${p.displayName} (${handle})${p.via.length > 0 ? ` — ${p.via.join('; ')}` : ''}`
+      );
     }
   }
 

--- a/src/services/cat/handlers/index.ts
+++ b/src/services/cat/handlers/index.ts
@@ -5,10 +5,12 @@ import { contextHandlers } from './context';
 import { productivityHandlers } from './productivity';
 import { paymentHandlers } from './payments';
 import { socialHandlers } from './social';
+import { interestHandlers } from './interests';
 import type { ActionHandler } from './types';
 
 export const ACTION_HANDLERS: Partial<Record<string, ActionHandler>> = {
   ...socialHandlers,
+  ...interestHandlers,
   ...entityHandlers,
   ...communicationHandlers,
   ...organizationHandlers,

--- a/src/services/cat/handlers/interests.ts
+++ b/src/services/cat/handlers/interests.ts
@@ -1,0 +1,93 @@
+/**
+ * Interest handlers — the user's public discoverability surface, plus topic
+ * watches.
+ *
+ * Publishing is the only Cat action that turns something the Cat learned into
+ * something other people can see, so the guard rails are deliberate: the action
+ * is high-risk (never automatable), the handler re-validates the topic rather
+ * than trusting the model, and removal always succeeds quietly.
+ */
+
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { publishInterest, unpublishInterest, isValidTopic, cleanTopic } from '../interests';
+import type { ActionHandler } from './types';
+
+/** Watches are cheap, but not unlimited — a runaway loop shouldn't fill the table. */
+const MAX_ACTIVE_TOPIC_WATCHES = 20;
+
+export const interestHandlers: Record<string, ActionHandler> = {
+  publish_interest: async (supabase, userId, _actorId, params) => {
+    const raw = String(params.topic ?? '');
+    const result = await publishInterest(supabase, userId, raw);
+    if (!result.ok) {
+      return { success: false, error: result.error };
+    }
+    return {
+      success: true,
+      data: {
+        topic: result.topic,
+        alreadyPublished: result.alreadyPublished,
+        message: result.alreadyPublished
+          ? `"${result.topic}" was already in your public interests.`
+          : `"${result.topic}" is now on your public profile — people searching this topic can find you.`,
+      },
+    };
+  },
+
+  unpublish_interest: async (supabase, userId, _actorId, params) => {
+    const raw = String(params.topic ?? '');
+    const result = await unpublishInterest(supabase, userId, raw);
+    if (!result.ok) {
+      return {
+        success: false,
+        error: `"${raw}" is not in your published interests — nothing to remove.`,
+      };
+    }
+    return {
+      success: true,
+      data: {
+        removed: result.removed,
+        message: `Removed "${result.removed}" from your public interests.`,
+      },
+    };
+  },
+
+  watch_topic: async (supabase, userId, _actorId, params) => {
+    const raw = String(params.topic ?? '');
+    if (!isValidTopic(raw)) {
+      return { success: false, error: `"${raw}" is not a usable topic to watch.` };
+    }
+    const topic = cleanTopic(raw);
+
+    const { data: existing } = await supabase
+      .from(DATABASE_TABLES.CAT_WATCHES)
+      .select('id, topic')
+      .eq('user_id', userId)
+      .eq('kind', 'topic_match')
+      .eq('status', 'active');
+    const rows = (existing ?? []) as { id: string; topic: string | null }[];
+    if (rows.some(r => (r.topic ?? '').toLowerCase() === topic.toLowerCase())) {
+      return { success: true, data: { topic, message: `Already watching "${topic}".` } };
+    }
+    if (rows.length >= MAX_ACTIVE_TOPIC_WATCHES) {
+      return {
+        success: false,
+        error: `You already have ${rows.length} active topic watches (max ${MAX_ACTIVE_TOPIC_WATCHES}).`,
+      };
+    }
+
+    const { error } = await supabase.from(DATABASE_TABLES.CAT_WATCHES).insert({
+      user_id: userId,
+      kind: 'topic_match',
+      label: `Someone new is working on ${topic}`,
+      topic,
+    });
+    if (error) {
+      return { success: false, error: 'Could not set up that watch.' };
+    }
+    return {
+      success: true,
+      data: { topic, message: `Watching "${topic}" — I'll tell you as soon as someone shows up.` },
+    };
+  },
+};

--- a/src/services/cat/handlers/interests.ts
+++ b/src/services/cat/handlers/interests.ts
@@ -9,7 +9,13 @@
  */
 
 import { DATABASE_TABLES } from '@/config/database-tables';
-import { publishInterest, unpublishInterest, isValidTopic, cleanTopic } from '../interests';
+import {
+  publishInterest,
+  unpublishInterest,
+  isValidTopic,
+  cleanTopic,
+  findPeopleByInterest,
+} from '../interests';
 import type { ActionHandler } from './types';
 
 /** Watches are cheap, but not unlimited — a runaway loop shouldn't fill the table. */
@@ -22,14 +28,34 @@ export const interestHandlers: Record<string, ActionHandler> = {
     if (!result.ok) {
       return { success: false, error: result.error };
     }
+
+    // The moment someone becomes findable is also the moment to tell them who
+    // they can already find. Publishing and then saying nothing wastes the one
+    // event in this system most likely to start a real conversation.
+    const others = await findPeopleByInterest(supabase, userId, result.topic);
+    const peers = others.map(p => ({
+      displayName: p.displayName,
+      username: p.username,
+      profileUrl: p.profileUrl,
+    }));
+
+    const base = result.alreadyPublished
+      ? `"${result.topic}" was already in your public interests.`
+      : `"${result.topic}" is now on your public profile — people searching this topic can find you.`;
+    const peerNote =
+      peers.length > 0
+        ? ` ${peers.length} other ${peers.length === 1 ? 'person is' : 'people are'} into this too: ${peers
+            .map(p => (p.username ? `${p.displayName} (@${p.username})` : p.displayName))
+            .join(', ')}. Offer to introduce them or to follow.`
+        : '';
+
     return {
       success: true,
       data: {
         topic: result.topic,
         alreadyPublished: result.alreadyPublished,
-        message: result.alreadyPublished
-          ? `"${result.topic}" was already in your public interests.`
-          : `"${result.topic}" is now on your public profile — people searching this topic can find you.`,
+        peers,
+        message: base + peerNote,
       },
     };
   },

--- a/src/services/cat/interests.ts
+++ b/src/services/cat/interests.ts
@@ -1,0 +1,242 @@
+/**
+ * Interests — the bridge from what the Cat privately learns to what makes a
+ * person findable.
+ *
+ * The problem this solves is measurable: of 148 profiles, 5 carry a bio. Topic
+ * search could therefore only ever find people who had already published an
+ * entity, which is a high bar. An interest is one phrase, captured from a
+ * conversation the user was already having, and it makes them discoverable
+ * immediately.
+ *
+ * The privacy rule is absolute and lives in two places on purpose: publishing
+ * is a separate, explicitly-confirmed write into a public-by-design table
+ * (see the migration), and the action that calls it is high-risk so it can
+ * never be automated. The Cat may *propose*; only the user publishes.
+ */
+
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { embeddingsEnabled, embedText } from '@/services/ai/embeddings';
+import { logger } from '@/utils/logger';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import type { DiscoveryPerson } from './discovery-types';
+
+const LOG_SOURCE = 'CatInterests';
+
+export const MAX_TOPIC_LENGTH = 80;
+const MIN_TOPIC_LENGTH = 2;
+/** Above this two phrasings mean the same interest ("longevity" ~ "long life"). */
+const PEOPLE_MIN_SIMILARITY = 0.45;
+const PEOPLE_MATCH_COUNT = 8;
+/** A person is a directory, not a tag cloud. */
+export const MAX_INTERESTS_PER_USER = 40;
+
+/** Filler that carries no topical meaning, so it never reaches the stored phrase. */
+const LEADING_FILLER =
+  /^(?:i(?:'m| am)?\s+)?(?:really\s+|very\s+|quite\s+)?(?:interested\s+in|into|curious\s+about|passionate\s+about|keen\s+on)\s+/i;
+
+export interface Interest {
+  id: string;
+  topic: string;
+  normalized: string;
+  source: 'cat' | 'manual';
+  createdAt: string;
+}
+
+/**
+ * Reduce a phrase to its dedupe key. Deliberately conservative: it strips
+ * lead-in filler and punctuation but never stems, because "longevity" and
+ * "longevity research" are genuinely different interests and collapsing them
+ * would silently rewrite what someone published about themselves.
+ */
+export function normalizeTopic(raw: string): string {
+  return collapse(raw)
+    .toLowerCase()
+    .replace(LEADING_FILLER, '')
+    .replace(/[.!?,;:]+$/g, '')
+    .trim();
+}
+
+/** The display form: filler stripped, original casing otherwise preserved. */
+export function cleanTopic(raw: string): string {
+  return collapse(raw)
+    .replace(LEADING_FILLER, '')
+    .replace(/[.!?,;:]+$/g, '')
+    .trim()
+    .slice(0, MAX_TOPIC_LENGTH);
+}
+
+/**
+ * Whitespace is collapsed FIRST so the filler pattern's `^` anchor still bites
+ * on padded input — otherwise "  interested in longevity" would be stored as a
+ * separate interest from "longevity".
+ */
+function collapse(raw: string): string {
+  return raw.replace(/\s+/g, ' ').trim();
+}
+
+export function isValidTopic(topic: string): boolean {
+  const n = normalizeTopic(topic);
+  return n.length >= MIN_TOPIC_LENGTH && n.length <= MAX_TOPIC_LENGTH;
+}
+
+/**
+ * Make an interest discoverable. Idempotent per (user, normalized topic) — the
+ * unique index means re-publishing is a no-op rather than a duplicate row.
+ */
+export async function publishInterest(
+  supabase: AnySupabaseClient,
+  userId: string,
+  rawTopic: string
+): Promise<{ ok: true; topic: string; alreadyPublished: boolean } | { ok: false; error: string }> {
+  const topic = cleanTopic(rawTopic);
+  const normalized = normalizeTopic(rawTopic);
+  if (!isValidTopic(rawTopic)) {
+    return {
+      ok: false,
+      error: `"${rawTopic}" is not a usable interest — give a short topic between ${MIN_TOPIC_LENGTH} and ${MAX_TOPIC_LENGTH} characters.`,
+    };
+  }
+
+  const existing = await listInterests(supabase, userId);
+  if (existing.some(i => i.normalized === normalized)) {
+    return { ok: true, topic, alreadyPublished: true };
+  }
+  if (existing.length >= MAX_INTERESTS_PER_USER) {
+    return {
+      ok: false,
+      error: `You already have ${existing.length} published interests (max ${MAX_INTERESTS_PER_USER}). Remove one first.`,
+    };
+  }
+
+  // No embedding → the row would be invisible to matching, which is the entire
+  // point of publishing. Fail loudly instead of storing a decoration.
+  if (!embeddingsEnabled()) {
+    return { ok: false, error: 'Interest matching is unavailable right now — try again later.' };
+  }
+  const vec = await embedText(topic);
+  if (!vec) {
+    return { ok: false, error: 'Could not index that interest right now — try again later.' };
+  }
+
+  const { error } = await supabase.from(DATABASE_TABLES.CAT_INTERESTS).insert({
+    user_id: userId,
+    topic,
+    normalized,
+    embedding: JSON.stringify(vec),
+    source: 'cat',
+  });
+  if (error) {
+    logger.error('publishInterest failed', { error }, LOG_SOURCE);
+    return { ok: false, error: 'Could not publish that interest.' };
+  }
+  return { ok: true, topic, alreadyPublished: false };
+}
+
+export async function listInterests(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<Interest[]> {
+  const { data, error } = await supabase
+    .from(DATABASE_TABLES.CAT_INTERESTS)
+    .select('id, topic, normalized, source, created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+  if (error || !data) {
+    return [];
+  }
+  return (data as Record<string, unknown>[]).map(r => ({
+    id: String(r.id),
+    topic: String(r.topic),
+    normalized: String(r.normalized),
+    source: r.source === 'manual' ? 'manual' : 'cat',
+    createdAt: String(r.created_at),
+  }));
+}
+
+/** Stop being discoverable for a topic. Matches on the normalized form. */
+export async function unpublishInterest(
+  supabase: AnySupabaseClient,
+  userId: string,
+  rawTopic: string
+): Promise<{ ok: boolean; removed: string | null }> {
+  const normalized = normalizeTopic(rawTopic);
+  const match = (await listInterests(supabase, userId)).find(i => i.normalized === normalized);
+  if (!match) {
+    return { ok: false, removed: null };
+  }
+  const { error } = await supabase
+    .from(DATABASE_TABLES.CAT_INTERESTS)
+    .delete()
+    .eq('id', match.id)
+    .eq('user_id', userId);
+  return { ok: !error, removed: error ? null : match.topic };
+}
+
+/**
+ * People who declared an interest close to this topic. This is what lets
+ * someone be found on day one, before they have published anything at all.
+ */
+export async function findPeopleByInterest(
+  supabase: AnySupabaseClient,
+  viewerUserId: string,
+  topic: string,
+  /** Reuse the caller's vector for this same topic — saves a round trip and its cost. */
+  precomputedEmbedding?: number[] | null
+): Promise<DiscoveryPerson[]> {
+  if (!topic.trim() || !embeddingsEnabled()) {
+    return [];
+  }
+  try {
+    const vec = precomputedEmbedding ?? (await embedText(topic));
+    if (!vec) {
+      return [];
+    }
+    const { data, error } = await supabase.rpc('match_interested_people', {
+      query_embedding: JSON.stringify(vec),
+      exclude_user: viewerUserId,
+      match_count: PEOPLE_MATCH_COUNT,
+      min_similarity: PEOPLE_MIN_SIMILARITY,
+    });
+    if (error || !data) {
+      logger.warn('match_interested_people failed', { error }, LOG_SOURCE);
+      return [];
+    }
+
+    const rows = data as { user_id: string; topic: string }[];
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const { data: profiles } = await supabase
+      .from(DATABASE_TABLES.PROFILES)
+      .select('id, username, name')
+      .in(
+        'id',
+        rows.map(r => r.user_id)
+      );
+    type ProfileRow = { id: string; username: string | null; name: string | null };
+    const byId = new Map<string, ProfileRow>(
+      ((profiles ?? []) as ProfileRow[]).map(p => [p.id, p] as const)
+    );
+
+    const people: DiscoveryPerson[] = [];
+    for (const r of rows) {
+      const p = byId.get(r.user_id);
+      // No readable profile → a name-less ghost. Drop it rather than show it.
+      if (!p) {
+        continue;
+      }
+      people.push({
+        userId: r.user_id,
+        displayName: p.name || p.username || 'Someone',
+        username: p.username,
+        profileUrl: p.username ? `/profiles/${p.username}` : null,
+        via: [`Interested in ${r.topic}`],
+      });
+    }
+    return people;
+  } catch (err) {
+    logger.warn('findPeopleByInterest threw', { err }, LOG_SOURCE);
+    return [];
+  }
+}

--- a/src/services/cat/my-data-topics.ts
+++ b/src/services/cat/my-data-topics.ts
@@ -10,6 +10,7 @@ export const MY_DATA_TOPICS = [
   'wallets',
   'notifications',
   'tasks',
+  'interests',
   'overview',
 ] as const;
 export type MyDataTopic = (typeof MY_DATA_TOPICS)[number];

--- a/src/services/cat/my-data.ts
+++ b/src/services/cat/my-data.ts
@@ -16,6 +16,7 @@ import type { AnySupabaseClient } from '@/lib/supabase/types';
 
 export { MY_DATA_TOPICS, type MyDataTopic } from './my-data-topics';
 import type { MyDataTopic } from './my-data-topics';
+import { listInterests } from './interests';
 
 const DEFAULT_WINDOW_DAYS = 30;
 const MAX_ROWS_PER_TYPE = 8;
@@ -330,6 +331,21 @@ async function tasksSection(supabase: AnySupabaseClient, userId: string): Promis
   }
 }
 
+async function interestsSection(supabase: AnySupabaseClient, userId: string): Promise<string> {
+  try {
+    const interests = await listInterests(supabase, userId);
+    if (interests.length === 0) {
+      return 'PUBLIC INTERESTS: none published. Nothing about their interests is visible to other people.';
+    }
+    return (
+      `PUBLIC INTERESTS (${interests.length}, visible to other signed-in users, findable in topic search):\n` +
+      interests.map(i => `- ${i.topic}`).join('\n')
+    );
+  } catch {
+    return 'PUBLIC INTERESTS: could not be read right now.';
+  }
+}
+
 /**
  * Answer a read-only "my data" question. Returns a compact plain-text report
  * the model paraphrases — never raw JSON, so weak models don't echo it.
@@ -358,6 +374,8 @@ export async function queryMyData(
       return notificationsSection(supabase, userId);
     case 'tasks':
       return tasksSection(supabase, userId);
+    case 'interests':
+      return interestsSection(supabase, userId);
     case 'overview': {
       const sections = await Promise.all([
         listingsSection(supabase, userId),
@@ -366,6 +384,7 @@ export async function queryMyData(
         walletsSection(supabase, userId),
         notificationsSection(supabase, userId),
         tasksSection(supabase, userId),
+        interestsSection(supabase, userId),
       ]);
       return sections.join('\n\n');
     }

--- a/src/services/cat/proactive.ts
+++ b/src/services/cat/proactive.ts
@@ -13,6 +13,8 @@ import { DATABASE_TABLES } from '@/config/database-tables';
 import { STATUS } from '@/config/database-constants';
 import { NotificationService } from '@/lib/services/notifications';
 import { logger } from '@/utils/logger';
+import { exploreTopic } from './discovery';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
 
 const LOG_SOURCE = 'CatProactive';
 
@@ -191,16 +193,35 @@ export async function runDailyBrief(admin: SupabaseClient, limit: number): Promi
 interface WatchRow {
   id: string;
   user_id: string;
-  kind: 'funding_reached' | 'sale_received' | 'booking_received';
+  kind: 'funding_reached' | 'sale_received' | 'booking_received' | 'topic_match';
   label: string;
   entity_type: string | null;
   entity_id: string | null;
   target_btc: number | null;
+  topic: string | null;
   created_at: string;
 }
 
 /** Has this watch's condition become true? */
 async function watchConditionMet(admin: SupabaseClient, watch: WatchRow): Promise<boolean> {
+  if (watch.kind === 'topic_match') {
+    if (!watch.topic) {
+      return false;
+    }
+    // Fires on either channel: something published on the topic, or someone
+    // declaring the interest. The watcher is excluded as the viewer, so their
+    // own work can never trigger their own watch.
+    const result = await exploreTopic(
+      admin as unknown as AnySupabaseClient,
+      watch.user_id,
+      watch.topic
+    );
+    if (result.degraded) {
+      return false;
+    }
+    return result.hits.length > 0 || result.people.length > 0;
+  }
+
   if (watch.kind === 'funding_reached') {
     if (!watch.entity_id || !watch.target_btc) {
       return false;
@@ -256,7 +277,7 @@ export interface WatchRunResult {
 export async function runWatchEvaluation(admin: SupabaseClient): Promise<WatchRunResult> {
   const { data, error } = await admin
     .from(DATABASE_TABLES.CAT_WATCHES)
-    .select('id, user_id, kind, label, entity_type, entity_id, target_btc, created_at')
+    .select('id, user_id, kind, label, entity_type, entity_id, target_btc, topic, created_at')
     .eq('status', 'active')
     .order('created_at', { ascending: true })
     .limit(MAX_WATCHES_PER_RUN);

--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -66,6 +66,8 @@ export const PROSE_DOCUMENTED_ACTION_IDS = new Set([
   'invite_to_organization',
   'archive_entity',
   'update_profile',
+  'publish_interest',
+  'watch_topic',
   // forget_memories runs as a TOOL (documented in "Tools You Can Call");
   // its exec_action twin exists for registry completeness only.
   'forget_memories',
@@ -781,6 +783,21 @@ You have access to tools that run BEFORE you write your response. Use them when 
 - **suggest_offers(focus?, count?)**: The economic agent. Call this when the user asks what THEY could offer, sell, or create, how they could make money or participate economically, or wants ideas grounded in who they are ("what can I offer?", "help me make money", "any ideas for me?"). It reads everything you know about them (profile, documents, memories, existing entities) and proposes several ready-to-publish offers across the economic spectrum, each as a draft card — you do not pass the message, just an optional focus area.
 - **forget_memories(facts)**: Delete stored memories the user says are wrong or wants removed ("I don't speak French", "that's not true — remove it", "forget the weekend thing"). Pass each wrong fact as a short phrase near the user's wording. This is the ONLY way stored memories change from chat.
 - **explore_topic(topic, entityType?)**: The discovery engine. Call it whenever the user expresses an INTEREST rather than naming a specific thing — "I'm interested in longevity", "anyone working on X?", "what's happening with Y?", "introduce me to people doing Z". It returns related public entities of every type, each attributed to its owner, plus the PEOPLE working in that space (found through what they've published, since most profiles have no bio). Present the result as a short guided tour — group it, say in one clause why each thing is relevant to them, link the titles — then offer the real next step: following someone, or an introduction. If it returns nothing, say so plainly and note they'd be early here, which is an opportunity; never invent entities or people.
+
+### Making the user findable (this is a two-way street)
+
+Discovery only works if people are discoverable, and almost nobody here has written a bio. So when someone tells you what they care about — "I'm into longevity", "I've been getting into tattoo art" — do BOTH halves:
+
+1. Search it for them (explore_topic), and
+2. Offer to publish it: **publish_interest(topic)** puts that topic on their public profile so the next person searching it finds THEM.
+
+Rules for publishing, without exception:
+- **Ask first, every time, in plain words.** "Want me to add longevity to your public interests so others working on it can find you?" A passing mention is not consent, and enthusiasm is not consent.
+- **Say it's public.** Never let someone discover after the fact that something is visible.
+- **Never publish anything sensitive** — health conditions, money troubles, relationships, politics, immigration status, anything they told you in confidence or asked you to keep private. If you would hesitate to put it on a business card, do not offer it.
+- If they say no, drop it and do not ask again in that conversation.
+
+When a search comes back empty, offer **watch_topic(topic)** too — you'll tell them the moment someone shows up. An empty result should end with two open doors, never a shrug.
 - **check_cat_health()**: Live health check of the AI providers powering you. Call it when the user asks why you (or "the Cat"/"the AI") aren't answering, are slow, or are erroring — or when they ask about a system notification that mentions provider failures, eval/harness errors, or Cat health. Explain the result in plain language and suggest one concrete next step.
 
 If you call prefill_entity_form or suggest_offers, your reply should be SHORT and complement the card(s) — confirm what you drafted in a sentence or two, invite the user to review and adjust. Do NOT repeat the field values in prose — the cards show them already. Example after prefill: "Drafted a service for you below — adjust the price and duration if needed, then open it to publish." Example after suggest_offers: "Here are a few ways you could put what you do to work — each is a draft you can tweak and publish."

--- a/supabase/migrations/20260805120000_cat_interests.sql
+++ b/supabase/migrations/20260805120000_cat_interests.sql
@@ -76,15 +76,23 @@ CREATE OR REPLACE FUNCTION public.match_interested_people(
     LANGUAGE sql STABLE
     SET search_path TO 'public', 'printcraft'
     AS $$
-  select distinct on (i.user_id)
-    i.user_id,
-    i.topic,
-    1 - (i.embedding <=> query_embedding) as similarity
-  from public.cat_interests i
-  where i.embedding is not null
-    and i.user_id <> exclude_user
-    and 1 - (i.embedding <=> query_embedding) >= min_similarity
-  order by i.user_id, i.embedding <=> query_embedding
+  -- Inner DISTINCT ON keeps each person's single closest interest; its ORDER BY
+  -- is forced to lead with user_id, so ranking by similarity has to happen in
+  -- the outer query. Applying LIMIT inside would return an arbitrary set of
+  -- users ordered by uuid rather than the best matches.
+  select t.user_id, t.topic, t.similarity
+  from (
+    select distinct on (i.user_id)
+      i.user_id,
+      i.topic,
+      1 - (i.embedding <=> query_embedding) as similarity
+    from public.cat_interests i
+    where i.embedding is not null
+      and i.user_id <> exclude_user
+      and 1 - (i.embedding <=> query_embedding) >= min_similarity
+    order by i.user_id, i.embedding <=> query_embedding
+  ) t
+  order by t.similarity desc
   limit match_count;
 $$;
 

--- a/supabase/migrations/20260805120000_cat_interests.sql
+++ b/supabase/migrations/20260805120000_cat_interests.sql
@@ -1,0 +1,108 @@
+-- Cat interests: the opt-in PUBLIC projection of what the Cat knows about you.
+--
+-- WHY A SEPARATE TABLE (and not a `shared` boolean on cat_memories):
+-- cat_memories is private by construction — everything in it is safe only
+-- because nothing outside the owner can read it. A visibility flag on that
+-- table would mean one bad predicate anywhere leaks private facts. Here the
+-- privacy boundary is structural instead: publishing requires deliberately
+-- writing a row into a table that is public by design, so the failure mode of
+-- a bug is "an interest is missing", never "a private memory leaked".
+--
+-- WHY IT EXISTS: 148 profiles, 5 bios. People are effectively undiscoverable,
+-- so topic search can only find those who already published an entity. An
+-- interest is the cheapest possible unit of discoverability — one phrase,
+-- captured from a conversation the user was already having.
+
+CREATE TABLE IF NOT EXISTS public.cat_interests (
+    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL PRIMARY KEY,
+    user_id uuid NOT NULL,
+    -- The user's own words, shown to others verbatim.
+    topic text NOT NULL CHECK (char_length(topic) BETWEEN 2 AND 80),
+    -- Lowercased/collapsed form, used only for dedupe.
+    normalized text NOT NULL,
+    embedding printcraft.vector(1536),
+    -- 'cat' = proposed by the Cat and confirmed by the user; 'manual' = typed.
+    source text DEFAULT 'cat' NOT NULL CHECK (source IN ('cat', 'manual')),
+    created_at timestamptz DEFAULT now() NOT NULL
+);
+
+-- One row per person per topic: re-publishing is idempotent, not a duplicate.
+CREATE UNIQUE INDEX IF NOT EXISTS cat_interests_user_topic_key
+    ON public.cat_interests (user_id, normalized);
+CREATE INDEX IF NOT EXISTS cat_interests_user_idx ON public.cat_interests (user_id);
+CREATE INDEX IF NOT EXISTS cat_interests_hnsw
+    ON public.cat_interests USING hnsw (embedding printcraft.vector_cosine_ops);
+
+ALTER TABLE public.cat_interests ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  -- Readable by any signed-in user: that IS the feature. Discovery happens
+  -- inside the Cat, which requires auth, so anon stays excluded.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+      AND tablename = 'cat_interests' AND policyname = 'Interests are publicly readable'
+  ) THEN
+    CREATE POLICY "Interests are publicly readable" ON public.cat_interests
+      FOR SELECT TO authenticated USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+      AND tablename = 'cat_interests' AND policyname = 'Users can insert own interests'
+  ) THEN
+    CREATE POLICY "Users can insert own interests" ON public.cat_interests
+      FOR INSERT TO authenticated WITH CHECK (user_id = (SELECT auth.uid()));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+      AND tablename = 'cat_interests' AND policyname = 'Users can delete own interests'
+  ) THEN
+    CREATE POLICY "Users can delete own interests" ON public.cat_interests
+      FOR DELETE TO authenticated USING (user_id = (SELECT auth.uid()));
+  END IF;
+END $$;
+
+GRANT SELECT, INSERT, DELETE ON public.cat_interests TO authenticated;
+GRANT ALL ON public.cat_interests TO service_role;
+
+-- Who else is into this? Excludes the caller: discovering yourself is not
+-- discovery. STABLE + invoker rights, so the SELECT policy above still applies.
+CREATE OR REPLACE FUNCTION public.match_interested_people(
+    query_embedding printcraft.vector,
+    exclude_user uuid,
+    match_count integer DEFAULT 8,
+    min_similarity double precision DEFAULT 0.45
+) RETURNS TABLE(user_id uuid, topic text, similarity double precision)
+    LANGUAGE sql STABLE
+    SET search_path TO 'public', 'printcraft'
+    AS $$
+  select distinct on (i.user_id)
+    i.user_id,
+    i.topic,
+    1 - (i.embedding <=> query_embedding) as similarity
+  from public.cat_interests i
+  where i.embedding is not null
+    and i.user_id <> exclude_user
+    and 1 - (i.embedding <=> query_embedding) >= min_similarity
+  order by i.user_id, i.embedding <=> query_embedding
+  limit match_count;
+$$;
+
+GRANT ALL ON FUNCTION public.match_interested_people(printcraft.vector, uuid, integer, double precision) TO authenticated;
+GRANT ALL ON FUNCTION public.match_interested_people(printcraft.vector, uuid, integer, double precision) TO service_role;
+
+-- Topic watches: "tell me when someone shows up working on longevity".
+-- An empty search today becomes a standing subscription instead of a dead end.
+ALTER TABLE public.cat_watches ADD COLUMN IF NOT EXISTS topic text;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.cat_watches'::regclass AND conname = 'cat_watches_kind_check'
+  ) THEN
+    ALTER TABLE public.cat_watches DROP CONSTRAINT cat_watches_kind_check;
+  END IF;
+  ALTER TABLE public.cat_watches ADD CONSTRAINT cat_watches_kind_check
+    CHECK (kind IN ('funding_reached', 'sale_received', 'booking_received', 'topic_match'));
+END $$;

--- a/supabase/migrations/20260805120000_cat_interests.sql
+++ b/supabase/migrations/20260805120000_cat_interests.sql
@@ -95,6 +95,12 @@ GRANT ALL ON FUNCTION public.match_interested_people(printcraft.vector, uuid, in
 -- An empty search today becomes a standing subscription instead of a dead end.
 ALTER TABLE public.cat_watches ADD COLUMN IF NOT EXISTS topic text;
 
+-- migration-safety: contract-ok widening a CHECK in place — the constraint is
+-- dropped and immediately re-added in the same transaction with a strictly
+-- larger value set (the three existing kinds plus 'topic_match'). Every row and
+-- every INSERT the previous release can produce still passes, so a rollback is
+-- safe; only rows using the new kind would fail the old constraint, and the
+-- previous release never writes those.
 DO $$
 BEGIN
   IF EXISTS (


### PR DESCRIPTION
## The problem, measured in production

| metric | prod |
|---|---|
| profiles | 148 |
| **profiles with a bio** | **5** |
| searchable corpus | 29 items |
| cat conversations | 45 |
| cat messages | 46 |
| cat actions ever performed | 6 |

Topic discovery could only ever find people who had **already published an entity**. With 5 bios out of 148, that means "I'm interested in longevity" honestly returns nobody — while Cat privately knows several people care about it and does nothing with that.

I built 43 actions last session. They have fired 6 times. The bottleneck is not capability, it's that **nobody is findable**.

## What this adds

Interests: one phrase, captured from a conversation the user was already having, that makes them discoverable immediately.

- `exploreTopic` gains a **second channel** — people who *declared* an interest, merged with people found via ownership. Someone who has published nothing is now findable on day one. If they match on both, both reasons are kept and they sort first.
- An empty search ends with **two open doors** instead of a shrug: `publish_interest` (be findable) and `watch_topic` (I'll tell you when someone shows up), the latter firing through the existing watch cron on either channel.
- `query_my_data` gains an `interests` topic, so "what am I publishing about myself?" is answerable.

## Privacy is structural, not a flag

This is the only thing Cat writes that other people can see, so the guarantee is enforced in four independent places:

1. **A separate public-by-design table.** A `shared` boolean on `cat_memories` would mean one bad predicate leaks private facts; here the worst case of a bug is an interest going *missing*.
2. **`publish_interest` is `riskLevel: high` + `requiresConfirmation: true`** — `allowedLevelsForRisk('high')` returns `['off','ask']`, so it is structurally impossible to automate. Pinned by a test.
3. **The prompt forbids** publishing anything sensitive or merely mentioned in passing, and requires saying out loud that it is public.
4. **Revocable outside the chat** — Settings → AI lists every published interest with one-click removal, because a control you can only reach by asking an AI is not a control. Removal never requires confirmation.

## Verification

`npm run verify` green: **178 suites, 1718 tests, 0 errors** (3 pre-existing lint warnings in an untouched wishlist form).

Migration assumptions checked against the live database before shipping: `printcraft.vector`, `extensions.uuid_generate_v4`, and the `cat_watches_kind_check` constraint name all confirmed present.

Two bugs the tests caught during development:
- leading whitespace defeated the filler regex's `^` anchor, so `"  interested in longevity"` would have been stored as a *separate* interest from `"longevity"`
- the existing discovery test mock returned entity rows for *any* RPC — it now routes by name, since conflating the two channels would hide exactly the bug worth catching

🤖 Generated with [Claude Code](https://claude.com/claude-code)