### PR TITLE
fix(money): a rate is either real and recent, or it does not exist

### DIFF
--- a/__tests__/unit/cat/credit-metering.test.ts
+++ b/__tests__/unit/cat/credit-metering.test.ts
@@ -22,9 +22,11 @@ jest.mock('@/utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }));
 
-// Live-rate lookup is best-effort; pin it for determinism.
-jest.mock('@/services/currency/rates', () => ({
-  convertFromBTC: jest.fn().mockResolvedValue(100000), // 1 BTC = 100k USD
+// Registry estimates are priced in USD, so they need a BTC/USD rate. Pin it for
+// determinism — and let a test return null to prove we bill nothing without one.
+const convertBtcToOrNull = jest.fn().mockResolvedValue(100000); // 1 BTC = 100k USD
+jest.mock('@/services/currency/rates.server', () => ({
+  convertBtcToOrNull: (...a: unknown[]) => convertBtcToOrNull(...a),
 }));
 
 const appendCreditEntry = jest.fn();
@@ -168,6 +170,39 @@ describe('meterCreditUsage', () => {
     const [, , entry] = appendCreditEntry.mock.calls[0] as [unknown, string, any];
     expect(entry.metadata.rawCostBtc).toBe(providerReportedRawCostBtc);
     expect(entry.metadata.pricingSource).toBe('provider_reported');
+  });
+
+  it('bills nothing when a registry estimate has no BTC/USD rate to price it', async () => {
+    // This used to fall back to a hardcoded 100,000 USD/BTC and debit a real
+    // ledger against it. Taking the wrong amount of someone's money is worse
+    // than taking none and reconciling from the logs.
+    convertBtcToOrNull.mockResolvedValueOnce(null);
+    appendCreditEntry.mockResolvedValue(0.001);
+
+    const charged = await meterCreditUsage(admin, 'u1', {
+      model: PAID_MODEL,
+      inputTokens: 100000,
+      outputTokens: 100000,
+      ref: 'no-rate',
+    });
+
+    expect(charged).toBe(0);
+    expect(appendCreditEntry).not.toHaveBeenCalled();
+  });
+
+  it('needs no rate at all for a provider-reported cost — it is already in BTC', async () => {
+    appendCreditEntry.mockResolvedValue(0.001);
+
+    const charged = await meterCreditUsage(admin, 'u1', {
+      model: PAID_MODEL,
+      inputTokens: 100,
+      outputTokens: 100,
+      rawCostBtc: 0.00000234,
+      ref: 'no-rate-provider-cost',
+    });
+
+    expect(charged).toBeGreaterThan(0);
+    expect(convertBtcToOrNull).not.toHaveBeenCalled();
   });
 
   it('returns 0 (never throws) but retries before giving up when the ledger keeps failing', async () => {

--- a/__tests__/unit/components/money/AmountField.test.tsx
+++ b/__tests__/unit/components/money/AmountField.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { AmountField } from '@/components/money/AmountField';
 
 const RATE_CHF_PER_BTC = 100_000;
@@ -174,8 +174,30 @@ describe('suggestions are exact', () => {
     // by looking at the rendered page.
     setup({ presetsBtc: undefined });
 
-    for (const label of ['CHF 1.00', 'CHF 5.00', 'CHF 10.00', 'CHF 20.00', 'CHF 50.00']) {
+    for (const label of ['CHF 1', 'CHF 5', 'CHF 10', 'CHF 20', 'CHF 50']) {
       expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it('spaces an alphabetic currency code but not a symbol glyph', () => {
+    // "CHF 5" and "$5" are both right; "CHF5" and "$ 5" are both wrong.
+    setup({ presetsBtc: undefined });
+    expect(screen.getByRole('button', { name: 'CHF 5' })).toBeInTheDocument();
+
+    cleanup();
+    mockCurrency = 'USD';
+    setup({ presetsBtc: undefined });
+    expect(screen.getByRole('button', { name: '$5' })).toBeInTheDocument();
+  });
+
+  it('labels a suggestion as the round number it is, with no trailing zeros', () => {
+    // The rung was picked BECAUSE it is round, so it has to read as one.
+    // Converting it to BTC and formatting back gives "CHF 5.00" at best and
+    // "CHF 4.99" at worst, which makes a deliberate number look accidental.
+    setup({ presetsBtc: undefined });
+
+    for (const button of screen.getAllByRole('button')) {
+      expect(button.textContent).not.toMatch(/\.\d*0$/);
     }
   });
 

--- a/__tests__/unit/components/money/firstPaintCurrency.test.tsx
+++ b/__tests__/unit/components/money/firstPaintCurrency.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * The first paint must already speak the visitor's currency.
+ *
+ * A stranger landing on a support page used to be shown "How much in BTC" and a
+ * ladder of amounts like 0.0001 — because rates only arrived after a client-side
+ * fetch, roughly a second later when warm and far worse cold. That first second
+ * is the whole decision: 0.0001 BTC is a question almost nobody can answer,
+ * CHF 5 is one anybody can.
+ *
+ * CurrencyRatesProvider closes that gap by handing the browser the rates the
+ * server already had, applied before any child renders. This test renders the
+ * real server pass and asserts the rendered HTML, so a regression shows up as a
+ * failure rather than as a flicker nobody profiles.
+ */
+
+import { renderToString } from 'react-dom/server';
+import { CurrencyRatesProvider } from '@/components/providers/CurrencyRatesProvider';
+import { AmountField } from '@/components/money/AmountField';
+import { currencyConverter } from '@/services/currency/rates';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+// An anonymous visitor: no profile, so the platform default (CHF) applies.
+jest.mock('@/hooks/useUserCurrency', () => ({
+  useUserCurrency: () => 'CHF',
+}));
+
+const SNAPSHOT = { rates: { CHF: 50_000, USD: 60_000, EUR: 55_000 }, fetchedAt: Date.now() };
+
+beforeEach(() => {
+  currencyConverter.clearCache();
+});
+
+function ssr(snapshot: typeof SNAPSHOT | null): string {
+  return renderToString(
+    <CurrencyRatesProvider initialSnapshot={snapshot}>
+      <AmountField value={0.0001} onChange={() => {}} label="How much" />
+    </CurrencyRatesProvider>
+  );
+}
+
+describe('anonymous first paint', () => {
+  it('renders the amount field in the visitor’s currency, not BTC', () => {
+    const html = ssr(SNAPSHOT);
+
+    expect(html).toContain('How much in CHF');
+    expect(html).not.toContain('How much in BTC');
+    // 0.0001 BTC at 50,000 CHF/BTC = CHF 5 — the field is pre-filled with the
+    // fiat figure, not the Bitcoin one.
+    expect(html).toContain('value="5"');
+  });
+
+  it('falls back to BTC — honestly — when the server had no rates', () => {
+    const html = ssr(null);
+
+    expect(html).toContain('How much in BTC');
+  });
+
+  it('ignores a snapshot too old to stand behind', () => {
+    // A page prerendered at build time must not ship a fossilised rate.
+    const html = ssr({ ...SNAPSHOT, fetchedAt: Date.now() - 60 * 60_000 });
+
+    expect(html).toContain('How much in BTC');
+  });
+});

--- a/__tests__/unit/config/entity-cta-terminology.test.ts
+++ b/__tests__/unit/config/entity-cta-terminology.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The primary CTA is the single most-read sentence on a public entity page —
+ * it is the label on the button a stranger presses to part with money. Our
+ * terminology guide bans a specific set of words there, for a reason that is
+ * about product positioning rather than style:
+ *
+ *  - "donate"/"donation" frames the payer as a charity's benefactor. OrangeCat
+ *    spans gift → loan → investment; the giving end of that range is still an
+ *    economic relationship, not alms.
+ *  - "tip" frames the payment as optional garnish.
+ *  - "crypto" is a category we are not in — this is Bitcoin.
+ *  - "campaign" is crowdfunding vocabulary we deliberately left behind.
+ *
+ * A `cause` shipped as "Donate" for months and nothing caught it, so this is
+ * the check rather than a note in a doc.
+ */
+
+import { ENTITY_PRIMARY_CTA } from '@/config/entity-cta';
+
+const BANNED = ['donate', 'donation', 'tip', 'crypto', 'campaign', 'charity'];
+
+describe('entity primary CTA terminology', () => {
+  it.each(Object.entries(ENTITY_PRIMARY_CTA))('%s: "%s" avoids banned wording', (_type, label) => {
+    const words = label.toLowerCase().split(/[^a-z]+/).filter(Boolean);
+    for (const banned of BANNED) {
+      expect(words).not.toContain(banned);
+    }
+  });
+
+  it('gives every entity a verb, not a shrug', () => {
+    // "View" is the registry fallback for entities with no transaction. A real
+    // economic entity landing on it means someone added a type and never chose
+    // its verb — the page then asks the visitor to do nothing in particular.
+    for (const [type, label] of Object.entries(ENTITY_PRIMARY_CTA)) {
+      expect(label.trim().length).toBeGreaterThan(2);
+      expect(`${type}:${label}`).not.toMatch(/:(TODO|TBD)/i);
+    }
+  });
+});

--- a/__tests__/unit/config/payment-bounds-agreement.test.ts
+++ b/__tests__/unit/config/payment-bounds-agreement.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The amount field and the server must agree on what a payable amount is.
+ *
+ * When they disagree the failure is silent and lands on the payer: the form
+ * accepts a number, enables the button, and the request comes back rejected
+ * after they have already decided to pay. The public support panel shipped
+ * with the range written out by hand in three places (two input attributes and
+ * a disabled-check) against a fourth copy in the Zod schema — four numbers that
+ * were only equal by luck.
+ *
+ * There is now one pair of constants. This asserts the server still uses it.
+ */
+
+import { publicSupportCreateSchema } from '@/lib/validation/finance';
+import { PAY_MAX_BTC, PAY_MIN_BTC } from '@/config/pay';
+
+const valid = { entity_type: 'cause', entity_id: '00000000-0000-4000-8000-000000000000' };
+
+describe('public support amount bounds', () => {
+  it('accepts exactly what the amount field offers', () => {
+    for (const amount_btc of [PAY_MIN_BTC, PAY_MAX_BTC]) {
+      expect(publicSupportCreateSchema.safeParse({ ...valid, amount_btc }).success).toBe(true);
+    }
+  });
+
+  it('rejects just outside the range the field enforces', () => {
+    // Below the minimum the wallet cannot invoice it; above the maximum this is
+    // not the product a stranger should be able to trigger from a public page.
+    for (const amount_btc of [PAY_MIN_BTC / 2, PAY_MAX_BTC * 1.000001]) {
+      expect(publicSupportCreateSchema.safeParse({ ...valid, amount_btc }).success).toBe(false);
+    }
+  });
+});

--- a/__tests__/unit/domain/payments/fiatPricedAmount.test.ts
+++ b/__tests__/unit/domain/payments/fiatPricedAmount.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Pricing a fiat-denominated listing in Bitcoin.
+ *
+ * This is the exact spot where a wrong exchange rate stops being a display bug
+ * and becomes a money bug: `resolveAmount` turns a seller's asking price into
+ * the Bitcoin a buyer actually parts with. It previously fell back to a
+ * hardcoded 86,000 CHF/BTC. The real rate was 52,199 — so a CHF 100 listing
+ * invoiced for about CHF 61 of Bitcoin, every single time, with nothing on
+ * screen to say so.
+ *
+ * The rule these tests lock in: without a real rate, refuse. An unpriced
+ * payment must fail loudly, never quietly settle for the wrong amount.
+ */
+
+import { resolveAmount } from '@/domain/payments/paymentFlowHelpers';
+import { convertToBtcOrNull } from '@/services/currency/rates.server';
+import { getAdminClient } from '@/lib/supabase/admin';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/services/currency/rates.server', () => ({
+  convertToBtcOrNull: jest.fn(),
+}));
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: jest.fn(),
+}));
+
+const convertMock = convertToBtcOrNull as jest.Mock;
+const adminMock = getAdminClient as jest.Mock;
+
+/** Admin client serving one priced entity row. */
+function withEntity(row: Record<string, unknown> | null) {
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'eq']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  builder.single = jest.fn(() => Promise.resolve({ data: row, error: null }));
+  adminMock.mockReturnValue({ from: jest.fn(() => builder) });
+}
+
+const supabase = {} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('resolveAmount — fiat-priced entities', () => {
+  it('converts the asking price with the live rate', async () => {
+    withEntity({ price: 100, currency: 'CHF' });
+    convertMock.mockResolvedValue(0.0019157);
+
+    await expect(resolveAmount(supabase, 'product', 'prod-1')).resolves.toBe(0.0019157);
+    expect(convertMock).toHaveBeenCalledWith(100, 'CHF');
+  });
+
+  it('refuses to mint an invoice when no rate is available', async () => {
+    withEntity({ price: 100, currency: 'CHF' });
+    convertMock.mockResolvedValue(null);
+
+    await expect(resolveAmount(supabase, 'product', 'prod-1')).rejects.toThrow(
+      /exchange rate unavailable/i
+    );
+  });
+
+  it('refuses a zero conversion rather than invoicing for nothing', async () => {
+    withEntity({ price: 100, currency: 'CHF' });
+    convertMock.mockResolvedValue(0);
+
+    await expect(resolveAmount(supabase, 'product', 'prod-1')).rejects.toThrow(
+      /exchange rate unavailable/i
+    );
+  });
+
+  it('needs no rate at all for a BTC-priced entity', async () => {
+    withEntity({ price: 0.001, currency: 'BTC' });
+
+    await expect(resolveAmount(supabase, 'product', 'prod-1')).resolves.toBe(0.001);
+    expect(convertMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/domain/payments/sendPaymentService.test.ts
+++ b/__tests__/unit/domain/payments/sendPaymentService.test.ts
@@ -10,20 +10,24 @@ import { payInvoice, sendToRecipient } from '@/domain/payments/sendPaymentServic
 import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
 import { generateInvoice } from '@/domain/payments/invoiceGenerationService';
 import { getAdminClient } from '@/lib/supabase/admin';
-import { decrypt } from '@/domain/payments/encryptionService';
+import { decrypt, isEncryptionConfigured } from '@/domain/payments/encryptionService';
 import { NWCClient } from '@/lib/nostr/nwc';
 
 jest.mock('@/utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }));
 jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
-jest.mock('@/domain/payments/encryptionService', () => ({ decrypt: jest.fn() }));
+jest.mock('@/domain/payments/encryptionService', () => ({
+  decrypt: jest.fn(),
+  isEncryptionConfigured: jest.fn(() => true),
+}));
 jest.mock('@/domain/payments/walletResolutionService', () => ({ resolveUserWallet: jest.fn() }));
 jest.mock('@/domain/payments/invoiceGenerationService', () => ({ generateInvoice: jest.fn() }));
 jest.mock('@/lib/nostr/nwc', () => ({ NWCClient: jest.fn() }));
 
 const adminMock = getAdminClient as jest.Mock;
 const decryptMock = decrypt as jest.Mock;
+const isEncryptionConfiguredMock = isEncryptionConfigured as jest.Mock;
 const resolveWalletMock = resolveUserWallet as jest.Mock;
 const generateInvoiceMock = generateInvoice as jest.Mock;
 const NWCClientMock = NWCClient as unknown as jest.Mock;
@@ -62,6 +66,7 @@ beforeEach(() => {
     disconnect: jest.fn(),
   }));
   decryptMock.mockReturnValue('nostr+walletconnect://sender');
+  isEncryptionConfiguredMock.mockReturnValue(true);
 });
 
 describe('payInvoice', () => {
@@ -116,6 +121,21 @@ describe('payInvoice', () => {
     });
     const result = await payInvoice('user-1', MAINNET_INVOICE);
     expect(result).toMatchObject({ ok: false, reason: 'wallet_unreadable' });
+  });
+
+  it('blames itself, not the payer, when the encryption key is missing', async () => {
+    // Found live: every send failed with "reconnect your wallet" because the
+    // box had no PAYMENT_ENCRYPTION_KEY. Reconnecting needs the same key to
+    // encrypt, so that advice cannot work — it just moves our outage onto them.
+    mockAdmin({ nwc: 'enc' });
+    decryptMock.mockImplementation(() => {
+      throw new Error('no key');
+    });
+    isEncryptionConfiguredMock.mockReturnValue(false);
+
+    const result = await payInvoice('user-1', MAINNET_INVOICE);
+    expect(result).toMatchObject({ ok: false, reason: 'sending_unavailable' });
+    expect((result as { message: string }).message).not.toMatch(/reconnect/i);
   });
 
   it('surfaces a rejected payment as payment_failed', async () => {

--- a/__tests__/unit/serverOnlyModules.test.ts
+++ b/__tests__/unit/serverOnlyModules.test.ts
@@ -1,0 +1,41 @@
+/**
+ * `.server.ts` must actually stay on the server.
+ *
+ * The suffix is a convention, and conventions don't fail builds. The stakes are
+ * concrete: `services/currency/rateSource.server.ts` reaches a third party and
+ * kicks off a refresh the moment it loads. Bundled into a client chunk it would
+ * ship an outbound CoinGecko call to every visitor — a CSP violation, a privacy
+ * leak, and one upstream request per person instead of one per minute for the
+ * whole platform. Browsers get rates from our own /api/rates instead.
+ *
+ * A `'use client'` file importing anything `.server` is that mistake, so this
+ * catches it in CI rather than in a network tab.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const IMPORT_SERVER = /(?:from|import\()\s*['"][^'"]*\.server['"]/;
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) {
+      sourceFiles(path, out);
+    } else if (/\.tsx?$/.test(name)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe("'use client' modules never import server-only code", () => {
+  it('finds no client file importing a *.server module', () => {
+    const offenders = sourceFiles('src').filter(file => {
+      const source = readFileSync(file, 'utf8');
+      return /^\s*['"]use client['"]/m.test(source) && IMPORT_SERVER.test(source);
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/__tests__/unit/services/currency/conversion.test.ts
+++ b/__tests__/unit/services/currency/conversion.test.ts
@@ -1,9 +1,14 @@
 /**
  * Unit tests for the synchronous currency conversion module.
  *
- * Covers BTC<->SATS arithmetic, BTC<->fiat conversion against the seeded rate
- * cache, the round-trip identity, and — critically — the safe-failure behavior
- * when a currency has no known rate (must return 0, never fabricate a value).
+ * Covers BTC<->SATS arithmetic, BTC<->fiat conversion against an installed rate
+ * snapshot, the round-trip identity, and — critically — the safe-failure
+ * behavior when a currency has no known rate (must return 0, never fabricate).
+ *
+ * The rate cache starts EMPTY on purpose and every test that needs a rate
+ * installs one. See the "no fabricated rates" block at the bottom: seeded
+ * "sane defaults" once made a wrong-but-plausible rate the normal case, which
+ * mis-priced real invoices for as long as nobody looked.
  */
 
 import {
@@ -13,7 +18,15 @@ import {
   convertToBtc,
   convert,
 } from '@/services/currency/conversion';
-import { cache } from '@/services/currency/rates';
+import { applyRateSnapshot, cache, currencyConverter } from '@/services/currency/rates';
+
+/** Arbitrary, obviously-test values — never real-looking constants to copy. */
+const TEST_RATES = { CHF: 50_000, USD: 60_000, EUR: 55_000, GBP: 45_000 };
+
+beforeEach(() => {
+  currencyConverter.clearCache();
+  applyRateSnapshot({ rates: TEST_RATES, fetchedAt: Date.now() });
+});
 
 // Silence the warn that the missing-rate path emits.
 jest.mock('@/utils/logger', () => ({
@@ -50,12 +63,12 @@ describe('convertBtcTo', () => {
     expect(convertBtcTo(0.001, 'SATS')).toBe(100_000);
   });
 
-  it('converts BTC to a seeded fiat using the cached rate', () => {
+  it('converts BTC to fiat using the cached rate', () => {
     const rate = cache.rates['BTC_CHF'];
     expect(convertBtcTo(2, 'CHF')).toBe(2 * rate);
   });
 
-  it('returns 0 for an unsupported currency (never fabricates)', () => {
+  it('returns 0 for a currency with no rate (never fabricates)', () => {
     expect(convertBtcTo(1, 'JPY')).toBe(0);
   });
 });
@@ -69,12 +82,12 @@ describe('convertToBtc', () => {
     expect(convertToBtc(100_000, 'SATS')).toBe(0.001);
   });
 
-  it('converts a seeded fiat to BTC using the cached rate', () => {
+  it('converts fiat to BTC using the cached rate', () => {
     const rate = cache.rates['BTC_USD'];
     expect(convertToBtc(rate, 'USD')).toBe(1);
   });
 
-  it('returns 0 for an unsupported currency — must NOT treat fiat as BTC', () => {
+  it('returns 0 for a currency with no rate — must NOT treat fiat as BTC', () => {
     // The bug this guards against: `amount / 1` rendering "100 JPY" as "100 BTC".
     expect(convertToBtc(100, 'JPY')).toBe(0);
   });
@@ -90,7 +103,7 @@ describe('convert (fiat <-> fiat via BTC)', () => {
     expect(out).toBeCloseTo(100, 6);
   });
 
-  it('converts between two seeded fiats consistently with the rates', () => {
+  it('converts between two fiats consistently with the rates', () => {
     const usd = 100;
     const expectedChf = (usd / cache.rates['BTC_USD']) * cache.rates['BTC_CHF'];
     expect(convert(usd, 'USD', 'CHF')).toBeCloseTo(expectedChf, 8);
@@ -99,5 +112,25 @@ describe('convert (fiat <-> fiat via BTC)', () => {
   it('yields 0 when either leg has no rate', () => {
     expect(convert(100, 'JPY', 'CHF')).toBe(0);
     expect(convert(100, 'CHF', 'JPY')).toBe(0);
+  });
+});
+
+describe('no fabricated rates', () => {
+  it('starts with an empty cache — an unknown rate must stay unknown', () => {
+    currencyConverter.clearCache();
+    expect(Object.keys(cache.rates)).toHaveLength(0);
+    // Every supported fiat, not just an exotic one: the old seeded cache meant
+    // the "cannot convert" guard was unreachable for exactly the currencies
+    // people actually use.
+    for (const code of ['CHF', 'USD', 'EUR', 'GBP']) {
+      expect(convertBtcTo(1, code)).toBe(0);
+      expect(convertToBtc(100, code)).toBe(0);
+    }
+  });
+
+  it('forgets rates once they are too old to stand behind', () => {
+    currencyConverter.clearCache();
+    applyRateSnapshot({ rates: TEST_RATES, fetchedAt: Date.now() - 60 * 60_000 });
+    expect(convertBtcTo(1, 'CHF')).toBe(0);
   });
 });

--- a/__tests__/unit/services/currency/noHardcodedRates.test.ts
+++ b/__tests__/unit/services/currency/noHardcodedRates.test.ts
@@ -1,0 +1,60 @@
+/**
+ * A guard against the class of bug, not the instance.
+ *
+ * Hardcoded BTC/fiat rates were reintroduced three separate times — the rate
+ * cache's "sane defaults", the create-flow sidebar's `?? { btcToChf: 86000 }`,
+ * and a credit-metering fallback — because each looks harmless in isolation.
+ * They are not: a plausible wrong rate passes every "is this a number" check
+ * and silently mis-prices real money for as long as nobody happens to look. The
+ * live CHF rate had drifted 65% from the seeded one.
+ *
+ * So the rule is mechanical now. If you need a rate, get a real one or admit
+ * you don't have it. If this test fails, do not add an exception — delete the
+ * constant.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** `btcToChf: 86000`, `BTC_USD: 97000`, `btcPriceUsd = 100000`, … */
+const FORBIDDEN =
+  /(btcTo(Chf|Usd|Eur|Gbp)|BTC_(CHF|USD|EUR|GBP)|btcPrice[A-Za-z]*|[A-Za-z]*RateFallback)['"]?\s*[:=]\s*[0-9_]{4,}/;
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) {
+      sourceFiles(path, out);
+    } else if (/\.tsx?$/.test(name)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/** Comments explaining the old bug are the point of this file, not a relapse. */
+function isComment(line: string): boolean {
+  const code = line.trim();
+  return code.startsWith('*') || code.startsWith('//') || code.startsWith('/*');
+}
+
+describe('no hardcoded exchange rates in source', () => {
+  it('has no fiat-per-BTC constant anywhere in src/', () => {
+    const files = sourceFiles('src');
+    // Sanity: a scan that silently found nothing to read would pass vacuously.
+    expect(files.length).toBeGreaterThan(100);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (FORBIDDEN.test(line) && !isComment(line)) {
+            offenders.push(`${file}:${i + 1}: ${line.trim()}`);
+          }
+        });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/app/api/projects/[id]/stats/route.ts
+++ b/src/app/api/projects/[id]/stats/route.ts
@@ -5,7 +5,7 @@ import { getTableName } from '@/config/entity-registry';
 import { validateUUID, getValidationError } from '@/lib/api/validation';
 import { ENTITY_STATUS } from '@/config/database-constants';
 import { getEntityFundingStats } from '@/services/wallets/funding-stats';
-import { convertBtcTo, currencyConverter } from '@/services/currency';
+import { convertBtcToOrNull } from '@/services/currency/rates.server';
 
 const DEFAULT_CAMPAIGN_DURATION_DAYS = 30;
 
@@ -51,15 +51,18 @@ export const GET = withOptionalAuth(
       const fundingStats = await getEntityFundingStats(supabase, 'project', projectId);
       const raisedBtc = fundingStats?.totalBtc ?? 0;
       const supporterCount = fundingStats?.contributorCount ?? 0;
+      // The goal is written in the project's own currency but money arrives in
+      // Bitcoin, so every fiat figure below depends on a real rate. Without one
+      // we report null rather than 0 — "we can't say" is true, "nothing raised"
+      // would be a lie about someone's fundraiser.
       const goalCurrency = ((project.currency as string) || 'BTC').toUpperCase();
-      if (raisedBtc > 0 && goalCurrency !== 'BTC') {
-        await currencyConverter.getRates().catch(() => undefined);
-      }
-      const raisedAmount = raisedBtc > 0 ? convertBtcTo(raisedBtc, goalCurrency) : 0;
+      const raisedAmount = raisedBtc > 0 ? await convertBtcToOrNull(raisedBtc, goalCurrency) : 0;
+      const fiatUnavailable = raisedAmount === null;
 
-      // Calculate progress
       const progressPercent =
-        project.goal_amount > 0 ? Math.min((raisedAmount / project.goal_amount) * 100, 100) : 0;
+        raisedAmount !== null && project.goal_amount > 0
+          ? Math.min((raisedAmount / project.goal_amount) * 100, 100)
+          : null;
 
       // Calculate days remaining (default campaign duration from creation date)
       const createdDate = new Date(project.created_at);
@@ -77,7 +80,7 @@ export const GET = withOptionalAuth(
         1,
         Math.ceil((now.getTime() - createdDate.getTime()) / (24 * 60 * 60 * 1000))
       );
-      const dailyFundingRate = raisedAmount / daysSinceCreation;
+      const dailyFundingRate = raisedAmount !== null ? raisedAmount / daysSinceCreation : null;
 
       // Get project category and related projects
       const { data: relatedProjectsData, error: _relatedError } = await supabase
@@ -97,10 +100,16 @@ export const GET = withOptionalAuth(
           goalAmount: project.goal_amount,
           raisedAmount,
           raisedBtc,
-          progressPercent: Math.round(progressPercent * 100) / 100,
-          remaining: Math.max(0, project.goal_amount - raisedAmount),
+          /** True when no Bitcoin rate was available, so every fiat field is null. */
+          fiatUnavailable,
+          progressPercent:
+            progressPercent === null ? null : Math.round(progressPercent * 100) / 100,
+          remaining: raisedAmount === null ? null : Math.max(0, project.goal_amount - raisedAmount),
           supporterCount,
-          averageContribution: supporterCount > 0 ? Math.round(raisedAmount / supporterCount) : 0,
+          averageContribution:
+            raisedAmount !== null && supporterCount > 0
+              ? Math.round(raisedAmount / supporterCount)
+              : null,
         },
         timeMetrics: {
           createdAt: project.created_at,
@@ -113,9 +122,15 @@ export const GET = withOptionalAuth(
           ),
         },
         performanceMetrics: {
-          dailyFundingRate: Math.round(dailyFundingRate),
-          projectedTotal: Math.round(raisedAmount + dailyFundingRate * daysRemaining),
-          willReachGoal: raisedAmount + dailyFundingRate * daysRemaining >= project.goal_amount,
+          dailyFundingRate: dailyFundingRate === null ? null : Math.round(dailyFundingRate),
+          projectedTotal:
+            raisedAmount === null || dailyFundingRate === null
+              ? null
+              : Math.round(raisedAmount + dailyFundingRate * daysRemaining),
+          willReachGoal:
+            raisedAmount === null || dailyFundingRate === null
+              ? null
+              : raisedAmount + dailyFundingRate * daysRemaining >= project.goal_amount,
           category: project.category || 'uncategorized',
           categoryRank,
         },

--- a/src/app/api/rates/route.ts
+++ b/src/app/api/rates/route.ts
@@ -1,0 +1,33 @@
+/**
+ * GET /api/rates — what Bitcoin costs, served from our own origin.
+ *
+ * Browsers used to call CoinGecko directly. Two things were wrong with that:
+ * every visitor paid the upstream latency themselves (a cold call measured ~14s,
+ * during which every amount on the page sat in BTC), and the page needed a
+ * third-party host in `connect-src`, so the content policy could not honestly be
+ * tightened. Routing through here collapses one upstream call per visitor into
+ * one per minute for the whole platform, and keeps the policy at 'self'.
+ *
+ * 503 when we have no usable rate. That is the point: the client must be able to
+ * tell "Bitcoin costs X" apart from "we don't know", because the honest response
+ * to not knowing is to stop quoting francs — not to quote a guess.
+ */
+
+import { apiSuccess, apiServiceUnavailable } from '@/lib/api/standardResponse';
+import { getRateSnapshot } from '@/services/currency/rateSource.server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const snapshot = await getRateSnapshot();
+
+  if (!snapshot) {
+    return apiServiceUnavailable('Bitcoin rates are unavailable right now.');
+  }
+
+  return apiSuccess(snapshot, {
+    // Short and shared: a minute-old BTC rate is fine for display, and this is
+    // what stops a traffic spike becoming a spike of upstream calls.
+    headers: { 'Cache-Control': 'public, max-age=30, stale-while-revalidate=300' },
+  });
+}

--- a/src/app/api/v1/payments/public/route.ts
+++ b/src/app/api/v1/payments/public/route.ts
@@ -42,6 +42,10 @@ export async function POST(request: Request) {
       ['owner not found', 'This page no longer has a receiving owner.'],
       ['no wallet', 'The owner has not connected a Bitcoin wallet yet.'],
       ['outside allowed range', 'That amount is outside the wallet provider’s allowed range.'],
+      [
+        'exchange rate unavailable',
+        'We could not check the Bitcoin exchange rate just now, so we did not want to guess the amount. Please try again in a moment.',
+      ],
       ['LNURL', 'The Lightning Address could not create an invoice. Try again later.'],
     ];
     for (const [pattern, safe] of safeErrors) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,6 +45,8 @@ import Script from 'next/script';
 import { AuthProvider } from '@/components/providers/AuthProvider';
 import { QueryProvider } from '@/components/providers/QueryProvider';
 import { ThemeProvider } from '@/components/providers/ThemeProvider';
+import { CurrencyRatesProvider } from '@/components/providers/CurrencyRatesProvider';
+import { getRenderRates } from '@/services/currency/rates.server';
 import { AppShell } from '@/components/layout/AppShell';
 import { Toaster } from '@/components/ui/sonner';
 import { Suspense } from 'react';
@@ -100,6 +102,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  // Cache-only, never a network wait: rendering a page must not depend on a
+  // third party answering. Whatever we last knew gets handed to the browser so
+  // the first paint already speaks the visitor's currency.
+  const rateSnapshot = getRenderRates();
 
   return (
     <html
@@ -148,13 +154,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           Skip to main content
         </a>
         <ThemeProvider>
-          <QueryProvider>
-            <AuthProvider>
-              <AppShell>
-                <Suspense>{children}</Suspense>
-              </AppShell>
-            </AuthProvider>
-          </QueryProvider>
+          <CurrencyRatesProvider initialSnapshot={rateSnapshot}>
+            <QueryProvider>
+              <AuthProvider>
+                <AppShell>
+                  <Suspense>{children}</Suspense>
+                </AppShell>
+              </AuthProvider>
+            </QueryProvider>
+          </CurrencyRatesProvider>
           <Toaster position="top-right" richColors closeButton />
         </ThemeProvider>
         {/* FleetCrown feedback widget — OrangeCat is customer #2 of the sibling

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -231,13 +231,14 @@ export default async function PublicProjectPage({ params }: PageProps) {
           value: project.goal_amount,
           currency: project.currency || 'BTC',
         },
-        ...(settledRaised > 0 && {
-          amountRaised: {
-            '@type': 'MonetaryAmount',
-            value: settledRaised,
-            currency: project.currency || 'BTC',
-          },
-        }),
+        ...(settledRaised !== null &&
+          settledRaised > 0 && {
+            amountRaised: {
+              '@type': 'MonetaryAmount',
+              value: settledRaised,
+              currency: project.currency || 'BTC',
+            },
+          }),
       },
     }),
     ...(project.bitcoin_address && {

--- a/src/components/create/DynamicSidebar.tsx
+++ b/src/components/create/DynamicSidebar.tsx
@@ -13,7 +13,7 @@
 
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { ArrowLeftRight, TrendingUp } from 'lucide-react';
 import {
   GuidanceDefaultCard,
@@ -21,8 +21,8 @@ import {
   GuidanceFieldCard,
 } from '@/components/create/guidance-shared';
 import type { FieldGuidanceContent, DefaultContent } from '@/lib/project-guidance';
-import { currencyConverter, formatCurrency } from '@/services/currency';
-import type { ExchangeRates } from '@/services/currency/types';
+import { formatCurrency } from '@/services/currency';
+import { useCurrencyConversion } from '@/hooks/useCurrencyConversion';
 
 export type FieldType = string | null;
 
@@ -35,40 +35,27 @@ interface DynamicSidebarProps<T extends string = string> {
   className?: string;
 }
 
+/**
+ * What a goal is worth in the other denominations.
+ *
+ * This used to fall back to hardcoded rates (97000/91000/86000) whenever the
+ * real ones hadn't loaded, labelled "Estimated rates". They were years out of
+ * date — the CHF figure was off by roughly 65% — so someone setting a goal was
+ * shown a confidently wrong number. Without rates the breakdown simply doesn't
+ * render; the goal amount itself is still on screen.
+ */
 function CurrencyBreakdown({ amount, currency }: { amount: number; currency: string }) {
-  const [rates, setRates] = useState<ExchangeRates | null>(null);
+  const { convertToBTC, convertFromBTC, isLoading } = useCurrencyConversion();
 
-  useEffect(() => {
-    currencyConverter
-      .getRates()
-      .then(setRates)
-      .catch(() => {});
-  }, []);
+  const btc = !amount || isNaN(amount) ? 0 : convertToBTC(amount, currency);
+  const usd = convertFromBTC(btc, 'USD');
+  const eur = convertFromBTC(btc, 'EUR');
+  const chf = convertFromBTC(btc, 'CHF');
 
-  const r = rates ?? { btcToUsd: 97000, btcToEur: 91000, btcToChf: 86000 };
-
-  const toBtc = (): number => {
-    if (!amount || isNaN(amount)) {
-      return 0;
-    }
-    switch (currency) {
-      case 'BTC':
-        return amount;
-      case 'USD':
-        return amount / r.btcToUsd;
-      case 'EUR':
-        return amount / r.btcToEur;
-      case 'CHF':
-        return amount / r.btcToChf;
-      default:
-        return 0;
-    }
-  };
-
-  const btc = toBtc();
-  const usd = btc * r.btcToUsd;
-  const eur = btc * r.btcToEur;
-  const chf = btc * r.btcToChf;
+  // Nothing convertible yet (or at all) — say nothing rather than guess.
+  if (isLoading || btc <= 0 || (usd <= 0 && eur <= 0 && chf <= 0)) {
+    return null;
+  }
 
   const fmt = (num: number, decimals: number = 2): string => {
     if (num === 0) {
@@ -109,7 +96,7 @@ function CurrencyBreakdown({ amount, currency }: { amount: number; currency: str
       <div className="mt-3 pt-3 border-t border-subtle">
         <p className="text-xs text-fg-secondary flex items-start gap-1">
           <TrendingUp className="w-3 h-3 mt-0.5 flex-shrink-0" />
-          <span>{rates ? 'Live rates.' : 'Estimated rates.'} All funding settles in Bitcoin.</span>
+          <span>Live rates. All funding settles in Bitcoin.</span>
         </p>
       </div>
     </div>

--- a/src/components/money/AmountField.tsx
+++ b/src/components/money/AmountField.tsx
@@ -60,6 +60,13 @@ interface AmountFieldProps {
 
 const BTC_DECIMALS = CURRENCY_METADATA.BTC.precision;
 
+/**
+ * "CHF 5" but "$5" — an alphabetic code is a word and takes a space, a glyph
+ * hugs its number. Getting this backwards is the kind of small wrongness that
+ * makes a payment screen feel machine-generated.
+ */
+const ALPHABETIC_SYMBOL = /^[A-Za-z]+$/;
+
 /** A value the input can hold: plain digits, no thousands separators. */
 function toDraft(amount: number, decimals: number): string {
   if (!Number.isFinite(amount) || amount <= 0) {
@@ -151,19 +158,32 @@ export function AmountField({
     emit(btc);
   };
 
+  /**
+   * Suggestions, each carrying the label it was round in.
+   *
+   * A ladder rung is chosen because it is a round number, so it has to READ as
+   * one. Converting the fiat rung to BTC and formatting it back gives
+   * "CHF 5.00" at best and "CHF 4.99" at worst — the trailing zeros are noise
+   * and the drift makes a deliberate number look accidental. The rung labels
+   * itself in its own unit; only a caller-supplied BTC ladder is formatted.
+   */
   const presets = useMemo(() => {
-    const ladder =
-      presetsBtc ??
-      (inBtc
-        ? CONTRIBUTION_QUICK_AMOUNTS_BTC
-        : CONTRIBUTION_QUICK_AMOUNTS_FIAT.map(fiat => convertToBTC(fiat, displayCurrency)));
-    return ladder.filter(btc => btc > 0 && btc >= minBtc && btc <= maxBtc);
+    if (presetsBtc) {
+      return presetsBtc
+        .filter(btc => btc > 0 && btc >= minBtc && btc <= maxBtc)
+        .map(btc => ({ btc, label: inBtc ? `${toDraft(btc, BTC_DECIMALS)} BTC` : formatAmountBtc(btc) }));
+    }
+    if (inBtc) {
+      return CONTRIBUTION_QUICK_AMOUNTS_BTC.filter(btc => btc >= minBtc && btc <= maxBtc).map(
+        btc => ({ btc, label: `${toDraft(btc, BTC_DECIMALS)} BTC` })
+      );
+    }
+    return CONTRIBUTION_QUICK_AMOUNTS_FIAT.map(fiat => ({
+      btc: convertToBTC(fiat, displayCurrency),
+      label: `${symbol}${ALPHABETIC_SYMBOL.test(symbol) ? ' ' : ''}${fiat}`,
+    })).filter(p => p.btc > 0 && p.btc >= minBtc && p.btc <= maxBtc);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [presetsBtc, inBtc, displayCurrency, minBtc, maxBtc]);
-
-  /** A suggestion reads in the unit being typed, or it is noise. */
-  const presetLabel = (btc: number) =>
-    inBtc ? `${toDraft(btc, BTC_DECIMALS)} BTC` : formatAmountBtc(btc);
+  }, [presetsBtc, inBtc, displayCurrency, symbol, minBtc, maxBtc]);
 
   const tooSmall = value > 0 && value < minBtc;
   const tooLarge = value > maxBtc;
@@ -231,9 +251,9 @@ export function AmountField({
 
       {presets.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {presets.map(btc => (
+          {presets.map(({ btc, label }) => (
             <button
-              key={btc}
+              key={label}
               type="button"
               onClick={() => choosePreset(btc)}
               aria-pressed={Math.abs(value - btc) < btc * 0.001}
@@ -244,7 +264,7 @@ export function AmountField({
                   : 'border-default text-fg-secondary hover:text-fg-primary'
               )}
             >
-              {presetLabel(btc)}
+              {label}
             </button>
           ))}
         </div>

--- a/src/components/payment/PublicSupportPanel.tsx
+++ b/src/components/payment/PublicSupportPanel.tsx
@@ -6,12 +6,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { PaymentQRCode } from './PaymentQRCode';
 import { PaymentStatusIndicator } from './PaymentStatusIndicator';
+import { AmountField } from '@/components/money/AmountField';
 import { PUBLIC_API_BASE } from '@/config/public-api';
-import { CONTRIBUTION_QUICK_AMOUNTS_BTC } from '@/config/payment-presets';
-import { displayBTC } from '@/services/currency';
+import { DEFAULT_CONTRIBUTION_BTC } from '@/config/payment-presets';
+import { PAY_MAX_BTC, PAY_MIN_BTC } from '@/config/pay';
 import type { EntityType } from '@/config/entity-registry';
 import type { PaymentIntentStatus, PaymentMethod } from '@/domain/payments';
-import { cn } from '@/lib/utils';
 
 interface PublicSupportPanelProps {
   entityType: EntityType;
@@ -55,7 +55,7 @@ export function PublicSupportPanel({
   entityId,
   entityTitle,
 }: PublicSupportPanelProps) {
-  const [amountBtc, setAmountBtc] = useState<number>(0.0001);
+  const [amountBtc, setAmountBtc] = useState<number>(DEFAULT_CONTRIBUTION_BTC);
   const [phase, setPhase] = useState<Phase>('choose');
   const [intent, setIntent] = useState<PublicIntent | null>(null);
   const [error, setError] = useState<string>('');
@@ -160,42 +160,18 @@ export function PublicSupportPanel({
         {phase === 'choose' && (
           <>
             <p className="text-sm text-fg-secondary">
-              Choose a small contribution. You will pay {entityTitle} directly; no account is
-              required.
+              You will pay {entityTitle} directly; no account is required.
             </p>
-            <div className="grid grid-cols-3 gap-2">
-              {CONTRIBUTION_QUICK_AMOUNTS_BTC.slice(0, 3).map(value => (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => setAmountBtc(value)}
-                  aria-pressed={amountBtc === value}
-                  className={cn(
-                    'rounded-md border px-2 py-2 text-xs font-medium',
-                    amountBtc === value
-                      ? 'border-bitcoinOrange bg-bitcoinOrange/10 text-fg-primary'
-                      : 'border-default text-fg-secondary hover:bg-surface-raised'
-                  )}
-                >
-                  {displayBTC(value)}
-                </button>
-              ))}
-            </div>
-            <label className="block text-xs text-fg-secondary">
-              Custom amount in BTC
-              <input
-                type="number"
-                min="0.000001"
-                max="1"
-                step="0.000001"
-                value={amountBtc}
-                onChange={event => setAmountBtc(Number(event.target.value))}
-                className="mt-1 min-h-11 w-full rounded-md border border-default bg-surface-base px-3 font-mono text-sm text-fg-primary"
-              />
-            </label>
+            <AmountField
+              value={amountBtc}
+              onChange={setAmountBtc}
+              minBtc={PAY_MIN_BTC}
+              maxBtc={PAY_MAX_BTC}
+              label="How much"
+            />
             <Button
               onClick={createIntent}
-              disabled={!Number.isFinite(amountBtc) || amountBtc < 0.000001 || amountBtc > 1}
+              disabled={!Number.isFinite(amountBtc) || amountBtc < PAY_MIN_BTC || amountBtc > PAY_MAX_BTC}
               className="w-full min-h-11"
             >
               Create Bitcoin request

--- a/src/components/project/ProjectSummaryRail.tsx
+++ b/src/components/project/ProjectSummaryRail.tsx
@@ -35,7 +35,8 @@ interface Props {
 export default function ProjectSummaryRail({ project, settledRaisedBtc = 0, isOwner }: Props) {
   const { formatAmountBtc } = useDisplayCurrency();
   const goalCurrency = project.goal_currency || project.currency || PLATFORM_DEFAULT_CURRENCY;
-  const [amountRaised, setAmountRaised] = useState<number>(0);
+  // null = no Bitcoin rate available, so the goal currency can't be quoted.
+  const [amountRaised, setAmountRaised] = useState<number | null>(0);
   const [refreshing, setRefreshing] = useState(false);
   const [bitcoinBalanceBtc, setBitcoinBalanceBtc] = useState<number>(
     project.bitcoin_balance_btc || 0
@@ -58,7 +59,7 @@ export default function ProjectSummaryRail({ project, settledRaisedBtc = 0, isOw
 
   const progress = useMemo(() => {
     const goal = project.goal_amount || 0;
-    if (!goal) {
+    if (!goal || amountRaised === null) {
       return 0;
     }
     return Math.min((amountRaised / goal) * 100, 100);
@@ -103,8 +104,14 @@ export default function ProjectSummaryRail({ project, settledRaisedBtc = 0, isOw
   return (
     <aside className="sticky top-6 rounded-lg border bg-surface-base dark:border-default p-6 space-y-4">
       <div>
-        <div className="text-2xl font-bold">{formatCurrency(amountRaised, goalCurrency)}</div>
-        {project.goal_amount && (
+        {/* No rate → quote the Bitcoin that actually arrived rather than claim
+            "CHF 0 raised", which would be a false statement about the project. */}
+        <div className="text-2xl font-bold">
+          {amountRaised === null
+            ? formatCurrency(settledRaisedBtc, 'BTC')
+            : formatCurrency(amountRaised, goalCurrency)}
+        </div>
+        {project.goal_amount && amountRaised !== null && (
           <div className="text-sm text-fg-secondary">
             of {formatCurrency(project.goal_amount, goalCurrency)} goal
           </div>

--- a/src/components/providers/CurrencyRatesProvider.tsx
+++ b/src/components/providers/CurrencyRatesProvider.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/**
+ * Hands the browser the rates the server already had.
+ *
+ * Without this, every visitor's first paint was denominated in Bitcoin and only
+ * flipped to their own currency once a client-side fetch landed — around a
+ * second when warm, and far worse cold. For a stranger being asked to name an
+ * amount, that first second is the whole decision: "0.0001 BTC" is a question
+ * they can't answer, "CHF 5" is one they can.
+ *
+ * The snapshot is applied synchronously while this provider renders, before any
+ * child renders, so server and client agree on the very first pass and there is
+ * nothing to flip. A snapshot older than the cache's tolerance is ignored
+ * outright — a page prerendered at build time must not ship a fossilised rate.
+ */
+
+import { createContext, useContext, useEffect, useState } from 'react';
+import {
+  applyRateSnapshot,
+  currencyConverter,
+  hasUsableRates,
+  type RateSnapshotLike,
+} from '@/services/currency/rates';
+
+/** True once real, unexpired rates are in the cache. */
+const RatesReadyContext = createContext(false);
+
+export function useRatesReady(): boolean {
+  return useContext(RatesReadyContext);
+}
+
+/**
+ * Rates go stale, and a page left open (a payment screen, say) must not quietly
+ * start quoting yesterday's number. Refresh well inside the cache's own 15-minute
+ * tolerance; the endpoint is our own origin and caches for 30s, so this is cheap.
+ */
+const REFRESH_MS = 5 * 60_000;
+
+export function CurrencyRatesProvider({
+  initialSnapshot,
+  children,
+}: {
+  initialSnapshot: RateSnapshotLike | null;
+  children: React.ReactNode;
+}) {
+  const [ready, setReady] = useState(() => {
+    applyRateSnapshot(initialSnapshot);
+    return hasUsableRates();
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const sync = () => {
+      currencyConverter
+        .getRates()
+        .then(() => {
+          if (!cancelled) {
+            setReady(hasUsableRates());
+          }
+        })
+        .catch(() => {
+          // rates.ts already logged it; amounts stay in BTC, which is honest.
+        });
+    };
+
+    if (!hasUsableRates()) {
+      sync();
+    }
+    const timer = setInterval(sync, REFRESH_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  return <RatesReadyContext.Provider value={ready}>{children}</RatesReadyContext.Provider>;
+}

--- a/src/components/public/PriceDisplay.tsx
+++ b/src/components/public/PriceDisplay.tsx
@@ -12,7 +12,8 @@
  * dropped — never fabricated (a wrong rate is a money-correctness bug).
  */
 
-import { currencyConverter, formatCurrency } from '@/services/currency';
+import { formatCurrency } from '@/services/currency';
+import { convertBtcToOrNull, convertToBtcOrNull } from '@/services/currency/rates.server';
 import { PLATFORM_DEFAULT_CURRENCY, type CurrencyCode } from '@/config/currencies';
 
 interface PriceDisplayProps {
@@ -39,21 +40,20 @@ export default async function PriceDisplay({
   // fiat prices get the Bitcoin equivalent.
   const secondaryCurrency: CurrencyCode = currency === 'BTC' ? PLATFORM_DEFAULT_CURRENCY : 'BTC';
 
-  let secondary = 0;
+  let secondary: number | null = null;
   try {
-    secondary = await currencyConverter.convert(
-      amount,
-      currency as CurrencyCode,
-      secondaryCurrency
-    );
+    secondary =
+      currency === 'BTC'
+        ? await convertBtcToOrNull(amount, secondaryCurrency)
+        : await convertToBtcOrNull(amount, currency as CurrencyCode);
   } catch {
-    secondary = 0;
+    secondary = null;
   }
 
   return (
     <p className={className}>
       {formatCurrency(amount, currency)}
-      {secondary > 0 && (
+      {secondary !== null && secondary > 0 && (
         <span className="ml-2 text-base font-normal text-fg-secondary">
           ≈ {formatCurrency(secondary, secondaryCurrency)}
         </span>

--- a/src/components/public/PublicEntityDetailPage.tsx
+++ b/src/components/public/PublicEntityDetailPage.tsx
@@ -21,7 +21,7 @@ import PublicEntityHero from '@/components/public/PublicEntityHero';
 import { PublicEntityPaymentSection } from '@/components/payment';
 import { resolveSellerReceiveInfo, type SellerReceiveInfo } from '@/domain/payments';
 import { getSharedWalletUsage, type SharedWalletUsage } from '@/domain/wallets/walletUsage';
-import { currencyConverter } from '@/services/currency';
+import { convertToBtcOrNull } from '@/services/currency/rates.server';
 import { type CurrencyCode } from '@/config/currencies';
 import { fetchEntityOwner } from '@/lib/entities/fetchEntityOwner';
 import { fetchProfileListingCounts } from '@/services/profile/listingCounts';
@@ -161,7 +161,7 @@ export default async function PublicEntityDetailPage({
       priceAmountBtc =
         (price.currency || 'BTC') === 'BTC'
           ? priceAmount
-          : await currencyConverter.convert(priceAmount, price.currency as CurrencyCode, 'BTC');
+          : ((await convertToBtcOrNull(priceAmount, price.currency as CurrencyCode)) ?? undefined);
     }
   }
 

--- a/src/components/send/SendScreen.tsx
+++ b/src/components/send/SendScreen.tsx
@@ -130,14 +130,22 @@ export function SendScreen() {
   // Nothing on this screen can work without a wallet to spend from, so say so
   // instead of rendering a form that ends in a refusal.
   if (!capability.canSend) {
+    // "Connect a wallet" is the right ask only when the wallet is the problem.
+    // When it's our key that's missing, their wallet is already connected and
+    // sending them to set one up blames them for our outage.
+    const oursNotTheirs = capability.reason === 'sending_unavailable';
     return (
       <div className="mx-auto flex max-w-md flex-col items-center gap-4 px-4 py-16 text-center">
         <Wallet className="h-12 w-12 text-fg-tertiary" aria-hidden="true" />
-        <h2 className="text-lg font-semibold text-fg-primary">{SEND_COPY.noWalletTitle}</h2>
+        <h2 className="text-lg font-semibold text-fg-primary">
+          {oursNotTheirs ? SEND_COPY.unavailableTitle : SEND_COPY.noWalletTitle}
+        </h2>
         <p className="text-sm text-fg-secondary">{capability.message ?? SEND_COPY.noWalletBody}</p>
-        <Button variant="accent" href={ROUTES.DASHBOARD.WALLETS}>
-          {SEND_COPY.noWalletCta}
-        </Button>
+        {!oursNotTheirs && (
+          <Button variant="accent" href={ROUTES.DASHBOARD.WALLETS}>
+            {SEND_COPY.noWalletCta}
+          </Button>
+        )}
         <MoneyTabs className="mt-4 w-full" />
       </div>
     );
@@ -162,8 +170,7 @@ export function SendScreen() {
     );
   }
 
-  const canReview =
-    tab === 'invoice' ? invoiceIsPayable : recipientCheck.payable && amount > 0;
+  const canReview = tab === 'invoice' ? invoiceIsPayable : recipientCheck.payable && amount > 0;
 
   return (
     <div className="mx-auto w-full max-w-md px-4 py-6">

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -65,6 +65,8 @@ export const API_ROUTES = {
     RECEIVE_STATUS: '/api/wallets/receive-status',
   },
   ENTITY_WALLETS: '/api/entity-wallets',
+  /** What Bitcoin costs — our own origin, so no third-party call from a browser. */
+  RATES: '/api/rates',
   RECEIVE: {
     REQUEST: '/api/receive/request',
   },

--- a/src/config/entity-cta.ts
+++ b/src/config/entity-cta.ts
@@ -14,8 +14,11 @@ export const ENTITY_PRIMARY_CTA: Record<EntityType, string> = {
   // Exchange — market transaction
   product: 'Buy now',
   service: 'Book this service',
-  // Funding (no strings) — donation/gift
-  cause: 'Donate',
+  // Funding (no strings) — donation/gift.
+  // "Donate" is deliberately not used: it frames the giver as a charity case's
+  // benefactor rather than a backer, and it is the one word on this page that
+  // disagreed with the panel it scrolls to ("Support with Bitcoin").
+  cause: 'Fund this cause',
   research: 'Fund this research',
   wishlist: 'Gift an item',
   // Funding (soft strings) — milestone accountability

--- a/src/config/send.ts
+++ b/src/config/send.ts
@@ -53,6 +53,9 @@ export const SEND_COPY = {
     'Sending needs a wallet OrangeCat can ask to pay — any NWC-compatible Lightning wallet. Your keys stay yours.',
   noWalletCta: 'Set up a wallet',
 
+  /** Shown when sending is broken on our side — never blame the payer's wallet. */
+  unavailableTitle: 'Sending is paused right now',
+
   /** Honesty line: we ask the user's own wallet to pay; we never hold funds. */
   disclaimer: 'Paid from your own wallet. OrangeCat never holds your Bitcoin.',
 } as const;

--- a/src/domain/payments/encryptionService.ts
+++ b/src/domain/payments/encryptionService.ts
@@ -48,6 +48,24 @@ export function encrypt(plaintext: string): string {
  * Decrypt a base64-encoded ciphertext produced by encrypt().
  */
 /**
+ * Is there a usable key at all?
+ *
+ * Worth asking separately from "can this ciphertext be read", because the two
+ * failures need opposite responses. A ciphertext this key can't open is the
+ * user's problem to fix by reconnecting. No key at all is ours: reconnecting
+ * would fail at the encrypt step too, so telling them to try it wastes their
+ * time and hides an outage behind what looks like their mistake.
+ */
+export function isEncryptionConfigured(): boolean {
+  try {
+    getKey();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Can this deployment actually use the stored ciphertext? A stored NWC URI is
  * useless if the key is missing or was rotated (e.g. written by a dev machine
  * whose key production doesn't have) — the payment path silently falls back to

--- a/src/domain/payments/paymentFlowHelpers.ts
+++ b/src/domain/payments/paymentFlowHelpers.ts
@@ -10,8 +10,7 @@ import { createHash } from 'node:crypto';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { getEntityMetadata, type EntityType } from '@/config/entity-registry';
 import { getAdminClient } from '@/lib/supabase/admin';
-import { convertToBTC } from '@/services/currency/rates';
-import type { CurrencyCode } from '@/config/currencies';
+import { convertToBtcOrNull } from '@/services/currency/rates.server';
 import type { PaymentIntentStatus } from './types';
 import { logger } from '@/utils/logger';
 
@@ -70,7 +69,20 @@ export async function resolveAmount(
   if (currency === 'BTC') {
     return priceNum;
   }
-  return await convertToBTC(priceNum, currency as CurrencyCode);
+
+  // Refuse rather than guess. This converts a seller's asking price into the
+  // Bitcoin a buyer will actually part with, so an approximate rate is not a
+  // cosmetic problem — it is charging the wrong amount. The old code fell back
+  // to a hardcoded 86,000 CHF/BTC that had drifted ~65% from the market, which
+  // would have invoiced a CHF 100 listing at roughly CHF 61 worth of Bitcoin,
+  // every time, with no error and nothing on screen to notice.
+  const amountBtc = await convertToBtcOrNull(priceNum, currency);
+  if (amountBtc === null || !(amountBtc > 0)) {
+    throw new Error(
+      `Bitcoin exchange rate unavailable for ${currency}; refusing to price this payment`
+    );
+  }
+  return amountBtc;
 }
 
 export async function getEntityTitle(

--- a/src/domain/payments/sendPaymentService.ts
+++ b/src/domain/payments/sendPaymentService.ts
@@ -20,7 +20,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { NWCClient } from '@/lib/nostr/nwc';
-import { decrypt } from '@/domain/payments/encryptionService';
+import { decrypt, isEncryptionConfigured } from '@/domain/payments/encryptionService';
 import { generateInvoice } from '@/domain/payments/invoiceGenerationService';
 import { resolveUserWallet } from '@/domain/payments/walletResolutionService';
 import { getAdminClient } from '@/lib/supabase/admin';
@@ -32,6 +32,8 @@ import { logger } from '@/utils/logger';
 export type SendFailureReason =
   | 'no_sender_wallet'
   | 'wallet_unreadable'
+  /** Our key is missing or rotated — nothing the payer can do about it. */
+  | 'sending_unavailable'
   | 'recipient_not_found'
   | 'recipient_cannot_receive'
   | 'invalid_invoice'
@@ -89,6 +91,22 @@ export async function resolveSenderNwcUri(userId: string): Promise<string | Send
   try {
     return decrypt(encrypted);
   } catch {
+    // Two very different failures used to share one message. With no key
+    // configured, "reconnect it" is advice that cannot work — reconnecting has
+    // to encrypt, which needs the same key — so it sends the payer chasing a
+    // problem that is ours. Say so, and make it loud in the logs, because
+    // nothing else on the box reports it.
+    if (!isEncryptionConfigured()) {
+      logger.error(
+        'PAYMENT_ENCRYPTION_KEY is missing or invalid — no user can send from a connected wallet',
+        { userId },
+        'Payments'
+      );
+      return fail(
+        'sending_unavailable',
+        'Sending is temporarily unavailable on our side. Your wallet is fine — please try again shortly.'
+      );
+    }
     return fail(
       'wallet_unreadable',
       'We could not read your wallet connection. Reconnect it and try again.'

--- a/src/hooks/useCurrencyConversion.ts
+++ b/src/hooks/useCurrencyConversion.ts
@@ -1,111 +1,62 @@
 /**
- * useCurrencyConversion Hook
+ * Synchronous currency conversion for components.
  *
- * React hook wrapper for the centralized currency converter service.
- * Provides synchronous conversion using cached rates.
+ * Reads the shared rate cache (SSOT: /src/services/currency). Rates normally
+ * arrive with the page — CurrencyRatesProvider seeds the cache from the server
+ * before anything renders — so `isLoading` is false on the very first paint and
+ * amounts are shown in the visitor's own currency straight away. The fetch-on-
+ * mount path below is the fallback for trees rendered without that provider
+ * (tests, isolated stories).
  *
- * Single source of truth: /src/services/currency
- *
- * Created: 2025-06-05
+ * An unknown rate returns 0, which display code reads as "keep showing BTC".
+ * It never guesses: a plausible wrong rate is the one bug nobody notices.
  */
 
 import { useState, useEffect } from 'react';
-import { currencyConverter } from '@/services/currency';
-import { type CurrencyCode } from '@/config/currencies';
+import { currencyConverter, getRate } from '@/services/currency/rates';
+import { useRatesReady } from '@/components/providers/CurrencyRatesProvider';
 
 export function useCurrencyConversion() {
-  const [isLoading, setIsLoading] = useState(true);
+  const ratesReady = useRatesReady();
+  const [fetched, setFetched] = useState(false);
 
   useEffect(() => {
-    // Pre-fetch rates on mount
+    if (ratesReady) {
+      return;
+    }
+    let cancelled = false;
     currencyConverter
       .getRates()
-      .then(() => {
-        setIsLoading(false);
-      })
-      .catch(() => {
-        setIsLoading(false);
+      .catch(() => undefined)
+      .finally(() => {
+        if (!cancelled) {
+          setFetched(true);
+        }
       });
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [ratesReady]);
 
-  /**
-   * Convert to BTC (uses cached rates, returns immediately)
-   */
   const convertToBTC = (amount: number, fromCurrency: string): number => {
-    if (amount === 0 || !fromCurrency) {
+    if (!amount || !fromCurrency) {
       return 0;
     }
-
-    const currency = fromCurrency.toUpperCase() as CurrencyCode;
-
-    // For BTC, no API call needed
-    if (currency === 'BTC') {
-      return amount;
-    }
-
-    // Use last cached rates (synchronous)
-    // This is safe because we pre-fetch in useEffect
-    // For real-time accuracy, the service auto-refreshes every minute
-    try {
-      // Get cached rates synchronously
-      const rates = currencyConverter.getCachedRates();
-      if (!rates) {
-        return 0;
-      }
-
-      switch (currency) {
-        case 'CHF':
-          return amount / rates.btcToChf;
-        case 'USD':
-          return amount / rates.btcToUsd;
-        case 'EUR':
-          return amount / rates.btcToEur;
-        default:
-          return 0;
-      }
-    } catch {
-      return 0;
-    }
+    const rate = getRate(fromCurrency.toUpperCase());
+    return rate ? amount / rate : 0;
   };
 
-  /**
-   * Convert from BTC (uses cached rates, returns immediately)
-   */
   const convertFromBTC = (amountBTC: number, toCurrency: string): number => {
-    if (amountBTC === 0 || !toCurrency) {
+    if (!amountBTC || !toCurrency) {
       return 0;
     }
-
-    const currency = toCurrency.toUpperCase() as CurrencyCode;
-
-    if (currency === 'BTC') {
-      return amountBTC;
-    }
-
-    try {
-      const rates = currencyConverter.getCachedRates();
-      if (!rates) {
-        return 0;
-      }
-
-      switch (currency) {
-        case 'CHF':
-          return amountBTC * rates.btcToChf;
-        case 'USD':
-          return amountBTC * rates.btcToUsd;
-        case 'EUR':
-          return amountBTC * rates.btcToEur;
-        default:
-          return 0;
-      }
-    } catch {
-      return 0;
-    }
+    const rate = getRate(toCurrency.toUpperCase());
+    return rate ? amountBTC * rate : 0;
   };
 
   return {
     convertToBTC,
     convertFromBTC,
-    isLoading,
+    isLoading: !ratesReady && !fetched,
   };
 }

--- a/src/lib/projectGoal.ts
+++ b/src/lib/projectGoal.ts
@@ -1,32 +1,24 @@
 'use server';
 
-import { currencyConverter } from '@/services/currency';
+import { convertBtcToOrNull } from '@/services/currency/rates.server';
 
 /**
- * Compute amount raised in goal currency from BTC balance.
- * Falls back to 0 for unknown currencies.
+ * A project's settled BTC total expressed in the currency its goal is written in.
+ *
+ * Returns null when there is no usable Bitcoin rate. That is not the same as
+ * zero: "CHF 0 raised" tells a visitor the fundraiser has nothing, which is a
+ * false claim about someone's project. Callers should fall back to showing the
+ * Bitcoin figure instead.
  */
 export async function computeAmountRaised(
   bitcoin_balance_btc: number,
   goal_currency: string
-): Promise<number> {
+): Promise<number | null> {
   if (!bitcoin_balance_btc || bitcoin_balance_btc === 0) {
     return 0;
   }
   if (goal_currency === 'BTC') {
     return bitcoin_balance_btc;
   }
-
-  const rates = await currencyConverter.getRates();
-
-  const rate =
-    goal_currency === 'CHF'
-      ? rates.btcToChf
-      : goal_currency === 'USD'
-        ? rates.btcToUsd
-        : goal_currency === 'EUR'
-          ? rates.btcToEur
-          : 0;
-
-  return bitcoin_balance_btc * rate;
+  return convertBtcToOrNull(bitcoin_balance_btc, goal_currency);
 }

--- a/src/lib/validation/finance.ts
+++ b/src/lib/validation/finance.ts
@@ -11,6 +11,7 @@ import {
   ALLOWED_CATEGORY_ICONS,
 } from '@/types/wallet';
 import { WALLET_VISIBILITY_LEVELS } from '@/config/wallet-visibility';
+import { TIP_MAX_BTC, TIP_MIN_BTC } from '@/config/tips';
 import { lightningAddressSchema, optionalText } from './base';
 
 /**
@@ -354,10 +355,12 @@ export const publicSupportCreateSchema = z.object({
     errorMap: () => ({ message: 'Invalid entity type' }),
   }),
   entity_id: z.string().uuid('entity_id must be a valid UUID'),
+  // Same bounds the payer's amount field enforces — one place, so a change to
+  // the range can never leave the form offering what the server rejects.
   amount_btc: z
     .number()
-    .min(0.000001, 'Minimum support amount is 0.000001 BTC')
-    .max(1, 'Maximum support amount is 1 BTC'),
+    .min(TIP_MIN_BTC, `Minimum support amount is ${TIP_MIN_BTC} BTC`)
+    .max(TIP_MAX_BTC, `Maximum support amount is ${TIP_MAX_BTC} BTC`),
 });
 
 export const publicPaymentActionSchema = z.object({

--- a/src/services/ai/document-context.ts
+++ b/src/services/ai/document-context.ts
@@ -28,7 +28,7 @@ import type {
   RuntimeContext,
 } from './document-context-types';
 import { isSupportedCurrency, PLATFORM_DEFAULT_CURRENCY } from '@/config/currencies';
-import { currencyConverter } from '@/services/currency/rates';
+import { convertBtcToOrNull } from '@/services/currency/rates.server';
 
 import { fetchEntitiesForCat } from './entity-context-fetcher';
 import { getEconomicProfile } from '@/services/cat/economic-profile';
@@ -358,15 +358,18 @@ async function fetchRuntimeContextForCat(
   // is instructed (in the system prompt) not to invent one.
   let btcRate: RuntimeContext['btcRate'] = null;
   try {
-    const rates = await currencyConverter.getRates();
-    const byCur: Record<string, number> = {
-      CHF: rates.btcToChf,
-      USD: rates.btcToUsd,
-      EUR: rates.btcToEur,
-    };
+    // Ask for the currency the user actually thinks in, and fall back to the
+    // platform default only if that one is unknown. Omitting the line entirely
+    // is the correct outcome when we have no rate — Cat is told not to invent
+    // one, and a made-up rate quoted with confidence is worse than silence.
     const fiat = preferredCurrency === 'BTC' ? 'CHF' : preferredCurrency.toUpperCase();
-    const rate = byCur[fiat];
-    btcRate = rate ? { currency: fiat, rate } : { currency: 'CHF', rate: rates.btcToChf };
+    const rate = await convertBtcToOrNull(1, fiat);
+    if (rate !== null && rate > 0) {
+      btcRate = { currency: fiat, rate };
+    } else {
+      const chf = await convertBtcToOrNull(1, 'CHF');
+      btcRate = chf !== null && chf > 0 ? { currency: 'CHF', rate: chf } : null;
+    }
   } catch (error) {
     logger.warn('Could not fetch BTC rate for cat runtime', { error }, 'DocumentContext');
   }

--- a/src/services/bookings/index.ts
+++ b/src/services/bookings/index.ts
@@ -13,7 +13,7 @@ import { logger } from '@/utils/logger';
 import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { ROUTES } from '@/config/routes';
 import { NotificationDispatcher } from '@/services/notifications/dispatcher';
-import { convertToBTC } from '@/services/currency/rates';
+import { convertToBtcOrNull } from '@/services/currency/rates.server';
 import type { CurrencyCode } from '@/config/currencies';
 
 // Types
@@ -145,10 +145,20 @@ class BookingService {
     // paymentFlowService so the booking record stores real BTC.
     const priceCol = input.bookable_type === 'service' ? 'fixed_price' : 'rental_price_btc';
     const rawPrice = Number(row[priceCol] ?? 0);
-    const priceBtc =
-      input.bookable_type === 'service' && rawPrice > 0
-        ? await convertToBTC(rawPrice, String(row.currency || 'BTC').toUpperCase() as CurrencyCode)
-        : rawPrice;
+    let priceBtc = rawPrice;
+    if (input.bookable_type === 'service' && rawPrice > 0) {
+      // A booking records what the customer owes. Without a real rate we cannot
+      // say what a fiat price is in Bitcoin, and writing a guess (or a zero)
+      // into the record is worse than making them try again in a moment.
+      const converted = await convertToBtcOrNull(
+        rawPrice,
+        String(row.currency || 'BTC').toUpperCase() as CurrencyCode
+      );
+      if (converted === null || !(converted > 0)) {
+        throw new Error('Bitcoin exchange rate unavailable; could not price this booking');
+      }
+      priceBtc = converted;
+    }
     const durationMinutes =
       input.bookable_type === 'service' ? ((row.duration_minutes as number | null) ?? null) : null;
 

--- a/src/services/cat/credit-metering.ts
+++ b/src/services/cat/credit-metering.ts
@@ -18,7 +18,7 @@
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { calculateCostBtc, getModelMetadata, isModelFree } from '@/config/ai-models';
 import { appendCreditEntry, getCreditBalance } from '@/services/cat/credits';
-import { convertFromBTC } from '@/services/currency/rates';
+import { convertBtcToOrNull } from '@/services/currency/rates.server';
 import { logger } from '@/utils/logger';
 
 /**
@@ -108,44 +108,48 @@ export async function meterCreditUsage(
 
   const hasProviderCost = Number.isFinite(rawCostBtc) && (rawCostBtc ?? 0) > 0;
 
-  let btcPriceUsd = 100000;
-  let liveRate = false;
-  try {
-    const usdPerBtc = await convertFromBTC(1, 'USD');
-    if (Number.isFinite(usdPerBtc) && usdPerBtc > 0) {
-      btcPriceUsd = usdPerBtc;
-      liveRate = true;
+  // Only the registry-ESTIMATE path needs a rate: the price table is in USD, so
+  // turning it into a BTC charge requires knowing what Bitcoin costs. A
+  // provider-reported cost is already BTC and needs nothing.
+  let btcPriceUsd: number | null = null;
+  if (!hasProviderCost) {
+    try {
+      const usdPerBtc = await convertBtcToOrNull(1, 'USD');
+      if (usdPerBtc !== null && Number.isFinite(usdPerBtc) && usdPerBtc > 0) {
+        btcPriceUsd = usdPerBtc;
+      }
+    } catch {
+      /* handled by the null check below */
     }
-  } catch {
-    /* fall through to the conservative default + the warning below */
+
+    if (btcPriceUsd === null) {
+      // No rate, no bill. This used to fall back to a hardcoded 100,000 USD/BTC,
+      // which debited a real ledger against a made-up number — taking the wrong
+      // amount of someone's money is worse than taking none and reconciling.
+      logger.error(
+        'Cat frontier usage NOT billed — no BTC/USD rate to price a registry estimate',
+        { userId, model, ref, inputTokens, outputTokens },
+        'CatCredits'
+      );
+      return 0;
+    }
   }
 
   const meteredRawCostBtc = hasProviderCost
     ? (rawCostBtc as number)
-    : calculateCostBtc(model, inputTokens, outputTokens, btcPriceUsd);
+    : calculateCostBtc(model, inputTokens, outputTokens, btcPriceUsd as number);
   if (meteredRawCostBtc <= 0) {
     return 0;
   }
 
   // Provider-reported cost is ground truth → charge margin only. A registry
-  // estimate is less reliable (hand-maintained prices lag), and doubly so if
-  // the live BTC/USD rate was unavailable — pad it and record the source so a
-  // low-confidence bill is auditable rather than a silent under-charge.
+  // estimate is less reliable (hand-maintained prices lag), so pad it and record
+  // the source, keeping a low-confidence bill auditable rather than a silent
+  // under-charge. Either way the rate behind it is real — see above.
   const effectiveMarkup = hasProviderCost
     ? CREDIT_USAGE_MARKUP
     : CREDIT_USAGE_MARKUP * ESTIMATE_SAFETY_MULTIPLIER;
-  const pricingSource = hasProviderCost
-    ? 'provider_reported'
-    : liveRate
-      ? 'registry_estimate'
-      : 'registry_estimate_norate';
-  if (!hasProviderCost && !liveRate) {
-    logger.warn(
-      'Cat credit debit priced from a registry estimate with no live BTC rate — used the conservative fallback',
-      { userId, model, ref, btcPriceUsd },
-      'CatCredits'
-    );
-  }
+  const pricingSource = hasProviderCost ? 'provider_reported' : 'registry_estimate';
 
   const chargeBtc = ceilBtc(meteredRawCostBtc * effectiveMarkup);
 

--- a/src/services/currency/conversion.ts
+++ b/src/services/currency/conversion.ts
@@ -3,11 +3,17 @@
  *
  * Synchronous conversion between BTC, sats, and fiat currencies.
  *
- * These read the in-memory `cache.rates`, which is seeded with sane defaults for
- * every supported fiat (USD/EUR/CHF/GBP) and refreshed from the API. A missing
- * rate therefore means an *unsupported* currency code — we must NOT fabricate a
- * value. Fabricating is a money-correctness bug: `amount / 1` would render e.g.
- * "100 CHF" as "100 BTC". For an unknown rate we fail safe to 0 and warn.
+ * These read the in-memory `cache.rates`, which starts EMPTY and is filled only
+ * from a real, recent quote (see rateSource.server.ts). A missing rate therefore
+ * means "we do not know what Bitcoin is worth right now" — an ordinary, expected
+ * state, not an unsupported currency. Either way we must NOT fabricate a value:
+ * `amount / 1` would render "100 CHF" as "100 BTC", and a *plausible* wrong rate
+ * is worse still because nothing on screen looks amiss. Unknown fails safe to 0
+ * and warns; display code reads 0 as "keep showing BTC".
+ *
+ * These are the DISPLAY conversions. Anything that prices money server-side must
+ * use rates.server.ts, whose helpers return `number | null` so a zero can never
+ * be mistaken for an amount.
  */
 
 import { logger } from '@/utils/logger';

--- a/src/services/currency/rateSource.server.ts
+++ b/src/services/currency/rateSource.server.ts
@@ -1,0 +1,174 @@
+/**
+ * The one place that asks the outside world what Bitcoin costs.
+ *
+ * Everything else in the app reads the snapshot this module holds. That matters
+ * because a BTC/fiat rate is not decoration — it decides how much Bitcoin
+ * actually leaves a payer's wallet for a price written in francs. A rate that is
+ * merely *plausible* is the most dangerous kind: it passes every "is this a
+ * number" check and silently mis-prices real money.
+ *
+ * So the contract here is deliberately blunt:
+ *
+ *   A rate is either real and recent, or it does not exist.
+ *
+ * There are no seeded defaults and no fallback constants. When we cannot reach
+ * the upstream, callers get `null` and must degrade honestly (show Bitcoin,
+ * refuse to price an invoice) rather than transact against a guess. The previous
+ * design fell back to 86,000 CHF/BTC; the real rate was 52,199, so every
+ * fiat-priced sale would have minted an invoice worth ~39% less than the seller
+ * asked for, with nothing on screen to say so.
+ *
+ * Freshness has two thresholds, because "slightly old" and "no idea" are
+ * different states:
+ *   - under FRESH_MS      → serve as-is, no upstream call
+ *   - under MAX_AGE_MS    → serve, and refresh in the background
+ *   - beyond MAX_AGE_MS   → treat as absent
+ *
+ * Server-side only. Browsers read /api/rates instead, which keeps the rate on
+ * one origin (no third-party connect-src) and collapses one upstream call per
+ * visitor into one per minute for the whole platform.
+ */
+
+import { logger } from '@/utils/logger';
+
+/** BTC price per fiat unit code, e.g. `{ CHF: 52199 }`. */
+export interface RateSnapshot {
+  rates: Readonly<Record<string, number>>;
+  fetchedAt: number;
+}
+
+/** Fiat we ask upstream for. Must stay a subset of CURRENCY_CODES. */
+const UPSTREAM_CURRENCIES = ['chf', 'usd', 'eur', 'gbp'] as const;
+
+const SOURCE_URL =
+  'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=' +
+  UPSTREAM_CURRENCIES.join(',');
+
+/** Serve without touching the network. */
+const FRESH_MS = 60_000;
+/** Older than this and we would rather say "unknown" than quote it. */
+const MAX_AGE_MS = 15 * 60_000;
+/**
+ * Upstream is occasionally very slow — a cold call measured ~14s in the wild.
+ * Nothing may block on it that long, and nothing needs to: a timed-out refresh
+ * just leaves the previous snapshot in place.
+ */
+const TIMEOUT_MS = 8_000;
+
+let snapshot: RateSnapshot | null = null;
+let inFlight: Promise<RateSnapshot | null> | null = null;
+
+function ageOf(s: RateSnapshot): number {
+  return Date.now() - s.fetchedAt;
+}
+
+/**
+ * A rate we would be willing to price money with.
+ *
+ * Guards against upstream handing back nonsense as much as against network
+ * failure — a zero, a negative, a NaN or an absurd magnitude means we did not
+ * understand the response, and misunderstanding it is exactly how a wrong
+ * number gets treated as authoritative.
+ */
+function isSaneRate(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 && value < 100_000_000;
+}
+
+async function fetchUpstream(): Promise<RateSnapshot | null> {
+  try {
+    const response = await fetch(SOURCE_URL, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      // We do our own caching with an explicit freshness policy; letting the
+      // fetch layer cache too would make "how old is this rate" unanswerable.
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      throw new Error(`upstream responded ${response.status}`);
+    }
+
+    const body = (await response.json()) as { bitcoin?: Record<string, unknown> };
+    const quoted = body.bitcoin ?? {};
+
+    const rates: Record<string, number> = {};
+    for (const code of UPSTREAM_CURRENCIES) {
+      const value = quoted[code];
+      if (isSaneRate(value)) {
+        rates[code.toUpperCase()] = value;
+      }
+    }
+
+    // A response we cannot read any rate out of is a failure, not an empty
+    // success — otherwise it would overwrite a good snapshot with nothing.
+    if (Object.keys(rates).length === 0) {
+      throw new Error('upstream returned no usable rates');
+    }
+
+    snapshot = { rates, fetchedAt: Date.now() };
+    return snapshot;
+  } catch (error) {
+    logger.warn(
+      'Bitcoin rate lookup failed; amounts stay in BTC until it recovers',
+      { error: String(error) },
+      'Currency'
+    );
+    return null;
+  }
+}
+
+function refresh(): Promise<RateSnapshot | null> {
+  // Collapse concurrent callers onto one upstream request.
+  if (!inFlight) {
+    inFlight = fetchUpstream().finally(() => {
+      inFlight = null;
+    });
+  }
+  return inFlight;
+}
+
+/**
+ * The current rates without ever touching the network.
+ *
+ * This is what server rendering uses: a page must not wait on a third party to
+ * paint. A stale-but-usable snapshot is returned immediately and refreshed in
+ * the background, so the next render is current.
+ */
+export function getCachedRateSnapshot(): RateSnapshot | null {
+  if (!snapshot) {
+    return null;
+  }
+  const age = ageOf(snapshot);
+  if (age > MAX_AGE_MS) {
+    void refresh();
+    return null;
+  }
+  if (age > FRESH_MS) {
+    void refresh();
+  }
+  return snapshot;
+}
+
+/**
+ * The current rates, fetching if we have nothing usable.
+ *
+ * For callers that can afford to wait and must not guess — chiefly pricing an
+ * invoice, where the honest alternative to waiting is refusing the payment.
+ */
+export async function getRateSnapshot(): Promise<RateSnapshot | null> {
+  const cached = getCachedRateSnapshot();
+  if (cached && ageOf(cached) <= FRESH_MS) {
+    return cached;
+  }
+  return (await refresh()) ?? cached;
+}
+
+/** Test seam. Not exported through the barrel. */
+export function __setSnapshotForTests(next: RateSnapshot | null): void {
+  snapshot = next;
+  inFlight = null;
+}
+
+// Warm on first import so the first visitor after a restart is not the one who
+// pays the cold-start latency. Fire-and-forget by design: nothing waits on it.
+void refresh();

--- a/src/services/currency/rates.server.ts
+++ b/src/services/currency/rates.server.ts
@@ -1,0 +1,75 @@
+/**
+ * Rates for server-side callers — rendering, and above all pricing.
+ *
+ * Split from rates.ts because this reaches the upstream directly and must never
+ * be bundled for a browser. Everything here answers with `null` rather than a
+ * number it cannot stand behind; the conversions deliberately return
+ * `number | null` instead of the usual 0-means-unknown convention, because on
+ * this side of the app the caller is often minting an invoice, and a zero that
+ * looks like an amount is precisely the bug being designed out.
+ */
+
+import type { CurrencyCode } from '@/config/currencies';
+import { getCachedRateSnapshot, getRateSnapshot } from './rateSource.server';
+import { applyRateSnapshot, getRate } from './rates';
+
+const SATS_PER_BTC = 100_000_000;
+
+/**
+ * Rates without touching the network — for server rendering, which must not
+ * wait on a third party to paint a page.
+ */
+export function getRenderRates(): {
+  rates: Readonly<Record<string, number>>;
+  fetchedAt: number;
+} | null {
+  const snapshot = getCachedRateSnapshot();
+  applyRateSnapshot(snapshot);
+  return snapshot;
+}
+
+/** Rates, fetching if needed. For callers that must not guess. */
+export async function loadServerRates(): Promise<boolean> {
+  const snapshot = await getRateSnapshot();
+  applyRateSnapshot(snapshot);
+  return !!snapshot;
+}
+
+/**
+ * Fiat → BTC, or null when we have no rate.
+ *
+ * Null is not an edge case to paper over: it means we cannot say what this price
+ * is worth in Bitcoin, so no invoice should be minted for it.
+ */
+export async function convertToBtcOrNull(
+  amount: number,
+  fromCurrency: CurrencyCode | string
+): Promise<number | null> {
+  const code = String(fromCurrency).toUpperCase();
+  if (code === 'BTC') {
+    return amount;
+  }
+  if (code === 'SATS') {
+    return amount / SATS_PER_BTC;
+  }
+  await loadServerRates();
+  const rate = getRate(code);
+  return rate ? amount / rate : null;
+}
+
+/** BTC → fiat, or null when we have no rate. */
+export async function convertBtcToOrNull(
+  amountBtc: number,
+  toCurrency: CurrencyCode | string
+): Promise<number | null> {
+  const code = String(toCurrency).toUpperCase();
+  if (code === 'BTC') {
+    return amountBtc;
+  }
+  if (code === 'SATS') {
+    return Math.round(amountBtc * SATS_PER_BTC);
+  }
+  await loadServerRates();
+  const rate = getRate(code);
+  return rate ? amountBtc * rate : null;
+}

--- a/src/services/currency/rates.ts
+++ b/src/services/currency/rates.ts
@@ -1,150 +1,204 @@
 /**
- * Currency Rate Management
+ * The rate cache every conversion reads from.
  *
- * Handles rate caching, fetching from CoinGecko, and rate lookups.
+ * It starts EMPTY, and that is the whole point. It used to be seeded with
+ * BTC_CHF: 86000 / BTC_USD: 97000 / BTC_EUR: 91000 "defaults", which meant the
+ * `if (!rate) cannot convert` guard downstream was unreachable for the very
+ * currencies people actually use — there was always a number, just not a true
+ * one. When those seeds were last plausible is anyone's guess; at the time this
+ * was rewritten the real CHF rate was 52,199, so a price of CHF 100 converted to
+ * an invoice worth about CHF 61 and nothing anywhere said so.
+ *
+ * Empty means "we don't know", and "we don't know" is a state the UI and the
+ * payment path both know how to handle honestly. See rateSource.server.ts for where
+ * real rates come from.
+ *
+ * This module is isomorphic. It never imports rateSource (that is server-only,
+ * and pulling it into a client bundle would ship an outbound third-party fetch
+ * to every browser). Instead:
+ *   - the browser fills the cache from our own /api/rates
+ *   - the server fills it via rates.server.ts
  */
 
+import { API_ROUTES } from '@/config/api-routes';
 import type { CurrencyCode } from '@/config/currencies';
 import { logger } from '@/utils/logger';
 import type { ExchangeRates, RateCache } from './types';
 
 // ==================== RATE CACHE ====================
 
+/**
+ * Known BTC prices, keyed `BTC_<CODE>`. Absent key = unknown rate, never zero
+ * and never a placeholder.
+ */
 export const cache: RateCache = {
-  rates: {
-    // Default rates (will be updated from API)
-    BTC_USD: 97000,
-    BTC_EUR: 91000,
-    BTC_CHF: 86000,
-    BTC_GBP: 78000,
-  },
+  rates: {},
   lastUpdated: null,
   expiresAt: null,
 };
 
-// ==================== RATE MANAGEMENT ====================
+const SATS_PER_BTC = 100_000_000;
 
-function updateRates(rates: Record<string, number>): void {
-  Object.assign(cache.rates, rates);
-  cache.lastUpdated = new Date();
-  cache.expiresAt = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes
+/** How long a snapshot stays usable before we treat it as unknown again. */
+const MAX_AGE_MS = 15 * 60_000;
+
+export interface RateSnapshotLike {
+  rates: Readonly<Record<string, number>>;
+  fetchedAt: number;
 }
 
-// ==================== COINGECKO CONVERTER SERVICE ====================
+/**
+ * Adopt a rate snapshot from whichever side fetched it.
+ *
+ * Exported so server rendering can hand the browser the rates it already had,
+ * letting the first paint be denominated in the payer's own currency instead of
+ * flashing BTC until a client fetch lands.
+ */
+export function applyRateSnapshot(snapshot: RateSnapshotLike | null): void {
+  if (!snapshot || Date.now() - snapshot.fetchedAt > MAX_AGE_MS) {
+    return;
+  }
+  for (const [code, value] of Object.entries(snapshot.rates)) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      cache.rates[`BTC_${code.toUpperCase()}`] = value;
+    }
+  }
+  cache.lastUpdated = new Date(snapshot.fetchedAt);
+  cache.expiresAt = new Date(snapshot.fetchedAt + MAX_AGE_MS);
+}
+
+/** The BTC price in `currency`, or null when we genuinely do not know it. */
+export function getRate(currency: string): number | null {
+  const code = currency.toUpperCase();
+  if (code === 'BTC') {
+    return 1;
+  }
+  if (cache.expiresAt && cache.expiresAt.getTime() < Date.now()) {
+    return null;
+  }
+  return cache.rates[`BTC_${code}`] ?? null;
+}
+
+/** Have we got a usable rate for anything? */
+export function hasUsableRates(): boolean {
+  return (
+    Object.keys(cache.rates).length > 0 &&
+    !!cache.expiresAt &&
+    cache.expiresAt.getTime() >= Date.now()
+  );
+}
+
+function toExchangeRates(): ExchangeRates | null {
+  const chf = getRate('CHF');
+  const usd = getRate('USD');
+  const eur = getRate('EUR');
+  const gbp = getRate('GBP');
+  if (!chf && !usd && !eur && !gbp) {
+    return null;
+  }
+  return {
+    btcToChf: chf ?? 0,
+    btcToUsd: usd ?? 0,
+    btcToEur: eur ?? 0,
+    btcToGbp: gbp ?? 0,
+    lastUpdated: cache.lastUpdated?.getTime() ?? 0,
+  };
+}
+
+// ==================== CONVERTER ====================
+
+const isBrowser = typeof window !== 'undefined';
 
 class CurrencyConverterService {
-  private apiRates: ExchangeRates | null = null;
-  private cacheDuration = 60 * 1000; // 1 minute cache
-  private fetchPromise: Promise<ExchangeRates> | null = null;
+  private fetchPromise: Promise<ExchangeRates | null> | null = null;
 
-  private async fetchRatesFromApi(): Promise<ExchangeRates> {
+  /**
+   * Load rates from our own origin.
+   *
+   * Browser-only: on the server the cache is filled by rates.server.ts, which
+   * talks to the upstream directly. A server calling its own HTTP endpoint would
+   * be a needless round trip and, behind a single-process reverse proxy, a good
+   * way to deadlock under load.
+   */
+  private async fetchRates(): Promise<ExchangeRates | null> {
+    if (!isBrowser) {
+      return toExchangeRates();
+    }
     if (this.fetchPromise) {
       return this.fetchPromise;
     }
 
     this.fetchPromise = (async () => {
       try {
-        const response = await fetch(
-          'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=chf,usd,eur',
-          { headers: { Accept: 'application/json' } }
-        );
-
-        if (!response.ok) {
-          throw new Error(`CoinGecko API error: ${response.status}`);
-        }
-
-        const data = await response.json();
-        const bitcoin = data.bitcoin;
-
-        const rates: ExchangeRates = {
-          btcToChf: bitcoin.chf || 86000,
-          btcToUsd: bitcoin.usd || 97000,
-          btcToEur: bitcoin.eur || 91000,
-          lastUpdated: Date.now(),
-        };
-
-        this.apiRates = rates;
-        updateRates({
-          BTC_USD: rates.btcToUsd,
-          BTC_EUR: rates.btcToEur,
-          BTC_CHF: rates.btcToChf,
+        const response = await fetch(API_ROUTES.RATES, {
+          headers: { Accept: 'application/json' },
         });
-        return rates;
+        if (!response.ok) {
+          throw new Error(`rates endpoint responded ${response.status}`);
+        }
+        const body = (await response.json()) as { data?: RateSnapshotLike };
+        applyRateSnapshot(body.data ?? null);
+        return toExchangeRates();
       } catch (error) {
-        logger.warn('Failed to fetch BTC prices, using fallback rates', error, 'Currency');
-
-        const fallbackRates: ExchangeRates = {
-          btcToChf: 86000,
-          btcToUsd: 97000,
-          btcToEur: 91000,
-          lastUpdated: Date.now(),
-        };
-
-        this.apiRates = fallbackRates;
-        return fallbackRates;
+        logger.warn(
+          'Could not load Bitcoin rates; amounts stay in BTC',
+          { error: String(error) },
+          'Currency'
+        );
+        return null;
       } finally {
-        setTimeout(() => {
-          this.fetchPromise = null;
-        }, 1000);
+        this.fetchPromise = null;
       }
     })();
 
     return this.fetchPromise;
   }
 
-  async getRates(): Promise<ExchangeRates> {
-    if (this.apiRates && Date.now() - this.apiRates.lastUpdated < this.cacheDuration) {
-      return this.apiRates;
+  /** Current rates, loading them if the cache has nothing usable. */
+  async getRates(): Promise<ExchangeRates | null> {
+    if (hasUsableRates()) {
+      return toExchangeRates();
     }
-    return this.fetchRatesFromApi();
+    return this.fetchRates();
   }
 
+  /** Cached rates only — null when unknown. Never blocks, never guesses. */
   getCachedRates(): ExchangeRates | null {
-    return this.apiRates;
+    return hasUsableRates() ? toExchangeRates() : null;
   }
 
+  /** Fiat → BTC. Returns 0 when the rate is unknown; callers must not treat that as free. */
   async toBTC(amount: number, fromCurrency: CurrencyCode): Promise<number> {
     if (amount === 0) {
       return 0;
     }
-    const rates = await this.getRates();
-
-    switch (fromCurrency.toUpperCase()) {
-      case 'BTC':
-        return amount;
-      case 'SATS':
-        return amount / 100_000_000;
-      case 'CHF':
-        return amount / rates.btcToChf;
-      case 'USD':
-        return amount / rates.btcToUsd;
-      case 'EUR':
-        return amount / rates.btcToEur;
-      default:
-        return 0;
+    const code = String(fromCurrency).toUpperCase();
+    if (code === 'BTC') {
+      return amount;
     }
+    if (code === 'SATS') {
+      return amount / SATS_PER_BTC;
+    }
+    await this.getRates();
+    const rate = getRate(code);
+    return rate ? amount / rate : 0;
   }
 
+  /** BTC → fiat. Returns 0 when the rate is unknown. */
   async fromBTC(amountBTC: number, toCurrency: CurrencyCode): Promise<number> {
     if (amountBTC === 0) {
       return 0;
     }
-    const rates = await this.getRates();
-
-    switch (toCurrency.toUpperCase()) {
-      case 'BTC':
-        return amountBTC;
-      case 'SATS':
-        return Math.round(amountBTC * 100_000_000);
-      case 'CHF':
-        return amountBTC * rates.btcToChf;
-      case 'USD':
-        return amountBTC * rates.btcToUsd;
-      case 'EUR':
-        return amountBTC * rates.btcToEur;
-      default:
-        return 0;
+    const code = String(toCurrency).toUpperCase();
+    if (code === 'BTC') {
+      return amountBTC;
     }
+    if (code === 'SATS') {
+      return Math.round(amountBTC * SATS_PER_BTC);
+    }
+    await this.getRates();
+    const rate = getRate(code);
+    return rate ? amountBTC * rate : 0;
   }
 
   async convert(
@@ -163,10 +217,6 @@ class CurrencyConverterService {
     if (amountBTC === 0) {
       return '0 BTC';
     }
-    if (amountBTC < 0.00001) {
-      const sats = Math.round(amountBTC * 100_000_000);
-      return `${sats.toLocaleString()} sat`;
-    }
     if (showDecimals) {
       return `${amountBTC.toLocaleString(undefined, { maximumFractionDigits: 8 })} BTC`;
     }
@@ -174,12 +224,13 @@ class CurrencyConverterService {
   }
 
   clearCache(): void {
-    this.apiRates = null;
+    cache.rates = {};
+    cache.lastUpdated = null;
+    cache.expiresAt = null;
     this.fetchPromise = null;
   }
 }
 
-// Singleton instance
 export const currencyConverter = new CurrencyConverterService();
 
 // Convenience async functions

--- a/src/services/currency/types.ts
+++ b/src/services/currency/types.ts
@@ -6,6 +6,8 @@ export interface ExchangeRates {
   btcToChf: number;
   btcToUsd: number;
   btcToEur: number;
+  /** GBP is a supported display currency; omitting it here silently converted to 0. */
+  btcToGbp: number;
   lastUpdated: number;
 }
 

--- a/src/services/send/send-client.ts
+++ b/src/services/send/send-client.ts
@@ -40,6 +40,8 @@ export interface SendCapability {
   canSend: boolean;
   /** Present when `canSend` is false — already payer-readable, shown as-is. */
   message?: string;
+  /** Why, so the screen can tell "you need a wallet" from "we're broken". */
+  reason?: string;
 }
 
 /**

--- a/src/services/wallets/project-funding.ts
+++ b/src/services/wallets/project-funding.ts
@@ -14,7 +14,8 @@
  */
 
 import type { AnySupabaseClient } from '@/lib/supabase/types';
-import { currencyConverter, convertBtcTo } from '@/services/currency';
+import { convertBtcTo } from '@/services/currency';
+import { loadServerRates } from '@/services/currency/rates.server';
 import { logger } from '@/utils/logger';
 import { getEntitiesFundingStats } from './funding-stats';
 
@@ -56,7 +57,7 @@ export async function enrichProjectsWithSettledFunding<
   // number); BTC-denominated projects are unaffected.
   if (stats.size > 0) {
     try {
-      await currencyConverter.getRates();
+      await loadServerRates();
     } catch (error) {
       logger.warn('Rates unavailable for funding enrichment', { error }, 'Wallets');
     }


### PR DESCRIPTION
The rate cache shipped with seeded "defaults" — 86,000 CHF/BTC, 97,000 USD, 91,000 EUR. The real CHF rate is 52,199.

That is not a stale display. `resolveAmount()` converts a seller's fiat asking price into the Bitcoin a buyer actually parts with, so every fiat-priced sale would have minted an invoice worth ~39% less than the price on screen — silently, every time, with nothing anywhere saying so. The seeds also made the `if (!rate) cannot convert` guard downstream unreachable for exactly the currencies people use.

A *plausible* wrong rate is the dangerous kind: it passes every "is this a number" check.

## The rule

**A rate is either real and recent, or it does not exist.** No seeded defaults, no fallback constants.

- `rateSource.server.ts` — the one place that asks upstream. Two freshness thresholds (serve / serve-and-refresh / treat as absent), sanity bounds on what upstream returns, and a failed fetch never overwrites a good snapshot.
- `/api/rates` — serves it from our own origin. One upstream call per minute for the whole platform instead of one per visitor, and `connect-src` stays `'self'`.
- `rates.ts` — starts empty. Unknown means unknown.
- `rates.server.ts` — answers `number | null` for anything that prices money, so a zero can never be mistaken for an amount.

## What now refuses instead of guessing

| Surface | Before | After |
|---|---|---|
| Fiat-priced checkout | invoiced ~39% short | refuses, payer-readable reason |
| Service booking | wrote a wrong BTC figure | refuses |
| Cat credits (registry estimate) | debited against a made-up 100,000 USD/BTC | bills nothing, logs for reconciliation |
| Create-flow goal breakdown | "Estimated rates" that were years stale | omits the breakdown |
| Project stats / summary rail | "CHF 0 raised" | null / the BTC figure |
| GBP anywhere | silently 0 | converts |

## First paint

Rates now travel with the page. `CurrencyRatesProvider` applies the server's snapshot before any child renders, so a stranger lands on **"How much in CHF · 5"** instead of "How much in BTC · 0.0001" flipping a second later. That second is the whole decision — 0.0001 BTC is a question almost nobody can answer. A snapshot too old to stand behind is ignored, so a prerendered page cannot ship a fossilised rate.

## Sending

A missing `PAYMENT_ENCRYPTION_KEY` told every payer to "reconnect your wallet" — advice that cannot work (reconnecting encrypts with the same key) and that moves our outage onto them. It now says so plainly and logs loudly.

## Guards, so this doesn't come back a fourth time

- a scan that fails on any fiat-per-BTC constant in `src/`
- a scan that fails if a `'use client'` module imports server-only code
- SSR assertions on the first paint (CHF present, BTC absent; honest BTC fallback when the server had no rates; stale snapshot ignored)
- tests that the payment path refuses to price without a rate

`npm run verify` green: 188 suites, 1823 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)