### PR TITLE
fix(db): profiles outlived their users — make that structurally impossible

### DIFF
--- a/scripts/check-data-invariants.mjs
+++ b/scripts/check-data-invariants.mjs
@@ -56,6 +56,23 @@ async function rest(path) {
   return res.json();
 }
 
+/** PostgREST RPC (POST). `rest` only does GET; functions need a body. */
+async function rpc(fn, body = {}) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: {
+      apikey: SERVICE_KEY,
+      authorization: `Bearer ${SERVICE_KEY}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`PostgREST ${res.status} on rpc/${fn}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
 /**
  * entity_type → table. MUST mirror src/config/entity-registry.ts; a type
  * missing here is reported as UNKNOWN rather than silently passing, so a new
@@ -238,6 +255,38 @@ async function checkSilentlyDroppedCatTurns() {
   }
 }
 
+/**
+ * Profiles whose auth user is gone.
+ *
+ * public.profiles carried NO foreign key until 2026-08-06, so deleting a user
+ * left the profile standing: a public page and a taken username for an account
+ * that no longer exists, and a row counted by every signup metric. That is how
+ * 73% of production profiles came to be `e2e-reset-*` CI fixtures while the
+ * real number (39) stayed invisible — the platform could not see its own users.
+ *
+ * The migration's ON DELETE CASCADE makes new orphans impossible. This check is
+ * the backstop that notices if the constraint is ever dropped, bypassed, or
+ * left NOT VALID while a delete path writes around it — and it is the reason
+ * the count is worth watching rather than assuming.
+ *
+ * auth.users is not exposed through PostgREST, so this goes through the
+ * service_role-only count_orphaned_profiles() function.
+ */
+async function checkOrphanedProfiles() {
+  const count = Number(await rpc('count_orphaned_profiles'));
+
+  if (count > 0) {
+    violation(
+      'profiles.orphaned',
+      `${count} profile(s) have no auth user — a deleted account left its public profile behind, ` +
+        `and every user-count metric is inflated by that much`,
+      []
+    );
+  } else {
+    notes.push('profiles: every profile belongs to a live auth user');
+  }
+}
+
 async function main() {
   const checks = [
     checkOrphanedWalletLinks,
@@ -245,6 +294,7 @@ async function main() {
     checkUnpayableActiveWallets,
     checkPaidWithoutTimestamp,
     checkSilentlyDroppedCatTurns,
+    checkOrphanedProfiles,
   ];
 
   for (const check of checks) {

--- a/scripts/test-setup/refresh-e2e-reset-tokens.mjs
+++ b/scripts/test-setup/refresh-e2e-reset-tokens.mjs
@@ -45,6 +45,15 @@ const admin = createClient(url, serviceKey, {
 
 // Opportunistic cleanup of yesterday's throwaway reset users. Best-effort —
 // a failure here must never block the run.
+//
+// This deletes the AUTH user; the profile row goes with it via
+// profiles.profiles_id_fkey ON DELETE CASCADE (migration 20260806150000).
+// Before that constraint existed the profile survived every deletion, so this
+// loop ran successfully for two months while quietly leaving 113 orphaned
+// profiles in production — 73% of the profiles table, which made the platform's
+// signup numbers mostly synthetic. If that constraint is ever dropped, this
+// script silently starts leaking again; the nightly `profiles.orphaned`
+// invariant is what would notice.
 try {
   const cutoff = Date.now() - 24 * 60 * 60 * 1000;
   for (let page = 1; page <= 10; page++) {

--- a/supabase/migrations/20260806150000_profiles_cascade_from_auth_users.sql
+++ b/supabase/migrations/20260806150000_profiles_cascade_from_auth_users.sql
@@ -1,0 +1,61 @@
+-- profiles outlived their users. Make that structurally impossible.
+--
+-- `public.profiles` had NO foreign key at all — `profiles.id` held an
+-- auth.users id by convention only. So deleting a user removed the auth row and
+-- left the profile behind forever: a public page, a username still taken, and a
+-- row counted by every "how many users do we have" query.
+--
+-- Measured in production 2026-08-06: 115 orphaned profiles, 113 of them from
+-- the per-run `e2e-reset-*` fixtures that CI has minted since 2026-06-12.
+-- scripts/test-setup/refresh-e2e-reset-tokens.mjs was doing its job — it calls
+-- admin.deleteUser on throwaways older than a day — but with no cascade the
+-- profile survived every time. The result: 136 of 185 profile rows (73%) were
+-- test accounts, so the platform's own signup numbers were mostly synthetic and
+-- the real figure (39, of which 3 in the last 30 days) was invisible.
+--
+-- No real end user has been orphaned yet: the other 2 are our own
+-- `memtest_*` / `selfhost-verify+*` fixtures. But nothing prevented it, and
+-- account deletion is a data-protection promise — "delete my account" must not
+-- leave a public profile standing.
+--
+-- The cascade is the fix, not a cleanup script. A delete path you have to
+-- remember to call is a delete path that eventually is not called; a foreign key
+-- cannot be forgotten. `on_auth_user_created` → `handle_new_user` already
+-- creates the profile AFTER the auth row, so ordering satisfies the constraint,
+-- and the reverse direction (a profile with no user) is exactly what we want
+-- rejected.
+--
+-- NOT VALID deliberately: it enforces the rule for every future insert and
+-- makes ON DELETE CASCADE fire from now on, WITHOUT requiring the 115 existing
+-- orphans to be deleted first. Purging live production rows is a separate,
+-- explicit decision — this migration must not smuggle it in. Once those rows
+-- are cleared, `ALTER TABLE public.profiles VALIDATE CONSTRAINT
+-- profiles_id_fkey;` promotes it to fully validated.
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_id_fkey
+  FOREIGN KEY (id) REFERENCES auth.users(id) ON DELETE CASCADE
+  NOT VALID;
+
+-- The detection half. auth.users is not reachable through PostgREST, so the
+-- nightly invariant gate (scripts/check-data-invariants.mjs) cannot see an
+-- orphan by querying tables — it needs this. SECURITY DEFINER to read the auth
+-- schema, locked to service_role so nothing user-facing can enumerate it.
+--
+-- Returns a count, not rows: the gate only needs to know the invariant broke,
+-- and a count cannot leak usernames of deleted accounts.
+CREATE OR REPLACE FUNCTION public.count_orphaned_profiles()
+RETURNS bigint
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+  SELECT count(*)::bigint
+  FROM public.profiles p
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users u WHERE u.id = p.id);
+$$;
+
+REVOKE ALL ON FUNCTION public.count_orphaned_profiles() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.count_orphaned_profiles() FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.count_orphaned_profiles() TO service_role;


### PR DESCRIPTION
## What we found

`public.profiles` had **no foreign key at all**. `profiles.id` held an `auth.users` id by convention only, so deleting a user removed the auth row and left the profile standing forever — a public page, a username still taken, and a row counted by every "how many users do we have" query.

Production today:

| | count |
|---|---|
| profiles | 185 |
| …that are `e2e-reset-*` CI fixtures | **136 (73%)** |
| orphaned profiles (no auth user) | **115** |
| **real profiles** | **39** |
| real profiles with a bio | 5 |
| **real signups in the last 30 days** | **3** |

`scripts/test-setup/refresh-e2e-reset-tokens.mjs` was doing its job the entire time — it calls `admin.deleteUser` on throwaways older than a day. Without a cascade, the profile survived every single deletion. It has been leaking since **2026-06-12**.

## Why this mattered more than the row count

The consequence was never cosmetic: **OrangeCat's own signup numbers were mostly synthetic**, and the real figure was invisible behind them. A metric nobody can trust is worse than no metric, because it still gets used to decide what to build. This contamination had already produced one wrong conclusion that needed correcting afterwards.

No real end user has been orphaned yet — the other 2 are our own `memtest_*` / `selfhost-verify+*` fixtures. But nothing prevented it, and "delete my account" must not leave a public profile behind.

## The fix

- **`FK profiles.id → auth.users(id) ON DELETE CASCADE`.** A delete path you have to remember to call is one that eventually is not called; a foreign key cannot be forgotten. This is the structural fix, not another cleanup script.
- **`NOT VALID`, deliberately.** It governs every future write and makes the cascade fire now, *without* requiring the 115 existing rows to be deleted. Purging live production data is a separate, explicit decision and this migration must not smuggle it in.
- **`count_orphaned_profiles()`**, service_role only — `auth.users` is not reachable through PostgREST and the nightly gate needs to see it. Returns a count, not rows, so it cannot leak usernames of deleted accounts.
- **New `profiles.orphaned` invariant** in `check-data-invariants.mjs`: the backstop for the constraint being dropped, bypassed, or left `NOT VALID` while something writes around it.

## Verification

Validated against the **production schema** in a rolled-back transaction — no changes made:

- migration applies clean; the gate function reports `115`
- end to end: inserting an auth user creates a profile (**1**), and deleting that user now removes it (**0**). Before this constraint, that second number was **1** — which is precisely how the 113 e2e orphans accumulated.

Full pre-push gate green: **1,929 tests / 196 suites**.

## Heads-up: the nightly gate will report the backlog

Once deployed, `profiles.orphaned` will flag the 115 pre-existing rows every night. **That is the honest state, not a regression** — the invariant genuinely does not hold yet. It clears the moment those rows are purged, which is a deliberate decision left to the owner. After clearing:

```sql
ALTER TABLE public.profiles VALIDATE CONSTRAINT profiles_id_fkey;
```

Related class: `test-suites-have-no-sandbox-for-global-tools` — a test suite acting on real shared infrastructure because nothing scoped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)