### PR TITLE
fix(credits): make top-up amounts legible and a live invoice recoverable

### DIFF
--- a/__tests__/unit/hooks/useDisplayCurrency.test.ts
+++ b/__tests__/unit/hooks/useDisplayCurrency.test.ts
@@ -67,3 +67,36 @@ describe('useDisplayCurrency', () => {
     expect(result.current.isLoading).toBe(true);
   });
 });
+
+/**
+ * A metered micropayment product routinely charges less than a cent per Cat
+ * message. At CHF's 2-decimal precision those amounts formatted as "CHF 0.00" —
+ * money genuinely spent, displayed as nothing. A credits ledger became a column
+ * of zeros and a non-empty balance looked empty. BTC carries 8 decimals, so it
+ * can always say what a fiat unit cannot.
+ */
+describe('amounts smaller than the display currency can express', () => {
+  it('never renders a non-zero amount as zero — falls back to BTC', () => {
+    mockCurrency = 'CHF';
+    const { result } = renderHook(() => useDisplayCurrency());
+
+    // 0.00000005 BTC * 86,000 = CHF 0.0043 → would print "CHF 0.00".
+    const rendered = result.current.formatAmountBtc(0.00000005);
+    expect(rendered).not.toBe('CHF 0.00');
+    expect(rendered).toBe('₿0.00000005');
+  });
+
+  it('still uses fiat once the amount is large enough to express', () => {
+    mockCurrency = 'CHF';
+    const { result } = renderHook(() => useDisplayCurrency());
+
+    // 0.0000001 BTC * 86,000 = CHF 0.0086 → rounds to CHF 0.01, which is honest.
+    expect(result.current.formatAmountBtc(0.0000001)).toBe('CHF 0.01');
+  });
+
+  it('leaves a true zero rendered in the display currency', () => {
+    mockCurrency = 'CHF';
+    const { result } = renderHook(() => useDisplayCurrency());
+    expect(result.current.formatAmountBtc(0)).toBe('CHF 0.00');
+  });
+});

