### PR TITLE
fix(ci): stop CI users leaking into production, and notice if they do

### DIFF
--- a/scripts/check-data-invariants.mjs
+++ b/scripts/check-data-invariants.mjs
@@ -238,6 +238,58 @@ async function checkSilentlyDroppedCatTurns() {
   }
 }
 
+/**
+ * Profiles whose auth user is gone.
+ *
+ * `public.profiles` has NO foreign key to `auth.users`, so deleting an auth
+ * user leaves the profile — with its email, phone, location, bio and payment
+ * addresses — behind forever. Nothing enforced it and nothing watched it, so
+ * the per-CI-run throwaway users accumulated silently: on 2026-08-06 the table
+ * held 188 rows of which 136 were CI exhaust and 115 were orphans, and every
+ * product metric read off `profiles` was inflated by it.
+ *
+ * Beyond the noise this is the account-deletion path: the same missing
+ * constraint means a real user pressing "delete my account" keeps their PII.
+ * Until profiles is either cascaded or anonymised on delete, this check is the
+ * thing standing between that bug and silence.
+ */
+async function checkOrphanedProfiles() {
+  // PostgREST cannot join auth.users, so compare id sets. Profiles are small
+  // enough (tens) that fetching both is cheaper than adding an RPC.
+  const profiles = await rest('profiles?select=id,email');
+  if (profiles.length === 0) {
+    notes.push('profiles: table is empty');
+    return;
+  }
+
+  const seen = new Set();
+  for (let page = 0; page < 20; page++) {
+    const res = await fetch(
+      `${SUPABASE_URL}/auth/v1/admin/users?page=${page + 1}&per_page=200`,
+      { headers: { apikey: SERVICE_KEY, authorization: `Bearer ${SERVICE_KEY}` } }
+    );
+    if (!res.ok) {
+      throw new Error(`GoTrue admin list ${res.status}`);
+    }
+    const users = (await res.json())?.users ?? [];
+    for (const u of users) {
+      seen.add(u.id);
+    }
+    if (users.length < 200) break;
+  }
+
+  const orphans = profiles.filter(p => !seen.has(p.id));
+  if (orphans.length > 0) {
+    violation(
+      'profiles.orphaned_from_auth',
+      `${orphans.length} profile(s) have no auth user — deleting an account leaves its PII behind (profiles has no FK to auth.users)`,
+      orphans.slice(0, 5).map(p => p.email || p.id)
+    );
+  } else {
+    notes.push(`profiles: all ${profiles.length} row(s) have a live auth user`);
+  }
+}
+
 async function main() {
   const checks = [
     checkOrphanedWalletLinks,
@@ -245,6 +297,7 @@ async function main() {
     checkUnpayableActiveWallets,
     checkPaidWithoutTimestamp,
     checkSilentlyDroppedCatTurns,
+    checkOrphanedProfiles,
   ];
 
   for (const check of checks) {

--- a/scripts/test-setup/refresh-e2e-reset-tokens.mjs
+++ b/scripts/test-setup/refresh-e2e-reset-tokens.mjs
@@ -45,6 +45,13 @@ const admin = createClient(url, serviceKey, {
 
 // Opportunistic cleanup of yesterday's throwaway reset users. Best-effort —
 // a failure here must never block the run.
+//
+// deleteUser only removes the auth.users row. public.profiles has NO foreign
+// key to auth.users, so the profile (and its actor) survived every cleanup:
+// by 2026-08-06 that had left 113 orphaned profiles in PRODUCTION, 136 of 188
+// rows in the table were CI exhaust, and every product metric read off
+// `profiles` was inflated by it. Delete the rows this script created, in
+// every table it touched — not just the one the API happens to cascade.
 try {
   const cutoff = Date.now() - 24 * 60 * 60 * 1000;
   for (let page = 1; page <= 10; page++) {
@@ -52,6 +59,11 @@ try {
     const users = data?.users ?? [];
     for (const u of users) {
       if (/^e2e-reset-/.test(u.email || '') && new Date(u.created_at).getTime() < cutoff) {
+        // Order matters: drop the dependents first, so a failure part-way
+        // leaves the auth user behind as the marker that cleanup is unfinished
+        // rather than stranding rows with no auth user to find them by.
+        await admin.from('actors').delete().eq('user_id', u.id);
+        await admin.from('profiles').delete().eq('id', u.id);
         await admin.auth.admin.deleteUser(u.id);
         console.log(`cleaned up stale reset user ${u.email}`);
       }


### PR DESCRIPTION
## What was wrong

Every CI run mints a throwaway auth user for the password-reset E2E (`e2e-reset-<run_id>@orangecat.ch`) and then deletes it. But **`public.profiles` has no foreign key to `auth.users`** — so `admin.auth.admin.deleteUser()` removed the auth row and left the profile, and its actor, behind. Forever.

By 2026-08-06 the production `profiles` table held **188 rows, of which 136 were CI accounts and 115 were orphans**. Every product metric read off `profiles` was inflated by test traffic: "162 users, 5 bios, 0 who ever messaged Cat" was really **~7 humans**.

Those rows are already cleaned up in production (188 → 73, zero orphans, zero orphaned actors — verified none carried loans, messages, memories, wallets, products, projects, follows, or contracts).

## What this changes

**1. The fixture cleans up after itself** — `refresh-e2e-reset-tokens.mjs` now deletes `actors`, then `profiles`, then the auth user. Dependents first, so a part-way failure leaves the auth user behind as the marker that cleanup is unfinished, rather than stranding rows with nothing to find them by.

**2. A nightly invariant** — `checkOrphanedProfiles` in `check-data-invariants.mjs` fails if any profile outlives its auth user.

## The part that outlives this fix

The same missing constraint means the shipped **"delete my account"** path keeps the user's email, phone, location, bio and payment addresses. `src/app/api/delete-user/route.ts` does exactly one thing — `deleteUser()` — and never touches `profiles`.

Nobody real has deleted yet, so nothing real is retained today. It fires on the first one.

The fix is **not** a CASCADE, and I deliberately did not write that migration:

| relationship | on delete | consequence of cascading |
|---|---|---|
| `profiles` → `loans`, `loan_offers`, `payment_requests`, `messages` | CASCADE | destroys the **counterparty's** records |
| `profiles` → `loan_payments` | NO ACTION | would **block** deletion outright |
| `actors` → `contracts`, `investments`, `bookings` | CASCADE | destroys counterparty agreements |

The correct fix is to **anonymise** the profile rather than delete it, preserving the counterparty side. That's a schema decision, not a drive-by. Until it lands, this invariant is what stands between that bug and silence.

## Verification

- `npm run verify` green — 1937 tests, exit 0
- Ran live against production: `ok    profiles: all 74 row(s) have a live auth user`
- **Mutation-tested**: inserted an orphan probe → `FAIL profiles.orphaned_from_auth: 1 profile(s) have no auth user`, gate `exit=1`; removed the probe → `exit=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)