### PR TITLE
fix(db): a deleted account left its private Cat conversations behind

### DIFF
--- a/scripts/check-data-invariants.mjs
+++ b/scripts/check-data-invariants.mjs
@@ -287,6 +287,55 @@ async function checkOrphanedProfiles() {
   }
 }
 
+/**
+ * Cat conversations whose owner is gone.
+ *
+ * cat_conversations.user_id carried no foreign key at all until 2026-08-07,
+ * while every sibling in the family (cat_messages, cat_memories,
+ * cat_pending_actions, wallets) already cascaded from the account. Deleting a
+ * user therefore removed their profile, memories, pending actions and wallets
+ * and left their conversations — private chats with Cat — standing forever.
+ *
+ * The migration's ON DELETE CASCADE makes new orphans impossible; this is the
+ * backstop for the constraint being dropped or written around, exactly as
+ * checkOrphanedProfiles is for #637.
+ *
+ * Checked against `profiles` rather than auth.users: profiles cascade from
+ * auth.users, so "no profile" and "no account" are the same set, and profiles
+ * is reachable through PostgREST without another service_role-only function.
+ */
+async function checkOrphanedCatConversations() {
+  const convs = await rest('cat_conversations?select=id,user_id');
+  if (convs.length === 0) {
+    notes.push('cat_conversations: table is empty');
+    return;
+  }
+  const ownerIds = [...new Set(convs.map(c => c.user_id))];
+  const live = new Set();
+  // Chunked so the id list cannot outgrow the URL as the table grows.
+  for (let i = 0; i < ownerIds.length; i += 100) {
+    const chunk = ownerIds.slice(i, i + 100);
+    const found = await rest(`profiles?select=id&id=in.(${chunk.join(',')})`);
+    for (const p of found) {
+      live.add(p.id);
+    }
+  }
+
+  const orphans = convs.filter(c => !live.has(c.user_id));
+  if (orphans.length > 0) {
+    violation(
+      'cat_conversations.orphaned',
+      `${orphans.length} conversation(s) belong to accounts that no longer exist — ` +
+        `a deleted account left its private Cat history behind`,
+      orphans.slice(0, 5).map(o => o.id)
+    );
+  } else {
+    notes.push(
+      `cat_conversations: ${convs.length} conversation(s), all owned by a live account`
+    );
+  }
+}
+
 async function main() {
   const checks = [
     checkOrphanedWalletLinks,
@@ -295,6 +344,7 @@ async function main() {
     checkPaidWithoutTimestamp,
     checkSilentlyDroppedCatTurns,
     checkOrphanedProfiles,
+    checkOrphanedCatConversations,
   ];
 
   for (const check of checks) {

--- a/supabase/migrations/20260807120000_cat_conversations_cascade_from_auth_users.sql
+++ b/supabase/migrations/20260807120000_cat_conversations_cascade_from_auth_users.sql
@@ -1,0 +1,41 @@
+-- cat_conversations is the last table in the Cat family with no owner.
+--
+-- Every sibling already cascades from the account:
+--
+--   cat_messages.user_id        -> auth.users  ON DELETE CASCADE
+--   cat_messages.conversation_id-> cat_conversations ON DELETE CASCADE
+--   cat_memories.user_id        -> auth.users  ON DELETE CASCADE
+--   cat_pending_actions.user_id -> auth.users  ON DELETE CASCADE
+--   wallets.profile_id          -> profiles    ON DELETE CASCADE
+--   profiles.id                 -> auth.users  ON DELETE CASCADE   (#637)
+--
+-- cat_conversations.user_id references NOTHING. So deleting an account removes
+-- the profile, the memories, the pending actions and the wallets — and leaves
+-- the conversations standing, with their titles, forever. For a real person
+-- deleting their account that is not untidiness, it is their private chat with
+-- Cat surviving the deletion they asked for.
+--
+-- Found on 2026-08-07 by an eval harness that deleted 7 throwaway users and
+-- left 20 conversations behind while its own cleanup check reported success —
+-- the check watched `profiles`, which does cascade. Same shape as #637, one
+-- table over, and the reason to close it in the schema rather than in the
+-- harness: the harness was only the thing that happened to notice.
+--
+-- Safe on a 33-row table. The DELETE cannot remove a live user's data — it
+-- matches only rows whose auth user no longer exists — and `psql -1` runs the
+-- whole file in one transaction, so the constraint can never see a row the
+-- DELETE did not. NOT VALID + VALIDATE rather than a plain ADD so that the
+-- validation failure, if the assumption is ever wrong, names the constraint.
+
+DELETE FROM public.cat_conversations c
+WHERE NOT EXISTS (
+  SELECT 1 FROM auth.users u WHERE u.id = c.user_id
+);
+
+ALTER TABLE public.cat_conversations
+  ADD CONSTRAINT cat_conversations_user_id_fkey
+  FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE
+  NOT VALID;
+
+ALTER TABLE public.cat_conversations
+  VALIDATE CONSTRAINT cat_conversations_user_id_fkey;


### PR DESCRIPTION
## The gap

`cat_conversations.user_id` references **nothing**. Every sibling in the family already cascades from the account:

| column | references | on delete |
|---|---|---|
| `cat_messages.user_id` | `auth.users` | CASCADE |
| `cat_messages.conversation_id` | `cat_conversations` | CASCADE |
| `cat_memories.user_id` | `auth.users` | CASCADE |
| `cat_pending_actions.user_id` | `auth.users` | CASCADE |
| `wallets.profile_id` | `profiles` | CASCADE |
| `profiles.id` | `auth.users` | CASCADE (#637) |
| **`cat_conversations.user_id`** | **—** | **—** |

So deleting an account removes the profile, the memories, the pending actions and the wallets — and leaves the conversations standing, with their titles, forever.

For a real person deleting their account, that is not untidiness. It is their private chat with Cat surviving the deletion they asked for.

## How it surfaced

An eval harness deleted 7 throwaway users and left **20 conversations** behind while its own cleanup check reported success — the check watched `profiles`, which does cascade. Fixed in #648; this PR fixes the reason it was possible.

Same shape as #637, one table over. The harness was only the thing that happened to notice, which is why this belongs in the schema and not in the harness.

## Change

**Migration** — delete orphans (currently 0), then `ADD CONSTRAINT … NOT VALID` + `VALIDATE`. `scripts/apply-migrations.sh` runs each file under `psql -1`, so the constraint can never see a row the `DELETE` did not. `NOT VALID` + `VALIDATE` rather than a plain `ADD` so that a validation failure, if the assumption is ever wrong, names the constraint.

**Nightly backstop** — `checkOrphanedCatConversations` in `check-data-invariants.mjs`, mirroring `checkOrphanedProfiles`: the constraint makes new orphans impossible, so the check exists for the constraint being dropped or written around. Checked against `profiles` rather than `auth.users` — profiles cascade from auth.users, so the two sets are identical and this needs no second `service_role`-only function.

## Verification

Live against production:

```
cat_conversations: 34 conversation(s), all owned by a live account
profiles: every profile belongs to a live auth user
All invariants hold.
```

**Mutation-tested both directions** — inverting the orphan predicate turns it red with a real count, restoring it turns it green:

```
FAIL  cat_conversations.orphaned: 34 conversation(s) belong to accounts that no longer exist
1 invariant(s) violated.
--- restored ---
ok    cat_conversations: 34 conversation(s), all owned by a live account
```

`validate-migration-sql` passes; type-check, lint and the unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
