### PR TITLE
fix(api): an owner filter that cannot be honoured must return nothing, not everything

### DIFF
--- a/__tests__/unit/lib/api-owner-filter.test.ts
+++ b/__tests__/unit/lib/api-owner-filter.test.ts
@@ -1,0 +1,108 @@
+/**
+ * resolveOwnerFilter — the owner filter of a list endpoint.
+ *
+ * Regression under test (observed on prod 2026-08-06): GET /api/projects read
+ * only `?user_id=`, so `?username=<anything>` was silently ignored and the
+ * caller got the FULL public list back. A filter that cannot be honoured must
+ * narrow the result to nothing, never widen it to everything.
+ */
+import { resolveOwnerFilter } from '@/lib/api/query';
+
+jest.mock('@/lib/supabase/server', () => ({
+  createServerClient: jest.fn(),
+}));
+
+import { createServerClient } from '@/lib/supabase/server';
+
+const mockedCreateServerClient = createServerClient as jest.MockedFunction<
+  typeof createServerClient
+>;
+
+/** Minimal stub of the one query resolveOwnerFilter makes. */
+function stubProfileLookup(result: { id: string } | null) {
+  const maybeSingle = jest.fn().mockResolvedValue({ data: result, error: null });
+  const eq = jest.fn(() => ({ maybeSingle }));
+  const select = jest.fn(() => ({ eq }));
+  const from = jest.fn(() => ({ select }));
+  mockedCreateServerClient.mockResolvedValue({ from } as never);
+  return { from, select, eq, maybeSingle };
+}
+
+const URL_BASE = 'https://orangecat.ch/api/projects';
+
+describe('resolveOwnerFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns no filter when neither param is present', async () => {
+    const stub = stubProfileLookup(null);
+    await expect(resolveOwnerFilter(URL_BASE)).resolves.toEqual({
+      userId: undefined,
+      unresolved: false,
+    });
+    // An unfiltered list must not cost a profile lookup.
+    expect(stub.from).not.toHaveBeenCalled();
+  });
+
+  it('passes through an explicit user_id without a lookup', async () => {
+    const stub = stubProfileLookup(null);
+    await expect(resolveOwnerFilter(`${URL_BASE}?user_id=abc-123`)).resolves.toEqual({
+      userId: 'abc-123',
+      unresolved: false,
+    });
+    expect(stub.from).not.toHaveBeenCalled();
+  });
+
+  it('resolves a known username to its user id', async () => {
+    const stub = stubProfileLookup({ id: 'cec88bc9' });
+    await expect(resolveOwnerFilter(`${URL_BASE}?username=mao`)).resolves.toEqual({
+      userId: 'cec88bc9',
+      unresolved: false,
+    });
+    expect(stub.eq).toHaveBeenCalledWith('username', 'mao');
+  });
+
+  // The actual bug: this used to fall through to "no filter", which the list
+  // endpoint reads as "return everything".
+  it('reports an unknown username as unresolved, NOT as an absent filter', async () => {
+    stubProfileLookup(null);
+    await expect(resolveOwnerFilter(`${URL_BASE}?username=nobody-here`)).resolves.toEqual({
+      userId: undefined,
+      unresolved: true,
+    });
+  });
+
+  it('never lets an unknown owner look like an unfiltered request', async () => {
+    stubProfileLookup(null);
+    const unknown = await resolveOwnerFilter(`${URL_BASE}?username=nobody-here`);
+    const none = await resolveOwnerFilter(URL_BASE);
+    // Both have userId undefined — `unresolved` is the only thing that keeps
+    // them apart, so it must differ.
+    expect(unknown.userId).toBe(none.userId);
+    expect(unknown.unresolved).not.toBe(none.unresolved);
+  });
+
+  it('prefers user_id when both are supplied', async () => {
+    const stub = stubProfileLookup({ id: 'from-username' });
+    await expect(resolveOwnerFilter(`${URL_BASE}?user_id=from-uuid&username=mao`)).resolves.toEqual(
+      { userId: 'from-uuid', unresolved: false }
+    );
+    expect(stub.from).not.toHaveBeenCalled();
+  });
+
+  it('treats a blank username as no filter, not as an unknown owner', async () => {
+    const stub = stubProfileLookup(null);
+    await expect(resolveOwnerFilter(`${URL_BASE}?username=%20%20`)).resolves.toEqual({
+      userId: undefined,
+      unresolved: false,
+    });
+    expect(stub.from).not.toHaveBeenCalled();
+  });
+
+  it('trims a padded username before looking it up', async () => {
+    const stub = stubProfileLookup({ id: 'cec88bc9' });
+    await resolveOwnerFilter(`${URL_BASE}?username=%20mao%20`);
+    expect(stub.eq).toHaveBeenCalledWith('username', 'mao');
+  });
+});

