### PR TITLE
refactor(cat): asking the Cat to pay runs the same code as tapping Send

### DIFF
--- a/__tests__/unit/cat/sendPaymentHandler.test.ts
+++ b/__tests__/unit/cat/sendPaymentHandler.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The Cat's `send_payment` runs the same code as tapping Send.
+ *
+ * It used to be a second, older implementation of paying a person, and the
+ * drift was not cosmetic: it read `wallets.lightning_address` directly, so an
+ * NWC-only recipient — perfectly payable everywhere else on the platform —
+ * came back as "has no Lightning address configured"; and it matched usernames
+ * with `.eq`, so paying @Alice failed for a user stored as @alice.
+ *
+ * These tests pin the delegation itself. If someone reintroduces a local
+ * implementation, the shared service stops being called and this fails.
+ */
+
+import { paymentHandlers } from '@/services/cat/handlers/payments';
+import { sendToRecipient } from '@/domain/payments/sendPaymentService';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/domain/payments/sendPaymentService', () => ({
+  sendToRecipient: jest.fn(),
+  resolveSenderNwcUri: jest.fn(),
+}));
+
+const sendToRecipientMock = sendToRecipient as jest.Mock;
+const supabase = {} as never;
+const send = (params: Record<string, unknown>) =>
+  paymentHandlers.send_payment(supabase, 'user-1', 'actor-1', params);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('cat send_payment', () => {
+  it('delegates to the shared send service and reports what was paid', async () => {
+    sendToRecipientMock.mockResolvedValue({
+      ok: true,
+      paymentHash: 'hash-1',
+      amountBtc: 0.0001,
+      destination: 'alice@getalby.com',
+    });
+
+    const result = await send({ amount_btc: 0.0001, recipient: '@alice', memo: 'coffee' });
+
+    expect(sendToRecipientMock).toHaveBeenCalledWith('user-1', '@alice', 0.0001, 'coffee');
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      payment_hash: 'hash-1',
+      amount_btc: 0.0001,
+      recipient: 'alice@getalby.com',
+      status: 'paid',
+    });
+  });
+
+  it('passes the service’s own wording through rather than inventing its own', async () => {
+    sendToRecipientMock.mockResolvedValue({
+      ok: false,
+      reason: 'recipient_cannot_receive',
+      message: "@bob can't receive Bitcoin payments right now.",
+    });
+
+    const result = await send({ amount_btc: 0.0001, recipient: 'bob' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("@bob can't receive Bitcoin payments right now.");
+  });
+
+  it('refuses an amount the model did not fill in, without calling the service', async () => {
+    // The params come from a model response, so "a number" is an assumption,
+    // not a guarantee — and `undefined <= 0` is false, so a bare comparison
+    // would have let it through to a service that expects a real figure.
+    for (const amount of [undefined, null, 'lots', NaN, 0, -1]) {
+      const result = await send({ amount_btc: amount, recipient: 'alice' });
+      expect(result.success).toBe(false);
+    }
+    expect(sendToRecipientMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a missing recipient, without calling the service', async () => {
+    for (const recipient of [undefined, null, '', '   ']) {
+      const result = await send({ amount_btc: 0.0001, recipient });
+      expect(result.success).toBe(false);
+    }
+    expect(sendToRecipientMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/cat/handlers/payments.ts
+++ b/src/services/cat/handlers/payments.ts
@@ -3,11 +3,10 @@ import { ENTITY_REGISTRY } from '@/config/entity-registry';
 import { DATABASE_TABLES } from '@/config/database-tables';
 import { STATUS } from '@/config/database-constants';
 import { NWCClient } from '@/lib/nostr/nwc';
-import { decrypt } from '@/domain/payments/encryptionService';
 import { generateInvoice } from '@/domain/payments/invoiceGenerationService';
+import { resolveSenderNwcUri, sendToRecipient } from '@/domain/payments/sendPaymentService';
 import { resolveSellerWallet, getSellerUserId } from '@/domain/payments/walletResolutionService';
 import { getAdminClient } from '@/lib/supabase/admin';
-import type { ResolvedWallet } from '@/domain/payments/types';
 import type { ActionHandler } from './types';
 
 export const paymentHandlers: Record<string, ActionHandler> = {
@@ -118,138 +117,49 @@ export const paymentHandlers: Record<string, ActionHandler> = {
     };
   },
 
-  send_payment: async (supabase, userId, _actorId, params) => {
+  /**
+   * Asking the Cat to pay someone runs the same code as tapping Send.
+   *
+   * This used to be its own 130-line implementation, and the differences were
+   * not stylistic. It resolved recipients by reading `wallets.lightning_address`
+   * directly, so anyone receiving over NWC — which the rest of the platform
+   * handles fine — came back as "has no Lightning address configured". It also
+   * matched usernames case-sensitively, so asking to pay @Alice failed for a
+   * user stored as @alice. Both were fixed once, in the shared service, and this
+   * handler was still carrying the old copy.
+   */
+  send_payment: async (_supabase, userId, _actorId, params) => {
     const amountBtc = params.amount_btc as number;
     const recipient = params.recipient as string;
     const memo = (params.memo as string) || 'Payment via My Cat';
 
-    if (!amountBtc || amountBtc <= 0) {
+    // The service takes a number and a string; the Cat fills these from a model
+    // response, so neither is guaranteed to be either.
+    if (typeof amountBtc !== 'number' || !Number.isFinite(amountBtc) || amountBtc <= 0) {
       return { success: false, error: 'Amount must be positive' };
     }
-
-    // 1. Get sender's NWC wallet (user can only read their own wallets via RLS)
-    // Own-secret read: the NWC URI has no client-role column grant (write-only
-    // for anon/authenticated), so read it via service role — scoped to the
-    // authenticated user's own profile_id established by the caller.
-    const { data: senderWallets } = await (getAdminClient() as unknown as SupabaseClient)
-      .from(DATABASE_TABLES.WALLETS)
-      .select('nwc_connection_uri')
-      .eq('profile_id', userId)
-      .eq('is_active', true)
-      .not('nwc_connection_uri', 'is', null)
-      .order('is_primary', { ascending: false })
-      .limit(1);
-
-    if (!senderWallets || senderWallets.length === 0 || !senderWallets[0].nwc_connection_uri) {
-      return {
-        success: false,
-        error:
-          'No Lightning wallet (NWC) connected. Add one in Settings → Wallet to enable automatic payments.',
-      };
+    if (typeof recipient !== 'string' || !recipient.trim()) {
+      return { success: false, error: 'Recipient is required — a username or Lightning address' };
     }
 
-    let senderNwcUri: string;
-    try {
-      senderNwcUri = decrypt(senderWallets[0].nwc_connection_uri);
-    } catch {
-      return {
-        success: false,
-        error: 'Wallet connection is corrupted. Please reconnect your wallet in Settings.',
-      };
+    const result = await sendToRecipient(userId, recipient, amountBtc, memo);
+    if (!result.ok) {
+      return { success: false, error: result.message };
     }
 
-    // 2. Resolve recipient's lightning address
-    const trimmedRecipient = recipient.trim();
-    let lightningAddress: string;
-
-    if (trimmedRecipient.includes('@') && !trimmedRecipient.startsWith('@')) {
-      // Direct lightning address: alice@getalby.com
-      lightningAddress = trimmedRecipient;
-    } else {
-      // Username lookup: @alice or alice
-      const username = trimmedRecipient.startsWith('@')
-        ? trimmedRecipient.slice(1)
-        : trimmedRecipient;
-      const admin = getAdminClient() as unknown as SupabaseClient;
-
-      const { data: profile } = await admin
-        .from(DATABASE_TABLES.PROFILES)
-        .select('id')
-        .eq('username', username)
-        .single();
-
-      if (!profile) {
-        return { success: false, error: `User @${username} not found` };
-      }
-
-      const { data: recipientWallets } = await admin
-        .from(DATABASE_TABLES.WALLETS)
-        .select('lightning_address')
-        .eq('profile_id', profile.id)
-        .eq('is_active', true)
-        .not('lightning_address', 'is', null)
-        .order('is_primary', { ascending: false })
-        .limit(1);
-
-      if (
-        !recipientWallets ||
-        recipientWallets.length === 0 ||
-        !recipientWallets[0].lightning_address
-      ) {
-        return {
-          success: false,
-          error: `@${username} has no Lightning address configured. Ask them to add one in their settings.`,
-        };
-      }
-
-      lightningAddress = recipientWallets[0].lightning_address;
-    }
-
-    // 3. Generate invoice from recipient's lightning address
-    const recipientWallet: ResolvedWallet = {
-      method: 'lightning_address',
-      wallet_id: 'recipient',
-      lightning_address: lightningAddress,
+    const paid = result.amountBtc ?? amountBtc;
+    const displayMemo = memo !== 'Payment via My Cat' ? ` — "${memo}"` : '';
+    return {
+      success: true,
+      data: {
+        payment_hash: result.paymentHash,
+        amount_btc: paid,
+        recipient: result.destination,
+        memo,
+        status: 'paid',
+        displayMessage: `Sent ${paid} BTC to ${result.destination}${displayMemo}`,
+      },
     };
-
-    let invoice;
-    try {
-      invoice = await generateInvoice(recipientWallet, amountBtc, memo);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Unknown error';
-      return { success: false, error: `Could not reach ${lightningAddress}: ${msg}` };
-    }
-
-    if (!invoice.bolt11) {
-      return { success: false, error: 'Failed to get a Lightning invoice from the recipient' };
-    }
-
-    // 4. Pay invoice from sender's NWC wallet
-    const sendNwcClient = new NWCClient(senderNwcUri);
-    try {
-      await sendNwcClient.connect();
-      const payResult = await sendNwcClient.payInvoice(invoice.bolt11);
-      const displayMemo = memo !== 'Payment via My Cat' ? ` — "${memo}"` : '';
-      return {
-        success: true,
-        data: {
-          payment_hash: payResult.payment_hash,
-          amount_btc: amountBtc,
-          recipient: lightningAddress,
-          memo,
-          status: 'paid',
-          displayMessage: `Sent ${amountBtc} BTC to ${lightningAddress}${displayMemo}`,
-        },
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Unknown error';
-      return {
-        success: false,
-        error: `Lightning payment failed: ${msg}. Check your wallet has sufficient balance.`,
-      };
-    } finally {
-      sendNwcClient.disconnect();
-    }
   },
 
   fund_project: async (supabase, userId, _actorId, params) => {
@@ -261,35 +171,13 @@ export const paymentHandlers: Record<string, ActionHandler> = {
       return { success: false, error: 'Amount must be positive' };
     }
 
-    // 1. Get sender's NWC wallet
-    // Own-secret read: the NWC URI has no client-role column grant (write-only
-    // for anon/authenticated), so read it via service role — scoped to the
-    // authenticated user's own profile_id established by the caller.
-    const { data: senderWallets } = await (getAdminClient() as unknown as SupabaseClient)
-      .from(DATABASE_TABLES.WALLETS)
-      .select('nwc_connection_uri')
-      .eq('profile_id', userId)
-      .eq('is_active', true)
-      .not('nwc_connection_uri', 'is', null)
-      .order('is_primary', { ascending: false })
-      .limit(1);
-
-    if (!senderWallets || senderWallets.length === 0 || !senderWallets[0].nwc_connection_uri) {
-      return {
-        success: false,
-        error:
-          'No Lightning wallet (NWC) connected. Add one in Settings → Wallet to fund projects automatically.',
-      };
-    }
-
-    let senderNwcUri: string;
-    try {
-      senderNwcUri = decrypt(senderWallets[0].nwc_connection_uri);
-    } catch {
-      return {
-        success: false,
-        error: 'Wallet connection is corrupted. Please reconnect your wallet in Settings.',
-      };
+    // 1. Get the sender's NWC connection through the shared resolver, so a
+    // missing wallet and an unreadable one stay distinguishable — and so a key
+    // problem on our side isn't reported to the user as their wallet being
+    // "corrupted", which is the one diagnosis they can't act on.
+    const senderNwcUri = await resolveSenderNwcUri(userId);
+    if (typeof senderNwcUri !== 'string') {
+      return { success: false, error: senderNwcUri.message };
     }
 
     // 2. Resolve project owner's payment method (uses admin internally for cross-user lookup)


### PR DESCRIPTION
The Cat's `send_payment` tool carried its own 130-line implementation of paying a person. The drift from the shared service was **not cosmetic** — it had two live bugs the service had already fixed:

| | Cat's copy | Shared service |
|---|---|---|
| Recipient resolution | read `wallets.lightning_address` directly → an **NWC-only recipient** came back as *"has no Lightning address configured"*, despite being payable everywhere else on the platform | `resolveUserWallet` — the same resolution a payer gets anywhere |
| Username match | `.eq('username', …)` → paying **@Alice** failed for a user stored as `@alice` | `.ilike(…)` |

Both were fixed once, in `sendPaymentService`, when `/send` was built. This handler was still carrying the version from before that.

## Changes

- `send_payment` delegates to `sendToRecipient`. 130 lines → ~30.
- Params arrive from a **model response**, so the amount and recipient are validated as actually being a positive number and a non-empty string before the call. `undefined <= 0` is `false`, so a bare comparison would have passed a missing amount straight through to a service that expects a real figure.
- `fund_project`'s duplicated sender-wallet block now goes through `resolveSenderNwcUri`, inheriting the distinction between *"your wallet is unreadable"* and *"our encryption key is missing"* — so a problem on our side stops being reported as the user's wallet being corrupted.

## Tests

Four, pinning the delegation itself — if someone reintroduces a local implementation, the shared service stops being called and they fail:

- delegates and reports what was paid
- passes the service's own wording through rather than inventing its own
- refuses an amount the model didn't fill in (`undefined`, `null`, `'lots'`, `NaN`, `0`, `-1`) without calling the service
- refuses a missing recipient without calling the service

🤖 Generated with [Claude Code](https://claude.com/claude-code)