### PR TITLE
fix(ci): the merge train deadlocked, and its retry path could never have worked

### DIFF
--- a/__tests__/unit/ci/auto-merge-base-guard.test.ts
+++ b/__tests__/unit/ci/auto-merge-base-guard.test.ts
@@ -105,3 +105,34 @@ describe('auto-merge base-branch guard', () => {
     expect(calls).not.toContain('pr merge');
   });
 });
+
+/**
+ * A retry path is only a recovery path if the retried thing can succeed.
+ *
+ * `refresh-e2e-reset-tokens.mjs` keys its disposable fixture user on
+ * GITHUB_RUN_ID, which is STABLE across a re-run. So the second attempt of any
+ * run that reached fixture bootstrap tried to create a user that already
+ * existed, `createUser` 422'd with `email_exists`, and the job exited 1 —
+ * meaning re-running CI could never succeed. That silently disabled every
+ * recovery built on re-running: the PR-side cancelled-run retry above (added
+ * for #603/#604) and the base-branch one added in this change. It surfaced on
+ * 2026-08-06, when re-running main's outage-cancelled CI turned a stalled merge
+ * queue into a genuinely red main.
+ *
+ * These are source assertions, not executions: the script is a top-level-await
+ * ESM entry point that talks to Supabase on import, and jest here only
+ * transforms .ts/.tsx. They still fail if someone reverts the fix, which is the
+ * job.
+ */
+describe('e2e reset fixture survives a re-run', () => {
+  const source = readFileSync('scripts/test-setup/refresh-e2e-reset-tokens.mjs', 'utf8');
+
+  it('keys the fixture on the attempt, not just the run', () => {
+    expect(source).toContain('GITHUB_RUN_ATTEMPT');
+  });
+
+  it('treats a leftover fixture of the same tag as something to clear, not fail on', () => {
+    expect(source).toContain('email_exists');
+    expect(source).toContain('deleteUser');
+  });
+});

