### PR TITLE
feat(cat): tell someone when a user's chat fails

### DIFF
--- a/__tests__/unit/cat/failure-alert.test.ts
+++ b/__tests__/unit/cat/failure-alert.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { alertCatChatFailure } from '@/services/cat/failure-alert';
+import { getAdminClient } from '@/lib/supabase/admin';
+
+jest.mock('@/lib/supabase/admin', () => ({ getAdminClient: jest.fn() }));
+
+/**
+ * Alerting a Cat chat failure must never make the failure worse.
+ *
+ * This runs inside the catch block of a request that has ALREADY failed. If it
+ * throws, the user's error response is replaced by a different, worse failure —
+ * so "cannot write the alert" has to degrade to silence plus a log line.
+ */
+describe('Cat failure alerting', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('never throws when the alert cannot be written', async () => {
+    (getAdminClient as jest.Mock).mockImplementation(() => {
+      throw new Error('no service key in this environment');
+    });
+    await expect(
+      alertCatChatFailure({ code: 'ALL_PROVIDERS_DOWN', provider: 'groq', model: 'x' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('never throws when the insert itself rejects', async () => {
+    const rejecting = {
+      select: () => rejecting,
+      eq: () => rejecting,
+      order: () => rejecting,
+      limit: () => rejecting,
+      maybeSingle: () => Promise.resolve({ data: null }),
+      insert: () => Promise.reject(new Error('RLS denied')),
+    };
+    (getAdminClient as jest.Mock).mockReturnValue({ from: () => rejecting });
+    await expect(alertCatChatFailure({ code: 'STREAM_ERROR' })).resolves.toBeUndefined();
+  });
+
+  it('coalesces onto an existing unread alert for the same code instead of stacking rows', async () => {
+    const update = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({}) });
+    const insert = jest.fn().mockResolvedValue({});
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      order: () => chain,
+      limit: () => chain,
+      maybeSingle: () => Promise.resolve({ data: { id: 'n1', metadata: { occurrences: 3 } } }),
+      update,
+      insert,
+    };
+    (getAdminClient as jest.Mock).mockReturnValue({ from: () => chain });
+
+    await alertCatChatFailure({ code: 'AI_RATE_LIMITED', provider: 'openrouter' });
+
+    // A capacity outage hits every user at once; one row per request would
+    // bury the very signal the alert exists to raise.
+    expect(insert).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0][0].metadata.occurrences).toBe(4);
+  });
+
+  it('inserts a first alert when none is open', async () => {
+    const insert = jest.fn().mockResolvedValue({});
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      order: () => chain,
+      limit: () => chain,
+      maybeSingle: () => Promise.resolve({ data: null }),
+      update: jest.fn(),
+      insert,
+    };
+    (getAdminClient as jest.Mock).mockReturnValue({ from: () => chain });
+
+    await alertCatChatFailure({ code: 'ALL_PROVIDERS_DOWN', provider: 'groq', model: 'llama' });
+
+    expect(insert).toHaveBeenCalledTimes(1);
+    const row = insert.mock.calls[0][0];
+    expect(row.metadata.occurrences).toBe(1);
+    expect(row.metadata.title).toBe('ALL_PROVIDERS_DOWN');
+    expect(row.is_read).toBe(false);
+    expect(row.message).toContain('got nothing back');
+  });
+
+  it('stays wired into the streaming failure path', () => {
+    // Same reasoning as failed-turn.test.ts: the streaming path cannot be
+    // unit-booted, and the regression being prevented is "the failure branch
+    // silently stops alerting".
+    const source = readFileSync(
+      join(process.cwd(), 'src/services/cat/chat-orchestrator.ts'),
+      'utf8'
+    );
+    const catchStart = source.indexOf('} catch (err) {', source.indexOf('async start(controller)'));
+    const errorEmit = source.indexOf('event: error', catchStart);
+    expect(source.slice(catchStart, errorEmit)).toContain('alertCatChatFailure');
+  });
+});

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -20,6 +20,7 @@ import { prepareCatChat } from '@/services/cat/chat-prepare';
 import { parseActionsFromResponse } from '@/services/cat/response-parser';
 import { saveMessages } from '@/services/cat/conversation-history';
 import { buildFailedTurnMessages } from '@/services/cat/failed-turn';
+import { alertCatChatFailure } from '@/services/cat/failure-alert';
 import { resolveProvider, type FallbackProvider } from '@/services/cat/provider-resolver';
 import { meterCreditUsage } from '@/services/cat/credit-metering';
 import { getAdminClient } from '@/lib/supabase/admin';
@@ -588,6 +589,16 @@ export async function orchestrateCatChat(
               logger.error('Failed to persist failed turn', { persistErr }, 'cat/chat');
             });
           }
