### PR TITLE
fix(eval): a dropped PostgREST connection is not a verdict

### DIFF
--- a/scripts/eval-wallet-routing.mjs
+++ b/scripts/eval-wallet-routing.mjs
@@ -136,17 +136,54 @@ const svcHeaders = {
   'Content-Type': 'application/json',
 };
 
+const REST_RETRIES = 4;
+const REST_BACKOFF_MS = 1500;
+
+/**
+ * PostgREST call with the same transient tolerance as eval-cat.mjs. A dropped
+ * connection or a schema-cache 503 anywhere in here does not throw a verdict —
+ * it killed a whole run with "harness error — fetch failed" before this existed,
+ * losing the two probes that had already passed. 4xx is a real answer about the
+ * request and is never retried.
+ */
 async function rest(method, path, { body, prefer } = {}) {
-  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
-    method,
-    headers: { ...svcHeaders, ...(prefer ? { Prefer: prefer } : {}) },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  if (!res.ok) {
-    throw new Error(`PostgREST ${method} ${path} → ${res.status}: ${await res.text()}`);
+  let lastErr;
+  for (let attempt = 1; attempt <= REST_RETRIES; attempt++) {
+    let res;
+    try {
+      res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+        method,
+        headers: { ...svcHeaders, ...(prefer ? { Prefer: prefer } : {}) },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+    } catch (err) {
+      lastErr = new Error(`PostgREST ${method} ${path} → transport: ${err.message}`);
+      await restBackoff(attempt, 'transport');
+      continue;
+    }
+    if (res.ok) {
+      const text = await res.text();
+      return text ? JSON.parse(text) : null;
+    }
+    const detail = await res.text();
+    lastErr = new Error(`PostgREST ${method} ${path} → ${res.status}: ${detail}`);
+    if (res.status < 500) {
+      throw lastErr;
+    }
+    await restBackoff(attempt, `${res.status}`);
   }
-  const text = await res.text();
-  return text ? JSON.parse(text) : null;
+  throw lastErr;
+}
+
+async function restBackoff(attempt, why) {
+  if (attempt >= REST_RETRIES) {
+    return;
+  }
+  const wait = REST_BACKOFF_MS * attempt;
+  console.error(
+    `eval-wallet-routing: PostgREST transient (${why}) — retry ${attempt}/${REST_RETRIES - 1} in ${wait}ms`
+  );
+  await new Promise(r => setTimeout(r, wait));
 }
 
 /** Rebuild the cookie @supabase/ssr expects (see eval-cat.mjs for the format). */


### PR DESCRIPTION
## What

A transient `fetch failed` on the wallets-staging INSERT killed a whole run of `eval-wallet-routing.mjs` with `harness error — fetch failed`, discarding the two probes that had **already passed**.

`eval-cat.mjs` has had this tolerance for a while (added after a PostgREST schema-cache 503 killed the nightly gate on 2026-08-04). The new harness copied its model-call retry but not its PostgREST retry — which is the usual shape of this mistake: the retry goes on the call everyone thinks of as flaky, and the five bookkeeping calls holding it up are left bare.

## Change

`rest()` now retries transport errors and 5xx with linear backoff (4 attempts, 1.5s × attempt), and never retries a 4xx — that is a real answer about the request, not a hiccup.

## Verification

Reproduced live: the run at 08:2x died on `TypeError: fetch failed` after two green probes. Cleanup still ran (it is in a `finally`), so no throwaway user leaked — but the verdict was lost.

`eslint` clean (same 6 `no-console` warnings as `eval-cat.mjs`, which is how these harnesses report), `node --check` passes.

A fully green end-to-end run of the harness is still pending free-tier capacity — OpenRouter is currently returning `429 free-models-per-day` platform-wide (see `/api/cat/diagnose`), so no Cat probe can run at all right now. The three probes were each verified live earlier today before the pool was exhausted; this PR changes only the retry behaviour around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
