### PR TITLE
fix(ci): a red base must not trap the PR that repairs it

### DIFF
--- a/__tests__/unit/ci/auto-merge-red-base.test.ts
+++ b/__tests__/unit/ci/auto-merge-red-base.test.ts
@@ -1,0 +1,145 @@
+/**
+ * A red base must not trap the PR that repairs it.
+ *
+ * `auto-merge-sweep.sh` refused to merge anything onto a base whose CI failed.
+ * That is right for an unrelated change — a broken base should not quietly
+ * collect more of them. It is a deadlock when the PR *is* the repair: the fix
+ * cannot travel the path its own redness blocks, and only a human can move it.
+ *
+ * Observed in maonakamoto/aoz-housing on 2026-08-07 — E2E red on master, the
+ * fix sitting green in a PR, every sweep refusing politely. Same shape as the
+ * cancelled-base deadlock (see auto-merge-base-guard.test.ts): a guard that is
+ * correct about the code and wrong about the queue.
+ *
+ * The rule now: identify which jobs are red, and let a PR through only if its
+ * own checks pass every one of them. That is not a weakening — a PR's checks
+ * run on the MERGE result (refs/pull/N/merge), so green-on-those-jobs is direct
+ * evidence the post-merge base is better than the pre-merge base.
+ *
+ * These run the real script against a fake `gh` on PATH, so they test the
+ * shipped control flow rather than a description of it.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SHA = 'b6750a3430f3048ca8235e22555577cbcb462a29';
+
+/** A green, non-draft PR carrying exactly the named checks. */
+function prJson(checkNames: string[]) {
+  return JSON.stringify([
+    {
+      number: 26,
+      title: 'the repair',
+      isDraft: false,
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+      labels: [],
+      createdAt: '2026-08-07T00:00:00Z',
+      statusCheckRollup: checkNames.map(name => ({
+        __typename: 'CheckRun',
+        name,
+        status: 'COMPLETED',
+        conclusion: 'SUCCESS',
+      })),
+    },
+  ]);
+}
+
+/**
+ * `gh` answers only what the sweep asks. It ignores `--jq` and prints the
+ * already-projected value the script consumes — including, for `run view`, the
+ * newline-separated names of the base's FAILING jobs.
+ */
+function sweep(baseConclusion: string, failingJobs: string[], prChecks: string[]) {
+  const dir = mkdtempSync(join(tmpdir(), 'automerge-redbase-'));
+  const log = join(dir, 'calls.log');
+  const summary = join(dir, 'summary.md');
+  writeFileSync(summary, '');
+  const runList = JSON.stringify({
+    databaseId: 4242,
+    status: 'completed',
+    conclusion: baseConclusion,
+    headSha: SHA,
+  });
+  writeFileSync(
+    join(dir, 'gh'),
+    `#!/usr/bin/env bash
+echo "$@" >> ${JSON.stringify(log)}
+case "$1 $2" in
+  "api repos/"*"/pulls/"*"/update-branch"*) exit 0 ;;
+  "api repos/"*) echo '${SHA}' ;;
+  "run list") echo '${runList}' ;;
+  "run view") printf '%s' ${JSON.stringify(failingJobs.join('\n'))} ;;
+  "run rerun") ;;
+  "pr list") echo '${prJson(prChecks).replace(/'/g, "'\\''")}' ;;
+  "pr view") echo '{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN"}' ;;
+  "pr merge") ;;
+  *) ;;
+esac
+exit 0
+`
+  );
+  chmodSync(join(dir, 'gh'), 0o755);
+
+  const stdout = execFileSync('bash', ['-c', 'scripts/ci/auto-merge-sweep.sh 2>&1'], {
+    env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_STEP_SUMMARY: summary },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    stdout,
+    calls: existsSync(log) ? readFileSync(log, 'utf8') : '',
+    summary: readFileSync(summary, 'utf8'),
+  };
+}
+
+describe('a PR that repairs the base may merge onto it', () => {
+  it('merges when the PR is green on every job the base fails', () => {
+    const { stdout, calls, summary } = sweep('failure', ['E2E Tests'], ['E2E Tests', 'Build']);
+
+    expect(calls).toContain('pr merge 26');
+    expect(stdout).toContain('green on every job');
+    // And it is announced where someone will see it — this is a deliberate
+    // exception to the guard, not a silent one.
+    expect(summary).toContain('#26');
+  });
+
+  it('still refuses a PR that does not run the failing job at all', () => {
+    // The dangerous case: base red on E2E, PR never proves E2E. Merging that
+    // is exactly the "stacking onto broken" the guard exists to prevent.
+    const { stdout, calls } = sweep('failure', ['E2E Tests'], ['Build']);
+
+    expect(calls).not.toContain('pr merge');
+    expect(stdout).toContain('does not prove those green');
+  });
+
+  it('refuses when the PR covers only SOME of the failing jobs', () => {
+    const { stdout, calls } = sweep('failure', ['E2E Tests', 'Unit Tests'], ['E2E Tests']);
+
+    expect(calls).not.toContain('pr merge');
+    expect(stdout).toContain('Unit Tests');
+  });
+
+  it('refuses when the base failure has no identifiable failing job', () => {
+    // e.g. a cancelled/timed-out run: no job carries conclusion "failure", so
+    // there is nothing for a PR to prove. Falling back to the old refusal is
+    // the safe answer.
+    const { stdout, calls } = sweep('failure', [], ['E2E Tests']);
+
+    expect(calls).not.toContain('pr merge');
+    expect(stdout).toContain('no failing job could be identified');
+  });
+});
+
+describe('a green base is completely unaffected', () => {
+  it('merges normally and never asks which jobs failed', () => {
+    const { calls } = sweep('success', [], ['E2E Tests', 'Build']);
+
+    expect(calls).toContain('pr merge 26');
+    // No wasted API call, and no chance of the carve-out firing on a green base.
+    expect(calls).not.toContain('run view');
+  });
+});