+          // Raise it with the operator too. Persisting the turn makes the
+          // failure visible to anyone who goes looking; this makes it visible
+          // to someone who isn't looking. Detached and self-swallowing — a
+          // chat that already failed must not fail differently because the
+          // alert could not be written.
+          void alertCatChatFailure({
+            code: errPayload.code,
+            provider: activeProvider,
+            model: activeModel,
+          });
           controller.enqueue(encoder.encode(`event: error\n`));
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(errPayload)}\n\n`));
         } finally {

--- a/src/services/cat/failure-alert.ts
+++ b/src/services/cat/failure-alert.ts
@@ -1,0 +1,94 @@
+/**
+ * Tell the operator when a user's Cat turn failed outright.
+ *
+ * Until now a total provider-chain failure was logged server-side and shown to
+ * the user, and that was all — nobody was told. The only standing signal was
+ * the nightly eval, which runs against a test account and can pass at 03:00
+ * while real users are being turned away at noon. Six real accounts were failed
+ * in June 2026 and nothing surfaced it; see failed-turn.ts.
+ *
+ * Deliberately quiet: one unread row per failure CODE, bumping `occurrences`,
+ * mirroring the coalescing the eval harness already uses. A capacity outage
+ * affects every user at once, so stacking one row per affected request would
+ * bury the signal it is meant to raise.
+ */
+import { getAdminClient } from '@/lib/supabase/admin';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { logger } from '@/utils/logger';
+
+/** Recipient of operational alerts. Same default as scripts/eval-cat.mjs. */
+const OPS_NOTIFY_USER_ID = process.env.OPS_NOTIFY_USER_ID || 'cec88bc9-557f-452b-92f1-e093092fecd6';
+
+const SOURCE = 'cat/chat';
+
+interface FailureAlertParams {
+  /** The user whose turn failed — named so the operator can tell real users from our own testing. */
+  username?: string | null;
+  /** Structured error code already shown to the client (e.g. ALL_PROVIDERS_DOWN). */
+  code: string;
+  provider?: string;
+  model?: string;
+}
+
+function describe({ username, code, provider, model }: FailureAlertParams): string {
+  const who = username ? `@${username}` : 'a user';
+  const link = [provider, model].filter(Boolean).join('/');
+  return `${who} asked Cat something and got nothing back (${code}${link ? ` on ${link}` : ''}).`;
+}
+
+/**
+ * Fire-and-forget. Never throws and never blocks the response: a chat that
+ * already failed must not fail differently because the alert could not be
+ * written.
+ */
+export async function alertCatChatFailure(params: FailureAlertParams): Promise<void> {
+  try {
+    const supabase = getAdminClient();
+    const message = describe(params);
+    const question = `Help me with this notification: ${params.code} — "${message}" What does it mean and what should I do?`;
+
+    const { data: existing } = await supabase
+      .from(DATABASE_TABLES.NOTIFICATIONS)
+      .select('id, metadata')
+      .eq('user_id', OPS_NOTIFY_USER_ID)
+      .eq('type', 'system')
+      .eq('is_read', false)
+      .eq('metadata->>source', SOURCE)
+      .eq('metadata->>title', params.code)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const metadata = {
+      title: params.code,
+      source: SOURCE,
+      provider: params.provider ?? null,
+      model: params.model ?? null,
+      lastSeenAt: new Date().toISOString(),
+    };
+
+    if (existing) {
+      const prev = (existing.metadata ?? {}) as { occurrences?: number };
+      await supabase
+        .from(DATABASE_TABLES.NOTIFICATIONS)
+        .update({
+          message,
+          action_url: `/dashboard/cat?q=${encodeURIComponent(question)}`,
+          metadata: { ...metadata, occurrences: (Number(prev.occurrences) || 1) + 1 },
+        })
+        .eq('id', existing.id);
+      return;
+    }
+
+    await supabase.from(DATABASE_TABLES.NOTIFICATIONS).insert({
+      user_id: OPS_NOTIFY_USER_ID,
+      type: 'system',
+      message,
+      action_url: `/dashboard/cat?q=${encodeURIComponent(question)}`,
+      metadata: { ...metadata, occurrences: 1 },
+      is_read: false,
+    });
+  } catch (err) {
+    logger.warn('Failed to raise Cat failure alert', { err }, 'cat/chat');
+  }
+}


### PR DESCRIPTION
> Branch is named `perf/cat-prompt-diet` because it started as a prompt-size investigation. That work is **not** in here — the measurement said it needs a 20,514-char cut out of hand-written behavioural prose with no partial credit, so it's deferred as its own project. What shipped instead is the finding that came out of it.

## What was wrong

A total provider-chain failure was logged server-side and shown to the user, and that was all. **Nobody was told.** The only standing signal is the nightly eval — which runs against a test account and can pass at 03:00 while real users are turned away at noon.

That is how six real accounts were failed in June 2026 with nothing surfacing it. Given that zero real users have ever completed a conversation with Cat, a real user's chat failing is the most important event this product can emit.

## The alert

Deliberately quiet: **one unread row per failure code**, bumping `metadata.occurrences`, mirroring the coalescing `scripts/eval-cat.mjs` already uses. A capacity outage hits every user at once, so stacking one row per failed request would bury the very signal the alert exists to raise. It links to Cat with the question pre-filled, so Cat triages its own outage.

It runs inside the `catch` of a request that has **already** failed, so it is detached and self-swallowing — if the notification cannot be written, the user still gets their original error, never a worse one.

## Tests

Five, covering both throwing paths, the coalesce, the first insert, and that it stays wired into the failure branch. Two are mutation-verified: making the alert throw fails 2 tests, unwiring it from the failure branch fails the wiring guard.

## Context

This is the third trace a failed first contact now leaves, where it previously left none:

1. the user's message is preserved (#623)
2. a nightly invariant catches a send that stored nothing (#623)
3. someone is told at the time it happens (this PR)

`npm run verify` green: 192 suites, 1860 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
