### PR TITLE
fix(db): actors outlived their accounts — the last table in the family

### DIFF
--- a/scripts/check-data-invariants.mjs
+++ b/scripts/check-data-invariants.mjs
@@ -336,6 +336,65 @@ async function checkOrphanedCatConversations() {
   }
 }
 
+/**
+ * Actors whose account is gone.
+ *
+ * `actors.user_id` is the last member of this family carrying NO foreign key —
+ * profiles (#637) and cat_conversations (#651) both cascade now, and the sweep
+ * that fixed them stopped one table short. So deleting an account still leaves
+ * its actor standing: the row that owns every product, service, project, cause,
+ * event, loan and asset the person ever created.
+ *
+ * Unlike its siblings this cannot be closed by adding `ON DELETE CASCADE`, and
+ * that is why it is a check rather than a migration:
+ *
+ *   - CASCADE would delete the actor, which cascades on into `contracts`,
+ *     `investments` and `bookings` — destroying the COUNTERPARTY's record of an
+ *     agreement because the other side closed their account.
+ *   - SET NULL is rejected outright by `actor_type_check`, which requires
+ *     `actor_type = 'user'` to have a non-null `user_id`.
+ *
+ * The honest fix is a tombstone — keep the actor, sever the identity — which
+ * needs a deleted/anonymous actor_type and so is a schema decision, not a
+ * drive-by. Until that lands this check is what stands between the leak and
+ * silence, and it is not a formality: 15 orphaned actors were live in
+ * production when it was written.
+ *
+ * Checked against `profiles` rather than auth.users, for the same reason as
+ * checkOrphanedCatConversations: profiles cascade from auth.users, so "no
+ * profile" and "no account" are the same set, reachable through PostgREST
+ * without another service_role-only function.
+ */
+async function checkOrphanedActors() {
+  const actors = await rest('actors?select=id,user_id,display_name&user_id=not.is.null');
+  if (actors.length === 0) {
+    notes.push('actors: no user-owned actors');
+    return;
+  }
+  const ownerIds = [...new Set(actors.map(a => a.user_id))];
+  const live = new Set();
+  // Chunked so the id list cannot outgrow the URL as the table grows.
+  for (let i = 0; i < ownerIds.length; i += 100) {
+    const chunk = ownerIds.slice(i, i + 100);
+    const found = await rest(`profiles?select=id&id=in.(${chunk.join(',')})`);
+    for (const p of found) {
+      live.add(p.id);
+    }
+  }
+
+  const orphans = actors.filter(a => !live.has(a.user_id));
+  if (orphans.length > 0) {
+    violation(
+      'actors.orphaned',
+      `${orphans.length} actor(s) belong to accounts that no longer exist — ` +
+        `a deleted account left behind the row that owns everything it published`,
+      orphans.slice(0, 5).map(o => o.display_name || o.id)
+    );
+  } else {
+    notes.push(`actors: ${actors.length} user actor(s), all owned by a live account`);
+  }
+}
+
 async function main() {
   const checks = [
     checkOrphanedWalletLinks,
@@ -345,6 +404,7 @@ async function main() {
     checkSilentlyDroppedCatTurns,
     checkOrphanedProfiles,
     checkOrphanedCatConversations,
+    checkOrphanedActors,
   ];
 
   for (const check of checks) {

--- a/scripts/diagnostics/write-test-supabase.js
+++ b/scripts/diagnostics/write-test-supabase.js
@@ -3,33 +3,38 @@
 // Supabase write test (local/dev/prod)
 // Safely creates a temporary auth user, ensures profile exists, creates a funding page, then cleans up.
 
-const path = require('path')
-const fs = require('fs')
-const { createClient } = require('@supabase/supabase-js')
+const path = require('path');
+const fs = require('fs');
+const { createClient } = require('@supabase/supabase-js');
 
 // Load env from .env.local if available
 try {
-  const envPath = path.join(process.cwd(), '.env.local')
+  const envPath = path.join(process.cwd(), '.env.local');
   if (fs.existsSync(envPath)) {
-    require('dotenv').config({ path: envPath })
+    require('dotenv').config({ path: envPath });
   }
 } catch {}
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-const service = process.env.SUPABASE_SERVICE_ROLE_KEY
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const service = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 function log(section, message, extra) {
-  const ts = new Date().toISOString()
-  const tail = extra ? `\n${JSON.stringify(extra, null, 2)}` : ''
-  console.log(`[${ts}] [${section}] ${message}${tail}`)
+  const ts = new Date().toISOString();
+  const tail = extra ? `\n${JSON.stringify(extra, null, 2)}` : '';
+  console.log(`[${ts}] [${section}] ${message}${tail}`);
 }
 
 if (!url || !service) {
-  log('ERROR', 'Missing env: require NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in .env.local')
-  process.exit(1)
+  log(
+    'ERROR',
+    'Missing env: require NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in .env.local'
+  );
+  process.exit(1);
 }
 
-const supabase = createClient(url, service, { auth: { persistSession: false, autoRefreshToken: false } })
+const supabase = createClient(url, service, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
 
 async function columnExists(table, column) {
   const { data, error } = await supabase
@@ -38,58 +43,66 @@ async function columnExists(table, column) {
     .eq('table_schema', 'public')
     .eq('table_name', table)
     .eq('column_name', column)
-    .limit(1)
-  if (error) return false
-  return Array.isArray(data) && data.length > 0
+    .limit(1);
+  if (error) return false;
+  return Array.isArray(data) && data.length > 0;
 }
 
 async function ensureProfile(userId) {
   // Check if profile exists (trigger should create it on auth.users insert)
-  const { data, error } = await supabase.from('profiles').select('id').eq('id', userId).limit(1)
-  if (!error && data && data.length > 0) return true
+  const { data, error } = await supabase.from('profiles').select('id').eq('id', userId).limit(1);
+  if (!error && data && data.length > 0) return true;
 
   // Attempt to create minimal profile if trigger is not present
-  const { error: insErr } = await supabase.from('profiles').insert({ id: userId, username: `diag_${userId.substring(0,8)}`, display_name: 'Diag User' })
-  return !insErr
+  const { error: insErr } = await supabase
+    .from('profiles')
+    .insert({ id: userId, username: `diag_${userId.substring(0, 8)}`, display_name: 'Diag User' });
+  return !insErr;
 }
 
-async function sleep(ms) { return new Promise(r => setTimeout(r, ms)) }
+async function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
 
 async function main() {
-  const runId = Math.random().toString(36).slice(2, 8)
-  const email = `oc_diag_${Date.now()}_${runId}@example.com`
+  const runId = Math.random().toString(36).slice(2, 8);
+  const email = `oc_diag_${Date.now()}_${runId}@example.com`;
 
-  log('INFO', 'Creating test auth user', { email })
-  const { data: created, error: createErr } = await supabase.auth.admin.createUser({ email, email_confirm: true })
+  log('INFO', 'Creating test auth user', { email });
+  const { data: created, error: createErr } = await supabase.auth.admin.createUser({
+    email,
+    email_confirm: true,
+  });
   if (createErr || !created?.user?.id) {
-    log('ERROR', 'Failed to create auth user', { error: createErr?.message })
-    process.exit(2)
+    log('ERROR', 'Failed to create auth user', { error: createErr?.message });
+    process.exit(2);
   }
 
-  const userId = created.user.id
-  log('INFO', 'Created auth user', { userId })
+  const userId = created.user.id;
+  log('INFO', 'Created auth user', { userId });
 
   // Give trigger a moment (if present)
-  await sleep(250)
+  await sleep(250);
 
-  const profileOk = await ensureProfile(userId)
+  const profileOk = await ensureProfile(userId);
   if (!profileOk) {
-    log('ERROR', 'Profile not present and failed to create')
-    // cleanup user before exit
-    await supabase.auth.admin.deleteUser(userId)
-    process.exit(3)
+    log('ERROR', 'Profile not present and failed to create');
+    // cleanup user before exit — actor first, see the note at the end of main()
+    await supabase.from('actors').delete().eq('user_id', userId);
+    await supabase.auth.admin.deleteUser(userId);
+    process.exit(3);
   }
 
   // Determine funding_pages column for owner
-  const hasCreator = await columnExists('funding_pages', 'creator_id')
-  const hasUser = !hasCreator && await columnExists('funding_pages', 'user_id')
-  const ownerColumn = hasCreator ? 'creator_id' : hasUser ? 'user_id' : null
+  const hasCreator = await columnExists('funding_pages', 'creator_id');
+  const hasUser = !hasCreator && (await columnExists('funding_pages', 'user_id'));
+  const ownerColumn = hasCreator ? 'creator_id' : hasUser ? 'user_id' : null;
 
   // Insert a test funding page if table and owner column exist
-  let fundingId = null
-  let fundingOk = false
+  let fundingId = null;
+  let fundingOk = false;
   if (ownerColumn) {
-    const slug = `diag-${runId}-${Date.now()}`
+    const slug = `diag-${runId}-${Date.now()}`;
     const payload = {
       [ownerColumn]: userId,
       slug,
@@ -99,40 +112,48 @@ async function main() {
       is_active: true,
       total_raised: 0,
       supporter_count: 0,
-    }
-    const { data, error } = await supabase.from('funding_pages').insert(payload).select('id').limit(1)
+    };
+    const { data, error } = await supabase
+      .from('funding_pages')
+      .insert(payload)
+      .select('id')
+      .limit(1);
     if (!error && data && data.length > 0) {
-      fundingId = data[0].id
-      fundingOk = true
-      log('INFO', 'Inserted funding page', { fundingId, slug })
+      fundingId = data[0].id;
+      fundingOk = true;
+      log('INFO', 'Inserted funding page', { fundingId, slug });
     } else {
-      log('WARN', 'Failed to insert funding page (continuing)', { error: error?.message })
+      log('WARN', 'Failed to insert funding page (continuing)', { error: error?.message });
     }
   } else {
-    log('WARN', 'No suitable owner column found on funding_pages (skipping funding page write)')
+    log('WARN', 'No suitable owner column found on funding_pages (skipping funding page write)');
   }
 
   // Cleanup: delete funding page if created
   if (fundingId) {
-    await supabase.from('funding_pages').delete().eq('id', fundingId)
-    log('INFO', 'Deleted test funding page', { fundingId })
+    await supabase.from('funding_pages').delete().eq('id', fundingId);
+    log('INFO', 'Deleted test funding page', { fundingId });
   }
 
-  // Cleanup: delete auth user (cascade removes profile)
-  await supabase.auth.admin.deleteUser(userId)
-  log('INFO', 'Deleted test auth user', { userId })
+  // Cleanup: the profile goes with the auth user via profiles_id_fkey CASCADE,
+  // but the ACTOR does not — actors.user_id still has no foreign key, so it has
+  // to be deleted explicitly or this diagnostic leaks a row into production
+  // every time it runs. (The nightly `actors.orphaned` invariant is the
+  // backstop for every call site that forgets, including future ones.)
+  await supabase.from('actors').delete().eq('user_id', userId);
+  await supabase.auth.admin.deleteUser(userId);
+  log('INFO', 'Deleted test auth user', { userId });
 
-  const summary = { userCreated: true, profileOk, fundingOk }
+  const summary = { userCreated: true, profileOk, fundingOk };
   if (profileOk && (fundingOk || ownerColumn === null)) {
-    log('RESULT', 'Write test successful', summary)
+    log('RESULT', 'Write test successful', summary);
   } else {
-    log('RESULT', 'Write test completed with issues', summary)
-    process.exit(4)
+    log('RESULT', 'Write test completed with issues', summary);
+    process.exit(4);
   }
 }
 
-main().catch(async (err) => {
-  log('ERROR', 'Write test crashed', { error: err?.message || String(err) })
-  process.exit(1)
-})
-
+main().catch(async err => {
+  log('ERROR', 'Write test crashed', { error: err?.message || String(err) });
+  process.exit(1);
+});

--- a/scripts/test-setup/refresh-e2e-reset-tokens.mjs
+++ b/scripts/test-setup/refresh-e2e-reset-tokens.mjs
@@ -65,6 +65,10 @@ const admin = createClient(url, serviceKey, {
 // signup numbers mostly synthetic. If that constraint is ever dropped, this
 // script silently starts leaking again; the nightly `profiles.orphaned`
 // invariant is what would notice.
+//
+// The actor does NOT go with it. `actors.user_id` is the one member of this
+// family still carrying no foreign key, so it has to be deleted by hand here.
+// See the `actors.orphaned` invariant for why an FK is not a drive-by fix.
 try {
   const cutoff = Date.now() - 24 * 60 * 60 * 1000;
   for (let page = 1; page <= 10; page++) {
@@ -72,6 +76,11 @@ try {
     const users = data?.users ?? [];
     for (const u of users) {
       if (/^e2e-reset-/.test(u.email || '') && new Date(u.created_at).getTime() < cutoff) {
+        // Actor first: it is the row nothing else will clean up, so if the
+        // deletion fails part-way the auth user is left behind as the marker
+        // that cleanup is unfinished, rather than an actor with no account to
+        // find it by.
+        await admin.from('actors').delete().eq('user_id', u.id);
         await admin.auth.admin.deleteUser(u.id);
         console.log(`cleaned up stale reset user ${u.email}`);
       }


### PR DESCRIPTION
## The gap

`profiles` (#637) and `cat_conversations` (#651) both cascade from the account now. Each sweep stopped one table short of done, and **`actors.user_id` references nothing at all**.

So deleting an account still leaves the actor standing — the row that owns every product, service, project, cause, event, loan and asset the person ever published.

**15 orphaned actors were live in production.** They were `e2e-reset-*`, `cat-wallet-eval-*` and `cascade-proof-*` rows — i.e. *the verification of the earlier fixes leaked rows into the table the next fix would be about.* Already purged, behind a guard that proved they owned **0 rows across all 25 child foreign keys** before deleting anything.

## Why this is a check and not a migration

Unlike its siblings, this one can't be closed with a constraint:

| option | why it fails |
|---|---|
| `ON DELETE CASCADE` | deletes the actor, which cascades on into `contracts`, `investments`, `bookings` — destroying the **counterparty's** record of an agreement because the other side closed their account |
| `ON DELETE SET NULL` | rejected outright by `actor_type_check`, which requires `actor_type='user'` to have a non-null `user_id` |

The honest fix is a **tombstone** — keep the actor, sever the identity — which needs a deleted/anonymous `actor_type`. That's a schema decision, not a drive-by, so it's stated here and left for one rather than improvised into production.

## What this ships

- **`actors.orphaned`** in the nightly invariant gate (systemd timer, 05:00 UTC, `OnFailure` → Telegram). This is the part that covers call sites nobody thought to patch, including future ones.
- **The two known leak sites now delete the actor explicitly** — `refresh-e2e-reset-tokens.mjs` (fires every CI run) and `write-test-supabase.js`, whose comment claimed *"cascade removes profile"*: true, and exactly the trap — it names the fixed thing while missing the one still broken.

## Verification

- `npm run verify` green — **210 suites, 2117 tests, exit 0**
- Ran live against production: reported the real 15, then `ok actors: 104 user actor(s), all owned by a live account` after the purge
- **Mutation-tested both directions with `--gate`**: one injected orphan → `FAIL actors.orphaned`, `exit 1`; removed → `exit 0`
- Confirmed `PGRST_DB_MAX_ROWS` is unset on the box, so `rest()` can't silently truncate the comparison as the table grows (checked rather than assumed)

Supersedes #653, which was written against a stale base and duplicated #637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)