--- a/scripts/ci/auto-merge-sweep.sh
+++ b/scripts/ci/auto-merge-sweep.sh
@@ -96,9 +96,34 @@ else
       || echo "[auto-merge] could not re-run ${main_run_id}" >&2
     exit 0
   fi
+  # A red base must not become a trap for the PR that repairs it.
+  #
+  # "Never merge onto red" is right for an unrelated change: it stops a broken
+  # base quietly collecting more changes and getting harder to diagnose. But
+  # when the PR *is* the repair, the same rule deadlocks the repo — the fix
+  # cannot travel the path its own redness blocks, and only a human can move
+  # it. Seen in maonakamoto/aoz-housing on 2026-08-07: E2E red on master, the
+  # fix sitting green in a PR, every sweep refusing politely. That is the same
+  # shape as the cancelled-base deadlock handled just above — a guard that is
+  # correct about the code and wrong about the queue.
+  #
+  # So identify WHICH jobs are red, and let a PR through only if its own checks
+  # pass every one of them. This is not a weakening: a PR's checks run on the
+  # MERGE result (refs/pull/N/merge), so green-on-those-jobs is direct evidence
+  # that the post-merge base is better than the pre-merge base. A PR that does
+  # not cover the failing jobs is still refused, and so is a base failure whose
+  # jobs cannot be identified at all.
+  main_red_jobs=""
   if [ "$main_conclusion" != "success" ]; then
-    echo "[auto-merge] ${BASE_BRANCH} CI is ${main_conclusion} — refusing to merge onto a broken base" >&2
-    exit 0
+    main_run_id=$(printf '%s' "$main_ci" | jq -r '.databaseId')
+    main_red_jobs=$(gh run view "$main_run_id" --repo "$REPO" --json jobs \
+      --jq '[.jobs[] | select(.conclusion == "failure") | .name] | .[]' 2>/dev/null || true)
+    if [ -z "$main_red_jobs" ]; then
+      echo "[auto-merge] ${BASE_BRANCH} CI is ${main_conclusion} and no failing job could be identified — refusing to merge onto a broken base" >&2
+      exit 0
+    fi
+    echo "[auto-merge] ${BASE_BRANCH} CI is ${main_conclusion} — failing: $(printf '%s' "$main_red_jobs" | tr '\n' ' ')" >&2
+    echo "[auto-merge] only a PR that is green on those exact jobs may merge (its checks run on the merge result)"
   fi
 fi
 
@@ -215,6 +240,29 @@ for number in $(printf '%s' "$prs_json" | jq -r '.[].number'); do
       echo "[auto-merge] #${number} update-branch failed — leaving for the next sweep" >&2
     fi
     break
+  fi
+
+  # Red base: this PR merges only if it proves every failing job green.
+  if [ -n "$main_red_jobs" ]; then
+    pr_green=$(printf '%s' "$pr" | jq -r '
+      [ .statusCheckRollup[]?
+        | select(((.conclusion // .state // "") | test("^(SUCCESS|NEUTRAL|SKIPPED)$")))
+        | (.name // .context) ] | .[]')
+    uncovered=""
+    while IFS= read -r job; do
+      [ -z "$job" ] && continue
+      printf '%s\n' "$pr_green" | grep -Fxq "$job" || uncovered="${uncovered}${job}; "
+    done <<INNER_EOF
+$main_red_jobs
+INNER_EOF
+    if [ -n "$uncovered" ]; then
+      echo "[auto-merge] #${number} skip: ${BASE_BRANCH} is red on [${uncovered%; }] and this PR does not prove those green — ${title}"
+      continue
+    fi
+    echo "[auto-merge] #${number} is green on every job ${BASE_BRANCH} fails — merging it to repair the base: ${title}" >&2
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+      echo "- 🔧 #${number} merged onto a red \`${BASE_BRANCH}\` because it passes every failing job — ${title}" >> "$GITHUB_STEP_SUMMARY"
+    fi
   fi
 
   echo "[auto-merge] #${number} green and ready — merging: ${title}"


### PR DESCRIPTION
Closing the last deadlock in the merge train.

`auto-merge-sweep.sh` refused to merge anything onto a base whose CI failed.
That is right for an unrelated change — a broken base should not quietly
collect more of them. It is a **deadlock** when the PR *is* the repair: the fix
cannot travel the path its own redness blocks, so only a human can move it.

Seen in `maonakamoto/aoz-housing` on 2026-08-07 — E2E red on master, the fix
sitting green in a PR, every sweep refusing politely, repo frozen on whatever
last landed. Same shape as the cancelled-base deadlock this script already
learned: a guard that is correct about the code and wrong about the queue.

### The rule

Identify **which** jobs are red, and let a PR through only if its own checks
pass every one of them.

This is not a weakening. A PR's checks run on the **merge result**
(`refs/pull/N/merge`), so green-on-those-jobs is direct evidence that the
post-merge base is better than the pre-merge base — strictly stronger evidence
than the base's own stale red run.

Still refused, and tested:
- a PR that does not run the failing job at all
- a PR that covers only **some** of the failing jobs
- a base failure whose jobs cannot be identified (e.g. cancelled/timed-out) —
  falls back to the old blanket refusal
- a green base is untouched, and never even makes the extra API call

5 new tests in `__tests__/unit/ci/auto-merge-red-base.test.ts`, run against the
real script with a fake `gh` on PATH. Full suite green (2109/2109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)