### PR TITLE
fix(cat): name the account in a chat-failure alert

### DIFF
--- a/__tests__/unit/cat/failure-alert.test.ts
+++ b/__tests__/unit/cat/failure-alert.test.ts
@@ -21,7 +21,12 @@ describe('Cat failure alerting', () => {
       throw new Error('no service key in this environment');
     });
     await expect(
-      alertCatChatFailure({ code: 'ALL_PROVIDERS_DOWN', provider: 'groq', model: 'x' })
+      alertCatChatFailure({
+        userId: 'u1',
+        code: 'ALL_PROVIDERS_DOWN',
+        provider: 'groq',
+        model: 'x',
+      })
     ).resolves.toBeUndefined();
   });
 
@@ -35,7 +40,9 @@ describe('Cat failure alerting', () => {
       insert: () => Promise.reject(new Error('RLS denied')),
     };
     (getAdminClient as jest.Mock).mockReturnValue({ from: () => rejecting });
-    await expect(alertCatChatFailure({ code: 'STREAM_ERROR' })).resolves.toBeUndefined();
+    await expect(
+      alertCatChatFailure({ userId: 'u1', code: 'STREAM_ERROR' })
+    ).resolves.toBeUndefined();
   });
 
   it('coalesces onto an existing unread alert for the same code instead of stacking rows', async () => {
@@ -46,13 +53,16 @@ describe('Cat failure alerting', () => {
       eq: () => chain,
       order: () => chain,
       limit: () => chain,
-      maybeSingle: () => Promise.resolve({ data: { id: 'n1', metadata: { occurrences: 3 } } }),
+      maybeSingle: jest
+        .fn()
+        .mockResolvedValueOnce({ data: { username: 'mao' } })
+        .mockResolvedValue({ data: { id: 'n1', metadata: { occurrences: 3 } } }),
       update,
       insert,
     };
     (getAdminClient as jest.Mock).mockReturnValue({ from: () => chain });
 
-    await alertCatChatFailure({ code: 'AI_RATE_LIMITED', provider: 'openrouter' });
+    await alertCatChatFailure({ userId: 'u1', code: 'AI_RATE_LIMITED', provider: 'openrouter' });
 
     // A capacity outage hits every user at once; one row per request would
     // bury the very signal the alert exists to raise.
@@ -68,13 +78,21 @@ describe('Cat failure alerting', () => {
       eq: () => chain,
       order: () => chain,
       limit: () => chain,
-      maybeSingle: () => Promise.resolve({ data: null }),
+      maybeSingle: jest
+        .fn()
+        .mockResolvedValueOnce({ data: { username: 'user_2dd6f19e' } })
+        .mockResolvedValue({ data: null }),
       update: jest.fn(),
       insert,
     };
     (getAdminClient as jest.Mock).mockReturnValue({ from: () => chain });
 
-    await alertCatChatFailure({ code: 'ALL_PROVIDERS_DOWN', provider: 'groq', model: 'llama' });
+    await alertCatChatFailure({
+      userId: 'u1',
+      code: 'ALL_PROVIDERS_DOWN',
+      provider: 'groq',
+      model: 'llama',
+    });
 
     expect(insert).toHaveBeenCalledTimes(1);
     const row = insert.mock.calls[0][0];
@@ -82,6 +100,32 @@ describe('Cat failure alerting', () => {
     expect(row.metadata.title).toBe('ALL_PROVIDERS_DOWN');
     expect(row.is_read).toBe(false);
     expect(row.message).toContain('got nothing back');
+    // Naming the account is the difference between a triageable alert and a
+    // useless one: the question this exists to answer is whether a REAL user
+    // was turned away or whether it was our own eval / founder account.
+    expect(row.message).toContain('@user_2dd6f19e');
+    expect(row.metadata.lastFailedUserId).toBe('u1');
+  });
+
+  it('still alerts when the account cannot be named', async () => {
+    const insert = jest.fn().mockResolvedValue({});
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      order: () => chain,
+      limit: () => chain,
+      maybeSingle: jest.fn().mockResolvedValue({ data: null }),
+      update: jest.fn(),
+      insert,
+    };
+    (getAdminClient as jest.Mock).mockReturnValue({ from: () => chain });
+
+    await alertCatChatFailure({ userId: 'u9', code: 'STREAM_ERROR' });
+
+    // A missing profile must degrade the wording, never suppress the alert.
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(insert.mock.calls[0][0].message).toContain('someone');
+    expect(insert.mock.calls[0][0].metadata.lastFailedUserId).toBe('u9');
   });
 
   it('stays wired into the streaming failure path', () => {

--- a/src/services/cat/chat-orchestrator.ts
+++ b/src/services/cat/chat-orchestrator.ts
@@ -595,6 +595,7 @@ export async function orchestrateCatChat(
           // chat that already failed must not fail differently because the
           // alert could not be written.
           void alertCatChatFailure({
+            userId: user.id,
             code: errPayload.code,
             provider: activeProvider,
             model: activeModel,

--- a/src/services/cat/failure-alert.ts
+++ b/src/services/cat/failure-alert.ts
@@ -22,16 +22,16 @@ const OPS_NOTIFY_USER_ID = process.env.OPS_NOTIFY_USER_ID || 'cec88bc9-557f-452b
 const SOURCE = 'cat/chat';
 
 interface FailureAlertParams {
-  /** The user whose turn failed — named so the operator can tell real users from our own testing. */
-  username?: string | null;
+  /** Whose turn failed. Resolved to a username so the alert can be triaged. */
+  userId: string;
   /** Structured error code already shown to the client (e.g. ALL_PROVIDERS_DOWN). */
   code: string;
   provider?: string;
   model?: string;
 }
 
-function describe({ username, code, provider, model }: FailureAlertParams): string {
-  const who = username ? `@${username}` : 'a user';
+function describe(username: string | null, { code, provider, model }: FailureAlertParams): string {
+  const who = username ? `@${username}` : 'someone';
   const link = [provider, model].filter(Boolean).join('/');
   return `${who} asked Cat something and got nothing back (${code}${link ? ` on ${link}` : ''}).`;
 }
@@ -44,7 +44,18 @@ function describe({ username, code, provider, model }: FailureAlertParams): stri
 export async function alertCatChatFailure(params: FailureAlertParams): Promise<void> {
   try {
     const supabase = getAdminClient();
-    const message = describe(params);
+
+    // Name the person. "someone got nothing back" cannot be triaged: the whole
+    // question this alert exists to answer is whether a REAL user was turned
+    // away or whether it was our own eval / founder account. One indexed
+    // lookup, on a request that has already failed.
+    const { data: profile } = await supabase
+      .from(DATABASE_TABLES.PROFILES)
+      .select('username')
+      .eq('id', params.userId)
+      .maybeSingle();
+
+    const message = describe(profile?.username ?? null, params);
     const question = `Help me with this notification: ${params.code} — "${message}" What does it mean and what should I do?`;
 
     const { data: existing } = await supabase
@@ -64,6 +75,7 @@ export async function alertCatChatFailure(params: FailureAlertParams): Promise<v
       source: SOURCE,
       provider: params.provider ?? null,
       model: params.model ?? null,
+      lastFailedUserId: params.userId,
       lastSeenAt: new Date().toISOString(),
     };
 


### PR DESCRIPTION
Follow-up to #626, found by driving the alert against production rather than trusting the tests.

## What was wrong

The alert read:

> **a user** asked Cat something and got nothing back (AI_RATE_LIMITED on groq/llama-3.3-70b-versatile).

The entire question this alert exists to answer is whether a **real** user was turned away, or whether it was our own eval / founder account. It could not tell you which — which makes it half a feature, since with zero real users to date that distinction *is* the signal.

## The fix

One indexed lookup, on a request that has already failed, so it reads `@user_2dd6f19e` or `@mao`. The id also lands in `metadata.lastFailedUserId`, so the account stays recoverable even if the profile row cannot be read, and a missing profile degrades the wording to "someone" rather than suppressing the alert.

Mutation-verified: dropping the lookup fails the naming test.

## Verified live before this fix

Two real production failures were driven through the deployed build:

- alert created (0 → 1), then **coalesced** on the second — one row, `occurrences` = 2, unread
- the failed turn was persisted both times (#623 holding under repeat)

Both failed with `AI_RATE_LIMITED` — the 50/day free-tier ceiling, which is the underlying capacity problem being addressed separately.

`npm run verify` green: 192 suites, 1861 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
