### PR TITLE
fix(cat): publish_interest was losing to update_profile in the model's head

### DIFF
--- a/__tests__/unit/cat/interests.test.ts
+++ b/__tests__/unit/cat/interests.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_INTERESTS_PER_USER,
 } from '@/services/cat/interests';
 import { CAT_ACTIONS } from '@/config/cat-actions';
+import { formatDiscoveryForModel } from '@/services/cat/discovery';
 import { ACTION_HANDLERS } from '@/services/cat/handlers';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 
@@ -189,5 +190,30 @@ describe('publishing closes the loop immediately', () => {
     const data = result.data as { peers: unknown[]; message: string };
     expect(data.peers).toEqual([]);
     expect(data.message).not.toContain('into this too');
+  });
+});
+
+describe('publish_interest is not confusable with update_profile', () => {
+  /**
+   * Caught in production: a free model read "puts that topic on their public
+   * profile" and offered to edit the user's bio instead of publishing an
+   * interest, so the feature was unreachable by its natural path. The word
+   * "profile" is the trap; these assertions keep it out.
+   */
+  it('the action description steers away from bio editing', () => {
+    const d = CAT_ACTIONS.publish_interest.description;
+    expect(d).toContain('NOT update_profile');
+    expect(d).not.toMatch(/on their public profile/i);
+  });
+
+  it('the empty-search digest tells the model which verb to use', () => {
+    const digest = formatDiscoveryForModel({
+      topic: 'permaculture',
+      hits: [],
+      people: [],
+      degraded: false,
+    });
+    expect(digest).toContain('publish_interest');
+    expect(digest).toContain('NOT update_profile');
   });
 });

--- a/src/config/cat-actions.ts
+++ b/src/config/cat-actions.ts
@@ -838,7 +838,7 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
     id: 'publish_interest',
     name: 'Publish Interest',
     description:
-      "Add a topic to the user's PUBLIC interests so other people searching that topic can find them. Offer this when they express an interest ('I'm into longevity') or when explore_topic finds nothing — being findable is the fix for an empty result. This makes something public: state plainly that it goes on their public profile and wait for a clear yes. Never publish a topic they only mentioned in passing, and never publish anything sensitive (health, finances, relationships, politics, anything they asked you to keep private).",
+      "Add a topic to the user's PUBLIC INTERESTS LIST so other people searching that topic can find them. This is NOT update_profile — it does not touch their bio or background, it adds a searchable topic tag. Use this, never update_profile, whenever the goal is being findable by topic. Offer it when they express an interest ('I'm into longevity') or when explore_topic finds nothing — being findable is the fix for an empty result. It makes something public: say plainly that the topic becomes visible to anyone signed in, and wait for a clear yes. Never publish a topic they only mentioned in passing, and never publish anything sensitive (health, finances, relationships, politics, anything they asked you to keep private).",
     category: 'context',
     icon: Users,
     riskLevel: 'high',

--- a/src/services/cat/discovery.ts
+++ b/src/services/cat/discovery.ts
@@ -316,7 +316,7 @@ export function formatDiscoveryForModel(result: DiscoveryResult): string {
     return [
       `No public entities or people on OrangeCat match "${result.topic}" yet. Say so plainly — being early is the honest framing, not a failure.`,
       `Then offer BOTH of these, briefly, in one breath:`,
-      `1. publish_interest("${result.topic}") — so the next person who searches this finds THEM. Say what it does in plain words ("it goes on your public profile") and get a clear yes first; never publish silently.`,
+      `1. publish_interest("${result.topic}") — so the next person who searches this finds THEM. Call publish_interest, NOT update_profile: this is a searchable interest, not bio text, so do not offer to edit their bio or background. Say in plain words that the topic becomes visible to anyone signed in, and get a clear yes first; never publish silently.`,
       `2. watch_topic("${result.topic}") — you'll tell them the moment someone shows up.`,
       `Also offer to help them create the first entity in this space if that fits.`,
     ].join('\n');

--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -789,11 +789,13 @@ You have access to tools that run BEFORE you write your response. Use them when 
 Discovery only works if people are discoverable, and almost nobody here has written a bio. So when someone tells you what they care about — "I'm into longevity", "I've been getting into tattoo art" — do BOTH halves:
 
 1. Search it for them (explore_topic), and
-2. Offer to publish it: **publish_interest(topic)** puts that topic on their public profile so the next person searching it finds THEM.
+2. Offer to publish it: **publish_interest(topic)** adds that topic to their public interests list, so the next person searching it finds THEM.
+
+**publish_interest is not update_profile.** Being findable by topic is a searchable tag, not bio text. When someone wants to be discoverable for a subject, call publish_interest — do not offer to edit their bio or background, and never say "add it to your profile", which sounds like bio editing. Say "your public interests".
 
 Rules for publishing, without exception:
 - **Ask first, every time, in plain words.** "Want me to add longevity to your public interests so others working on it can find you?" A passing mention is not consent, and enthusiasm is not consent.
-- **Say it's public.** Never let someone discover after the fact that something is visible.
+- **Say it's public.** Never let someone discover after the fact that something is visible: it's visible to anyone signed in.
 - **Never publish anything sensitive** — health conditions, money troubles, relationships, politics, immigration status, anything they told you in confidence or asked you to keep private. If you would hesitate to put it on a business card, do not offer it.
 - If they say no, drop it and do not ask again in that conversation.
 


### PR DESCRIPTION
## Found by testing in production, not by reading the diff

I shipped #620, then asked the live Cat: *"I've been getting really into permaculture and regenerative farming. What's here on that, and who should I talk to?"*

It did the first half perfectly — searched, found nothing, and offered the two doors:

> There aren't any public projects, products, services, or people on OrangeCat yet that match "permaculture and regenerative farming." That's not a dead end—it means you could be the first to stake this ground here.
> 1. **Add this topic to your public profile** – so the next person searching finds *you*.
> 2. **Set up a watch** – I'll notify you the moment someone else posts about it.

Then I clicked "Add to my profile" and it said:

> Sure—I can add your interest in permaculture and regenerative farming to your OrangeCat profile. Would you like me to add it to your **bio**, your **background**, or both?

It routed to `update_profile`. **The word "profile" was the trap** — and I had put it there, in the action description (*"it goes on their public profile"*), the prompt, and the empty-search digest.

## What this means

- **The safety property held.** Nothing was published. I verified at the database: `cat_interests` contained only the row I had added by hand, so the confirmation gate did its job.
- **But the feature was unreachable by its natural path**, which is the path essentially every user takes. A verb the model won't select is a verb that does not exist.

## The fix

`publish_interest` is now described as adding to a public **interests list**, explicitly disambiguated from `update_profile`, in all three places the model reads: the action registry, the prompt section, and the digest returned when a search comes up empty. The public-visibility wording changed from "on your public profile" to "visible to anyone signed in", which is both clearer and true.

Two regression tests keep the trap word out — the description must contain `NOT update_profile` and must not match `/on their public profile/i`.

## Verification

`npm run verify` green: **185 suites, 1829 tests, 0 errors** (3 pre-existing lint warnings in an untouched wishlist form).

I'll re-run the same production conversation after deploy to confirm the verb is now selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)