### PR TITLE
fix(db): validate profiles_id_fkey now that no orphan remains

### DIFF
--- a/supabase/migrations/20260807010000_validate_profiles_id_fkey.sql
+++ b/supabase/migrations/20260807010000_validate_profiles_id_fkey.sql
@@ -1,0 +1,27 @@
+-- Promote profiles_id_fkey from NOT VALID to validated.
+--
+-- 20260806150000 added the constraint NOT VALID on purpose: that enforces every
+-- future write and makes ON DELETE CASCADE fire immediately, WITHOUT requiring
+-- the 115 pre-existing orphaned profiles to be deleted first. Purging live
+-- production rows was a separate, owner-level decision and the migration was
+-- right not to smuggle it in.
+--
+-- That decision has since been made and carried out: measured 2026-08-07,
+-- `public.profiles` and `auth.users` both hold 85 rows and
+-- count_orphaned_profiles() returns 0. The cascade was also proven against
+-- production inside a rolled-back transaction — inserting an auth user creates
+-- the profile via on_auth_user_created, deleting the user removes it, which
+-- before the constraint left the profile standing.
+--
+-- So the only thing left is the asterisk. A NOT VALID constraint tells every
+-- future reader "the rule holds from here on, but nobody has checked what came
+-- before" — and the planner cannot rely on it either. VALIDATE performs that
+-- check once and removes the ambiguity permanently.
+--
+-- Safety: VALIDATE CONSTRAINT takes only SHARE UPDATE EXCLUSIVE — it does not
+-- block reads or writes — and it scans the table without rewriting it. If any
+-- orphan somehow exists at apply time it raises instead of deleting anything,
+-- which aborts the deploy (scripts/apply-migrations.sh runs before the code) and
+-- leaves production exactly as it was. Failure here is a report, not damage.
+
+ALTER TABLE public.profiles VALIDATE CONSTRAINT profiles_id_fkey;


### PR DESCRIPTION
Closes the loop #637 deliberately left open.

## Why it was NOT VALID in the first place

#637 added `profiles_id_fkey` **NOT VALID** on purpose: that enforces every future write and makes `ON DELETE CASCADE` fire immediately, *without* demanding that the 115 pre-existing orphaned profiles be deleted first. Purging live production rows was an owner-level decision, and the migration had no business smuggling it in.

## That decision has since been made and carried out

Measured against production tonight:

```
conname            convalidated  confdeltype
profiles_id_fkey   f             c            ← the constraint, cascading
count_orphaned_profiles()        0
profiles 85 | auth_users 85                   ← exactly equal
```

The cascade was also **proven live**, inside a rolled-back transaction:

```
INSERT auth.users        → profile_after_insert       1   (via on_auth_user_created)
DELETE auth.users        → profile_after_user_delete  0   (before #637 this was 1)
ROLLBACK
```

Those counts moved 76 → 85 over the evening as CI minted e2e users, and **orphans stayed 0** the whole time — the fix working in real time on traffic that used to leak a profile per run.

## What remains is only an asterisk

`NOT VALID` tells every future reader *"the rule holds from here on, but nobody checked what came before"*, and the planner cannot rely on it either. `VALIDATE` performs that check once and removes the ambiguity permanently.

## Safe by construction

- `SHARE UPDATE EXCLUSIVE` only — does not block reads or writes, and does not rewrite the table
- If an orphan somehow exists at apply time it **raises rather than deleting anything**, which aborts the deploy (`scripts/apply-migrations.sh` runs before the code ships) and leaves production exactly as it was. Failure here is a report, not damage.

**Dry-run against the production schema** inside `BEGIN; … ROLLBACK;` — applies clean and flips `convalidated` to `t`. Zero production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