--- a/scripts/check-duplication.mjs
+++ b/scripts/check-duplication.mjs
@@ -15,6 +15,15 @@
  * Baseline history:
  *   1.3  (2026-08-02) — post phase-B dedup refactor; measured 1.20% with
  *                       `jscpd src --min-tokens 70`.
+ *   1.1  (2026-08-06) — measured 1.01% in CI (2232/221625 lines, 140 clones)
+ *                       and 0.99% locally (2191/222072, 138). Ratcheting per
+ *                       the rule above: the reduction had already happened and
+ *                       the baseline had not followed it down, so 0.29% of
+ *                       headroom was sitting there for new duplication to
+ *                       occupy without ever tripping the gate.
+ *                       Deliberately 1.1 and not 1.0: the two environments
+ *                       disagree by ~0.02%, so a baseline pinned to the lower
+ *                       reading would make the gate flaky rather than strict.
  *
  * Run: npm run check:duplication   (part of `npm run verify`; exit 1 on FAIL)
  */
@@ -25,7 +34,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 /** Max allowed duplicated-lines percentage across src/ (see ratchet rule above). */
-const BASELINE_PERCENT = 1.3;
+const BASELINE_PERCENT = 1.1;
 
 /** Keep detection settings pinned so the number is comparable across runs. */
 const MIN_TOKENS = '70';

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -4,7 +4,7 @@ import { withRateLimit } from '@/lib/api/withRateLimit';
 import { withRequestId } from '@/lib/api/withRequestId';
 import { projectSchema, type ProjectData } from '@/lib/validation';
 import { handleApiError, apiSuccess } from '@/lib/api/standardResponse';
-import { getPagination } from '@/lib/api/query';
+import { getPagination, resolveOwnerFilter } from '@/lib/api/query';
 import { listProjectsPage, createProject } from '@/domain/projects/service';
 import { calculatePage, getCacheControl } from '@/lib/api/helpers';
 import { createEntityPostHandler } from '@/lib/api/entityPostHandler';
@@ -12,8 +12,12 @@ import { getAuthenticatedUserId, shouldIncludeDrafts } from '@/lib/api/authHelpe
 
 // GET /api/projects - Get all projects
 //
-// Security: when `?user_id=X` is passed, only return drafts if the
-// authenticated user IS X. Without this guard, anonymous callers can
+// Accepts `?user_id=<uuid>` or `?username=<handle>` to scope the list to one
+// owner. An unknown handle returns an EMPTY page — never the unfiltered list;
+// see resolveOwnerFilter for why that distinction is load-bearing.
+//
+// Security: when an owner is requested, only return drafts if the
+// authenticated user IS that owner. Without this guard, anonymous callers can
 // enumerate any user's drafts by passing their UUID. The actor lookup
 // downstream resolves the UUID to actor_id, which then becomes a public
 // data window for that owner.