--- a/__tests__/unit/services/cat/credit-topup.test.ts
+++ b/__tests__/unit/services/cat/credit-topup.test.ts
@@ -18,6 +18,7 @@ import {
   MIN_TOPUP_BTC,
   MAX_TOPUP_BTC,
   TOPUP_EXPIRY_GRACE_MS,
+  getResumableTopUp,
 } from '@/services/cat/credit-topup';
 
 jest.mock('@/utils/logger', () => ({
@@ -48,6 +49,9 @@ jest.mock('@/lib/supabase/admin', () => ({
  * the builder (e.g. `.update().eq()`) resolves to `awaitResult`; `.single()` /
  * `.maybeSingle()` resolve to the configured terminal.
  */
+/** Filter clauses the builder saw, so a query's scoping can be asserted. */
+const qbCalls: unknown[][] = [];
+
 function qb(
   opts: {
     terminal?: unknown;
@@ -57,6 +61,7 @@ function qb(
 ) {
   const terminal = opts.terminal ?? { data: null, error: null };
   const awaitResult = opts.awaitResult ?? { data: null, error: null };
+  const calls: unknown[][] = qbCalls;
   const builder: Record<string, unknown> = {
     insert: () => builder,
     update: (payload: Record<string, unknown>) => {
@@ -64,7 +69,14 @@ function qb(
       return builder;
     },
     select: () => builder,
-    eq: () => builder,
+    eq: (...a: unknown[]) => {
+      calls.push(['eq', ...a]);
+      return builder;
+    },
+    gt: (...a: unknown[]) => {
+      calls.push(['gt', ...a]);
+      return builder;
+    },
     order: () => builder,
     limit: () => builder,
     single: async () => terminal,
@@ -85,7 +97,53 @@ function nwcClient(over: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  qbCalls.length = 0;
   platformReceiveEnabled.mockReturnValue(true);
+});
+
+describe('getResumableTopUp', () => {
+  const supabase = { from: (...a: unknown[]) => adminFrom(...a) } as never;
+
+  it('returns the still-payable invoice so a closed dialog can be reopened', async () => {
+    const expiresAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    adminFrom.mockReturnValue(
+      qb({
+        terminal: {
+          data: {
+            id: 'tp1',
+            bolt11: 'lnbc1...',
+            payment_hash: 'ph_1',
+            amount_btc: '0.00010000', // numeric(18,8) arrives as a string
+            expires_at: expiresAt,
+          },
+        },
+      })
+    );
+
+    await expect(getResumableTopUp(supabase, 'owner')).resolves.toEqual({
+      topupId: 'tp1',
+      bolt11: 'lnbc1...',
+      paymentHash: 'ph_1',
+      amountBtc: 0.0001, // coerced — a string here would break BTC formatting
+      expiresAt,
+    });
+  });
+
+  it('scopes to the caller, to pending only, and excludes already-expired rows', async () => {
+    adminFrom.mockReturnValue(qb({ terminal: { data: null } }));
+
+    await getResumableTopUp(supabase, 'owner');
+
+    // Resuming an expired invoice could only produce a payment that cannot land.
+    expect(qbCalls).toContainEqual(['eq', 'user_id', 'owner']);
+    expect(qbCalls).toContainEqual(['eq', 'status', 'pending']);
+    expect(qbCalls.some(c => c[0] === 'gt' && c[1] === 'expires_at')).toBe(true);
+  });
+
+  it('returns null when there is nothing to resume', async () => {
+    adminFrom.mockReturnValue(qb({ terminal: { data: null } }));
+    await expect(getResumableTopUp(supabase, 'owner')).resolves.toBeNull();
+  });
 });
 
 describe('initiateTopUp', () => {

--- a/src/app/api/cat/credits/route.ts
+++ b/src/app/api/cat/credits/route.ts
@@ -9,6 +9,7 @@
  */
 
 import { getCreditBalance, listCreditEntries } from '@/services/cat/credits';
+import { getResumableTopUp } from '@/services/cat/credit-topup';
 import { platformReceiveEnabled } from '@/lib/bitcoin/platform-wallet';
 import { apiSuccess, handleApiError } from '@/lib/api/standardResponse';
 import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
@@ -16,13 +17,21 @@ import { withAuth, type AuthenticatedRequest } from '@/lib/api/withAuth';
 export const GET = withAuth(async (request: AuthenticatedRequest) => {
   const { user, supabase } = request;
   try {
-    const [balanceBtc, entries] = await Promise.all([
+    const [balanceBtc, entries, pendingTopup] = await Promise.all([
       getCreditBalance(supabase, user.id),
       listCreditEntries(supabase, user.id),
+      getResumableTopUp(supabase, user.id),
     ]);
     // topupEnabled tells the UI whether to offer Lightning top-up (only when a
     // platform receiving wallet is configured — otherwise the button stays off).
-    return apiSuccess({ balanceBtc, entries, topupEnabled: platformReceiveEnabled() });
+    // pendingTopup carries a still-payable invoice so the panel can offer it
+    // again; without it, closing the dialog lost the only handle on the invoice.
+    return apiSuccess({
+      balanceBtc,
+      entries,
+      topupEnabled: platformReceiveEnabled(),
+      pendingTopup,
+    });
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/components/ai/CatCreditsPanel.tsx
+++ b/src/components/ai/CatCreditsPanel.tsx
@@ -10,11 +10,12 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Coins, Loader2, AlertCircle, ArrowDownLeft, ArrowUpRight } from 'lucide-react';
+import { Coins, Loader2, AlertCircle, ArrowDownLeft, ArrowUpRight, Clock } from 'lucide-react';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { displayBTC } from '@/services/currency';
 import { logger } from '@/utils/logger';
 import { API_ROUTES } from '@/config/api-routes';
-import { TopUpDialog } from './TopUpDialog';
+import { TopUpDialog, type TopUpInvoiceView } from './TopUpDialog';
 
 interface CreditEntry {
   id: string;
@@ -37,9 +38,12 @@ export function CatCreditsPanel() {
   const [balanceBtc, setBalanceBtc] = useState(0);
   const [entries, setEntries] = useState<CreditEntry[]>([]);
   const [topupEnabled, setTopupEnabled] = useState(false);
+  const [pendingTopup, setPendingTopup] = useState<TopUpInvoiceView | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [topUpOpen, setTopUpOpen] = useState(false);
+  /** Set when the dialog is opened to RESUME `pendingTopup` rather than start fresh. */
+  const [resuming, setResuming] = useState<TopUpInvoiceView | null>(null);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -53,6 +57,7 @@ export function CatCreditsPanel() {
       setBalanceBtc(json?.data?.balanceBtc ?? 0);
       setEntries((json?.data?.entries ?? []) as CreditEntry[]);
       setTopupEnabled(!!json?.data?.topupEnabled);
+      setPendingTopup((json?.data?.pendingTopup ?? null) as TopUpInvoiceView | null);
     } catch (err) {
       logger.error('Failed to load cat credits', err, 'CatCredits');
       setError('Could not load your credits. Try again.');
@@ -94,7 +99,10 @@ export function CatCreditsPanel() {
         </div>
         <button
           type="button"
-          onClick={() => setTopUpOpen(true)}
+          onClick={() => {
+            setResuming(null);
+            setTopUpOpen(true);
+          }}
           disabled={!topupEnabled}
           title={topupEnabled ? 'Top up with Lightning' : 'Lightning top-up is coming soon'}
           className={
@@ -106,6 +114,28 @@ export function CatCreditsPanel() {
           {topupEnabled ? 'Top up' : 'Top up (soon)'}
         </button>
       </div>
+
+      {/* An invoice issued earlier and still payable. Without this the only
+          handle on it was the dialog's own state, so closing the modal made a
+          live invoice unreachable and invisible. */}
+      {pendingTopup && (
+        <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-subtle bg-surface-raised/30 p-3">
+          <span className="flex items-center gap-2 text-sm text-fg-secondary">
+            <Clock className="h-4 w-4 text-status-warning" />
+            {displayBTC(pendingTopup.amountBtc)} invoice waiting for payment
+          </span>
+          <button
+            type="button"
+            onClick={() => {
+              setResuming(pendingTopup);
+              setTopUpOpen(true);
+            }}
+            className="rounded-md border border-subtle px-3 py-1.5 text-sm text-fg-primary hover:bg-surface-raised"
+          >
+            Show invoice
+          </button>
+        </div>
+      )}
 
       {/* History */}
       {error ? (
@@ -155,7 +185,13 @@ export function CatCreditsPanel() {
 
       {topUpOpen && (
         <TopUpDialog
-          onClose={() => setTopUpOpen(false)}
+          initialInvoice={resuming}
+          onClose={() => {
+            setTopUpOpen(false);
+            // Refresh so a top-up created and then closed shows up as pending
+            // rather than vanishing until the next page load.
+            void load();
+          }}
           onSuccess={() => {
             setTopUpOpen(false);
             void load();

--- a/src/components/ai/TopUpDialog.tsx
+++ b/src/components/ai/TopUpDialog.tsx
@@ -5,15 +5,25 @@
  *
  * Pick an amount → POST issues a platform invoice → show the bolt11 as a QR +
  * copy → poll settlement → on payment, credit lands and the panel refreshes.
- * Amounts are BTC (canonical), shown in the user's display currency.
+ *
+ * Amounts lead with BTC, the canonical unit, and carry the user's display
+ * currency as an approximation. Leading with fiat (as this did) meant the three
+ * presets read "CHF 5.23 / 26.15 / 52.31" — values nobody would choose, which
+ * silently changed every day with the exchange rate. The amount actually being
+ * invoiced is the BTC one, so that is the number shown.
+ *
+ * Can also RESUME an invoice issued earlier (`initialInvoice`): a top-up whose
+ * dialog was closed is still payable until it expires, and settlement no longer
+ * depends on this component being mounted (services/cat/topup-reconcile).
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
-import { Loader2, Copy, Check, X, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Loader2, Copy, Check, X, AlertCircle, CheckCircle2, ExternalLink } from 'lucide-react';
 import { toast } from 'sonner';
 import Button from '@/components/ui/Button';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
+import { displayBTC } from '@/services/currency';
 import { logger } from '@/utils/logger';
 import { API_ROUTES } from '@/config/api-routes';
 
@@ -21,24 +31,38 @@ import { API_ROUTES } from '@/config/api-routes';
 import { TOPUP_PRESETS_BTC as PRESETS_BTC } from '@/config/cat-plans';
 const POLL_MS = 3000;
 
-interface Invoice {
+export interface TopUpInvoiceView {
   topupId: string;
   bolt11: string;
   amountBtc: number;
+  expiresAt: string;
 }
 
 interface TopUpDialogProps {
   onClose: () => void;
   onSuccess: () => void;
+  /** Resume an invoice issued earlier instead of asking for an amount. */
+  initialInvoice?: TopUpInvoiceView | null;
 }
 
-export function TopUpDialog({ onClose, onSuccess }: TopUpDialogProps) {
-  const { formatAmountBtc } = useDisplayCurrency();
-  const [invoice, setInvoice] = useState<Invoice | null>(null);
+/** mm:ss left, or null once the window has passed. */
+function timeLeft(expiresAt: string): string | null {
+  const ms = new Date(expiresAt).getTime() - Date.now();
+  if (!isFinite(ms) || ms <= 0) {
+    return null;
+  }
+  const total = Math.floor(ms / 1000);
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+}
+
+export function TopUpDialog({ onClose, onSuccess, initialInvoice }: TopUpDialogProps) {
+  const { formatAmountBtc, prefersFiat } = useDisplayCurrency();
+  const [invoice, setInvoice] = useState<TopUpInvoiceView | null>(initialInvoice ?? null);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [expired, setExpired] = useState(false);
+  const [remaining, setRemaining] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const stopPolling = useCallback(() => {
@@ -49,6 +73,15 @@ export function TopUpDialog({ onClose, onSuccess }: TopUpDialogProps) {
   }, []);
 
   useEffect(() => stopPolling, [stopPolling]);
+
+  /**
+   * BTC leads; fiat is the approximation. A user who prefers BTC/SATS as their
+   * display currency would otherwise see the same number twice.
+   */
+  const fiatHint = useCallback(
+    (btc: number): string | null => (prefersFiat ? `≈ ${formatAmountBtc(btc)}` : null),
+    [prefersFiat, formatAmountBtc]
+  );
 
   const create = useCallback(async (amountBtc: number) => {
     setCreating(true);
@@ -67,6 +100,7 @@ export function TopUpDialog({ onClose, onSuccess }: TopUpDialogProps) {
         topupId: json.data.topupId,
         bolt11: json.data.bolt11,
         amountBtc: json.data.amountBtc,
+        expiresAt: json.data.expiresAt,
       });
     } catch (err) {
       logger.error('Top-up create failed', err, 'CatCredits');
@@ -102,6 +136,17 @@ export function TopUpDialog({ onClose, onSuccess }: TopUpDialogProps) {
     }, POLL_MS);
     return stopPolling;
   }, [invoice, onSuccess, stopPolling]);
+
+  // Count the window down. "Waiting for payment…" with no deadline gave no clue
+  // that the invoice dies in an hour.
+  useEffect(() => {
+    if (!invoice || expired) {
+      return;
+    }
+    setRemaining(timeLeft(invoice.expiresAt));
+    const tick = setInterval(() => setRemaining(timeLeft(invoice.expiresAt)), 1000);
+    return () => clearInterval(tick);
+  }, [invoice, expired]);
 
   const copy = async () => {
     if (!invoice) {
@@ -146,9 +191,12 @@ export function TopUpDialog({ onClose, onSuccess }: TopUpDialogProps) {
                   type="button"
                   disabled={creating}
                   onClick={() => create(amt)}
-                  className="rounded-md border border-subtle bg-surface-raised/30 px-3 py-3 text-sm font-medium text-fg-primary hover:border-strong hover:bg-surface-raised disabled:opacity-50"
+                  className="flex flex-col items-center gap-0.5 rounded-md border border-subtle bg-surface-raised/30 px-3 py-3 text-sm font-medium text-fg-primary hover:border-strong hover:bg-surface-raised disabled:opacity-50"
                 >
-                  {formatAmountBtc(amt)}
+                  <span>{displayBTC(amt)}</span>
+                  {fiatHint(amt) && (
+                    <span className="text-xs font-normal text-fg-tertiary">{fiatHint(amt)}</span>
+                  )}
                 </button>
               ))}
             </div>
@@ -181,28 +229,51 @@ export function TopUpDialog({ onClose, onSuccess }: TopUpDialogProps) {
         ) : (
           <div className="flex flex-col items-center gap-3">
             <p className="text-sm text-fg-secondary">
-              Pay {formatAmountBtc(invoice.amountBtc)} with any Lightning wallet:
+              Pay{' '}
+              <span className="font-medium text-fg-primary">{displayBTC(invoice.amountBtc)}</span>
+              {fiatHint(invoice.amountBtc) && (
+                <span className="text-fg-tertiary"> ({fiatHint(invoice.amountBtc)})</span>
+              )}{' '}
+              with any Lightning wallet:
             </p>
             <div className="rounded-md bg-white p-3">
-              <QRCodeSVG value={invoice.bolt11.toUpperCase()} size={200} />
+              {/*
+                The `LIGHTNING:` scheme is what makes a phone camera or a desktop
+                wallet handler offer to pay this. A bare bolt11 (what was here)
+                scans as meaningless text unless the user is already inside a
+                wallet app. Uppercase keeps the QR in bech32 alphanumeric mode,
+                and `:` is in that charset, so the prefix costs no density.
+              */}
+              <QRCodeSVG value={`LIGHTNING:${invoice.bolt11.toUpperCase()}`} size={200} />
             </div>
-            <button
-              type="button"
-              onClick={copy}
-              className="inline-flex items-center gap-1.5 rounded-md border border-subtle px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-raised"
-            >
-              {copied ? (
-                <Check className="h-4 w-4 text-status-positive" />
-              ) : (
-                <Copy className="h-4 w-4" />
-              )}
-              {copied ? 'Copied' : 'Copy invoice'}
-            </button>
+            <div className="flex items-center gap-2">
+              <a
+                href={`lightning:${invoice.bolt11}`}
+                className="inline-flex items-center gap-1.5 rounded-md border border-subtle px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-raised"
+              >
+                <ExternalLink className="h-4 w-4" />
+                Open in wallet
+              </a>
+              <button
+                type="button"
+                onClick={copy}
+                className="inline-flex items-center gap-1.5 rounded-md border border-subtle px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-raised"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4 text-status-positive" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+                {copied ? 'Copied' : 'Copy invoice'}
+              </button>
+            </div>
             <div className="flex items-center gap-2 text-sm text-fg-tertiary">
-              <Loader2 className="h-4 w-4 animate-spin" /> Waiting for payment…
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {remaining ? `Waiting for payment — ${remaining} left` : 'Waiting for payment…'}
             </div>
-            <p className="flex items-center gap-1 text-xs text-fg-tertiary">
-              <CheckCircle2 className="h-3 w-3" /> Credits land automatically once paid.
+            <p className="flex items-center gap-1 text-center text-xs text-fg-tertiary">
+              <CheckCircle2 className="h-3 w-3 shrink-0" />
+              Credits land automatically once paid — you can close this.
             </p>
           </div>
         )}

--- a/src/hooks/useDisplayCurrency.ts
+++ b/src/hooks/useDisplayCurrency.ts
@@ -19,7 +19,21 @@ import { useUserCurrency } from './useUserCurrency';
 import { isFiatCurrency } from '@/utils/currency-helpers';
 import { useCurrencyConversion } from './useCurrencyConversion';
 import { formatCurrency, satsToBitcoin, bitcoinToSats } from '@/services/currency';
-import type { CurrencyCode } from '@/config/currencies';
+import { CURRENCY_METADATA, type CurrencyCode } from '@/config/currencies';
+
+/**
+ * Would this fiat amount render as all zeros at the currency's precision?
+ *
+ * CHF/USD/EUR/GBP carry 2 decimals, but this platform charges per Cat message —
+ * amounts that are routinely under half a cent. Formatting those the ordinary
+ * way prints "CHF 0.00" for money that was really spent, so a credits ledger
+ * reads as a column of zeros and a balance looks empty while it is not. A
+ * display that rounds a non-zero amount to zero is not imprecise, it is wrong.
+ */
+function roundsToZero(fiatAmount: number, currency: CurrencyCode): boolean {
+  const precision = CURRENCY_METADATA[currency]?.precision ?? 2;
+  return Math.abs(fiatAmount) < 0.5 * Math.pow(10, -precision);
+}
 
 interface DisplayCurrencyOptions {
   /** Show currency symbol (default: true) */
@@ -90,10 +104,16 @@ export function useDisplayCurrency(): UseDisplayCurrencyReturn {
       const btc = satsToBitcoin(sats);
       const fiatAmount = convertFromBTC(btc, displayCurrency);
 
-      // Rates not loaded yet (e.g. logged-out visitors) → fall back to BTC, the
-      // canonical unit — NEVER sats. Showing sats here was why public pages
-      // rendered "100,000 sat" before rates arrived.
-      if (isLoading || fiatAmount === 0) {
+      // Fall back to BTC, the canonical unit — NEVER sats. Showing sats here was
+      // why public pages rendered "100,000 sat" before rates arrived. Three
+      // cases reach it:
+      //   - rates not loaded yet (e.g. logged-out visitors),
+      //   - the conversion produced nothing,
+      //   - the amount is real but smaller than the currency can express, which
+      //     would otherwise print "CHF 0.00" for money that was genuinely spent
+      //     (see roundsToZero — per-message Cat charges live below half a cent).
+      // BTC has 8 decimals, so it can always say what a fiat unit cannot.
+      if (isLoading || fiatAmount === 0 || roundsToZero(fiatAmount, displayCurrency)) {
         return formatCurrency(btc, 'BTC', { showSymbol, compact });
       }
 

--- a/src/services/cat/credit-topup.ts
+++ b/src/services/cat/credit-topup.ts
@@ -230,6 +230,52 @@ export async function settleTopUpRow(
 }
 
 /**
+ * The caller's most recent top-up that can still be paid.
+ *
+ * An invoice does not stop being payable because its dialog was closed, but
+ * nothing in the UI referenced a pending top-up once that happened — the only
+ * handle on it was component state that went away with the modal. A user who
+ * closed the dialog (or reloaded, or came back on their phone) had no way to
+ * reach the invoice again and no evidence it existed, so the honest options
+ * were "pay a QR I can no longer see" or "make a second one".
+ *
+ * Read with the caller's own client so RLS scopes it; expired rows are excluded
+ * because resuming one would only produce a payment that cannot land.
+ */
+export async function getResumableTopUp(
+  supabase: AnySupabaseClient,
+  userId: string
+): Promise<TopUpInvoice | null> {
+  const { data } = await supabase
+    .from(DATABASE_TABLES.CAT_CREDIT_TOPUPS)
+    .select('id, bolt11, payment_hash, amount_btc, expires_at')
+    .eq('user_id', userId)
+    .eq('status', 'pending')
+    .gt('expires_at', new Date().toISOString())
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!data) {
+    return null;
+  }
+  const row = data as {
+    id: string;
+    bolt11: string;
+    payment_hash: string;
+    amount_btc: number | string;
+    expires_at: string;
+  };
+  return {
+    topupId: row.id,
+    bolt11: row.bolt11,
+    paymentHash: row.payment_hash,
+    amountBtc: Number(row.amount_btc),
+    expiresAt: row.expires_at,
+  };
+}
+
+/**
  * Poll one of YOUR top-ups. Scoped to the caller by user_id; terminal rows
  * answer without a wallet round-trip.
  */


### PR DESCRIPTION
Follow-up to #627. That one was money loss; these are five ways the UI **misrepresents or hides** money, all found by driving the top-up flow in a browser rather than reading the code.

### 1. Presets showed prices nobody would choose — and they moved daily

The three buttons rendered **CHF 5.23 / 26.15 / 52.31**. They are round in BTC (`0.0001 / 0.0005 / 0.001`) and arbitrary in the currency the user thinks in. Worse, they convert at render time, so the *same three buttons show different numbers every day*. That is a strange thing to do on a page selling prepaid credit.

BTC now leads — it is the amount actually invoiced, and it is stable — with fiat as an approximation, shown only to users who prefer fiat.

### 2. A non-zero amount could render as `CHF 0.00`

CHF/USD/EUR/GBP carry two decimals. This platform charges **per Cat message**, routinely under half a cent. So the credits ledger would have been a column of `− CHF 0.00` rows and a non-empty balance would have looked empty.

`useDisplayCurrency` now falls back to BTC (8 decimals — and never sats, per the platform rule) when the display currency cannot express the amount. This *extends the guard already in that file* for unloaded rates, which caught `fiatAmount === 0` but not "converts to something real that rounds to zero". Fleet-wide fix, not a credits-only one.

### 3. The QR was unscannable outside a wallet app

It carried a bare bolt11. Now `LIGHTNING:`-prefixed, so a phone camera or desktop wallet handler offers to pay it — plus an explicit **Open in wallet** link. Uppercase keeps the QR in bech32 alphanumeric mode and `:` is in that charset, so density is unchanged.

### 4. No deadline

"Waiting for payment…" spun forever with no hint the invoice dies in an hour. Now counts down.

### 5. A live invoice became unreachable the moment the dialog closed

Its only handle was component state. Close the modal — or reload, or come back on a phone — and a still-payable invoice was invisible, leaving "pay a QR I can no longer see" or "make a second one".

`GET /api/cat/credits` now returns a still-payable `pendingTopup` and the panel offers **Show invoice**. Expired rows are excluded: resuming one could only produce a payment that cannot land.

## Verification

- Full pre-push gate green: **1,881 tests / 194 suites**, typecheck clean, lint clean.
- 3 new tests for the sub-cent rendering rule (including that a *true* zero still renders as `CHF 0.00`, and that amounts large enough to express still use fiat).
- 3 for `getResumableTopUp`: scoping to caller + `pending` + not-yet-expired, and `numeric(18,8)` → `number` coercion (a string there would break BTC formatting).

## Note on #627, verified live

The reconcile sweep from #627 is deployed and running — the cron response now carries a `credits` block, and it correctly retired the 4-day-old orphan row that motivated it. The 24h expiry grace has not yet been exercised in production; the one row that expired during testing was written by the *old* code path from a browser tab I had left open, which is precisely the behaviour #627 removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)