### PR TITLE
fix(eval): the wallet eval orphaned 20 conversations while asserting it was clean

### DIFF
--- a/scripts/eval-wallet-routing.mjs
+++ b/scripts/eval-wallet-routing.mjs
@@ -403,18 +403,53 @@ async function main() {
       console.log(`${score.ok ? '✓' : '✗'} ${probe.id} — ${score.detail}`);
     }
   } finally {
-    // Deleting the auth user is the whole cleanup: conversations, messages and
-    // the profile all cascade. Asserting it is a free live re-test of PR #637.
+    // Delete everything this run wrote, explicitly, and only THEN the user.
+    //
+    // The first version assumed deleting the auth user was the whole cleanup
+    // and asserted it by checking `profiles` came back empty. It always did —
+    // profiles cascade since #637 — so the check passed on every run while
+    // `cat_conversations` quietly orphaned: 20 rows, 7 vanished owners, found
+    // only by going and looking. The assertion proved the thing already fixed
+    // rather than the thing being done, which is the failure mode to watch for
+    // whenever a cleanup check is written next to a recent cascade fix.
+    //
+    // So: own the rows. Every table below is one this harness writes to.
+    for (const { id } of (await rest('GET', `cat_conversations?user_id=eq.${userId}&select=id`)) ??
+      []) {
+      await rest('DELETE', `cat_messages?conversation_id=eq.${id}`, { prefer: 'return=minimal' });
+    }
+    for (const path of [
+      `cat_conversations?user_id=eq.${userId}`,
+      `cat_memories?user_id=eq.${userId}`,
+      `cat_pending_actions?user_id=eq.${userId}`,
+      `wallets?profile_id=eq.${userId}`,
+    ]) {
+      await rest('DELETE', path, { prefer: 'return=minimal' });
+    }
     const del = await fetch(`${SUPABASE_URL}/auth/v1/admin/users/${userId}`, {
       method: 'DELETE',
       headers: svcHeaders,
     });
-    const left = await rest('GET', `profiles?id=eq.${userId}&select=id`);
+
+    // Verify per table, not by proxy. `profiles` is still checked because that
+    // one IS a cascade and re-testing it live every run is free.
+    const leftovers = [];
+    for (const [label, path] of [
+      ['profiles', `profiles?id=eq.${userId}&select=id`],
+      ['cat_conversations', `cat_conversations?user_id=eq.${userId}&select=id`],
+      ['cat_memories', `cat_memories?user_id=eq.${userId}&select=id`],
+      ['wallets', `wallets?profile_id=eq.${userId}&select=id`],
+    ]) {
+      const rows = await rest('GET', path);
+      if (rows?.length) {
+        leftovers.push(`${label}=${rows.length}`);
+      }
+    }
     console.error(
-      `eval-wallet-routing: deleted probe user (${del.status}); profile rows left behind: ${left?.length ?? '?'}`
+      `eval-wallet-routing: deleted probe user (${del.status}); leftovers: ${leftovers.join(', ') || 'none'}`
     );
-    if (left?.length) {
-      console.error('eval-wallet-routing: CASCADE REGRESSION — probe user left an orphaned profile');
+    if (leftovers.length) {
+      console.error('eval-wallet-routing: CLEANUP INCOMPLETE — probe user left rows behind');
       failures++;
     }
   }


### PR DESCRIPTION
## The bug

`eval-wallet-routing.mjs` deleted its throwaway auth user and asserted cleanliness by checking that `profiles` came back empty. It always did — **profiles cascade since #637** — so the check passed on every run while `cat_conversations` quietly orphaned.

Found by going and looking, not by the check:

```
20 [eval] conversations · 7 distinct owners · 0 of those owners still exist
```

Same leak `eval-cat.mjs` already sweeps for (18 rows from a single July run sat in production for a month), one table over.

## Why it's worth a commit message rather than a silent fix

The assertion proved **the thing that was already fixed**, not the thing being done. A cleanup check written next to a recent cascade fix will reach for that cascade as its evidence every time — it is right there, it is green, and it is answering a different question.

## Change

The harness owns its rows. Messages → conversations → memories → pending actions → wallets are deleted explicitly *before* the user, and each table is verified individually afterwards instead of through one proxy. `profiles` stays in the verification list: that one genuinely is a cascade, and re-testing it live on every run is free.

## Verification

Seeded a conversation, a message and a wallet onto a throwaway user, ran the exact cleanup sequence, confirmed every table came back empty:

```
minted 04b8ce37-…
seeded conversation + message + wallet
user delete 200 | leftovers: none
✓ cleanup verified complete
```

The 20 orphans from earlier runs are deleted; `[eval]` conversations in production are back to 0.

`node --check` and `eslint` clean (same 6 `no-console` warnings these harnesses report through).

## Note

A fully green end-to-end run of the probes themselves is still blocked on free-tier capacity — OpenRouter is returning `429 free-models-per-day` platform-wide, so no Cat probe can run at all. The routing behaviour was verified live earlier today (#646); this PR touches only cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
