### PR TITLE
chore(ci): ratchet duplication baseline to 1.0 and correct why it was 1.1

### DIFF
--- a/scripts/check-duplication.mjs
+++ b/scripts/check-duplication.mjs
@@ -15,15 +15,20 @@
  * Baseline history:
  *   1.3  (2026-08-02) — post phase-B dedup refactor; measured 1.20% with
  *                       `jscpd src --min-tokens 70`.
- *   1.1  (2026-08-06) — measured 1.01% in CI (2232/221625 lines, 140 clones)
- *                       and 0.99% locally (2191/222072, 138). Ratcheting per
- *                       the rule above: the reduction had already happened and
- *                       the baseline had not followed it down, so 0.29% of
- *                       headroom was sitting there for new duplication to
- *                       occupy without ever tripping the gate.
- *                       Deliberately 1.1 and not 1.0: the two environments
- *                       disagree by ~0.02%, so a baseline pinned to the lower
- *                       reading would make the gate flaky rather than strict.
+ *   1.1  (2026-08-06) — ratcheted down from 1.3: the reduction had already
+ *                       happened and the baseline never followed it, leaving
+ *                       0.29% of headroom for new duplication to occupy
+ *                       without tripping the gate. Stopped at 1.1 rather than
+ *                       1.0 on the belief that CI and local disagreed
+ *                       (1.01% vs 0.99%) — that was wrong. The two numbers
+ *                       came from different commits, not different machines.
+ *   1.0  (2026-08-06) — measured 0.99% (2191/222073 lines, 138 clones),
+ *                       identical in CI and locally, so the rule above applies
+ *                       literally: round the measurement up to the next 0.1.
+ *                       The measurement is deterministic, so the remaining
+ *                       ~0.01% (≈22 lines) is genuine headroom, not noise — if
+ *                       this trips, a real block got duplicated, which is
+ *                       precisely the signal the ratchet exists to give.
  *
  * Run: npm run check:duplication   (part of `npm run verify`; exit 1 on FAIL)
  */
@@ -34,7 +39,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 /** Max allowed duplicated-lines percentage across src/ (see ratchet rule above). */
-const BASELINE_PERCENT = 1.1;
+const BASELINE_PERCENT = 1.0;
 
 /** Keep detection settings pinned so the number is comparable across runs. */
 const MIN_TOKENS = '70';


### PR DESCRIPTION
Follow-up to #636, correcting a claim I put in that PR.

The 1.1 baseline shipped with a justification that was **false**. It said CI and local disagreed (1.01% vs 0.99%) and that pinning to the lower reading would make the gate flaky.

They don't disagree. The 1.01% came from an **earlier commit**, not another machine — CI and local both measure **0.99%** on the same code, byte for byte (2191/222073 lines, 138 clones, confirmed in the #636 CI run).

With the false premise removed there's no reason to hold at 1.1, so this file's own documented rule applies literally: *"lower BASELINE_PERCENT to the new measured value rounded UP to the next 0.1"* → **1.0**.

The remaining ~0.01% is about 22 lines out of 222k. Because the measurement is deterministic that's real headroom rather than noise: if this gate trips, a block genuinely got duplicated — which is the signal it exists to give.

CI verifies the new baseline holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)