### PR TITLE
fix(cat): a failed reply was throwing away the user's message

### DIFF
--- a/__tests__/unit/cat/failed-turn.test.ts
+++ b/__tests__/unit/cat/failed-turn.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { buildFailedTurnMessages, TRUNCATED_REPLY_SUFFIX } from '@/services/cat/failed-turn';
+
+/**
+ * A failed Cat turn must still keep the user's message.
+ *
+ * The streaming path saved a turn only `if (fullContent)`, so when the whole
+ * provider chain died the exchange was discarded — including the question the
+ * user had just typed. Production showed the cost: six accounts (June 2026)
+ * each held one conversation with zero messages, and because "message never
+ * saved" looks exactly like "never typed anything", those six failures were
+ * invisible in every usage metric.
+ */
+
+const ERROR_TEXT = 'Cat couldn’t reach an AI model just now — this is usually momentary.';
+
+describe('failed Cat turns are still recorded', () => {
+  it("keeps the user's message verbatim when nothing streamed", () => {
+    const question = 'can I fund a solar project in sats?';
+    const rows = buildFailedTurnMessages({ message: question, errorText: ERROR_TEXT });
+
+    const user = rows.find(r => r.role === 'user');
+    expect(user?.content).toBe(question);
+  });
+
+  it('stores the sentence the user was actually shown', () => {
+    const rows = buildFailedTurnMessages({ message: 'hi', errorText: ERROR_TEXT });
+    expect(rows.find(r => r.role === 'assistant')?.content).toBe(ERROR_TEXT);
+  });
+
+  it('marks a half-streamed reply as truncated instead of passing it off as complete', () => {
+    const rows = buildFailedTurnMessages({
+      message: 'explain lightning',
+      partialContent: 'Lightning is a payment layer that',
+      errorText: ERROR_TEXT,
+    });
+
+    const assistant = rows.find(r => r.role === 'assistant')!;
+    expect(assistant.content).toContain('Lightning is a payment layer that');
+    expect(assistant.content).toContain(TRUNCATED_REPLY_SUFFIX.trim());
+    // The partial answer is the honest record — not the error copy.
+    expect(assistant.content).not.toContain(ERROR_TEXT);
+  });
+
+  it('emits a user/assistant pair so replayed history never has two user turns in a row', () => {
+    // The next request appends a fresh user turn after this history. A
+    // dangling user message would put two user turns back to back, which
+    // strict providers reject.
+    for (const partialContent of ['', 'partial text']) {
+      const rows = buildFailedTurnMessages({ message: 'q', partialContent, errorText: ERROR_TEXT });
+      expect(rows.map(r => r.role)).toEqual(['user', 'assistant']);
+    }
+  });
+
+  it('never stores an empty assistant turn, even with no error copy to fall back on', () => {
+    const rows = buildFailedTurnMessages({ message: 'q', partialContent: '   ', errorText: '' });
+    expect(rows.find(r => r.role === 'assistant')?.content.trim()).not.toBe('');
+  });
+
+  // The rule above is only worth anything if the streaming path still applies
+  // it. That path can't be unit-booted (it needs a live provider chain and a
+  // ReadableStream), so guard the wiring at the source level: the regression
+  // being prevented is precisely "the failure branch stops saving the turn".
+  it('is still wired into the streaming failure path', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/services/cat/chat-orchestrator.ts'),
+      'utf8'
+    );
+    const catchStart = source.indexOf('} catch (err) {', source.indexOf('async start(controller)'));
+    const errorEmit = source.indexOf('event: error', catchStart);
+    expect(catchStart).toBeGreaterThan(-1);
+    expect(errorEmit).toBeGreaterThan(catchStart);
+
+    const failureBranch = source.slice(catchStart, errorEmit);
+    expect(failureBranch).toContain('buildFailedTurnMessages');
+    expect(failureBranch).toContain('saveMessages');
+  });
+
+  it('records which provider and model were active when it failed', () => {
+    const rows = buildFailedTurnMessages({
+      message: 'q',
+      errorText: ERROR_TEXT,
+      model: 'llama-3.3-70b',
+      provider: 'groq',
+    });
+    const assistant = rows.find(r => r.role === 'assistant')!;
+    expect(assistant.model_used).toBe('llama-3.3-70b');
+    expect(assistant.provider).toBe('groq');
+  });
+});

