### PR TITLE
feat(cat): the Cat can get you paid — connect a wallet, or find you one

### DIFF
--- a/__tests__/unit/cat/action-disambiguation.test.ts
+++ b/__tests__/unit/cat/action-disambiguation.test.ts
@@ -40,6 +40,17 @@ const CONFUSABLE: ConfusablePair[] = [
     shadowedBy: 'forget_memories',
     consequence: 'the model deletes private memories the user never asked it to touch',
   },
+  {
+    // "add a wallet" and "connect my wallet" are the same sentence to a model,
+    // but only one of them makes the user payable. add_wallet is the older,
+    // broader verb and refuses outright when there is no receiving rail — so a
+    // user with no wallet (73 of 76 production profiles in August 2026) hits a
+    // dead end at exactly the moment they were ready to be paid.
+    action: 'connect_wallet',
+    shadowedBy: 'add_wallet',
+    consequence:
+      'the model creates an empty savings goal and the user still cannot receive a single payment',
+  },
 ];
 
 describe('confusable Cat verbs stay disambiguated', () => {

--- a/__tests__/unit/cat/autonomy-ladder.test.ts
+++ b/__tests__/unit/cat/autonomy-ladder.test.ts
@@ -5,6 +5,7 @@ import {
   AUTONOMY_LEVELS,
 } from '@/config/cat-autonomy';
 import { CAT_ACTIONS } from '@/config/cat-actions';
+import { defaultAllowedFor } from '@/services/cat/permission-service';
 
 /**
  * The autonomy ladder maps three human levels onto the two booleans the
@@ -43,5 +44,36 @@ describe('autonomy level mapping', () => {
       expect(CAT_ACTIONS[id]?.riskLevel).toBe('high');
       expect(allowedLevelsForRisk(CAT_ACTIONS[id].riskLevel)).not.toContain('auto');
     }
+  });
+});
+
+/**
+ * Shipped defaults decide what a brand-new account can actually do. The
+ * payments category is off by default, correctly — but that swept up
+ * connect_wallet, the action that makes a profile payable in the first place.
+ * A user would have had to unlock the whole payments category (send_payment
+ * included) just to tell us where to send their money, which is a worse
+ * security posture than granting the harmless action alone.
+ */
+describe('shipped permission defaults', () => {
+  it('lets a new user connect a receiving wallet without unlocking payments', () => {
+    expect(defaultAllowedFor('connect_wallet', 'payments')).toBe(true);
+    // Still confirmed — this is where money lands, so a tap is required.
+    expect(CAT_ACTIONS.connect_wallet.requiresConfirmation).toBe(true);
+    expect(allowedLevelsForRisk(CAT_ACTIONS.connect_wallet.riskLevel)).not.toContain('auto');
+  });
+
+  it('does not let anything that moves money default on', () => {
+    const defaultedOn = Object.values(CAT_ACTIONS).filter(
+      a => a.enabled && a.category === 'payments' && defaultAllowedFor(a.id, a.category)
+    );
+    expect(defaultedOn.map(a => a.id)).toEqual(['connect_wallet']);
+  });
+
+  it('leaves every other category default untouched', () => {
+    expect(defaultAllowedFor('send_payment', 'payments')).toBe(false);
+    expect(defaultAllowedFor('add_wallet', 'payments')).toBe(false);
+    expect(defaultAllowedFor('create_product', 'entities')).toBe(false);
+    expect(defaultAllowedFor('add_context', 'context')).toBe(true);
   });
 });

--- a/__tests__/unit/cat/connectWalletHandler.test.ts
+++ b/__tests__/unit/cat/connectWalletHandler.test.ts
@@ -1,0 +1,192 @@
+/**
+ * `connect_wallet` is the Cat's answer to "I want to get paid".
+ *
+ * Measured in production 2026-08-06: 3 of 76 profiles could receive anything.
+ * The Cat's context already said "no lightning address configured" — it just
+ * had no verb that ended with a payable user, so it handed out a Settings link.
+ *
+ * Two properties matter more than the write itself, and both are pinned here:
+ *
+ *  1. **It never claims the user can be paid on the strength of an INSERT.**
+ *     The confirmation comes from getOwnerReceiveStatus — the same resolution a
+ *     payer's request runs. A stored value the payment path cannot use (an NWC
+ *     URI this deployment cannot decrypt, say) is precisely the divergence
+ *     receiveStatus.ts exists to prevent.
+ *  2. **A spending credential is never stored in the clear.** An NWC URI can
+ *     drain a wallet; if encryption is unavailable the action refuses instead of
+ *     writing plaintext.
+ */
+
+import { paymentHandlers } from '@/services/cat/handlers/payments';
+import { getOwnerReceiveStatus } from '@/domain/wallets/receiveStatus';
+import { encrypt, isEncryptionConfigured } from '@/domain/payments/encryptionService';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/domain/wallets/receiveStatus', () => ({ getOwnerReceiveStatus: jest.fn() }));
+jest.mock('@/domain/payments/encryptionService', () => ({
+  // Opaque on purpose: an `enc:${plaintext}` stub would contain the secret and
+  // make the "never stored in the clear" assertion below vacuous.
+  encrypt: jest.fn(() => 'ciphertext-blob'),
+  isEncryptionConfigured: jest.fn(() => true),
+}));
+jest.mock('@/domain/payments/sendPaymentService', () => ({
+  sendToRecipient: jest.fn(),
+  resolveSenderNwcUri: jest.fn(),
+}));
+
+const receiveStatusMock = getOwnerReceiveStatus as jest.Mock;
+const encryptMock = encrypt as jest.Mock;
+const encryptionConfiguredMock = isEncryptionConfigured as jest.Mock;
+
+/** Captures what the handler tried to write, without a real Supabase. */
+function makeSupabase(existingWallet: { id: string; label: string } | null) {
+  const writes: Array<{ op: 'update' | 'insert'; id?: string; values: Record<string, unknown> }> =
+    [];
+  const supabase = {
+    from: () => {
+      const chain: Record<string, unknown> = {};
+      const self = () => chain;
+      Object.assign(chain, {
+        select: self,
+        eq: self,
+        order: self,
+        limit: () => Promise.resolve({ data: existingWallet ? [existingWallet] : [] }),
+        insert: (values: Record<string, unknown>) => {
+          writes.push({ op: 'insert', values });
+          return Promise.resolve({ error: null });
+        },
+        update: (values: Record<string, unknown>) => ({
+          eq: (_col: string, id: string) => {
+            writes.push({ op: 'update', id, values });
+            return Promise.resolve({ error: null });
+          },
+        }),
+      });
+      return chain;
+    },
+  };
+  return { supabase: supabase as never, writes };
+}
+
+const connect = (
+  params: Record<string, unknown>,
+  existing: { id: string; label: string } | null = null
+) => {
+  const { supabase, writes } = makeSupabase(existing);
+  return paymentHandlers
+    .connect_wallet(supabase, 'user-1', 'actor-1', params)
+    .then(result => ({ result, writes }));
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  encryptionConfiguredMock.mockReturnValue(true);
+  encryptMock.mockReturnValue('ciphertext-blob');
+  receiveStatusMock.mockResolvedValue({
+    rail: 'lightning',
+    lightningAddressActive: true,
+    unusableConnectionWalletIds: [],
+  });
+});
+
+describe('cat connect_wallet routes whatever the user pasted', () => {
+  it('stores a Lightning address and confirms the address is live', async () => {
+    const { result, writes } = await connect({ wallet_string: 'me@primal.net' });
+
+    expect(writes).toEqual([
+      { op: 'insert', values: expect.objectContaining({ lightning_address: 'me@primal.net' }) },
+    ]);
+    expect(result.success).toBe(true);
+    expect((result.data as { rail: string }).rail).toBe('lightning');
+    expect((result.data as { displayMessage: string }).displayMessage).toContain('can now be paid');
+  });
+
+  it('stores an on-chain address without touching the lightning field', async () => {
+    const address = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+    const { writes } = await connect({ wallet_string: address });
+
+    expect(writes[0].values).toMatchObject({ address_or_xpub: address });
+    expect(writes[0].values).not.toHaveProperty('lightning_address');
+  });
+
+  it('attaches to the wallet a payer already resolves to instead of creating a rival', async () => {
+    const { writes } = await connect(
+      { wallet_string: 'me@coinos.io' },
+      {
+        id: 'wallet-9',
+        label: 'Rent',
+      }
+    );
+
+    expect(writes).toEqual([
+      { op: 'update', id: 'wallet-9', values: { lightning_address: 'me@coinos.io' } },
+    ]);
+  });
+
+  it('rejects a string that is not a wallet at all, rather than storing junk', async () => {
+    const { result, writes } = await connect({ wallet_string: 'my bank account' });
+
+    expect(result.success).toBe(false);
+    expect(writes).toEqual([]);
+  });
+});
+
+describe('cat connect_wallet protects the spending credential', () => {
+  const NWC = 'nostr+walletconnect://abc?relay=wss://relay.example&secret=deadbeef';
+
+  it('encrypts an NWC connection before it reaches the database', async () => {
+    const { writes } = await connect({ wallet_string: NWC });
+
+    expect(encryptMock).toHaveBeenCalledWith(NWC);
+    expect(writes[0].values).toMatchObject({ nwc_connection_uri: 'ciphertext-blob' });
+    expect(JSON.stringify(writes)).not.toContain('secret=deadbeef');
+  });
+
+  it('refuses the connection outright when encryption is unavailable', async () => {
+    encryptionConfiguredMock.mockReturnValue(false);
+
+    const { result, writes } = await connect({ wallet_string: NWC });
+
+    expect(result.success).toBe(false);
+    expect(writes).toEqual([]);
+    expect(encryptMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('cat connect_wallet tells the truth about whether money can arrive', () => {
+  it('does not claim success-to-receive when the payment path still resolves nothing', async () => {
+    receiveStatusMock.mockResolvedValue({
+      rail: null,
+      lightningAddressActive: false,
+      unusableConnectionWalletIds: [],
+    });
+
+    const { result } = await connect({ wallet_string: 'me@primal.net' });
+    const message = (result.data as { displayMessage: string }).displayMessage;
+
+    // The row was written, so this is not a failure — but the user must not be
+    // told they are payable when a payer would still get nothing.
+    expect(result.success).toBe(true);
+    expect((result.data as { rail: string | null }).rail).toBeNull();
+    expect(message).not.toContain('can now be paid');
+    expect(message).toMatch(/do not resolve|not yet working/i);
+  });
+
+  it('only advertises the @orangecat.ch address when LNURL would actually serve it', async () => {
+    receiveStatusMock.mockResolvedValue({
+      rail: 'onchain',
+      lightningAddressActive: false,
+      unusableConnectionWalletIds: [],
+    });
+
+    const { result } = await connect({
+      wallet_string: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+    });
+
+    expect((result.data as { displayMessage: string }).displayMessage).not.toContain(
+      'orangecat.ch'
+    );
+  });
+});

--- a/__tests__/unit/config/wallet-providers-ssot.test.ts
+++ b/__tests__/unit/config/wallet-providers-ssot.test.ts
@@ -1,0 +1,78 @@
+/**
+ * One place names a wallet provider.
+ *
+ * Three surfaces used to tell a user which Bitcoin wallet to get — the public
+ * guide, the wallets page, and the field tips — each with its own copy of the
+ * names, URLs and platform lists. They had already drifted (the guide's top pick
+ * was Primal; the wallets page's was BlueWallet; neither knew about the other),
+ * and none of them was reachable by the Cat, which is the surface that actually
+ * meets someone with no wallet.
+ *
+ * This test is the reason a fourth copy cannot appear: adding a provider URL
+ * anywhere but the registry fails the build.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { WALLET_PROVIDERS, LIGHTNING_ADDRESS_PROVIDERS } from '@/config/wallet-providers';
+
+const SSOT_FILE = join('src', 'config', 'wallet-providers.ts');
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      return sourceFiles(path);
+    }
+    return /\.tsx?$/.test(entry) ? [path] : [];
+  });
+}
+
+describe('wallet provider registry is the only place providers are named', () => {
+  it('no source file outside the registry hardcodes a provider website', () => {
+    const websites = Object.values(WALLET_PROVIDERS).map(p => p.website);
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles('src')) {
+      if (file === SSOT_FILE) {
+        continue;
+      }
+      const contents = readFileSync(file, 'utf8');
+      for (const website of websites) {
+        if (contents.includes(website)) {
+          offenders.push(`${file} hardcodes ${website}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('every provider carries the facts a recommendation needs', () => {
+    for (const provider of Object.values(WALLET_PROVIDERS)) {
+      expect(provider.website).toMatch(/^https:\/\//);
+      expect(provider.platforms.length).toBeGreaterThan(0);
+      expect(provider.oneLiner.length).toBeGreaterThan(0);
+      // A provider that hands out a Lightning address has to say how long that
+      // takes, because the shortlist is ordered by it — an undeclared one would
+      // silently sort last and never be recommended.
+      if (provider.lightningAddress) {
+        expect(provider.minutesToLightningAddress).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('the Lightning-address shortlist is ordered fastest-first', () => {
+    const minutes = LIGHTNING_ADDRESS_PROVIDERS.map(p => p.minutesToLightningAddress ?? 99);
+    expect(minutes).toEqual([...minutes].sort((a, b) => a - b));
+  });
+
+  it('a wallet that cannot give a Lightning address never reaches the shortlist', () => {
+    // The distinction the old copies blurred: "supports Lightning" is not
+    // "gives you an address OrangeCat can store".
+    expect(LIGHTNING_ADDRESS_PROVIDERS.every(p => p.lightningAddress)).toBe(true);
+    expect(Object.values(WALLET_PROVIDERS).some(p => p.lightning && !p.lightningAddress)).toBe(
+      true
+    );
+  });
+});

--- a/__tests__/unit/services/ai/payment-capabilities-context.test.ts
+++ b/__tests__/unit/services/ai/payment-capabilities-context.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The one context block that decides whether a user can ever be paid.
+ *
+ * The context builder snapshot only covers a fully set-up account (NWC wallet +
+ * Lightning address), which is 3 of 76 production profiles. The branch every
+ * other user actually gets — "no receiving wallet" — was rendered by nobody's
+ * test, and for months it said only that the address was missing plus a link to
+ * Settings. A diagnosis with no cure is why the Cat never fixed this for anyone.
+ */
+
+import { renderPaymentCapabilities } from '@/services/ai/context-sections';
+import { LIGHTNING_ADDRESS_PROVIDERS, WALLET_PROVIDERS } from '@/config/wallet-providers';
+
+const withAddress = { hasNwcWallet: true, lightningAddress: 'mao@orangecat.ch' };
+const withoutAddress = { hasNwcWallet: false, lightningAddress: null };
+
+describe('payment capabilities context', () => {
+  it('gives a user who cannot be paid both routes out, not just the diagnosis', () => {
+    const rendered = renderPaymentCapabilities(withoutAddress as never);
+
+    // Route 1: they already have a wallet — the verb that ends with them payable.
+    expect(rendered).toContain('connect_wallet');
+    // Route 2: they have no wallet — somewhere concrete to get one.
+    expect(rendered).toContain(WALLET_PROVIDERS.primal.website);
+  });
+
+  it('only lists providers that actually hand out a Lightning address', () => {
+    const rendered = renderPaymentCapabilities(withoutAddress as never);
+
+    // A wallet can support Lightning and still never give the user a
+    // name@domain address — which is the only thing OrangeCat can store. Listing
+    // one of those sends someone through a full setup that ends unpayable.
+    const wrongfullyListed = Object.values(WALLET_PROVIDERS).filter(
+      p => !p.lightningAddress && rendered.includes(p.website)
+    );
+    expect(wrongfullyListed.map(p => p.name)).toEqual([]);
+    expect(LIGHTNING_ADDRESS_PROVIDERS.length).toBeGreaterThan(0);
+  });
+
+  it('is honest that custodial providers are custodial', () => {
+    const rendered = renderPaymentCapabilities(withoutAddress as never);
+    const custodial = LIGHTNING_ADDRESS_PROVIDERS.filter(p => p.custody === 'custodial');
+
+    // Every fast option starts custodial today. Recommending one without saying
+    // so would have the Cat quietly trading away the platform's own premise.
+    expect(custodial.length).toBeGreaterThan(0);
+    expect(rendered).toContain('custodial');
+  });
+
+  it('spends nothing on setup instructions for a user who is already payable', () => {
+    const rendered = renderPaymentCapabilities(withAddress as never);
+
+    expect(rendered).toContain('mao@orangecat.ch');
+    expect(rendered).not.toContain(WALLET_PROVIDERS.primal.website);
+    expect(rendered).not.toContain('CANNOT BE PAID');
+  });
+});

--- a/src/app/(public)/bitcoin-wallet-guide/config.ts
+++ b/src/app/(public)/bitcoin-wallet-guide/config.ts
@@ -1,9 +1,10 @@
 import { Bitcoin, Download, Shield, CheckCircle } from 'lucide-react';
+import { WALLET_PROVIDERS, type WalletFormFactor } from '@/config/wallet-providers';
 
 export interface WalletOption {
   id: string;
   name: string;
-  type: 'mobile' | 'desktop' | 'browser' | 'hardware';
+  type: WalletFormFactor;
   description: string;
   pros: string[];
   cons: string[];
@@ -15,11 +16,19 @@ export interface WalletOption {
   recommended?: boolean;
 }
 
-export const walletOptions: WalletOption[] = [
+/**
+ * Editorial only. Name, URL, platforms and form factor come from
+ * `@/config/wallet-providers` — the same record the Cat reads — so this page and
+ * the Cat can never recommend the same wallet with different details.
+ */
+type WalletEditorial = Pick<
+  WalletOption,
+  'description' | 'pros' | 'cons' | 'difficulty' | 'features' | 'recommended'
+>;
+
+const GUIDE_EDITORIAL: Array<{ providerId: string } & WalletEditorial> = [
   {
-    id: 'primal',
-    name: 'Primal',
-    type: 'mobile',
+    providerId: 'primal',
     description:
       'The fastest way to start receiving on OrangeCat. Install it and you get a Lightning address (like name@primal.net) in about a minute — exactly what OrangeCat needs to receive tips and funding.',
     pros: [
@@ -30,15 +39,11 @@ export const walletOptions: WalletOption[] = [
     ],
     cons: ['Mobile only', 'Starts custodial — you can move to self-custody later'],
     difficulty: 'beginner',
-    downloadUrl: 'https://primal.net/downloads',
-    supportedPlatforms: ['iOS', 'Android'],
     features: ['Lightning address', 'Instant receiving', 'Beginner-friendly'],
     recommended: true,
   },
   {
-    id: 'brave',
-    name: 'Brave Wallet',
-    type: 'browser',
+    providerId: 'brave',
     description:
       'Built-in wallet in the Brave browser. Good for holding on-chain Bitcoin, but it has no Lightning support — so it cannot receive Lightning tips or back a name@orangecat.ch address.',
     pros: [
@@ -52,14 +57,10 @@ export const walletOptions: WalletOption[] = [
       'Only available in Brave browser',
     ],
     difficulty: 'beginner',
-    downloadUrl: 'https://brave.com/',
-    supportedPlatforms: ['Windows', 'macOS', 'Linux', 'iOS', 'Android'],
     features: ['Self-custody', 'Multi-chain', 'Browser integrated', 'Open source'],
   },
   {
-    id: 'blue-wallet',
-    name: 'BlueWallet',
-    type: 'mobile',
+    providerId: 'bluewallet',
     description: 'Popular Bitcoin-only mobile wallet with Lightning Network support.',
     pros: [
       'Bitcoin-only focus',
@@ -70,14 +71,10 @@ export const walletOptions: WalletOption[] = [
     ],
     cons: ['Mobile only', 'May be complex for absolute beginners'],
     difficulty: 'beginner',
-    downloadUrl: 'https://bluewallet.io/',
-    supportedPlatforms: ['iOS', 'Android'],
     features: ['Bitcoin-only', 'Lightning Network', 'Open source', 'Watch-only wallets'],
   },
   {
-    id: 'exodus',
-    name: 'Exodus',
-    type: 'desktop',
+    providerId: 'exodus',
     description:
       'User-friendly desktop wallet with beautiful design and multi-cryptocurrency support.',
     pros: [
@@ -89,14 +86,10 @@ export const walletOptions: WalletOption[] = [
     ],
     cons: ['Not open source', 'Higher fees for built-in exchange', 'Less privacy-focused'],
     difficulty: 'beginner',
-    downloadUrl: 'https://www.exodus.com/',
-    supportedPlatforms: ['Windows', 'macOS', 'Linux', 'iOS', 'Android'],
     features: ['Multi-crypto', 'Built-in exchange', 'Portfolio tracking', 'Mobile & desktop'],
   },
   {
-    id: 'electrum',
-    name: 'Electrum',
-    type: 'desktop',
+    providerId: 'electrum',
     description: 'Lightweight Bitcoin wallet focused on speed and low resource usage.',
     pros: [
       'Very lightweight and fast',
@@ -111,11 +104,21 @@ export const walletOptions: WalletOption[] = [
       'Requires more technical knowledge',
     ],
     difficulty: 'intermediate',
-    downloadUrl: 'https://electrum.org/',
-    supportedPlatforms: ['Windows', 'macOS', 'Linux', 'Android'],
     features: ['Bitcoin-only', 'Lightweight', 'Hardware wallet support', 'Advanced features'],
   },
 ];
+
+export const walletOptions: WalletOption[] = GUIDE_EDITORIAL.map(({ providerId, ...editorial }) => {
+  const provider = WALLET_PROVIDERS[providerId];
+  return {
+    id: provider.id,
+    name: provider.name,
+    type: provider.formFactor,
+    downloadUrl: provider.website,
+    supportedPlatforms: provider.platforms,
+    ...editorial,
+  };
+});
 
 export const setupSteps = [
   {

--- a/src/app/api/cat/permissions/route.ts
+++ b/src/app/api/cat/permissions/route.ts
@@ -8,7 +8,7 @@
 
 import { NextRequest } from 'next/server';
 import { createPermissionService } from '@/services/cat';
-import { DEFAULT_PERMISSIONS } from '@/services/cat/permission-service';
+import { defaultAllowedFor } from '@/services/cat/permission-service';
 import {
   CAT_ACTIONS,
   ACTION_CATEGORIES,
@@ -65,7 +65,7 @@ export const GET = withAuth(async (request: AuthenticatedRequest) => {
         const row = byAction.get(a.id) ?? byCategory.get(a.category);
         const autonomy = row
           ? toAutonomyLevel(row.granted, row.requires_confirmation)
-          : toAutonomyLevel(DEFAULT_PERMISSIONS[a.category] ?? false, a.requiresConfirmation);
+          : toAutonomyLevel(defaultAllowedFor(a.id, a.category), a.requiresConfirmation);
         return {
           id: a.id,
           name: a.name,

--- a/src/components/ai-chat/ModernChatPanel/components/MessageBubble.tsx
+++ b/src/components/ai-chat/ModernChatPanel/components/MessageBubble.tsx
@@ -40,6 +40,7 @@ const ACTION_LABELS: Record<string, string> = {
   // Payments & wallets
   send_payment: 'Payment',
   fund_project: 'Contribution',
+  connect_wallet: 'Wallet connected',
   add_wallet: 'Wallet',
   // Context
   add_context: 'Context saved',
@@ -289,8 +290,8 @@ export function MessageBubble({
         {!isUser && message.fallback && displayContent && (
           <p className="mt-1 text-xs text-fg-tertiary italic">
             ↻ {PROVIDER_LABELS[message.fallback.from] ?? message.fallback.from} was rate-limited;
-            answered on {PROVIDER_LABELS[message.fallback.to] ?? message.fallback.to} instead —
-            both run on OrangeCat&apos;s free pool, not your keys.
+            answered on {PROVIDER_LABELS[message.fallback.to] ?? message.fallback.to} instead — both
+            run on OrangeCat&apos;s free pool, not your keys.
           </p>
         )}
 

--- a/src/components/nostr/NostrConnectionCard.tsx
+++ b/src/components/nostr/NostrConnectionCard.tsx
@@ -5,6 +5,7 @@ import Button from '@/components/ui/Button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import Input from '@/components/ui/Input';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
+import { WALLET_PROVIDERS } from '@/config/wallet-providers';
 import { shortenNpub } from '@/lib/nostr';
 import { useNostrConnectionCard } from './useNostrConnectionCard';
 import { useDisplayCurrency } from '@/hooks/useDisplayCurrency';
@@ -202,7 +203,7 @@ export function NostrConnectionCard() {
                 <p className="text-xs text-fg-secondary text-center">
                   Install{' '}
                   <a
-                    href="https://getalby.com"
+                    href={WALLET_PROVIDERS.alby.website}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-fg-primary hover:underline inline-flex items-center gap-0.5"

--- a/src/components/wallets/WalletManager/components/WalletForm.tsx
+++ b/src/components/wallets/WalletManager/components/WalletForm.tsx
@@ -12,6 +12,7 @@ import { ChevronDown, ChevronRight, Check, Wallet, ExternalLink } from 'lucide-r
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
+import { LIGHTNING_ADDRESS_PROVIDERS } from '@/config/wallet-providers';
 import {
   WalletFormData,
   WALLET_CATEGORIES,
@@ -198,28 +199,22 @@ export function WalletForm({
               Pick one, create a free account, then copy your <strong>Lightning address</strong>{' '}
               back into the box above:
             </p>
-            <a
-              href="https://primal.net"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-between rounded border border-subtle px-2.5 py-1.5 text-fg-primary hover:border-strong"
-            >
-              <span>
-                <strong>Primal</strong> — phone app, gives you a <code>you@primal.net</code> address
-              </span>
-              <ExternalLink className="h-3 w-3 flex-shrink-0 text-fg-tertiary" />
-            </a>
-            <a
-              href="https://coinos.io"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-between rounded border border-subtle px-2.5 py-1.5 text-fg-primary hover:border-strong"
-            >
-              <span>
-                <strong>Coinos</strong> — works in your browser, nothing to download
-              </span>
-              <ExternalLink className="h-3 w-3 flex-shrink-0 text-fg-tertiary" />
-            </a>
+            {/* Same list the Cat reads, so chat and form never recommend
+                different wallets — see @/config/wallet-providers. */}
+            {LIGHTNING_ADDRESS_PROVIDERS.map(provider => (
+              <a
+                key={provider.id}
+                href={provider.website}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between rounded border border-subtle px-2.5 py-1.5 text-fg-primary hover:border-strong"
+              >
+                <span>
+                  <strong>{provider.name}</strong> — {provider.oneLiner}
+                </span>
+                <ExternalLink className="h-3 w-3 flex-shrink-0 text-fg-tertiary" />
+              </a>
+            ))}
           </div>
         )}
       </div>

--- a/src/components/wallets/WalletRecommendationCards.tsx
+++ b/src/components/wallets/WalletRecommendationCards.tsx
@@ -2,77 +2,83 @@
 
 import { useState, useMemo } from 'react';
 import Button from '@/components/ui/Button';
+import { WALLET_PROVIDERS } from '@/config/wallet-providers';
 import { RecommendedWalletCard } from './RecommendedWalletCard';
 import { WalletRecommendationFilterBar } from './WalletRecommendationFilterBar';
 import type { RecommendedWallet } from './RecommendedWalletCard';
 import type { RecommendationFilters } from './WalletRecommendationFilterBar';
 
-const WALLETS: RecommendedWallet[] = [
+/**
+ * Editorial only — which self-custody wallets this page features, in what order,
+ * and how it describes them. Name, website, platform and custody come from
+ * `@/config/wallet-providers`, so this page cannot drift from the guide page or
+ * from what the Cat tells someone who has no wallet yet.
+ */
+const CARD_EDITORIAL: Array<{
+  providerId: string;
+  description: string;
+  level: RecommendedWallet['level'];
+  downloadLinks?: RecommendedWallet['downloadLinks'];
+  recommended: boolean;
+}> = [
   {
-    name: 'BlueWallet',
+    providerId: 'bluewallet',
     description: 'Best all-around mobile wallet with easy Lightning and on-chain support',
-    platform: 'mobile',
     level: 'beginner',
-    lightning: true,
-    custodial: false,
     downloadLinks: {
       ios: 'https://apps.apple.com/app/bluewallet-bitcoin-wallet/id1376878040',
       android: 'https://play.google.com/store/apps/details?id=io.bluewallet.bluewallet',
     },
-    website: 'https://bluewallet.io',
     recommended: true,
   },
   {
-    name: 'Phoenix Wallet',
+    providerId: 'phoenix',
     description: 'Simple mobile Lightning wallet with automatic channel management',
-    platform: 'mobile',
     level: 'beginner',
-    lightning: true,
-    custodial: false,
     downloadLinks: {
       ios: 'https://apps.apple.com/app/phoenix-wallet/id6449854979',
-      android: 'https://phoenix.acinq.co',
+      android: WALLET_PROVIDERS.phoenix.website,
     },
-    website: 'https://phoenix.acinq.co',
     recommended: true,
   },
   {
-    name: 'Breez',
+    providerId: 'breez',
     description: 'Non-custodial Lightning wallet with creator tools and instant payments',
-    platform: 'mobile',
     level: 'beginner',
-    lightning: true,
-    custodial: false,
     downloadLinks: {
       ios: 'https://apps.apple.com/app/breez-lightning-client-pos/id1473040547',
       android: 'https://play.google.com/store/apps/details?id=com.breez.client',
     },
-    website: 'https://breez.technology',
     recommended: false,
   },
   {
-    name: 'Electrum',
+    providerId: 'electrum',
     description: 'Powerful, lightweight desktop wallet with advanced features',
-    platform: 'desktop',
     level: 'advanced',
-    lightning: false,
-    custodial: false,
-    website: 'https://electrum.org',
     downloadLinks: {},
     recommended: false,
   },
   {
-    name: 'Sparrow Wallet',
+    providerId: 'sparrow',
     description: 'Privacy-focused desktop wallet with CoinJoin and full control',
-    platform: 'desktop',
     level: 'advanced',
-    lightning: false,
-    custodial: false,
-    website: 'https://sparrowwallet.com',
     downloadLinks: {},
     recommended: false,
   },
 ];
+
+const WALLETS: RecommendedWallet[] = CARD_EDITORIAL.map(({ providerId, ...editorial }) => {
+  const provider = WALLET_PROVIDERS[providerId];
+  return {
+    name: provider.name,
+    website: provider.website,
+    // This page only shows phone/laptop apps; the filter bar has no third option.
+    platform: provider.formFactor === 'desktop' ? 'desktop' : 'mobile',
+    lightning: provider.lightning,
+    custodial: provider.custody === 'custodial',
+    ...editorial,
+  };
+});
 
 export default function WalletRecommendationCards() {
   const [filters, setFilters] = useState<RecommendationFilters>({

--- a/src/config/cat-actions.ts
+++ b/src/config/cat-actions.ts
@@ -32,6 +32,7 @@ import {
   Shield,
   ShieldCheck,
   ShieldAlert,
+  Zap,
   type LucideIcon,
 } from 'lucide-react';
 import { API_ROUTES } from '@/config/api-routes';
@@ -1002,10 +1003,44 @@ export const CAT_ACTIONS: Record<string, CatAction> = {
     enabled: true,
   },
 
+  connect_wallet: {
+    id: 'connect_wallet',
+    name: 'Connect Wallet',
+    description:
+      'Make the user able to RECEIVE Bitcoin — store the Lightning address, Bitcoin address/xpub or NWC string they paste. The setup step, NOT add_wallet (a savings goal on top of a rail they already have). No wallet at all? Point them at a provider first, then run this.',
+    category: 'payments',
+    icon: Zap,
+    riskLevel: 'high',
+    requiresConfirmation: true,
+    parameters: [
+      {
+        name: 'wallet_string',
+        type: 'string',
+        required: true,
+        description:
+          'Exactly what the user pasted — a Lightning address (you@provider.com), a Bitcoin address or xpub/ypub/zpub, or a nostr+walletconnect:// string. Do not reformat it.',
+      },
+      {
+        name: 'label',
+        type: 'string',
+        required: false,
+        description: 'Name for the wallet if a new one has to be created (default "Main wallet")',
+      },
+    ],
+    examples: [
+      'My lightning address is me@primal.net',
+      'Here is my wallet: bc1q…',
+      'Connect this wallet: nostr+walletconnect://…',
+      'Set me up so people can pay me',
+    ],
+    enabled: true,
+  },
+
   add_wallet: {
     id: 'add_wallet',
     name: 'Add Wallet',
-    description: "Create a savings goal wallet or budget wallet on the user's profile",
+    description:
+      "Create a savings goal or budget wallet on the user's profile — a bucket to save toward, NOT a way to get paid. Use connect_wallet to give the user a receiving rail; this action reuses one they already have.",
     category: 'payments',
     icon: Wallet,
     riskLevel: 'medium',

--- a/src/config/wallet-providers.ts
+++ b/src/config/wallet-providers.ts
@@ -1,0 +1,185 @@
+/**
+ * Wallet providers — SSOT for provider IDENTITY.
+ *
+ * Four places in this repo told a user which Bitcoin wallet to get, each with
+ * its own copy of the names, URLs and platform lists:
+ *   - the public guide (`/bitcoin-wallet-guide`) recommended Primal
+ *   - the wallets page (`/wallets`) recommended BlueWallet and Phoenix
+ *   - the wallet form's "don't have a wallet?" panel offered Primal and Coinos
+ *   - the Nostr connection card linked Alby
+ * They had already drifted, and none of them was reachable by the Cat — which
+ * is the interface that actually meets a user with no wallet. The last two were
+ * found by the gate in wallet-providers-ssot.test.ts, not by reading the code.
+ *
+ * So identity lives here once. Each surface keeps its own EDITORIAL (pros, cons,
+ * difficulty, which subset it shows) and refers to providers by id. Changing a
+ * URL is a one-line change; adding a provider cannot half-land.
+ *
+ * Only claims already made in this repo are encoded here. `lightningAddress` is
+ * deliberately conservative: it means "this provider hands you a name@domain
+ * address", which is the ONE capability OrangeCat needs to receive — not merely
+ * "supports Lightning". A provider we are not sure about is marked false, so the
+ * Cat under-promises rather than sending someone on a dead-end setup.
+ */
+
+export type WalletFormFactor = 'mobile' | 'desktop' | 'browser' | 'hardware';
+
+/** Who holds the keys the moment you finish setup. */
+export type WalletCustody = 'self' | 'custodial';
+
+export interface WalletProvider {
+  id: string;
+  name: string;
+  website: string;
+  /** Where the user installs it — drives the "on your phone / on your laptop" phrasing. */
+  formFactor: WalletFormFactor;
+  /** Operating systems, as the provider ships them. */
+  platforms: string[];
+  custody: WalletCustody;
+  /** Can send/receive over the Lightning Network at all. */
+  lightning: boolean;
+  /**
+   * Hands the user a `name@domain` Lightning address. This is the field
+   * OrangeCat stores and the thing that makes a profile payable — a wallet that
+   * "supports Lightning" but never gives an address does not solve the problem.
+   */
+  lightningAddress: boolean;
+  /** Realistic minutes from install to holding a Lightning address. */
+  minutesToLightningAddress?: number;
+  /** One sentence, written for someone who has never owned Bitcoin. */
+  oneLiner: string;
+}
+
+export const WALLET_PROVIDERS: Record<string, WalletProvider> = {
+  primal: {
+    id: 'primal',
+    name: 'Primal',
+    website: 'https://primal.net/downloads',
+    formFactor: 'mobile',
+    platforms: ['iOS', 'Android'],
+    custody: 'custodial',
+    lightning: true,
+    lightningAddress: true,
+    minutesToLightningAddress: 1,
+    oneLiner: 'Install it and you have a Lightning address in about a minute.',
+  },
+  coinos: {
+    id: 'coinos',
+    name: 'Coinos',
+    website: 'https://coinos.io',
+    formFactor: 'browser',
+    platforms: ['Web', 'iOS', 'Android'],
+    custody: 'custodial',
+    lightning: true,
+    lightningAddress: true,
+    minutesToLightningAddress: 1,
+    oneLiner: 'Free, works in a browser, gives you a Lightning address immediately.',
+  },
+  alby: {
+    id: 'alby',
+    name: 'Alby',
+    website: 'https://getalby.com',
+    formFactor: 'browser',
+    platforms: ['Web', 'Chrome', 'Firefox'],
+    custody: 'custodial',
+    lightning: true,
+    lightningAddress: true,
+    minutesToLightningAddress: 2,
+    oneLiner: 'Browser wallet with a Lightning address, and it can connect to OrangeCat over NWC.',
+  },
+  bluewallet: {
+    id: 'bluewallet',
+    name: 'BlueWallet',
+    website: 'https://bluewallet.io',
+    formFactor: 'mobile',
+    platforms: ['iOS', 'Android'],
+    custody: 'self',
+    lightning: true,
+    lightningAddress: false,
+    oneLiner: 'Bitcoin-only mobile wallet with both on-chain and Lightning support.',
+  },
+  phoenix: {
+    id: 'phoenix',
+    name: 'Phoenix Wallet',
+    website: 'https://phoenix.acinq.co',
+    formFactor: 'mobile',
+    platforms: ['iOS', 'Android'],
+    custody: 'self',
+    lightning: true,
+    lightningAddress: false,
+    oneLiner: 'Self-custodial Lightning wallet that manages channels for you.',
+  },
+  breez: {
+    id: 'breez',
+    name: 'Breez',
+    website: 'https://breez.technology',
+    formFactor: 'mobile',
+    platforms: ['iOS', 'Android'],
+    custody: 'self',
+    lightning: true,
+    lightningAddress: false,
+    oneLiner: 'Non-custodial Lightning wallet with creator tools and instant payments.',
+  },
+  brave: {
+    id: 'brave',
+    name: 'Brave Wallet',
+    website: 'https://brave.com/',
+    formFactor: 'browser',
+    platforms: ['Windows', 'macOS', 'Linux', 'iOS', 'Android'],
+    custody: 'self',
+    lightning: false,
+    lightningAddress: false,
+    oneLiner: 'Built into the Brave browser. On-chain only — it cannot receive Lightning.',
+  },
+  exodus: {
+    id: 'exodus',
+    name: 'Exodus',
+    website: 'https://www.exodus.com/',
+    formFactor: 'desktop',
+    platforms: ['Windows', 'macOS', 'Linux', 'iOS', 'Android'],
+    custody: 'self',
+    lightning: false,
+    lightningAddress: false,
+    oneLiner: 'Friendly multi-currency desktop wallet with portfolio tracking.',
+  },
+  electrum: {
+    id: 'electrum',
+    name: 'Electrum',
+    website: 'https://electrum.org/',
+    formFactor: 'desktop',
+    platforms: ['Windows', 'macOS', 'Linux', 'Android'],
+    custody: 'self',
+    lightning: false,
+    lightningAddress: false,
+    oneLiner: 'Lightweight, fast, Bitcoin-only desktop wallet for power users.',
+  },
+  sparrow: {
+    id: 'sparrow',
+    name: 'Sparrow Wallet',
+    website: 'https://sparrowwallet.com',
+    formFactor: 'desktop',
+    platforms: ['Windows', 'macOS', 'Linux'],
+    custody: 'self',
+    lightning: false,
+    lightningAddress: false,
+    oneLiner: 'Privacy-focused desktop wallet with full control over coins.',
+  },
+};
+
+/**
+ * The answer to "I don't have a Bitcoin wallet — what do I do?", ordered by how
+ * fast the user ends up payable. Everything here hands out a Lightning address;
+ * nothing else does, so nothing else belongs in that answer.
+ */
+export const LIGHTNING_ADDRESS_PROVIDERS: WalletProvider[] = Object.values(WALLET_PROVIDERS)
+  .filter(p => p.lightningAddress)
+  .sort((a, b) => (a.minutesToLightningAddress ?? 99) - (b.minutesToLightningAddress ?? 99));
+
+/** Compact one-line-per-provider rendering, for prompts and plain-text surfaces. */
+export function renderLightningAddressProviders(): string {
+  return LIGHTNING_ADDRESS_PROVIDERS.map(
+    p =>
+      `- **${p.name}** (${p.website}) — ${p.oneLiner}` +
+      (p.custody === 'custodial' ? ' Starts custodial; they can move to self-custody later.' : '')
+  ).join('\n');
+}

--- a/src/services/ai/context-sections.ts
+++ b/src/services/ai/context-sections.ts
@@ -7,6 +7,7 @@
  */
 import type { DocumentContext, EntitySummary, FullUserContext } from './document-context-types';
 import { ENTITY_STATUS } from '@/config/database-constants';
+import { renderLightningAddressProviders } from '@/config/wallet-providers';
 import { economicProfileGaps, economicCompleteness } from '@/services/cat/economic-profile';
 
 const DOCUMENT_TYPE_LABELS: Record<string, string> = {
@@ -605,14 +606,25 @@ export function renderPaymentCapabilities(
     );
   } else {
     capLines.push(
-      '❌ **No NWC wallet** — cannot auto-send payments; if user asks to send Bitcoin, tell them to connect a Nostr Wallet Connect wallet first (Settings → Wallets)'
+      '❌ **No NWC wallet** — cannot auto-send payments; if the user asks to send Bitcoin, ask them to paste a nostr+walletconnect:// string and run connect_wallet'
     );
   }
   if (lightningAddress) {
     capLines.push(`📬 **Lightning address**: ${lightningAddress} (others can pay the user here)`);
   } else {
+    // The user cannot be paid. Everything else the Cat might help them build —
+    // a product, a project, a cause — ends at a page nobody can pay, so this is
+    // the one gap worth naming unprompted. Giving the Cat only the diagnosis
+    // ("no lightning address") is what left it describing the problem and
+    // handing the user a Settings link instead of fixing it.
     capLines.push(
-      '📬 **No lightning address configured** — user cannot receive lightning payments without one'
+      '📬 **CANNOT BE PAID — no receiving wallet.** Nothing they list or publish can be funded until this is fixed. Raise it once, warmly, when money comes up; do not nag.',
+      '',
+      'Two ways to fix it, and the right one depends on their answer to "do you already have a Bitcoin wallet?":',
+      '1. **They have one** → ask them to paste whatever it gives them (a Lightning address like you@provider.com, a Bitcoin address or xpub, or a nostr+walletconnect:// string) and run `connect_wallet` with it verbatim. Do not reformat it.',
+      '2. **They have none** → a Lightning address is what OrangeCat needs, and these hand one over fastest:',
+      renderLightningAddressProviders(),
+      'Then ask them to come back with the address and run `connect_wallet`. Never claim they can be paid until that action has run and reported success.'
     );
   }
   return `## Payment Capabilities\n${capLines.join('\n')}`;

--- a/src/services/cat/action-descriptions.ts
+++ b/src/services/cat/action-descriptions.ts
@@ -1,3 +1,4 @@
+import { classifyWalletInput } from '@/types/wallet';
 import type { CatAction } from '@/config/cat-actions';
 
 export function generateActionDescription(
@@ -106,6 +107,20 @@ export function generateActionDescription(
         .filter(f => parameters[f] !== undefined)
         .join(', ');
       return `Update profile${fields ? ': ' + fields : ''}`;
+    }
+    case 'connect_wallet': {
+      // Show the KIND, never the string itself. This confirmation is what the
+      // user reads before approving where their money lands, and an NWC URI is a
+      // spending credential that must not be echoed back into the transcript.
+      const kind = classifyWalletInput((parameters.wallet_string as string | undefined) ?? '');
+      const kindLabel: Record<string, string> = {
+        lightning: 'Lightning address',
+        onchain: 'Bitcoin address',
+        xpub: 'extended public key',
+        nwc: 'wallet connection',
+        unknown: 'wallet details',
+      };
+      return `Connect wallet: set your ${kindLabel[kind]} as where you get paid`;
     }
     case 'add_wallet': {
       const walletLabel = parameters.label as string | undefined;

--- a/src/services/cat/handlers/payments.ts
+++ b/src/services/cat/handlers/payments.ts
@@ -6,10 +6,139 @@ import { NWCClient } from '@/lib/nostr/nwc';
 import { generateInvoice } from '@/domain/payments/invoiceGenerationService';
 import { resolveSenderNwcUri, sendToRecipient } from '@/domain/payments/sendPaymentService';
 import { resolveSellerWallet, getSellerUserId } from '@/domain/payments/walletResolutionService';
+import { getOwnerReceiveStatus } from '@/domain/wallets/receiveStatus';
+import { encrypt, isEncryptionConfigured } from '@/domain/payments/encryptionService';
+import { classifyWalletInput, validateAddressOrXpub } from '@/types/wallet';
+import { isValidLightningAddress } from '@/lib/validation/base';
 import { getAdminClient } from '@/lib/supabase/admin';
 import type { ActionHandler } from './types';
 
 export const paymentHandlers: Record<string, ActionHandler> = {
+  /**
+   * Give the user a way to be PAID.
+   *
+   * Measured 2026-08-06: 3 of 76 production profiles could receive anything at
+   * all. The Cat already knew — its context says "❌ No lightning address
+   * configured" — but the only wallet verb it had was add_wallet, which refuses
+   * without an existing address and sent the user to Settings. So the interface
+   * that meets every user could describe the problem and not fix it.
+   *
+   * One parameter on purpose: the user pastes whatever their wallet app gave
+   * them and `classifyWalletInput` works out what it is. Asking a model to pick
+   * between three near-identical fields is asking it to guess, and guessing
+   * wrong here means money routed to the wrong rail.
+   *
+   * The success message is derived from `getOwnerReceiveStatus` — the same
+   * resolution a payer's request runs — never from "the write succeeded". A
+   * stored value that the payment path cannot use is exactly the divergence
+   * receiveStatus.ts exists to prevent; the Cat must not re-open it by claiming
+   * "you can now be paid" on the strength of an INSERT.
+   */
+  connect_wallet: async (supabase, userId, _actorId, params) => {
+    const raw = (params.wallet_string as string | undefined)?.trim();
+    if (!raw) {
+      return {
+        success: false,
+        error:
+          'wallet_string is required — ask the user to paste their Lightning address, Bitcoin address/xpub, or NWC connection string.',
+      };
+    }
+
+    const kind = classifyWalletInput(raw);
+    const receiveField: Record<string, unknown> = {};
+
+    if (kind === 'lightning') {
+      if (!isValidLightningAddress(raw)) {
+        return {
+          success: false,
+          error: `"${raw}" is not a valid Lightning address. It looks like an email: name@provider.com.`,
+        };
+      }
+      receiveField.lightning_address = raw;
+    } else if (kind === 'nwc') {
+      // Wallet connections are spending credentials. Refuse rather than store
+      // one we cannot encrypt — a plaintext NWC URI in the database is a wallet
+      // anyone with read access can drain.
+      if (!isEncryptionConfigured()) {
+        return {
+          success: false,
+          error:
+            'This deployment cannot store wallet connections securely right now, so I will not save it. A Lightning address works instead and carries no spending permission.',
+        };
+      }
+      receiveField.nwc_connection_uri = encrypt(raw);
+    } else if (kind === 'onchain' || kind === 'xpub') {
+      const validation = validateAddressOrXpub(raw);
+      if (!validation.valid) {
+        return { success: false, error: validation.error ?? 'That Bitcoin address is not valid.' };
+      }
+      receiveField.address_or_xpub = raw;
+    } else {
+      return {
+        success: false,
+        error:
+          'That does not look like a Lightning address (name@provider.com), a Bitcoin address or xpub, or a nostr+walletconnect:// string. Ask the user to paste it again straight from their wallet app.',
+      };
+    }
+
+    // Attach to the wallet a payer would already resolve to, so connecting a
+    // rail never silently creates a second wallet that outranks the first.
+    const { data: existing } = await supabase
+      .from(DATABASE_TABLES.WALLETS)
+      .select('id, label')
+      .eq('profile_id', userId)
+      .eq('is_active', true)
+      .order('is_primary', { ascending: false })
+      .limit(1);
+
+    const target = existing?.[0] as { id: string; label: string } | undefined;
+    const label = ((params.label as string | undefined) || 'Main wallet').trim();
+
+    const { error } = target
+      ? await supabase.from(DATABASE_TABLES.WALLETS).update(receiveField).eq('id', target.id)
+      : await supabase.from(DATABASE_TABLES.WALLETS).insert({
+          profile_id: userId,
+          label,
+          is_active: true,
+          is_primary: true,
+          behavior_type: 'general',
+          category: 'general',
+          ...receiveField,
+        });
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+
+    const status = await getOwnerReceiveStatus(userId);
+    const walletName = target?.label ?? label;
+
+    // The write landed but the payment path still resolves nothing — say so.
+    // Telling someone they can be paid when they cannot is the one outcome
+    // worse than not helping at all.
+    if (!status.rail) {
+      return {
+        success: true,
+        data: {
+          rail: null,
+          displayMessage: `⚠️ Saved to "${walletName}", but payments still do not resolve to it. Tell the user honestly that it is stored and not yet working, and offer to check their wallets page.`,
+        },
+      };
+    }
+
+    const canReceiveLightningAddress = status.lightningAddressActive;
+    return {
+      success: true,
+      data: {
+        rail: status.rail,
+        lightningAddressActive: canReceiveLightningAddress,
+        displayMessage: canReceiveLightningAddress
+          ? `⚡ Connected to "${walletName}" — the user can now be paid, and their @orangecat.ch Lightning address is live.`
+          : `✅ Connected to "${walletName}" — the user can now be paid over ${status.rail}.`,
+      },
+    };
+  },
+
   add_wallet: async (supabase, userId, _actorId, params) => {
     // Create a savings goal or budget wallet for the user's profile.
     // Wallets require a lightning address — we use the one provided, or fall back to
@@ -49,7 +178,7 @@ export const paymentHandlers: Record<string, ActionHandler> = {
       return {
         success: false,
         error:
-          'No lightning address available. Add one in Settings → Wallets first, or provide a lightning_address parameter.',
+          'The user has no receiving rail yet, so a savings goal would have nowhere to be paid. Run connect_wallet first with the Lightning address they paste — and if they have no wallet at all, point them at one from the list in their Payment Capabilities context, then come back to this.',
       };
     }
 

--- a/src/services/cat/permission-service.ts
+++ b/src/services/cat/permission-service.ts
@@ -76,6 +76,29 @@ export const DEFAULT_PERMISSIONS: Partial<Record<ActionCategory, boolean>> = {
 };
 
 /**
+ * Per-action defaults that override the category default.
+ *
+ * `payments: false` is right for actions that MOVE money, and wrong for the one
+ * that decides where the user's own money arrives. Without this override,
+ * connect_wallet — the action that makes a profile payable at all — is denied
+ * for every new user, and the only way to reach it is to enable the whole
+ * payments category, which ALSO unlocks send_payment. Defaulting one harmless
+ * action on is strictly safer than pushing people to unlock the harmful ones.
+ *
+ * The bar for adding a row here: the action moves no funds, writes only the
+ * user's own row under RLS, and still requires confirmation. An explicitly
+ * stored permission always wins — this is a default, not an override of intent.
+ */
+export const DEFAULT_ACTION_PERMISSIONS: Partial<Record<string, boolean>> = {
+  connect_wallet: true,
+};
+
+/** Resolve the shipped default for an action: per-action first, then category. */
+export function defaultAllowedFor(actionId: string, category: ActionCategory): boolean {
+  return DEFAULT_ACTION_PERMISSIONS[actionId] ?? DEFAULT_PERMISSIONS[category] ?? false;
+}
+
+/**
  * Combine caps from the matched permission rows (specific action + category '*').
  * The stricter (lower) non-null cap wins. Exported for tests.
  */
@@ -176,7 +199,7 @@ export class CatPermissionService {
     }
 
     // Fall back to defaults
-    const defaultAllowed = DEFAULT_PERMISSIONS[action.category] ?? false;
+    const defaultAllowed = defaultAllowedFor(action.id, action.category);
     return {
       allowed: defaultAllowed,
       reason: defaultAllowed ? undefined : 'Permission not granted',

--- a/src/services/cat/system-prompt.ts
+++ b/src/services/cat/system-prompt.ts
@@ -633,23 +633,17 @@ When the user wants to save toward a target or set up a recurring budget:
   "parameters": {
     "label": "Vacation Fund",
     "behavior_type": "one_time_goal",
-    "category": "general",
-    "description": "Saving for a trip to Japan",
     "goal_amount": 0.05,
     "goal_currency": "BTC",
     "goal_deadline": "2026-12-31"
   }
 }
 \`\`\`
-- label: wallet name (required)
-- behavior_type: "one_time_goal" (save toward a target) | "recurring_budget" (periodic spending limit) | "general"
-- category: general | rent | food | medical | education | emergency | transportation | utilities | projects | legal | entertainment
-- For one_time_goal: include goal_amount (BTC), goal_currency (BTC/CHF/USD), goal_deadline (ISO date)
-- For recurring_budget: include budget_amount (BTC per period), budget_period (daily | weekly | monthly | quarterly | yearly)
-- Uses the user's existing primary lightning address — no address parameter needed
-- Executes immediately without confirmation
-- Check "User's Wallets" context first — don't create duplicate goal wallets
-- When user says "save for X", "I want to put away Y BTC", "set up an emergency fund", "budget for rent" → use this
+- behavior_type: "one_time_goal" (goal_amount + goal_currency + goal_deadline) | "recurring_budget" (budget_amount + budget_period: daily|weekly|monthly|quarterly|yearly) | "general"
+- Optional: category (general|rent|food|medical|education|emergency|transportation|utilities|projects|legal|entertainment), description
+- This is a SAVINGS BUCKET, not a way to get paid. It reuses the user's existing receiving rail — if Payment Capabilities says they have none, run connect_wallet first or the goal has nowhere to be funded.
+- Executes immediately without confirmation. Check "User's Wallets" first — don't duplicate goals.
+- "save for X", "put away Y BTC", "emergency fund", "budget for rent" → use this
 
 ### Publish a draft entity
 When the user wants to make a draft entity live:


### PR DESCRIPTION
## The measurement

**3 of 76 production profiles can receive Bitcoin.** The platform's whole promise is "get paid", and 96% of accounts have no rail for it.

```
profiles 76 | profiles_with_any_wallet 4 | profiles_payable 3
```

## The gap

The Cat already *knew*. Its context has said `❌ No lightning address configured — user cannot receive lightning payments without one` for months. What it lacked was any verb that ends with a payable user: `add_wallet` — the only wallet action — refuses outright when there is no address and told the user to go to Settings → Wallets. So the interface that meets every user could state the problem and not fix it, and someone with no Bitcoin wallet at all hit a dead end at exactly the moment they were ready to earn.

## What this adds

`connect_wallet`, with the two branches a real conversation has:

1. **They have a wallet** → they paste whatever it gave them, and `classifyWalletInput` works out whether it is a Lightning address, a Bitcoin address/xpub, or an NWC string. **One parameter on purpose** — asking a model to choose between three near-identical fields is asking it to guess, and guessing wrong routes money to the wrong rail.
2. **They have none** → the Payment Capabilities context now carries the providers that hand out a Lightning address fastest, so the Cat answers instead of deflecting.

### Two load-bearing properties, both pinned by tests

- **It never claims the user can be paid on the strength of an `INSERT`.** The confirmation comes from `getOwnerReceiveStatus` — the same resolution a payer's request runs. A stored value the payment path cannot use is precisely the divergence `receiveStatus.ts` exists to prevent, and "you can be paid now" when a payer would get nothing is worse than not helping.
- **An NWC URI is a spending credential.** It is encrypted before it reaches the database, and if encryption is unavailable the action refuses rather than writing plaintext.

## The second commit: it shipped unreachable

`DEFAULT_PERMISSIONS.payments = false` is right for verbs that move money and wrong for the one that decides where the user's *own* money arrives — it swept up `connect_wallet`, so a new account would have been told the Cat needs permission. The only way out was unlocking the whole payments category, which also unlocks `send_payment`. `defaultAllowedFor()` now resolves per-action first; a test pins that `connect_wallet` is the **only** payments action allowed to default on, and it stays high-risk, confirmation-required, never "Automatic".

## SSOT

Four surfaces each kept their own copy of which wallet to get — the public guide (Primal), the wallets page (BlueWallet, Phoenix), the wallet form's "don't have a wallet?" panel (Primal, Coinos), the Nostr card (Alby). Already drifted; none reachable by the Cat. Identity now lives once in `src/config/wallet-providers.ts`; each surface keeps its editorial and refers to providers by id. **A source-scanning test fails the build if a provider URL appears anywhere else — which is how the 3rd and 4th copies were found in the first place.**

`lightningAddress` in that registry deliberately means *"hands you a name@domain address"*, not *"supports Lightning"* — the distinction the old copies blurred. A wallet that only does the latter would send someone through a full setup that ends unpayable, so it never reaches the shortlist.

## Verification

- 1671 unit tests green; `tsc --noEmit` clean; lint clean
- New: `connectWalletHandler.test.ts` (8), `payment-capabilities-context.test.ts` (4), `wallet-providers-ssot.test.ts` (4), plus rows in `action-disambiguation` and `autonomy-ladder`

## ⚠️ Follow-up, not optional

Prompt budget went 60,324 → 60,459 against a 60,500 ceiling. Paid for by compressing the `add_wallet` section (which was also wrong — it now says it is a savings bucket, not a way to get paid), and by putting the rich two-branch guidance in **user** context rather than the static prompt, so only users who actually cannot be paid spend tokens on it. **41 chars of headroom is too tight for the next change; the prompt needs a real shrink before another action lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)