### PR TITLE
fix(ci): declare the failing-job list before the branch that can skip it

### DIFF
--- a/__tests__/unit/ci/auto-merge-red-base.test.ts
+++ b/__tests__/unit/ci/auto-merge-red-base.test.ts
@@ -134,6 +134,46 @@ describe('a PR that repairs the base may merge onto it', () => {
   });
 });
 
+describe('the carve-out cannot break the sweep it lives in', () => {
+  it('survives a repo with no CI history at all', () => {
+    // `set -u` is on and the merge site always reads the failing-job list. When
+    // that assignment lived only in the else-branch of the "has CI history"
+    // check, a repo taking the "proceeding" path died with
+    //   main_red_jobs: unbound variable
+    // and the ENTIRE sweep exited 1 — auto-merge dead, for every PR, in any
+    // repo whose base branch had never run CI. Caught before shipping only
+    // because this case was executed rather than reasoned about.
+    const dir = mkdtempSync(join(tmpdir(), 'automerge-nohistory-'));
+    const log = join(dir, 'calls.log');
+    writeFileSync(
+      join(dir, 'gh'),
+      `#!/usr/bin/env bash
+echo "$@" >> ${JSON.stringify(log)}
+case "$1 $2" in
+  "api repos/"*) echo '${SHA}' ;;
+  "run list") ;;
+  "pr list") echo '${prJson(['CI']).replace(/'/g, "'\\''")}' ;;
+  "pr view") echo '{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN"}' ;;
+  *) ;;
+esac
+exit 0
+`
+    );
+    chmodSync(join(dir, 'gh'), 0o755);
+
+    // execFileSync throws on a non-zero exit, which is exactly the regression.
+    const stdout = execFileSync('bash', ['-c', 'scripts/ci/auto-merge-sweep.sh 2>&1'], {
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    expect(stdout).toContain('no CI history');
+    expect(stdout).not.toContain('unbound');
+    expect(readFileSync(log, 'utf8')).toContain('pr merge 26');
+  });
+});
+
 describe('a green base is completely unaffected', () => {
   it('merges normally and never asks which jobs failed', () => {
     const { calls } = sweep('success', [], ['E2E Tests', 'Build']);

--- a/scripts/ci/auto-merge-sweep.sh
+++ b/scripts/ci/auto-merge-sweep.sh
@@ -60,6 +60,12 @@ main_sha=$(gh api "repos/${REPO}/commits/${BASE_BRANCH}" --jq '.sha')
 main_ci=$(gh run list --repo "$REPO" --workflow ci.yml --branch "$BASE_BRANCH" --limit 1 \
   --json databaseId,status,conclusion,headSha --jq '.[0] // empty')
 
+# Declared before any branch that might skip it: `set -u` is on, and the merge
+# site below always reads it. A repo with no CI history at all takes the
+# "proceeding" path, and an assignment living only in the else-branch would
+# make the whole sweep die on an unbound variable.
+main_red_jobs=""
+
 if [ -z "$main_ci" ]; then
   echo "[auto-merge] no CI history for ${BASE_BRANCH} — proceeding"
 else
@@ -113,7 +119,6 @@ else
   # that the post-merge base is better than the pre-merge base. A PR that does
   # not cover the failing jobs is still refused, and so is a base failure whose
   # jobs cannot be identified at all.
-  main_red_jobs=""
   if [ "$main_conclusion" != "success" ]; then
     main_run_id=$(printf '%s' "$main_ci" | jq -r '.databaseId')
     main_red_jobs=$(gh run view "$main_run_id" --repo "$REPO" --json jobs \


### PR DESCRIPTION
Fixes a defect I introduced in #650.

The red-base carve-out declared `main_red_jobs` inside the `else` of the "does
the base have CI history?" check — but `set -u` is on and the merge site always
reads it. On a base branch with **no CI history at all**, the sweep takes the
"proceeding" path and dies:

    [auto-merge] no CI history for main — proceeding
    auto-merge-sweep.sh: line 246: main_red_jobs: unbound variable
    exit 1

That is auto-merge **dead for every PR in the repo**, not a degraded path.
Latent here because `main` has CI history — but it is one fresh repo away from
being real, and the same defect shipped to all the fleet ports (corrected there
in their own PRs, all merged and verified by running the shipped scripts).

Fixed by declaring it once, before the branch that can skip the assignment.

A regression test now runs the real script against a `gh` reporting no CI
history and asserts the sweep still merges. `execFileSync` throws on a non-zero
exit, so the test fails loudly on exactly this bug — it was caught only because
the case was **executed** rather than reasoned about.

Verified: 16/16 in `__tests__/unit/ci/`, `bash -n` clean, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)