--- a/__tests__/unit/ci/auto-merge-base-guard.test.ts
+++ b/__tests__/unit/ci/auto-merge-base-guard.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The base-branch guard must never be able to deadlock the merge train.
+ *
+ * `auto-merge-sweep.sh` refuses to merge onto a base whose CI is not green.
+ * That is right for a FAILURE — a verdict about the code. It was catastrophic
+ * for a CANCELLED run, which carries no verdict at all: the only thing that
+ * produces a new main CI run is a merge, and merges are exactly what the guard
+ * was blocking. On 2026-08-06 a GitHub Actions outage cancelled main's run and
+ * five green PRs sat stuck for seven hours until a human re-ran it by hand.
+ *
+ * The script had already learned this for PR checks (#603/#604) and left the
+ * identical hole on the base branch — the same shape as the top-up settlement
+ * bug: a class retired on one path and left open on its sibling.
+ *
+ * These run the real script against a fake `gh` on PATH, so they test the
+ * shipped control flow rather than a description of it.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SHA = 'b6750a3430f3048ca8235e22555577cbcb462a29';
+
+/**
+ * A `gh` that answers only what the guard asks. It ignores `--jq` and prints
+ * the already-projected value, which is what the script consumes. Every
+ * invocation is appended to a log so the assertions can see what was called.
+ */
+function fakeGh(runJson: string): { bin: string; log: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'automerge-'));
+  const log = join(dir, 'calls.log');
+  writeFileSync(
+    join(dir, 'gh'),
+    `#!/usr/bin/env bash
+echo "$@" >> ${JSON.stringify(log)}
+case "$1 $2" in
+  "api repos/"*) echo '${SHA}' ;;
+  "run list") echo '${runJson}' ;;
+  "run rerun") ;;
+  "pr list") echo '[]' ;;
+  *) ;;
+esac
+exit 0
+`
+  );
+  chmodSync(join(dir, 'gh'), 0o755);
+  return { bin: dir, log };
+}
+
+function sweep(runJson: string): { stdout: string; calls: string } {
+  const { bin, log } = fakeGh(runJson);
+  const stdout = execFileSync('bash', ['scripts/ci/auto-merge-sweep.sh'], {
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return { stdout, calls: existsSync(log) ? readFileSync(log, 'utf8') : '' };
+}
+
+const baseRun = (conclusion: string, status = 'completed') =>
+  JSON.stringify({ databaseId: 4242, status, conclusion, headSha: SHA });
+
+describe('auto-merge base-branch guard', () => {
+  it('re-runs a cancelled base run instead of stalling the queue forever', () => {
+    const { stdout, calls } = sweep(baseRun('cancelled'));
+
+    expect(stdout).toContain('was cancelled');
+    expect(calls).toContain('run rerun 4242');
+    // And it stops there — nothing is merged onto a base that has not passed.
+    expect(calls).not.toContain('pr merge');
+  });
+
+  it('still refuses a genuinely failed base, and does not retry it', () => {
+    // A failure IS a verdict about the code. Re-running it would be the script
+    // arguing with its own gate.
+    const { stdout, calls } = sweep(baseRun('failure'));
+
+    expect(stdout + calls).not.toContain('run rerun');
+    expect(calls).not.toContain('pr merge');
+  });
+
+  it('defers while the base run is still going rather than re-running it', () => {
+    // Guards against a retry loop: a re-run that is queued must not be re-run
+    // again by the next sweep.
+    const { stdout, calls } = sweep(baseRun('', 'in_progress'));
+
+    expect(stdout).toContain('still running');
+    expect(calls).not.toContain('run rerun');
+  });
+
+  it('waits when the newest base run belongs to an older commit', () => {
+    // The batching trap this guard exists for: right after a merge the newest
+    // run is the PREVIOUS commit's, and it is green.
+    const stale = JSON.stringify({
+      databaseId: 1,
+      status: 'completed',
+      conclusion: 'success',
+      headSha: 'a'.repeat(40),
+    });
+    const { stdout, calls } = sweep(stale);
+
+    expect(stdout).toContain('waiting for CI to catch up');
+    expect(calls).not.toContain('pr merge');
+  });
+});

--- a/scripts/ci/auto-merge-sweep.sh
+++ b/scripts/ci/auto-merge-sweep.sh
@@ -58,7 +58,7 @@ echo "[auto-merge] sweeping open PRs against ${BASE_BRANCH} in ${REPO}"
 # batching this script exists to prevent.
 main_sha=$(gh api "repos/${REPO}/commits/${BASE_BRANCH}" --jq '.sha')
 main_ci=$(gh run list --repo "$REPO" --workflow ci.yml --branch "$BASE_BRANCH" --limit 1 \
-  --json status,conclusion,headSha --jq '.[0] // empty')
+  --json databaseId,status,conclusion,headSha --jq '.[0] // empty')
 
 if [ -z "$main_ci" ]; then
   echo "[auto-merge] no CI history for ${BASE_BRANCH} — proceeding"
@@ -73,6 +73,27 @@ else
   fi
   if [ "$main_status" != "completed" ]; then
     echo "[auto-merge] ${BASE_BRANCH} CI is still running — deferring to the next sweep"
+    exit 0
+  fi
+  # A CANCELLED base run is a deadlock, not a red base.
+  #
+  # This script already learned the lesson for PRs (see the re-run below, added
+  # after #603/#604 stranded) and left the identical hole on the base branch: a
+  # cancelled main run is not "success", so the guard refused — and because the
+  # ONLY thing that produces a new main CI run is a merge, and merges are what
+  # the guard is blocking, nothing could ever clear it. On 2026-08-06 a GitHub
+  # Actions outage cancelled main's run and the queue sat stuck for seven hours
+  # behind five green PRs; it took a human `gh run rerun` to move.
+  #
+  # Cancellation carries no verdict about the code, so re-run it and let the
+  # next sweep judge the real result. A genuine `failure` still blocks — that IS
+  # a verdict. If the re-run is cancelled again, the next sweep retries; the
+  # `status != completed` check above keeps that from stacking runs.
+  if [ "$main_conclusion" = "cancelled" ]; then
+    main_run_id=$(printf '%s' "$main_ci" | jq -r '.databaseId')
+    echo "[auto-merge] ${BASE_BRANCH} CI was cancelled — re-running ${main_run_id} rather than stalling the queue"
+    gh run rerun "$main_run_id" --repo "$REPO" \
+      || echo "[auto-merge] could not re-run ${main_run_id}" >&2
     exit 0
   fi
   if [ "$main_conclusion" != "success" ]; then

--- a/scripts/test-setup/refresh-e2e-reset-tokens.mjs
+++ b/scripts/test-setup/refresh-e2e-reset-tokens.mjs
@@ -28,9 +28,20 @@ const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY;
 const anonKey =
   process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-// Unique per run (workflow run id in CI, pid+time locally) so no other run
-// can touch this user's recovery token or password.
-const runTag = process.env.GITHUB_RUN_ID || `${process.pid}-${Date.now()}`;
+// Unique per ATTEMPT (workflow run id + attempt in CI, pid+time locally) so no
+// other run can touch this user's recovery token or password.
+//
+// The attempt number is not decoration. GITHUB_RUN_ID is stable across a
+// re-run, so keying on it alone meant the second attempt of any run that got
+// this far tried to create a user that already existed — `createUser` 422s with
+// `email_exists` and the job exits 1. Effect: **re-running CI could never
+// succeed**, which silently disabled every recovery path built on re-running,
+// including auto-merge-sweep.sh's cancelled-run retry (added for #603/#604) and
+// its base-branch twin. It surfaced on 2026-08-06 when an Actions outage
+// cancelled main's CI and re-running it turned a stalled queue into a red main.
+const runTag = process.env.GITHUB_RUN_ID
+  ? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT || '1'}`
+  : `${process.pid}-${Date.now()}`;
 const email = `e2e-reset-${runTag}@orangecat.ch`;
 
 if (!url || !serviceKey || !anonKey) {
@@ -62,12 +73,31 @@ try {
   console.warn('stale reset-user cleanup skipped:', e?.message ?? e);
 }
 
-const { error: createErr } = await admin.auth.admin.createUser({
-  email,
-  password: `Reset-${runTag}-Aa1!`,
-  email_confirm: true,
-  user_metadata: { preferred_username: `e2e_reset_${runTag}`, name: 'E2E Reset User' },
-});
+async function createResetUser() {
+  return admin.auth.admin.createUser({
+    email,
+    password: `Reset-${runTag}-Aa1!`,
+    email_confirm: true,
+    user_metadata: { preferred_username: `e2e_reset_${runTag}`, name: 'E2E Reset User' },
+  });
+}
+
+let { error: createErr } = await createResetUser();
+
+// Belt and braces for the same class the attempt suffix above fixes: this
+// fixture is disposable by definition, so a leftover of the SAME tag is
+// something to clear, never something to fail on. Anything that makes CI
+// unrunnable twice in a row disables every retry-based recovery path we have.
+if (createErr?.code === 'email_exists') {
+  console.warn(`reset fixture ${email} already existed — replacing it`);
+  const { data } = await admin.auth.admin.listUsers({ page: 1, perPage: 100 });
+  const stale = (data?.users ?? []).find(u => u.email === email);
+  if (stale) {
+    await admin.auth.admin.deleteUser(stale.id);
+  }
+  ({ error: createErr } = await createResetUser());
+}
+
 if (createErr) {
   console.error('createUser for reset fixture failed', createErr);
   process.exit(1);


### PR DESCRIPTION
Two commits, one story: **a retry path is only a recovery path if the retried thing can succeed.**

---

## 1. A cancelled base run deadlocked the merge train

Five green, ready PRs (#637–#641) sat unmerged for **seven hours** behind one line:

```
[auto-merge] main CI is cancelled — refusing to merge onto a broken base
```

A GitHub Actions outage cancelled main's CI at 15:05. Actions recovered; the queue did not. Two Auto-merge sweeps ran to `success` at 20:41 and 22:21 and merged **nothing** — so from the outside the automation looked perfectly healthy.

Refusing a **red** base is correct. A **cancelled** run is not a red base — it carries no verdict about the code at all. And it is unrecoverable by construction:

> the only thing that produces a new CI run on main is a merge, and merges are precisely what the guard is blocking.

**The part that stings:** this script had *already retired this class for PR checks* — the `re-running cancelled run` branch further down was added after #603/#604 stranded the same way — and left the identical hole on the base branch. Same shape as the top-up settlement bug fixed earlier today (#627): a class retired on one path, left open on its sibling.

**Fix:** on `cancelled`, re-run the base run and let the next sweep judge. A genuine `failure` still blocks, because that **is** a verdict. The existing `status != completed` check keeps re-runs from stacking.

## 2. …except re-running CI could never succeed

Re-running main's cancelled CI to unstick it turned a stalled queue into a genuinely **red main**:

```
createUser for reset fixture failed AuthApiError:
A user with this email address has already been registered  (422 email_exists)
```

`refresh-e2e-reset-tokens.mjs` mints `e2e-reset-${GITHUB_RUN_ID}@…`, and **`GITHUB_RUN_ID` is stable across a re-run**. The second attempt of any run that reached fixture bootstrap tried to create a user the first attempt had already created, and exited 1.

The consequence is far bigger than one red run. **Re-running CI could never succeed**, which silently disabled every recovery mechanism built on re-running — including this repo's own cancelled-run retry for PRs. That retry cannot have worked in any case where the cancelled run got as far as fixture bootstrap. The retry existed; the thing it retried was guaranteed to fail.

It also makes commit 1 unsafe on its own: it would have converted *deadlocked* into *permanently red*. The two belong in one PR.

**Fix:** key the fixture on the **attempt** (`GITHUB_RUN_ID-GITHUB_RUN_ATTEMPT`), and treat a leftover of the same tag as something to clear rather than fail on — this fixture is disposable by definition.

---

## Tested against the real script, not a description of it

`__tests__/unit/ci/auto-merge-base-guard.test.ts` puts a fake `gh` on `PATH` and runs `auto-merge-sweep.sh` for real:

- cancelled → re-runs, merges nothing
- failure → neither re-runs nor merges
- in-progress → defers (no retry loop)
- run belongs to an older commit → still waits (the batching trap the guard exists for)

**Verified non-vacuous:** stubbing the new branch out (`if false; then`) turns the first test red.

The fixture assertions are source-level and say so in the file — that script is a top-level-await ESM entry point that talks to Supabase on import, and jest here only transforms `.ts/.tsx`. They still fail if someone reverts the fix, which is the job.

## Unblocking, meanwhile

`gh run rerun` cannot work until this lands, so main was unstuck with a fresh `workflow_dispatch` of CI instead — new run id, new fixture email, no merge required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
