### PR TITLE
fix(credits): credit top-ups nobody's browser was watching

### DIFF
--- a/__tests__/unit/services/cat/credit-topup.test.ts
+++ b/__tests__/unit/services/cat/credit-topup.test.ts
@@ -17,6 +17,7 @@ import {
   checkTopUp,
   MIN_TOPUP_BTC,
   MAX_TOPUP_BTC,
+  TOPUP_EXPIRY_GRACE_MS,
 } from '@/services/cat/credit-topup';
 
 jest.mock('@/utils/logger', () => ({
@@ -47,12 +48,21 @@ jest.mock('@/lib/supabase/admin', () => ({
  * the builder (e.g. `.update().eq()`) resolves to `awaitResult`; `.single()` /
  * `.maybeSingle()` resolve to the configured terminal.
  */
-function qb(opts: { terminal?: unknown; awaitResult?: unknown } = {}) {
+function qb(
+  opts: {
+    terminal?: unknown;
+    awaitResult?: unknown;
+    onUpdate?: (payload: Record<string, unknown>) => void;
+  } = {}
+) {
   const terminal = opts.terminal ?? { data: null, error: null };
   const awaitResult = opts.awaitResult ?? { data: null, error: null };
   const builder: Record<string, unknown> = {
     insert: () => builder,
-    update: () => builder,
+    update: (payload: Record<string, unknown>) => {
+      opts.onUpdate?.(payload);
+      return builder;
+    },
     select: () => builder,
     eq: () => builder,
     order: () => builder,
@@ -230,5 +240,45 @@ describe('checkTopUp', () => {
     getPlatformNwcClient.mockResolvedValue(nwcClient()); // settled_at: null
     await expect(checkTopUp('owner', 'tp1')).resolves.toEqual({ status: 'expired' });
     expect(appendCreditEntry).not.toHaveBeenCalled();
+  });
+
+  it('tells the user "expired" without RECORDING it while a payment could still land', async () => {
+    // Two different claims, deliberately decoupled: "start a new invoice" is
+    // safe to say the moment our own expires_at passes, but `expired` in the
+    // row is terminal — the branch above returns early and never looks the
+    // invoice up again. expires_at is our local Date.now()+1h guess, so writing
+    // it on that alone would strand a payment still in flight.
+    const updated: Array<Record<string, unknown>> = [];
+    adminFrom.mockReturnValue(
+      qb({
+        terminal: {
+          data: { ...pendingRow, expires_at: new Date(Date.now() - 1000).toISOString() },
+        },
+        onUpdate: (payload: Record<string, unknown>) => updated.push(payload),
+      })
+    );
+    getPlatformNwcClient.mockResolvedValue(nwcClient()); // settled_at: null
+
+    await expect(checkTopUp('owner', 'tp1')).resolves.toEqual({ status: 'expired' });
+    expect(updated).toHaveLength(0);
+  });
+
+  it('records expired only once no payment can still arrive (past grace)', async () => {
+    const updated: Array<Record<string, unknown>> = [];
+    adminFrom.mockReturnValue(
+      qb({
+        terminal: {
+          data: {
+            ...pendingRow,
+            expires_at: new Date(Date.now() - TOPUP_EXPIRY_GRACE_MS - 1000).toISOString(),
+          },
+        },
+        onUpdate: (payload: Record<string, unknown>) => updated.push(payload),
+      })
+    );
+    getPlatformNwcClient.mockResolvedValue(nwcClient()); // settled_at: null
+
+    await expect(checkTopUp('owner', 'tp1')).resolves.toEqual({ status: 'expired' });
+    expect(updated).toContainEqual({ status: 'expired' });
   });
 });

--- a/__tests__/unit/services/cat/topup-reconcile.test.ts
+++ b/__tests__/unit/services/cat/topup-reconcile.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Cat Credits top-up reconciliation — the backstop for money that already
+ * arrived.
+ *
+ * The bug this closes: settlement was detected ONLY by the payer's open
+ * TopUpDialog, so paying and closing the tab left the sats in the treasury and
+ * the row `pending` forever — no credit, no ledger entry, nothing to notice.
+ * Production held such a row for four days.
+ *
+ * These tests pin the properties that make the backstop trustworthy:
+ *   - it credits a settled top-up with NO browser involved,
+ *   - it credits the row's recorded OWNER,
+ *   - it never writes the terminal `expired` while a payment could still land,
+ *   - one unreachable/failing row does not abort the sweep,
+ *   - it stays off entirely when no platform wallet is configured.
+ */
+
+import { runTopUpReconcileSweep } from '@/services/cat/topup-reconcile';
+import { TOPUP_EXPIRY_GRACE_MS } from '@/services/cat/credit-topup';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const platformReceiveEnabled = jest.fn();
+const getPlatformNwcClient = jest.fn();
+jest.mock('@/lib/bitcoin/platform-wallet', () => ({
+  platformReceiveEnabled: () => platformReceiveEnabled(),
+  getPlatformNwcClient: () => getPlatformNwcClient(),
+}));
+
+const appendCreditEntry = jest.fn();
+const getCreditBalance = jest.fn();
+jest.mock('@/services/cat/credits', () => ({
+  appendCreditEntry: (...a: unknown[]) => appendCreditEntry(...a),
+  getCreditBalance: (...a: unknown[]) => getCreditBalance(...a),
+}));
+
+const adminFrom = jest.fn();
+jest.mock('@/lib/supabase/admin', () => ({
+  getAdminClient: () => ({ from: (...a: unknown[]) => adminFrom(...a) }),
+}));
+
+/** Records every `.update({...})` payload so we can assert what was persisted. */
+const updates: Array<Record<string, unknown>> = [];
+
+function qb(awaitResult: unknown) {
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    update: (payload: Record<string, unknown>) => {
+      updates.push(payload);
+      return builder;
+    },
+    eq: () => builder,
+    order: () => builder,
+    limit: () => builder,
+    then: (resolve: (v: unknown) => unknown) => resolve(awaitResult),
+  };
+  return builder;
+}
+
+const HOUR = 60 * 60 * 1000;
+
+function row(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'tu_1',
+    user_id: 'owner_1',
+    amount_btc: 0.0001,
+    payment_hash: 'ph_1',
+    status: 'pending',
+    expires_at: new Date(Date.now() + HOUR).toISOString(),
+    ...over,
+  };
+}
+
+function nwcClient(over: Record<string, unknown> = {}) {
+  return {
+    lookupInvoice: jest.fn().mockResolvedValue({ settled_at: null }),
+    disconnect: jest.fn(),
+    ...over,
+  };
+}
+
+/** Rows come back from the select; every later await resolves to the same stub. */
+function withRows(rows: unknown[]) {
+  adminFrom.mockReturnValue(qb({ data: rows, error: null }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  updates.length = 0;
+  platformReceiveEnabled.mockReturnValue(true);
+  appendCreditEntry.mockResolvedValue(0.0001);
+  getCreditBalance.mockResolvedValue(0.0001);
+});
+
+describe('runTopUpReconcileSweep', () => {
+  it('does nothing — and opens no connection — when no platform wallet is configured', async () => {
+    platformReceiveEnabled.mockReturnValue(false);
+
+    const result = await runTopUpReconcileSweep();
+
+    expect(result).toMatchObject({ scanned: 0, settled: 0, expired: 0 });
+    expect(getPlatformNwcClient).not.toHaveBeenCalled();
+    expect(adminFrom).not.toHaveBeenCalled();
+  });
+
+  it('credits a settled top-up nobody was watching, to the row OWNER', async () => {
+    withRows([row()]);
+    const client = nwcClient({
+      lookupInvoice: jest.fn().mockResolvedValue({ settled_at: 1_700_000_000 }),
+    });
+    getPlatformNwcClient.mockResolvedValue(client);
+
+    const result = await runTopUpReconcileSweep();
+
+    expect(result).toMatchObject({ scanned: 1, settled: 1, expired: 0 });
+    expect(appendCreditEntry).toHaveBeenCalledWith(
+      expect.anything(),
+      'owner_1', // the recorded owner — never "whoever asked"
+      expect.objectContaining({ kind: 'topup', amountBtc: 0.0001, ref: 'ph_1' })
+    );
+    expect(updates).toContainEqual(expect.objectContaining({ status: 'paid' }));
+    expect(client.disconnect).toHaveBeenCalled();
+  });
+
+  it('does not mark paid when crediting fails — the row stays pending for the next tick', async () => {
+    withRows([row()]);
+    appendCreditEntry.mockResolvedValue(null);
+    getPlatformNwcClient.mockResolvedValue(
+      nwcClient({ lookupInvoice: jest.fn().mockResolvedValue({ settled_at: 1_700_000_000 }) })
+    );
+
+    const result = await runTopUpReconcileSweep();
+
+    expect(result).toMatchObject({ scanned: 1, settled: 0 });
+    expect(updates).toHaveLength(0);
+  });
+
+  it('leaves an unsettled invoice inside its window pending', async () => {
+    withRows([row()]);
+    getPlatformNwcClient.mockResolvedValue(nwcClient());
+
+    const result = await runTopUpReconcileSweep();
+
+    expect(result).toMatchObject({ scanned: 1, settled: 0, expired: 0 });
+    expect(updates).toHaveLength(0);
+  });
+
+  it('NEVER writes expired while a payment could still land (past window, inside grace)', async () => {
+    // The money-loss trap: `expired` is terminal — the row is never looked up
+    // again — so writing it on our own locally-computed timestamp would strand
+    // any payment still in flight.
+    withRows([row({ expires_at: new Date(Date.now() - HOUR).toISOString() })]);
+    getPlatformNwcClient.mockResolvedValue(nwcClient());
+
+    const result = await runTopUpReconcileSweep();
+
+    expect(updates).toHaveLength(0);
+    expect(result.expired).toBe(0); // not retired, so not counted as retired
+  });
+
+  it('retires a row only once no payment can still arrive (past grace)', async () => {
+    withRows([
+      row({ expires_at: new Date(Date.now() - TOPUP_EXPIRY_GRACE_MS - HOUR).toISOString() }),
+    ]);
+    getPlatformNwcClient.mockResolvedValue(nwcClient());
+
+    const result = await runTopUpReconcileSweep();
+
+    expect(updates).toContainEqual({ status: 'expired' });
+    expect(result).toMatchObject({ scanned: 1, expired: 1 });
+  });
+
+  it('still checks a settled invoice that is past its window — payment wins over expiry', async () => {
+    withRows([row({ expires_at: new Date(Date.now() - HOUR).toISOString() })]);
+    getPlatformNwcClient.mockResolvedValue(
+      nwcClient({ lookupInvoice: jest.fn().mockResolvedValue({ settled_at: 1_700_000_000 }) })
+    );
+
+    const result = await runTopUpReconcileSweep();
+
+    expect(result.settled).toBe(1);
+    expect(updates).toContainEqual(expect.objectContaining({ status: 'paid' }));
+  });
+
+  it('one failing row does not abort the sweep', async () => {
+    withRows([row({ id: 'tu_bad' }), row({ id: 'tu_good', payment_hash: 'ph_2' })]);
+    const lookupInvoice = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('relay down'))
+      .mockResolvedValueOnce({ settled_at: 1_700_000_000 });
+    getPlatformNwcClient.mockResolvedValue(nwcClient({ lookupInvoice }));
+
+    const result = await runTopUpReconcileSweep();
+
+    expect(result).toMatchObject({ scanned: 2, settled: 1 });
+  });
+
+  it('reports zero and connects to nothing when there are no pending rows', async () => {
+    withRows([]);
+
+    const result = await runTopUpReconcileSweep();
+
+    expect(result).toMatchObject({ scanned: 0, settled: 0, expired: 0 });
+    expect(getPlatformNwcClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/cron/payment-reconcile/route.ts
+++ b/src/app/api/cron/payment-reconcile/route.ts
@@ -1,14 +1,22 @@
 /**
  * GET /api/cron/payment-reconcile — thin cron wrapper.
  *
- * All sweep logic lives in src/services/payments/reconcile.ts (see its header
- * for why this backstop exists). This route only: verifies the cron secret,
- * runs the sweep, and shapes the HTTP response.
+ * Runs every reconciliation sweep OrangeCat has: money OUT to recipients
+ * (payment_intents) and money IN to the treasury (cat_credit_topups). Both
+ * answer the same question — "did a payment land that nobody's browser was
+ * watching?" — so they share one tick rather than needing a second systemd
+ * timer that a deploy would never install. Sweep logic lives in the services;
+ * see each file's header for why the backstop exists.
+ *
+ * The two are independent: one rail being unreachable must not stop the other
+ * from reconciling, so neither failure aborts the request. Only a total failure
+ * is a 500.
  */
 
 import { verifyCronSecret } from '@/lib/api/cronAuth';
 import { apiSuccess, apiUnauthorized, apiInternalError } from '@/lib/api/standardResponse';
 import { runPaymentReconcileSweep } from '@/services/payments/reconcile';
+import { runTopUpReconcileSweep } from '@/services/cat/topup-reconcile';
 import { logger } from '@/utils/logger';
 
 export async function GET(request: Request) {
@@ -16,11 +24,17 @@ export async function GET(request: Request) {
     return apiUnauthorized();
   }
 
-  try {
-    const result = await runPaymentReconcileSweep();
-    return apiSuccess(result);
-  } catch (error) {
+  const payments = await runPaymentReconcileSweep().catch(error => {
     logger.error('Payment reconciliation sweep failed', { error }, 'PaymentSweep');
+    return null;
+  });
+  const credits = await runTopUpReconcileSweep().catch(error => {
+    logger.error('Top-up reconciliation sweep failed', { error }, 'CatCreditsSweep');
+    return null;
+  });
+
+  if (!payments && !credits) {
     return apiInternalError('Reconciliation sweep failed');
   }
+  return apiSuccess({ ...(payments ?? {}), payments, credits });
 }

--- a/src/services/cat/credit-topup.ts
+++ b/src/services/cat/credit-topup.ts
@@ -18,6 +18,7 @@ import { getAdminClient } from '@/lib/supabase/admin';
 import type { AnySupabaseClient } from '@/lib/supabase/types';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { getPlatformNwcClient, platformReceiveEnabled } from '@/lib/bitcoin/platform-wallet';
+import type { NWCClient } from '@/lib/nostr/nwc';
 import { appendCreditEntry, getCreditBalance } from '@/services/cat/credits';
 import { logger } from '@/utils/logger';
 
@@ -42,6 +43,46 @@ export type TopUpStatus =
   | { status: 'expired' }
   | { status: 'not_found' }
   | { status: 'not_enabled' };
+
+/**
+ * How long past `expires_at` we keep ASKING the wallet before recording the
+ * terminal `expired`.
+ *
+ * `expires_at` is our own `Date.now() + 3600s`, stamped after makeInvoice
+ * returned — it is a local guess at the wallet's expiry, not the wallet's fact.
+ * Server clock skew, a slow mint, or an HTLC still in flight all put a genuinely
+ * payable invoice past our timestamp. Writing `expired` on that guess is
+ * irreversible: the terminal short-circuit below then means the row is never
+ * looked up again, so a payment that lands afterwards is money in the treasury
+ * with no credit and nothing left to notice it.
+ *
+ * So the bound separates two different claims (the same split
+ * services/payments/reconcile.ts makes for on-chain intents):
+ *   - what we TELL the waiting user  → "past expires_at, start a new one" (now)
+ *   - what we WRITE as terminal      → only once no payment is possible (+grace)
+ */
+export const TOPUP_EXPIRY_GRACE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * True once no payment can still arrive for this invoice — the ONLY condition
+ * under which `expired` may be written. Exported so the reconcile sweep counts
+ * retirements by the same rule that performs them, instead of restating it.
+ */
+export function isPastExpiryGrace(expiresAt: string, now: number = Date.now()): boolean {
+  return new Date(expiresAt).getTime() + TOPUP_EXPIRY_GRACE_MS < now;
+}
+
+/** The columns any settlement decision needs. One list, both entry points. */
+export const TOPUP_ROW_COLUMNS = 'id, user_id, amount_btc, payment_hash, status, expires_at';
+
+export interface TopUpRow {
+  id: string;
+  user_id: string;
+  amount_btc: number;
+  payment_hash: string;
+  status: string;
+  expires_at: string;
+}
 
 /** Round a BTC amount to 8 dp (1-sat precision) — guards float drift. */
 function toBtc8(n: number): number {
@@ -114,45 +155,28 @@ export async function initiateTopUp(
 }
 
 /**
- * Poll a pending top-up: if the invoice has settled, credit the ledger (once)
- * and mark it paid. Crediting goes to the top-up's recorded owner, never the
- * caller, so a poller can't claim someone else's payment.
+ * Settle ONE top-up row against the wallet: if its invoice has settled, credit
+ * the ledger (once) and mark it paid. Crediting goes to the row's recorded
+ * owner, never to whoever asked, so a poller can't claim someone else's payment.
+ *
+ * The caller owns `client`'s lifecycle so a sweep can reuse one NWC connection
+ * across a batch instead of reconnecting per row.
+ *
+ * This is the ONE settlement implementation. Both entry points run it — the
+ * owner's browser poll (`checkTopUp`) and the server-side backstop sweep
+ * (services/cat/topup-reconcile) — so a top-up cannot settle differently
+ * depending on who noticed it.
  */
-export async function checkTopUp(userId: string, topupId: string): Promise<TopUpStatus> {
-  if (!platformReceiveEnabled()) {
-    return { status: 'not_enabled' };
-  }
-
-  const admin = getAdminClient() as unknown as AnySupabaseClient;
-  const { data: row } = await admin
-    .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
-    .select('id, user_id, amount_btc, payment_hash, status, expires_at')
-    .eq('id', topupId)
-    .eq('user_id', userId)
-    .maybeSingle();
-
-  if (!row) {
-    return { status: 'not_found' };
-  }
-  const topup = row as {
-    id: string;
-    user_id: string;
-    amount_btc: number;
-    payment_hash: string;
-    status: string;
-    expires_at: string;
-  };
-
+export async function settleTopUpRow(
+  admin: AnySupabaseClient,
+  topup: TopUpRow,
+  client: NWCClient
+): Promise<TopUpStatus> {
   if (topup.status === 'paid') {
     return { status: 'paid', balanceBtc: await getCreditBalance(admin, topup.user_id) };
   }
   if (topup.status === 'expired') {
     return { status: 'expired' };
-  }
-
-  const client = await getPlatformNwcClient();
-  if (!client) {
-    return { status: 'not_enabled' };
   }
 
   try {
@@ -163,7 +187,7 @@ export async function checkTopUp(userId: string, topupId: string): Promise<TopUp
       // the credit actually landed: if the append fails (transient DB error), we
       // must NOT flip status to paid, or the next poll short-circuits on 'paid'
       // and the user's Lightning payment is lost with no credit. Leaving it
-      // pending lets the next poll retry the (idempotent) credit.
+      // pending lets the next attempt retry the (idempotent) credit.
       const balanceBtc = await appendCreditEntry(admin, topup.user_id, {
         kind: 'topup',
         amountBtc: topup.amount_btc,
@@ -185,20 +209,62 @@ export async function checkTopUp(userId: string, topupId: string): Promise<TopUp
       return { status: 'paid', balanceBtc };
     }
   } catch (err) {
-    // Transient relay/lookup failure — report pending; client polls again.
-    logger.warn('checkTopUp lookup failed', { err }, 'CatCredits');
+    // Transient relay/lookup failure — report pending so it is asked again.
+    logger.warn('top-up lookup failed', { err, topupId: topup.id }, 'CatCredits');
     return { status: 'pending' };
-  } finally {
-    client.disconnect();
   }
 
-  // Not settled yet — expire it if the window passed.
-  if (new Date(topup.expires_at).getTime() < Date.now()) {
+  // Not settled. Past its window the user should start a new invoice, but only
+  // record the terminal `expired` once no payment can still arrive — see
+  // TOPUP_EXPIRY_GRACE_MS for why those are two different moments.
+  if (new Date(topup.expires_at).getTime() >= Date.now()) {
+    return { status: 'pending' };
+  }
+  if (isPastExpiryGrace(topup.expires_at)) {
     await admin
       .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
       .update({ status: 'expired' })
       .eq('id', topup.id);
+  }
+  return { status: 'expired' };
+}
+
+/**
+ * Poll one of YOUR top-ups. Scoped to the caller by user_id; terminal rows
+ * answer without a wallet round-trip.
+ */
+export async function checkTopUp(userId: string, topupId: string): Promise<TopUpStatus> {
+  if (!platformReceiveEnabled()) {
+    return { status: 'not_enabled' };
+  }
+
+  const admin = getAdminClient() as unknown as AnySupabaseClient;
+  const { data: row } = await admin
+    .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
+    .select(TOPUP_ROW_COLUMNS)
+    .eq('id', topupId)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (!row) {
+    return { status: 'not_found' };
+  }
+  const topup = row as TopUpRow;
+
+  if (topup.status === 'paid') {
+    return { status: 'paid', balanceBtc: await getCreditBalance(admin, topup.user_id) };
+  }
+  if (topup.status === 'expired') {
     return { status: 'expired' };
   }
-  return { status: 'pending' };
+
+  const client = await getPlatformNwcClient();
+  if (!client) {
+    return { status: 'not_enabled' };
+  }
+  try {
+    return await settleTopUpRow(admin, topup, client);
+  } finally {
+    client.disconnect();
+  }
 }

--- a/src/services/cat/topup-reconcile.ts
+++ b/src/services/cat/topup-reconcile.ts
@@ -1,0 +1,151 @@
+/**
+ * Cat Credits top-up reconciliation — credit the money that already arrived,
+ * without depending on anyone's browser being open.
+ *
+ * A top-up is money IN to OrangeCat's own treasury, and settlement is detected
+ * by polling the wallet. Until this existed, the only thing that ever polled was
+ * the payer's open TopUpDialog: pay, then close the tab (or lock the phone, or
+ * let the tab get discarded), and the sats landed in the treasury while the row
+ * stayed `pending` forever. The user paid and got no credits, the ledger has no
+ * entry, and nothing anywhere notices — a `pending` row looks identical whether
+ * it was never paid or was paid and dropped.
+ *
+ * That is not hypothetical. On 2026-08-06 production held a `pending` top-up
+ * created 2026-08-02, four days past its one-hour window, never asked about
+ * again by anything.
+ *
+ * The same class was already found and fixed on the OTHER money path —
+ * services/payments/reconcile.ts opens with the identical story for
+ * payment_intents. That sweep does not cover cat_credit_topups, so the newer
+ * revenue path reintroduced the bug the older path had already retired. This
+ * closes it, deliberately mirroring that file's shape: bounded batch, one
+ * connection, the SAME detection path the browser uses (settleTopUpRow), and a
+ * backstop that optimises for certainty rather than latency.
+ *
+ * It runs on the existing per-minute payment-reconcile cron rather than a new
+ * timer — deploys do not install systemd units, so a new timer would be a unit
+ * that silently never runs.
+ */
+
+import { getAdminClient } from '@/lib/supabase/admin';
+import type { AnySupabaseClient } from '@/lib/supabase/types';
+import { DATABASE_TABLES } from '@/config/database-tables';
+import { getPlatformNwcClient, platformReceiveEnabled } from '@/lib/bitcoin/platform-wallet';
+import {
+  settleTopUpRow,
+  isPastExpiryGrace,
+  TOPUP_ROW_COLUMNS,
+  type TopUpRow,
+} from '@/services/cat/credit-topup';
+import { logger } from '@/utils/logger';
+
+/**
+ * Oldest-first, bounded. Rows leave the pending pool for good (paid or expired
+ * past grace), so unlike an open-ended watch list this ordering cannot starve
+ * newer rows behind a permanent backlog.
+ */
+const BATCH_SIZE = 25;
+
+/** Headroom under the cron unit's 120s curl timeout, shared with the payments sweep. */
+const BUDGET_MS = 20_000;
+
+export interface TopUpSweepResult {
+  scanned: number;
+  settled: number;
+  expired: number;
+  skippedForBudget?: number;
+  ranAt: string;
+}
+
+function emptyResult(): TopUpSweepResult {
+  return { scanned: 0, settled: 0, expired: 0, ranAt: new Date().toISOString() };
+}
+
+/** Run one bounded top-up reconciliation sweep. Throws only on selection failure. */
+export async function runTopUpReconcileSweep(): Promise<TopUpSweepResult> {
+  if (!platformReceiveEnabled()) {
+    return emptyResult();
+  }
+
+  const startedAt = Date.now();
+  const admin = getAdminClient() as unknown as AnySupabaseClient;
+
+  const { data, error } = await admin
+    .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
+    .select(TOPUP_ROW_COLUMNS)
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(BATCH_SIZE);
+
+  if (error) {
+    throw new Error(`Failed to select top-up reconciliation candidates: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as TopUpRow[];
+  if (rows.length === 0) {
+    return emptyResult();
+  }
+
+  // One connection for the whole batch — a per-minute cron must not open and
+  // tear down a relay connection per row.
+  const client = await getPlatformNwcClient();
+  if (!client) {
+    return emptyResult();
+  }
+
+  let scanned = 0;
+  let settled = 0;
+  let expired = 0;
+  let skippedForBudget = 0;
+
+  try {
+    for (const row of rows) {
+      if (Date.now() - startedAt > BUDGET_MS) {
+        // Never silently pretend the batch was fully covered. Untouched rows
+        // stay pending and lead the next tick, since ordering is by created_at.
+        skippedForBudget = rows.length - scanned;
+        break;
+      }
+      scanned += 1;
+
+      try {
+        // The SAME path the payer's browser runs. Crediting is exactly-once
+        // (unique ledger ref on payment_hash), so racing a live poll is safe.
+        const result = await settleTopUpRow(admin, row, client);
+        if (result.status === 'paid') {
+          settled += 1;
+          logger.info(
+            'Reconciliation credited a top-up nobody was watching',
+            { topupId: row.id },
+            'CatCreditsSweep'
+          );
+        } else if (result.status === 'expired' && isPastExpiryGrace(row.expires_at)) {
+          // Counted only when the row was actually RETIRED. Past its window but
+          // still inside grace, settleTopUpRow reports 'expired' to whoever is
+          // waiting while deliberately leaving the row pending — counting that
+          // would report the same row expiring on every tick for a day.
+          expired += 1;
+        }
+      } catch (err) {
+        // One bad row must not abort the sweep.
+        logger.warn(
+          'Top-up reconciliation failed for one row',
+          { topupId: row.id, err },
+          'CatCreditsSweep'
+        );
+      }
+    }
+  } finally {
+    client.disconnect();
+  }
+
+  if (skippedForBudget > 0) {
+    logger.info(
+      'Top-up sweep hit its time budget',
+      { scanned, skippedForBudget },
+      'CatCreditsSweep'
+    );
+  }
+
+  return { scanned, settled, expired, skippedForBudget, ranAt: new Date().toISOString() };
+}


### PR DESCRIPTION
## The bug

Cat Credits settlement was detected **only** by the payer's open `TopUpDialog` polling every 3s. Pay the invoice, then close the tab — or lock the phone, or let the tab get discarded — and the sats land in the treasury while the row stays `pending` **forever**. No credit, no ledger entry, and nothing anywhere notices: a `pending` row looks identical whether it was never paid or was paid and dropped.

Production proved it. At the time of writing, `cat_credit_topups` held:

| created_at | status | past expiry by |
|---|---|---|
| 2026-08-02 10:29 | `pending` | **4 days** |

One hour of invoice validity, four days untouched. Nothing on the server had ever asked about it.

## Second occurrence of a class this repo already retired

`src/services/payments/reconcile.ts` opens with the identical story for `payment_intents` — *"the only thing that ever asked was the payer's open tab"* — and has run every minute since. It does not cover `cat_credit_topups`, so the newer **revenue** path reintroduced the bug the older path had already fixed. This closes it by mirroring that file's shape rather than inventing a second approach.

## Changes

- **`settleTopUpRow`** extracted from `checkTopUp` — the browser poll and the sweep now run **one** settlement implementation, and the caller owns the NWC client so a batch reuses a single connection.
- **`services/cat/topup-reconcile.ts`** — bounded oldest-first sweep, per-row failure isolation, time budget that reports what it skipped rather than pretending full coverage.
- Wired into the **existing** per-minute `payment-reconcile` cron. Deploys do not install systemd units, so a new timer would be a unit that silently never runs.
- **`expired` is no longer written at `expires_at`.** That timestamp is our own `Date.now() + 1h`, stamped *after* `makeInvoice` returned — a guess at the wallet's expiry, not its fact. `expired` is terminal (the row is never looked up again), so writing it on that guess stranded any payment still in flight behind clock skew or an in-flight HTLC. The user is still told "expired" immediately; only the *record* waits out the grace.

## Verification

- Full pre-push gate green: **1,866 tests / 192 suites**, typecheck clean, route audit clean.
- 9 new tests for the sweep, 2 for the expiry split.
- Teeth verified: removing the grace guard fails **exactly** the 2 tests that assert it.
- No migration — the sweep uses existing columns.

## Found while testing, deliberately not in this PR

Filed rather than mixed into a money fix:
- Top-up presets render as **CHF 5.23 / 26.15 / 52.31** — round in BTC, arbitrary and drifting daily in the user's display currency.
- The invoice screen shows no sats amount and no expiry countdown.
- The QR carries a bare bolt11 with no `lightning:` URI scheme, so there is no tap-to-pay handoff.
- A pending top-up is invisible in the UI once the dialog closes — no way to resume it.
- Usage debits are sub-cent, but CHF renders at 2dp, so the ledger will show rows of `− CHF 0.00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)