@@ -23,14 +27,27 @@ export const GET = compose(
 )(async (request: NextRequest) => {
   try {
     const { limit, offset } = getPagination(request.url, { defaultLimit: 20, maxLimit: 100 });
-    const url = new URL(request.url);
-    const requestedUserId = url.searchParams.get('user_id');
+    const { userId: requestedUserId, unresolved } = await resolveOwnerFilter(request.url);
+    if (unresolved) {
+      // The caller asked for one person's projects and that person does not
+      // exist. Answering with everyone's would be a wrong answer, not a
+      // broader one.
+      return apiSuccess([], {
+        page: calculatePage(offset, limit),
+        limit,
+        total: 0,
+        headers: { 'Cache-Control': getCacheControl(false) },
+      });
+    }
     const authenticatedUserId = await getAuthenticatedUserId();
-    const includeOwnDrafts = await shouldIncludeDrafts(requestedUserId, authenticatedUserId);
+    const includeOwnDrafts = await shouldIncludeDrafts(
+      requestedUserId ?? null,
+      authenticatedUserId
+    );
     const { items, total } = await listProjectsPage(
       limit,
       offset,
-      requestedUserId || undefined,
+      requestedUserId,
       includeOwnDrafts
     );
     return apiSuccess(items, {

--- a/src/lib/api/query.ts
+++ b/src/lib/api/query.ts
@@ -1,3 +1,6 @@
+import { createServerClient } from '@/lib/supabase/server';
+import { DATABASE_TABLES } from '@/config/database-tables';
+
 export function getPagination(url: string, opts?: { defaultLimit?: number; maxLimit?: number }) {
   const u = new URL(url);
   const def = opts?.defaultLimit ?? 20;
@@ -12,4 +15,49 @@ export function getPagination(url: string, opts?: { defaultLimit?: number; maxLi
 export function getString(url: string, key: string) {
   const val = new URL(url).searchParams.get(key);
   return val ?? undefined;
+}
+
+/**
+ * Resolve the owner filter of a list endpoint from `?user_id=` or `?username=`.
+ *
+ * `?username=` used to be accepted by nobody and ignored by everybody: the
+ * projects list read only `?user_id=`, so `?username=anything` — including a
+ * handle that does not exist — returned the FULL public list. A caller scoping
+ * a request to one person got everyone's data back, and nothing in the
+ * response said the filter had been dropped.
+ *
+ * The rule this encodes: a filter that cannot be honoured must narrow the
+ * result to nothing, never silently widen it to everything. An unknown handle
+ * is an empty result, not an unfiltered one.
+ *
+ * `user_id` wins when both are present — it is the unambiguous identifier, and
+ * it is what the drafts guard downstream compares against the authenticated
+ * user.
+ */
+export async function resolveOwnerFilter(
+  url: string
+): Promise<{ userId: string | undefined; unresolved: boolean }> {
+  const params = new URL(url).searchParams;
+
+  const userId = params.get('user_id');
+  if (userId) {
+    return { userId, unresolved: false };
+  }
+
+  const username = params.get('username')?.trim();
+  if (!username) {
+    return { userId: undefined, unresolved: false };
+  }
+
+  // Whether a username exists is already public (/profiles/<username> answers
+  // 404 vs 200), so resolving one here reveals nothing new.
+  const supabase = await createServerClient();
+  const { data } = await supabase
+    .from(DATABASE_TABLES.PROFILES)
+    .select('id')
+    .eq('username', username)
+    .maybeSingle();
+
+  const resolved = (data as { id: string } | null)?.id;
+  return { userId: resolved, unresolved: !resolved };
 }


### PR DESCRIPTION
## The bug

`GET /api/projects` read only `?user_id=`. `?username=` was accepted by nobody and ignored by everybody — so `?username=<anything>`, **including a handle that does not exist**, returned the full public list.

A caller scoping a request to one person got everyone's data back, and nothing in the response said the filter had been dropped.

That's the dangerous shape: not an error, but a wrong answer that looks like a right one. Silently *widening* a filter is worse than rejecting it, because the caller cannot tell the difference.

(To be clear about scope: this was never a data leak. The rows returned are public projects, and the drafts guard was and remains correct.)

## The fix

`resolveOwnerFilter` resolves `?username=` to a user id and reports whether it could:

- known handle → scoped to that owner
- **unknown handle → empty page, never the unfiltered list**
- `user_id` wins when both are present — it's the unambiguous identifier and the one the drafts guard compares against the authenticated user (unchanged)

## Verified against the live database

| Request | Result |
|---|---|
| `/api/projects` | FleetCrown, Bitcoin Art Series, OrangeCat |
| `?username=mao` | FleetCrown, OrangeCat |
| `?username=zzz-not-a-real-user` | **empty** (was: all 3) |
| `?username=alisa_orangecat` | Bitcoin Art Series |
| `?user_id=cec88bc9-…` | FleetCrown, OrangeCat (matches `username=mao`) |

Drafts stay invisible: `mao` has 7 projects, 5 of them drafts, and only the 2 active ones come back unauthenticated. The empty-page response carries a byte-identical envelope to a normal one (`success` / `data` / `metadata.page,limit,total`).

8 unit tests cover it, including the one that matters: an unknown owner and an absent filter both yield `userId: undefined`, so `unresolved` is the only thing keeping them apart — and it must differ.

## Also: duplication ratchet 1.3 → 1.1

CI had been measuring **1.01% against a 1.3% baseline**. The reduction happened and the baseline never followed it down, leaving 0.29% of headroom for new duplication to occupy without ever tripping the gate — which is precisely what the script's own documented one-way-ratchet rule says to close.

Kept at 1.1 rather than 1.0 deliberately: CI and local disagree by ~0.02% (1.01% vs 0.99%), so a baseline pinned to the lower reading would make the gate flaky instead of strict.

`npm run verify` green: 1887 tests / 196 suites, duplication 0.99%, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)