--- a/scripts/check-data-invariants.mjs
+++ b/scripts/check-data-invariants.mjs
@@ -193,12 +193,58 @@ async function checkPaidWithoutTimestamp() {
   }
 }
 
+/**
+ * A Cat send that stored nothing.
+ *
+ * A DEFAULT conversation is created in exactly one place — chat-prepare, while
+ * serving a send — so a default conversation with zero messages means a request
+ * reached the server and the user's message was never written. That was a real
+ * bug until 2026-08-06: the streaming path saved a turn only `if (fullContent)`,
+ * so a total provider-chain failure discarded the exchange. Six real accounts
+ * are still frozen in that state from June 2026, each having tried Cat once.
+ *
+ * It went unnoticed for two months because the leftover row is indistinguishable
+ * from "opened the page and never typed" — the failure erased its own evidence
+ * and then counted as engagement. Hence a scheduled check rather than a test.
+ *
+ * Scoped to 30 days so the historical rows stay as evidence (they are the only
+ * trace of those six attempts) without permanently reddening the gate. Empty
+ * NON-default conversations are legitimate: the rail's "new chat" button makes
+ * one before anything is typed.
+ */
+async function checkSilentlyDroppedCatTurns() {
+  const since = new Date(Date.now() - 30 * 864e5).toISOString();
+  const convs = await rest(
+    `cat_conversations?select=id,user_id,created_at&is_default=eq.true&created_at=gte.${since}`
+  );
+  if (convs.length === 0) {
+    notes.push('cat_conversations: no default conversations created in the last 30 days');
+    return;
+  }
+
+  const ids = convs.map(c => c.id);
+  const msgs = await rest(`cat_messages?select=conversation_id&conversation_id=in.(${ids.join(',')})`);
+  const answered = new Set(msgs.map(m => m.conversation_id));
+  const dropped = convs.filter(c => !answered.has(c.id));
+
+  if (dropped.length > 0) {
+    violation(
+      'cat_conversations.send_stored_nothing',
+      `${dropped.length} default conversation(s) hold zero messages — a send reached the server and the user's message was not persisted`,
+      dropped.slice(0, 5).map(c => c.id)
+    );
+  } else {
+    notes.push(`cat_conversations: all ${convs.length} recent send(s) stored their turn`);
+  }
+}
+
 async function main() {
   const checks = [
     checkOrphanedWalletLinks,
     checkDuplicatePrimaryLinks,
     checkUnpayableActiveWallets,
     checkPaidWithoutTimestamp,
+    checkSilentlyDroppedCatTurns,
   ];
 
   for (const check of checks) {

--- a/scripts/eval-cat.mjs
+++ b/scripts/eval-cat.mjs
@@ -443,6 +443,29 @@ async function purgeRunMemories(userId, sinceIso) {
   );
 }
 
+/**
+ * Delete eval conversations left behind by an EARLIER run. End-of-run cleanup
+ * only knows the ids it collected in memory, so a hard kill (CI timeout, box
+ * restart) between probes strands them forever: 18 such rows from a single
+ * 2026-07-03 run were still sitting in production a month later, making up
+ * more than a third of the whole conversations table and inflating every
+ * usage metric read off it. Sweeping by title at START is the durable fix —
+ * it needs no memory of the run that leaked.
+ */
+async function sweepStaleEvalConversations(userId) {
+  const stale = await rest(
+    'GET',
+    `cat_conversations?user_id=eq.${userId}&is_default=is.false&title=like.${encodeURIComponent('[eval]%')}&select=id`
+  );
+  for (const { id } of stale ?? []) {
+    await rest('DELETE', `cat_messages?conversation_id=eq.${id}`, { prefer: 'return=minimal' });
+    await rest('DELETE', `cat_conversations?id=eq.${id}`, { prefer: 'return=minimal' });
+  }
+  if (stale?.length) {
+    console.error(`eval-cat: swept ${stale.length} stale eval conversation(s) from a previous run`);
+  }
+}
+
 async function cleanupEvalArtifacts(userId, conversationIds, runStartIso) {
   await purgeRunMemories(userId, runStartIso);
   for (const id of conversationIds) {
@@ -539,6 +562,9 @@ async function main() {
   const cookie = buildAuthCookie(session);
 
   await resetDailyCap(userId);
+  await sweepStaleEvalConversations(userId).catch(err =>
+    console.error(`eval-cat: stale-conversation sweep failed (non-fatal): ${err}`)
+  );
 
   const runStartIso = new Date().toISOString();
   const report = {

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -19,6 +19,7 @@ import { applyRateLimitHeaders, type RateLimitResult } from '@/lib/rate-limit';
 import { prepareCatChat } from '@/services/cat/chat-prepare';
 import { parseActionsFromResponse } from '@/services/cat/response-parser';
 import { saveMessages } from '@/services/cat/conversation-history';
+import { buildFailedTurnMessages } from '@/services/cat/failed-turn';
 import { resolveProvider, type FallbackProvider } from '@/services/cat/provider-resolver';
 import { meterCreditUsage } from '@/services/cat/credit-metering';
 import { getAdminClient } from '@/lib/supabase/admin';
@@ -288,13 +289,15 @@ export async function orchestrateCatChat(
       async start(controller) {
         // Lifted outside the try block so the catch at the bottom can
         // tell whether the failover attempt was reached (and which
-        // provider/model was active when the chain died). Block-scoped
-        // `let` inside the try is invisible to the outer catch.
+        // provider/model was active when the chain died), and can persist
+        // whatever text had already streamed. Block-scoped `let` inside the
+        // try is invisible to the outer catch.
         let attemptedFallback = false;
         let activeProvider = provider;
         let activeModel = modelToUse;
         let activeService = aiService;
         let activeIsPlatform = !hasByok;
+        let fullContent = '';
         try {
           let usage:
             | {
@@ -304,7 +307,6 @@ export async function orchestrateCatChat(
                 costBtc?: number;
               }
             | undefined;
-          let fullContent = '';
           controller.enqueue(
             encoder.encode(`data: ${JSON.stringify({ model: modelToUse, provider })}\n\n`)
           );
@@ -557,6 +559,34 @@ export async function orchestrateCatChat(
                 'Cat couldn’t generate a response. Try again, or add your own key in Settings → API Keys.',
               code: 'STREAM_ERROR',
             };
+          }
+          // Persist the turn even though it failed. The success path saves
+          // only `if (fullContent)`, so before this a total provider failure
+          // threw away the user's own words: they reloaded to an empty thread
+          // and we kept no record of what they had asked. Six real accounts
+          // reached exactly this state in June 2026 — one message-less
+          // conversation each, never seen again — and because an unsaved turn
+          // is indistinguishable from "opened the page and typed nothing",
+          // those failures were invisible in the data too.
+          //
+          // The assistant turn stores the same sentence the user just saw, so
+          // the thread reads back honestly, and the user/assistant alternation
+          // the next request's history depends on stays intact.
+          if (conversationId) {
+            await saveMessages(
+              supabase,
+              conversationId,
+              user.id,
+              buildFailedTurnMessages({
+                message,
+                partialContent: fullContent,
+                errorText: errPayload.error,
+                model: activeModel,
+                provider: activeProvider,
+              })
+            ).catch((persistErr: unknown) => {
+              logger.error('Failed to persist failed turn', { persistErr }, 'cat/chat');
+            });
           }
           controller.enqueue(encoder.encode(`event: error\n`));
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(errPayload)}\n\n`));

--- a/src/services/cat/failed-turn.ts
+++ b/src/services/cat/failed-turn.ts
@@ -1,0 +1,52 @@
+/**
+ * What to store when a Cat turn fails.
+ *
+ * The success path persists a turn only once the model produced content, so a
+ * provider failure used to drop the exchange entirely: the user's own words
+ * were gone on reload, and the conversation was left with zero messages —
+ * indistinguishable from someone who opened the page and never typed. Six real
+ * accounts sat in exactly that state (June 2026), each having tried Cat once
+ * and never returned, with no record of what they had asked.
+ *
+ * Kept as a pure function so the rule is testable without booting the
+ * streaming orchestrator and its provider chain.
+ */
+
+/** Appended when a stream dies mid-answer, so the stored reply reads as truncated. */
+export const TRUNCATED_REPLY_SUFFIX = '\n\n[This reply was cut off by a connection error.]';
+
+/** Last-resort text if a caller somehow has no error copy to store. */
+const UNKNOWN_FAILURE_NOTE = "Cat couldn't complete this reply.";
+
+export interface FailedTurnMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  model_used?: string;
+  provider?: string;
+}
+
+export function buildFailedTurnMessages(params: {
+  /** What the user actually typed — the thing worth not losing. */
+  message: string;
+  /** Any text that streamed before the failure. */
+  partialContent?: string;
+  /** The sentence the client was shown, so the thread reads back honestly. */
+  errorText?: string;
+  model?: string;
+  provider?: string;
+}): FailedTurnMessage[] {
+  const { message, partialContent = '', errorText = '', model, provider } = params;
+
+  const partial = partialContent.trim();
+  const assistantContent = partial
+    ? `${partialContent}${TRUNCATED_REPLY_SUFFIX}`
+    : errorText.trim() || UNKNOWN_FAILURE_NOTE;
+
+  // Always a user/assistant pair: the next request replays history and then
+  // appends the new user turn, so a dangling user message would put two user
+  // turns back to back — a shape strict providers reject outright.
+  return [
+    { role: 'user', content: message },
+    { role: 'assistant', content: assistantContent, model_used: model, provider },
+  ];
+}


### PR DESCRIPTION
## What was wrong

`chat-orchestrator`'s streaming path persisted a turn only `if (conversationId && fullContent)`. When the whole provider fallback chain died it `throw`s before reaching that line — so **the user's own message was discarded**. They reloaded to an empty thread, and we kept no record of what they had asked.

## What it cost

Six real accounts each hold exactly one conversation with **zero messages** (June 6–18, 2026), `is_default: true` and untitled — created server-side by `chat-prepare` during a send, then abandoned when the stream failed. Every one of them tried Cat once and never came back, and we cannot see a single thing they asked.

It also corrupted the metric. An unsaved turn is indistinguishable from "opened the page and typed nothing", so those six failures counted as engagement:

| | recorded | actually |
|---|---|---|
| accounts holding a conversation | 9 | 9 |
| accounts that ever stored a message | — | **2** (both ours: `mao` + a `.test` seed) |
| **real users who ever got a reply** | assumed 9 | **0** |

The failure erased its own evidence and then read as usage.

## The fix

The failure branch now persists the turn: the user's words verbatim, plus an assistant turn carrying **the same sentence the client displayed**, so the thread reads back honestly. A half-streamed reply is stored with the partial text marked truncated rather than passed off as complete.

The rule lives in a pure `buildFailedTurnMessages()` so it is testable without booting the provider chain, and it always emits a user/assistant **pair** — a dangling user turn would put two user messages back to back in replayed history, a shape strict providers reject.

## Gates

Both halves are mutation-tested (breaking either fails the suite):

- `__tests__/unit/cat/failed-turn.test.ts` — the rule, plus a source-level assertion that the streaming catch block still calls it. A pure function passing while nobody calls it is the obvious way this regresses.
- `checkSilentlyDroppedCatTurns` in the nightly data-invariant gate — a *default* conversation is created in exactly one place, so one holding zero messages means a send stored nothing. Verified against production: widened to 120 days it reports exactly those six accounts and exits 1 under `--gate`. Scoped to 30 days so the rows survive as evidence.

## Also

Eval residue: the harness does clean up in a `finally`, but a hard kill strands rows — 18 from a single 2026-07-03 run were still in production a month later, over a third of the entire conversations table. It now sweeps `[eval]%` at run **start**, which needs no memory of the run that leaked. The 18 stale rows are purged from production.

`npm run verify` green: 187 suites, 1841 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
